### PR TITLE
Bound daily practice packet reminder queries

### DIFF
--- a/_migration/backfill-practice-packet-reminder-due-at.js
+++ b/_migration/backfill-practice-packet-reminder-due-at.js
@@ -4,6 +4,7 @@ import admin from 'firebase-admin';
 import { pathToFileURL } from 'node:url';
 
 const DEFAULT_PAGE_SIZE = 400;
+const MIGRATION_STATE_PATH = 'systemMigrations/practicePacketReminderDueAt';
 
 function coerceDate(value) {
     if (typeof value?.toDate === 'function') return value.toDate();
@@ -76,6 +77,8 @@ export async function backfillPracticePacketReminderDueAt({
             ? snapshot.docs[snapshot.docs.length - 1]
             : null;
     } while (lastDoc);
+
+    await db.doc(MIGRATION_STATE_PATH).set({ completed: true }, { merge: true });
 
     return { scanned, updated, skipped, malformed };
 }

--- a/_migration/backfill-practice-packet-reminder-due-at.js
+++ b/_migration/backfill-practice-packet-reminder-due-at.js
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+import admin from 'firebase-admin';
+import { pathToFileURL } from 'node:url';
+
+const DEFAULT_PAGE_SIZE = 400;
+
+function coerceDate(value) {
+    if (typeof value?.toDate === 'function') return value.toDate();
+    if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+    if (!value) return null;
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+export function derivePracticePacketReminderDueAt(session = {}) {
+    const packet = session.homePacketContent || {};
+    return coerceDate(
+        packet.dueAt
+        || packet.dueDate
+        || packet.deadline
+        || packet.deadlineAt
+        || packet.completeBy
+        || packet.completeByAt
+        || session.date
+    );
+}
+
+export async function backfillPracticePacketReminderDueAt({
+    db,
+    Timestamp,
+    pageSize = DEFAULT_PAGE_SIZE
+}) {
+    let lastDoc = null;
+    let scanned = 0;
+    let updated = 0;
+    let skipped = 0;
+    let malformed = 0;
+
+    do {
+        let query = db.collectionGroup('practiceSessions')
+            .orderBy(admin.firestore.FieldPath.documentId())
+            .limit(pageSize);
+        if (lastDoc) query = query.startAfter(lastDoc);
+
+        const snapshot = await query.get();
+        const batch = db.batch();
+        let pendingWrites = 0;
+
+        for (const docSnap of snapshot.docs) {
+            scanned += 1;
+            const session = docSnap.data() || {};
+            if (session.homePacketGenerated !== true || session.homePacketReminderDueAt) {
+                skipped += 1;
+                continue;
+            }
+
+            const dueAt = derivePracticePacketReminderDueAt(session);
+            if (!dueAt) {
+                malformed += 1;
+                continue;
+            }
+
+            batch.update(docSnap.ref, {
+                homePacketReminderDueAt: Timestamp.fromDate(dueAt)
+            });
+            pendingWrites += 1;
+        }
+
+        if (pendingWrites) {
+            await batch.commit();
+            updated += pendingWrites;
+        }
+
+        lastDoc = snapshot.docs.length === pageSize
+            ? snapshot.docs[snapshot.docs.length - 1]
+            : null;
+    } while (lastDoc);
+
+    return { scanned, updated, skipped, malformed };
+}
+
+async function main() {
+    if (!admin.apps.length) admin.initializeApp();
+    const result = await backfillPracticePacketReminderDueAt({
+        db: admin.firestore(),
+        Timestamp: admin.firestore.Timestamp
+    });
+    console.log('[backfill-practice-packet-reminder-due-at] Done.', result);
+}
+
+const isDirectRun = process.argv[1]
+    && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isDirectRun) {
+    main().catch((error) => {
+        console.error('[backfill-practice-packet-reminder-due-at] Failed:', error);
+        process.exitCode = 1;
+    });
+}

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -6569,6 +6569,7 @@ export async function saveStaffPracticePacket(event: ParentScheduleEvent, user: 
   assertPracticePacketManagementEvent(event, user);
   const authUser = user as AuthUser;
   const homePacketContent = buildStaffPracticePacketContent(input, event, authUser);
+  const homePacketReminderDueAt = Timestamp.fromDate(homePacketContent.dueAt || event.date);
   const sessionPayload = {
     eventId: event.id,
     eventType: 'practice',
@@ -6579,6 +6580,7 @@ export async function saveStaffPracticePacket(event: ParentScheduleEvent, user: 
     duration: homePacketContent.totalMinutes,
     status: 'draft',
     homePacketGenerated: true,
+    homePacketReminderDueAt,
     homePacketContent,
     updatedBy: authUser.uid
   };

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -6569,7 +6569,7 @@ export async function saveStaffPracticePacket(event: ParentScheduleEvent, user: 
   assertPracticePacketManagementEvent(event, user);
   const authUser = user as AuthUser;
   const homePacketContent = buildStaffPracticePacketContent(input, event, authUser);
-  const homePacketReminderDueAt = Timestamp.fromDate(homePacketContent.dueAt || event.date);
+  const homePacketReminderDueAt = homePacketContent.dueAt || event.date;
   const sessionPayload = {
     eventId: event.id,
     eventType: 'practice',

--- a/drills.html
+++ b/drills.html
@@ -4406,8 +4406,10 @@ ${userPrompt}
                 return;
             }
             const normalizedBlocks = normalizeHomePacketBlocks(state.homePacketBlocks);
+            const homePacketReminderDueAt = new Date(document.getElementById('session-date').value);
             const payload = {
                 homePacketGenerated: true,
+                homePacketReminderDueAt,
                 homePacketContent: {
                     blocks: normalizedBlocks,
                     totalMinutes: normalizedBlocks.reduce((sum, b) => sum + (parseInt(b.duration, 10) || 0), 0),

--- a/drills.html
+++ b/drills.html
@@ -3053,6 +3053,7 @@ ${text}
             };
             if (state.homePacketBlocks.length > 0) {
                 data.homePacketGenerated = true;
+                data.homePacketReminderDueAt = data.date;
                 data.homePacketContent = {
                     blocks: normalizeHomePacketBlocks(state.homePacketBlocks),
                     totalMinutes: state.homePacketBlocks.reduce((sum, b) => sum + (parseInt(b.duration, 10) || 0), 0),

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -132,6 +132,14 @@
       ]
     },
     {
+      "collectionGroup": "practiceSessions",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "homePacketGenerated", "order": "ASCENDING" },
+        { "fieldPath": "homePacketReminderDueAt", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "sharedGames",
       "queryScope": "COLLECTION_GROUP",
       "fields": [

--- a/functions/index.js
+++ b/functions/index.js
@@ -9068,13 +9068,96 @@ async function sendPracticePacketDueTomorrowReminders(now = new Date()) {
   const { start, end } = getTomorrowDateRange(now);
   const practiceTargetsByTeam = new Map();
   const results = [];
-  const candidateSessionDocs = [];
-  const candidateSessionPaths = new Set();
-  let lastSessionDoc = null;
   let indexedQueryFailed = false;
 
-  try {
-    do {
+  async function processCandidateSessionDocs(candidateSessionDocs) {
+    for (const docSnap of candidateSessionDocs) {
+      const session = docSnap.data() || {};
+      const packet = session.homePacketContent || null;
+      if (!hasPracticePacketContent(packet)) continue;
+
+      const pathParts = docSnap.ref.path.split('/');
+      const teamId = pathParts[1];
+      const sessionId = docSnap.id;
+      if (!teamId || !sessionId) continue;
+
+      const [playersSnap, completionsSnap] = await Promise.all([
+        firestore.collection(`teams/${teamId}/players`).get(),
+        firestore.collection(`teams/${teamId}/practiceSessions/${sessionId}/packetCompletions`).get()
+      ]);
+      const completedPlayerIds = new Set(
+        completionsSnap.docs
+          .map((completionSnap) => completionSnap.data() || {})
+          .filter((completion) => String(completion.status || 'completed').trim().toLowerCase() === 'completed')
+          .map((completion) => String(completion.childId || '').trim())
+          .filter(Boolean)
+      );
+
+      let practiceTargets = practiceTargetsByTeam.get(teamId);
+      if (!practiceTargets) {
+        practiceTargets = await getTargetsForCategory(teamId, 'practice', null);
+        practiceTargetsByTeam.set(teamId, practiceTargets);
+      }
+      if (!practiceTargets.length) continue;
+
+      const scheduleEventId = String(session.eventId || '').trim() || sessionId;
+      const destination = buildPracticePacketNotificationDestination({ teamId, eventId: scheduleEventId, sessionId });
+      const packetTitle = getPracticePacketNotificationTitle(packet, session);
+
+      for (const playerSnap of playersSnap.docs) {
+        const playerId = String(playerSnap.id || '').trim();
+        const player = playerSnap.data() || {};
+        if (!playerId || player.active === false) continue;
+        if (completedPlayerIds.has(playerId)) continue;
+
+        const candidateUserIds = await getPracticePacketReminderTargetUserIds(teamId, playerId, player);
+        if (!candidateUserIds.length) continue;
+
+        const candidateUserIdSet = new Set(candidateUserIds);
+        const parentTargets = practiceTargets.filter((target) => candidateUserIdSet.has(target.uid));
+        if (!parentTargets.length) continue;
+
+        const claimId = await claimPracticePacketReminder(teamId, sessionId, playerId, now);
+        if (!claimId) continue;
+
+        try {
+          await sendDirectTargetsNotification({
+            targets: parentTargets,
+            category: 'practice',
+            title: `Reminder: ${packetTitle} is due tomorrow`,
+            body: `${String(player.name || 'Your player').trim() || 'Your player'} has not completed the ${getPracticePacketNotificationLabel(session)} yet.`,
+            teamId,
+            eventId: sessionId,
+            linkOverride: destination.link,
+            appRouteOverride: destination.appRoute
+          });
+
+          const markedSent = await markPracticePacketReminderSent(teamId, sessionId, playerId, claimId);
+          if (!markedSent) continue;
+
+          results.push({
+            teamId,
+            sessionId,
+            playerId,
+            targetCount: parentTargets.length
+          });
+        } catch (error) {
+          await clearPracticePacketReminderClaim(teamId, sessionId, playerId, claimId, error);
+          functions.logger.error('Failed to send practice packet due tomorrow reminder.', {
+            teamId,
+            sessionId,
+            playerId,
+            error: error?.message || error
+          });
+        }
+      }
+    }
+  }
+
+  let lastSessionDoc = null;
+  do {
+    let sessionSnap;
+    try {
       let sessionQuery = firestore.collectionGroup('practiceSessions')
         .where('homePacketGenerated', '==', true)
         .where('homePacketReminderDueAt', '>=', admin.firestore.Timestamp.fromDate(start))
@@ -9084,23 +9167,20 @@ async function sendPracticePacketDueTomorrowReminders(now = new Date()) {
       if (lastSessionDoc) {
         sessionQuery = sessionQuery.startAfter(lastSessionDoc);
       }
-      const sessionSnap = await sessionQuery.get();
+      sessionSnap = await sessionQuery.get();
+    } catch (error) {
+      indexedQueryFailed = true;
+      functions.logger.error('Practice packet reminder indexed query unavailable; using migration compatibility scan.', {
+        error: error?.message || error
+      });
+      break;
+    }
 
-      for (const docSnap of sessionSnap.docs) {
-        candidateSessionDocs.push(docSnap);
-        candidateSessionPaths.add(docSnap.ref.path);
-      }
-
-      lastSessionDoc = sessionSnap.docs.length === PRACTICE_PACKET_REMINDER_PAGE_SIZE
-        ? sessionSnap.docs[sessionSnap.docs.length - 1]
-        : null;
-    } while (lastSessionDoc);
-  } catch (error) {
-    indexedQueryFailed = true;
-    functions.logger.error('Practice packet reminder indexed query unavailable; using migration compatibility scan.', {
-      error: error?.message || error
-    });
-  }
+    await processCandidateSessionDocs(sessionSnap.docs);
+    lastSessionDoc = sessionSnap.docs.length === PRACTICE_PACKET_REMINDER_PAGE_SIZE
+      ? sessionSnap.docs[sessionSnap.docs.length - 1]
+      : null;
+  } while (lastSessionDoc);
 
   const migrationStateSnap = await firestore.doc(PRACTICE_PACKET_REMINDER_MIGRATION_STATE_PATH).get();
   const migrationComplete = migrationStateSnap.exists && migrationStateSnap.data()?.completed === true;
@@ -9118,101 +9198,20 @@ async function sendPracticePacketDueTomorrowReminders(now = new Date()) {
       }
       const legacySessionSnap = await legacySessionQuery.get();
 
+      const eligibleLegacySessionDocs = [];
       for (const docSnap of legacySessionSnap.docs) {
         const session = docSnap.data() || {};
-        if ((!indexedQueryFailed && session.homePacketReminderDueAt) || candidateSessionPaths.has(docSnap.ref.path)) continue;
+        if (!indexedQueryFailed && session.homePacketReminderDueAt) continue;
         const packet = session.homePacketContent || null;
         if (!hasPracticePacketContent(packet) || !isPracticePacketDueTomorrow(packet, session, now)) continue;
-        candidateSessionDocs.push(docSnap);
-        candidateSessionPaths.add(docSnap.ref.path);
+        eligibleLegacySessionDocs.push(docSnap);
       }
+      await processCandidateSessionDocs(eligibleLegacySessionDocs);
 
       lastLegacySessionDoc = legacySessionSnap.docs.length === PRACTICE_PACKET_REMINDER_PAGE_SIZE
         ? legacySessionSnap.docs[legacySessionSnap.docs.length - 1]
         : null;
     } while (lastLegacySessionDoc);
-  }
-
-  for (const docSnap of candidateSessionDocs) {
-    const session = docSnap.data() || {};
-    const packet = session.homePacketContent || null;
-    if (!hasPracticePacketContent(packet)) continue;
-
-    const pathParts = docSnap.ref.path.split('/');
-    const teamId = pathParts[1];
-    const sessionId = docSnap.id;
-    if (!teamId || !sessionId) continue;
-
-    const [playersSnap, completionsSnap] = await Promise.all([
-      firestore.collection(`teams/${teamId}/players`).get(),
-      firestore.collection(`teams/${teamId}/practiceSessions/${sessionId}/packetCompletions`).get()
-    ]);
-    const completedPlayerIds = new Set(
-      completionsSnap.docs
-        .map((completionSnap) => completionSnap.data() || {})
-        .filter((completion) => String(completion.status || 'completed').trim().toLowerCase() === 'completed')
-        .map((completion) => String(completion.childId || '').trim())
-        .filter(Boolean)
-    );
-
-    let practiceTargets = practiceTargetsByTeam.get(teamId);
-    if (!practiceTargets) {
-      practiceTargets = await getTargetsForCategory(teamId, 'practice', null);
-      practiceTargetsByTeam.set(teamId, practiceTargets);
-    }
-    if (!practiceTargets.length) continue;
-
-    const scheduleEventId = String(session.eventId || '').trim() || sessionId;
-    const destination = buildPracticePacketNotificationDestination({ teamId, eventId: scheduleEventId, sessionId });
-    const packetTitle = getPracticePacketNotificationTitle(packet, session);
-
-    for (const playerSnap of playersSnap.docs) {
-      const playerId = String(playerSnap.id || '').trim();
-      const player = playerSnap.data() || {};
-      if (!playerId || player.active === false) continue;
-      if (completedPlayerIds.has(playerId)) continue;
-
-      const candidateUserIds = await getPracticePacketReminderTargetUserIds(teamId, playerId, player);
-      if (!candidateUserIds.length) continue;
-
-      const candidateUserIdSet = new Set(candidateUserIds);
-      const parentTargets = practiceTargets.filter((target) => candidateUserIdSet.has(target.uid));
-      if (!parentTargets.length) continue;
-
-      const claimId = await claimPracticePacketReminder(teamId, sessionId, playerId, now);
-      if (!claimId) continue;
-
-      try {
-        await sendDirectTargetsNotification({
-          targets: parentTargets,
-          category: 'practice',
-          title: `Reminder: ${packetTitle} is due tomorrow`,
-          body: `${String(player.name || 'Your player').trim() || 'Your player'} has not completed the ${getPracticePacketNotificationLabel(session)} yet.`,
-          teamId,
-          eventId: sessionId,
-          linkOverride: destination.link,
-          appRouteOverride: destination.appRoute
-        });
-
-        const markedSent = await markPracticePacketReminderSent(teamId, sessionId, playerId, claimId);
-        if (!markedSent) continue;
-
-        results.push({
-          teamId,
-          sessionId,
-          playerId,
-          targetCount: parentTargets.length
-        });
-      } catch (error) {
-        await clearPracticePacketReminderClaim(teamId, sessionId, playerId, claimId, error);
-        functions.logger.error('Failed to send practice packet due tomorrow reminder.', {
-          teamId,
-          sessionId,
-          playerId,
-          error: error?.message || error
-        });
-      }
-    }
   }
 
   return results;

--- a/functions/index.js
+++ b/functions/index.js
@@ -8947,7 +8947,27 @@ function getTomorrowDateRange(now = new Date()) {
   return { start, end };
 }
 
+function getPracticePacketReminderDueDate(packet = {}, session = {}) {
+  return coercePracticePacketDate(
+    packet.dueAt
+    || packet.dueDate
+    || packet.deadline
+    || packet.deadlineAt
+    || packet.completeBy
+    || packet.completeByAt
+    || session.date
+  );
+}
+
+function isPracticePacketDueTomorrow(packet = {}, session = {}, now = new Date()) {
+  const dueDate = getPracticePacketReminderDueDate(packet, session);
+  if (!dueDate) return false;
+  const { start, end } = getTomorrowDateRange(now);
+  return dueDate >= start && dueDate < end;
+}
+
 const PRACTICE_PACKET_REMINDER_PAGE_SIZE = 100;
+const PRACTICE_PACKET_REMINDER_MIGRATION_STATE_PATH = 'systemMigrations/practicePacketReminderDueAt';
 
 function getPracticePacketReminderDocRef(teamId, sessionId, playerId) {
   return firestore.doc(`teams/${teamId}/practiceSessions/${sessionId}/packetReminderSends/${playerId}`);
@@ -9048,106 +9068,152 @@ async function sendPracticePacketDueTomorrowReminders(now = new Date()) {
   const { start, end } = getTomorrowDateRange(now);
   const practiceTargetsByTeam = new Map();
   const results = [];
+  const candidateSessionDocs = [];
+  const candidateSessionPaths = new Set();
   let lastSessionDoc = null;
+  let indexedQueryFailed = false;
 
-  do {
-    let sessionQuery = firestore.collectionGroup('practiceSessions')
-      .where('homePacketGenerated', '==', true)
-      .where('homePacketReminderDueAt', '>=', admin.firestore.Timestamp.fromDate(start))
-      .where('homePacketReminderDueAt', '<', admin.firestore.Timestamp.fromDate(end))
-      .orderBy('homePacketReminderDueAt')
-      .limit(PRACTICE_PACKET_REMINDER_PAGE_SIZE);
-    if (lastSessionDoc) {
-      sessionQuery = sessionQuery.startAfter(lastSessionDoc);
-    }
-    const sessionSnap = await sessionQuery.get();
-
-    for (const docSnap of sessionSnap.docs) {
-      const session = docSnap.data() || {};
-      const packet = session.homePacketContent || null;
-      if (!hasPracticePacketContent(packet)) continue;
-
-      const pathParts = docSnap.ref.path.split('/');
-      const teamId = pathParts[1];
-      const sessionId = docSnap.id;
-      if (!teamId || !sessionId) continue;
-
-      const [playersSnap, completionsSnap] = await Promise.all([
-        firestore.collection(`teams/${teamId}/players`).get(),
-        firestore.collection(`teams/${teamId}/practiceSessions/${sessionId}/packetCompletions`).get()
-      ]);
-      const completedPlayerIds = new Set(
-        completionsSnap.docs
-          .map((completionSnap) => completionSnap.data() || {})
-          .filter((completion) => String(completion.status || 'completed').trim().toLowerCase() === 'completed')
-          .map((completion) => String(completion.childId || '').trim())
-          .filter(Boolean)
-      );
-
-      let practiceTargets = practiceTargetsByTeam.get(teamId);
-      if (!practiceTargets) {
-        practiceTargets = await getTargetsForCategory(teamId, 'practice', null);
-        practiceTargetsByTeam.set(teamId, practiceTargets);
+  try {
+    do {
+      let sessionQuery = firestore.collectionGroup('practiceSessions')
+        .where('homePacketGenerated', '==', true)
+        .where('homePacketReminderDueAt', '>=', admin.firestore.Timestamp.fromDate(start))
+        .where('homePacketReminderDueAt', '<', admin.firestore.Timestamp.fromDate(end))
+        .orderBy('homePacketReminderDueAt')
+        .limit(PRACTICE_PACKET_REMINDER_PAGE_SIZE);
+      if (lastSessionDoc) {
+        sessionQuery = sessionQuery.startAfter(lastSessionDoc);
       }
-      if (!practiceTargets.length) continue;
+      const sessionSnap = await sessionQuery.get();
 
-      const scheduleEventId = String(session.eventId || '').trim() || sessionId;
-      const destination = buildPracticePacketNotificationDestination({ teamId, eventId: scheduleEventId, sessionId });
-      const packetTitle = getPracticePacketNotificationTitle(packet, session);
+      for (const docSnap of sessionSnap.docs) {
+        candidateSessionDocs.push(docSnap);
+        candidateSessionPaths.add(docSnap.ref.path);
+      }
 
-      for (const playerSnap of playersSnap.docs) {
-        const playerId = String(playerSnap.id || '').trim();
-        const player = playerSnap.data() || {};
-        if (!playerId || player.active === false) continue;
-        if (completedPlayerIds.has(playerId)) continue;
+      lastSessionDoc = sessionSnap.docs.length === PRACTICE_PACKET_REMINDER_PAGE_SIZE
+        ? sessionSnap.docs[sessionSnap.docs.length - 1]
+        : null;
+    } while (lastSessionDoc);
+  } catch (error) {
+    indexedQueryFailed = true;
+    functions.logger.error('Practice packet reminder indexed query unavailable; using migration compatibility scan.', {
+      error: error?.message || error
+    });
+  }
 
-        const candidateUserIds = await getPracticePacketReminderTargetUserIds(teamId, playerId, player);
-        if (!candidateUserIds.length) continue;
+  const migrationStateSnap = await firestore.doc(PRACTICE_PACKET_REMINDER_MIGRATION_STATE_PATH).get();
+  const migrationComplete = migrationStateSnap.exists && migrationStateSnap.data()?.completed === true;
+  if (!migrationComplete || indexedQueryFailed) {
+    // Compatibility path for packets created before homePacketReminderDueAt was materialized.
+    // Keep every read bounded until the restart-safe migration records completion.
+    let lastLegacySessionDoc = null;
+    do {
+      let legacySessionQuery = firestore.collectionGroup('practiceSessions')
+        .where('homePacketGenerated', '==', true)
+        .orderBy(admin.firestore.FieldPath.documentId())
+        .limit(PRACTICE_PACKET_REMINDER_PAGE_SIZE);
+      if (lastLegacySessionDoc) {
+        legacySessionQuery = legacySessionQuery.startAfter(lastLegacySessionDoc);
+      }
+      const legacySessionSnap = await legacySessionQuery.get();
 
-        const candidateUserIdSet = new Set(candidateUserIds);
-        const parentTargets = practiceTargets.filter((target) => candidateUserIdSet.has(target.uid));
-        if (!parentTargets.length) continue;
+      for (const docSnap of legacySessionSnap.docs) {
+        const session = docSnap.data() || {};
+        if ((!indexedQueryFailed && session.homePacketReminderDueAt) || candidateSessionPaths.has(docSnap.ref.path)) continue;
+        const packet = session.homePacketContent || null;
+        if (!hasPracticePacketContent(packet) || !isPracticePacketDueTomorrow(packet, session, now)) continue;
+        candidateSessionDocs.push(docSnap);
+        candidateSessionPaths.add(docSnap.ref.path);
+      }
 
-        const claimId = await claimPracticePacketReminder(teamId, sessionId, playerId, now);
-        if (!claimId) continue;
+      lastLegacySessionDoc = legacySessionSnap.docs.length === PRACTICE_PACKET_REMINDER_PAGE_SIZE
+        ? legacySessionSnap.docs[legacySessionSnap.docs.length - 1]
+        : null;
+    } while (lastLegacySessionDoc);
+  }
 
-        try {
-          await sendDirectTargetsNotification({
-            targets: parentTargets,
-            category: 'practice',
-            title: `Reminder: ${packetTitle} is due tomorrow`,
-            body: `${String(player.name || 'Your player').trim() || 'Your player'} has not completed the ${getPracticePacketNotificationLabel(session)} yet.`,
-            teamId,
-            eventId: sessionId,
-            linkOverride: destination.link,
-            appRouteOverride: destination.appRoute
-          });
+  for (const docSnap of candidateSessionDocs) {
+    const session = docSnap.data() || {};
+    const packet = session.homePacketContent || null;
+    if (!hasPracticePacketContent(packet)) continue;
 
-          const markedSent = await markPracticePacketReminderSent(teamId, sessionId, playerId, claimId);
-          if (!markedSent) continue;
+    const pathParts = docSnap.ref.path.split('/');
+    const teamId = pathParts[1];
+    const sessionId = docSnap.id;
+    if (!teamId || !sessionId) continue;
 
-          results.push({
-            teamId,
-            sessionId,
-            playerId,
-            targetCount: parentTargets.length
-          });
-        } catch (error) {
-          await clearPracticePacketReminderClaim(teamId, sessionId, playerId, claimId, error);
-          functions.logger.error('Failed to send practice packet due tomorrow reminder.', {
-            teamId,
-            sessionId,
-            playerId,
-            error: error?.message || error
-          });
-        }
+    const [playersSnap, completionsSnap] = await Promise.all([
+      firestore.collection(`teams/${teamId}/players`).get(),
+      firestore.collection(`teams/${teamId}/practiceSessions/${sessionId}/packetCompletions`).get()
+    ]);
+    const completedPlayerIds = new Set(
+      completionsSnap.docs
+        .map((completionSnap) => completionSnap.data() || {})
+        .filter((completion) => String(completion.status || 'completed').trim().toLowerCase() === 'completed')
+        .map((completion) => String(completion.childId || '').trim())
+        .filter(Boolean)
+    );
+
+    let practiceTargets = practiceTargetsByTeam.get(teamId);
+    if (!practiceTargets) {
+      practiceTargets = await getTargetsForCategory(teamId, 'practice', null);
+      practiceTargetsByTeam.set(teamId, practiceTargets);
+    }
+    if (!practiceTargets.length) continue;
+
+    const scheduleEventId = String(session.eventId || '').trim() || sessionId;
+    const destination = buildPracticePacketNotificationDestination({ teamId, eventId: scheduleEventId, sessionId });
+    const packetTitle = getPracticePacketNotificationTitle(packet, session);
+
+    for (const playerSnap of playersSnap.docs) {
+      const playerId = String(playerSnap.id || '').trim();
+      const player = playerSnap.data() || {};
+      if (!playerId || player.active === false) continue;
+      if (completedPlayerIds.has(playerId)) continue;
+
+      const candidateUserIds = await getPracticePacketReminderTargetUserIds(teamId, playerId, player);
+      if (!candidateUserIds.length) continue;
+
+      const candidateUserIdSet = new Set(candidateUserIds);
+      const parentTargets = practiceTargets.filter((target) => candidateUserIdSet.has(target.uid));
+      if (!parentTargets.length) continue;
+
+      const claimId = await claimPracticePacketReminder(teamId, sessionId, playerId, now);
+      if (!claimId) continue;
+
+      try {
+        await sendDirectTargetsNotification({
+          targets: parentTargets,
+          category: 'practice',
+          title: `Reminder: ${packetTitle} is due tomorrow`,
+          body: `${String(player.name || 'Your player').trim() || 'Your player'} has not completed the ${getPracticePacketNotificationLabel(session)} yet.`,
+          teamId,
+          eventId: sessionId,
+          linkOverride: destination.link,
+          appRouteOverride: destination.appRoute
+        });
+
+        const markedSent = await markPracticePacketReminderSent(teamId, sessionId, playerId, claimId);
+        if (!markedSent) continue;
+
+        results.push({
+          teamId,
+          sessionId,
+          playerId,
+          targetCount: parentTargets.length
+        });
+      } catch (error) {
+        await clearPracticePacketReminderClaim(teamId, sessionId, playerId, claimId, error);
+        functions.logger.error('Failed to send practice packet due tomorrow reminder.', {
+          teamId,
+          sessionId,
+          playerId,
+          error: error?.message || error
+        });
       }
     }
-
-    lastSessionDoc = sessionSnap.docs.length === PRACTICE_PACKET_REMINDER_PAGE_SIZE
-      ? sessionSnap.docs[sessionSnap.docs.length - 1]
-      : null;
-  } while (lastSessionDoc);
+  }
 
   return results;
 }

--- a/functions/index.js
+++ b/functions/index.js
@@ -8932,18 +8932,6 @@ exports.queueDueRegistrationFailedPaymentReminders = functions.pubsub
   .schedule('every 6 hours')
   .onRun(() => queueDueRegistrationFailedPaymentReminders());
 
-function getPracticePacketReminderDueDate(packet = {}, session = {}) {
-  return coercePracticePacketDate(
-    packet.dueDate
-    || packet.dueAt
-    || packet.deadline
-    || packet.deadlineAt
-    || packet.completeBy
-    || packet.completeByAt
-    || session.date
-  );
-}
-
 function getTomorrowDateRange(now = new Date()) {
   const start = new Date(Date.UTC(
     now.getUTCFullYear(),
@@ -8959,12 +8947,7 @@ function getTomorrowDateRange(now = new Date()) {
   return { start, end };
 }
 
-function isPracticePacketDueTomorrow(packet = {}, session = {}, now = new Date()) {
-  const dueDate = getPracticePacketReminderDueDate(packet, session);
-  if (!dueDate) return false;
-  const { start, end } = getTomorrowDateRange(now);
-  return dueDate >= start && dueDate < end;
-}
+const PRACTICE_PACKET_REMINDER_PAGE_SIZE = 100;
 
 function getPracticePacketReminderDocRef(teamId, sessionId, playerId) {
   return firestore.doc(`teams/${teamId}/practiceSessions/${sessionId}/packetReminderSends/${playerId}`);
@@ -9062,95 +9045,109 @@ async function sendPracticePacketDueTomorrowReminders(now = new Date()) {
     return [];
   }
 
-  const sessionSnap = await firestore.collectionGroup('practiceSessions')
-    .where('homePacketGenerated', '==', true)
-    .get();
-
+  const { start, end } = getTomorrowDateRange(now);
   const practiceTargetsByTeam = new Map();
   const results = [];
+  let lastSessionDoc = null;
 
-  for (const docSnap of sessionSnap.docs) {
-    const session = docSnap.data() || {};
-    const packet = session.homePacketContent || null;
-    if (!hasPracticePacketContent(packet)) continue;
-    if (!isPracticePacketDueTomorrow(packet, session, now)) continue;
-
-    const pathParts = docSnap.ref.path.split('/');
-    const teamId = pathParts[1];
-    const sessionId = docSnap.id;
-    if (!teamId || !sessionId) continue;
-
-    const [playersSnap, completionsSnap] = await Promise.all([
-      firestore.collection(`teams/${teamId}/players`).get(),
-      firestore.collection(`teams/${teamId}/practiceSessions/${sessionId}/packetCompletions`).get()
-    ]);
-    const completedPlayerIds = new Set(
-      completionsSnap.docs
-        .map((completionSnap) => completionSnap.data() || {})
-        .filter((completion) => String(completion.status || 'completed').trim().toLowerCase() === 'completed')
-        .map((completion) => String(completion.childId || '').trim())
-        .filter(Boolean)
-    );
-
-    let practiceTargets = practiceTargetsByTeam.get(teamId);
-    if (!practiceTargets) {
-      practiceTargets = await getTargetsForCategory(teamId, 'practice', null);
-      practiceTargetsByTeam.set(teamId, practiceTargets);
+  do {
+    let sessionQuery = firestore.collectionGroup('practiceSessions')
+      .where('homePacketGenerated', '==', true)
+      .where('homePacketReminderDueAt', '>=', admin.firestore.Timestamp.fromDate(start))
+      .where('homePacketReminderDueAt', '<', admin.firestore.Timestamp.fromDate(end))
+      .orderBy('homePacketReminderDueAt')
+      .limit(PRACTICE_PACKET_REMINDER_PAGE_SIZE);
+    if (lastSessionDoc) {
+      sessionQuery = sessionQuery.startAfter(lastSessionDoc);
     }
-    if (!practiceTargets.length) continue;
+    const sessionSnap = await sessionQuery.get();
 
-    const scheduleEventId = String(session.eventId || '').trim() || sessionId;
-    const destination = buildPracticePacketNotificationDestination({ teamId, eventId: scheduleEventId, sessionId });
-    const packetTitle = getPracticePacketNotificationTitle(packet, session);
+    for (const docSnap of sessionSnap.docs) {
+      const session = docSnap.data() || {};
+      const packet = session.homePacketContent || null;
+      if (!hasPracticePacketContent(packet)) continue;
 
-    for (const playerSnap of playersSnap.docs) {
-      const playerId = String(playerSnap.id || '').trim();
-      const player = playerSnap.data() || {};
-      if (!playerId || player.active === false) continue;
-      if (completedPlayerIds.has(playerId)) continue;
+      const pathParts = docSnap.ref.path.split('/');
+      const teamId = pathParts[1];
+      const sessionId = docSnap.id;
+      if (!teamId || !sessionId) continue;
 
-      const candidateUserIds = await getPracticePacketReminderTargetUserIds(teamId, playerId, player);
-      if (!candidateUserIds.length) continue;
+      const [playersSnap, completionsSnap] = await Promise.all([
+        firestore.collection(`teams/${teamId}/players`).get(),
+        firestore.collection(`teams/${teamId}/practiceSessions/${sessionId}/packetCompletions`).get()
+      ]);
+      const completedPlayerIds = new Set(
+        completionsSnap.docs
+          .map((completionSnap) => completionSnap.data() || {})
+          .filter((completion) => String(completion.status || 'completed').trim().toLowerCase() === 'completed')
+          .map((completion) => String(completion.childId || '').trim())
+          .filter(Boolean)
+      );
 
-      const candidateUserIdSet = new Set(candidateUserIds);
-      const parentTargets = practiceTargets.filter((target) => candidateUserIdSet.has(target.uid));
-      if (!parentTargets.length) continue;
+      let practiceTargets = practiceTargetsByTeam.get(teamId);
+      if (!practiceTargets) {
+        practiceTargets = await getTargetsForCategory(teamId, 'practice', null);
+        practiceTargetsByTeam.set(teamId, practiceTargets);
+      }
+      if (!practiceTargets.length) continue;
 
-      const claimId = await claimPracticePacketReminder(teamId, sessionId, playerId, now);
-      if (!claimId) continue;
+      const scheduleEventId = String(session.eventId || '').trim() || sessionId;
+      const destination = buildPracticePacketNotificationDestination({ teamId, eventId: scheduleEventId, sessionId });
+      const packetTitle = getPracticePacketNotificationTitle(packet, session);
 
-      try {
-        await sendDirectTargetsNotification({
-          targets: parentTargets,
-          category: 'practice',
-          title: `Reminder: ${packetTitle} is due tomorrow`,
-          body: `${String(player.name || 'Your player').trim() || 'Your player'} has not completed the ${getPracticePacketNotificationLabel(session)} yet.`,
-          teamId,
-          eventId: sessionId,
-          linkOverride: destination.link,
-          appRouteOverride: destination.appRoute
-        });
+      for (const playerSnap of playersSnap.docs) {
+        const playerId = String(playerSnap.id || '').trim();
+        const player = playerSnap.data() || {};
+        if (!playerId || player.active === false) continue;
+        if (completedPlayerIds.has(playerId)) continue;
 
-        const markedSent = await markPracticePacketReminderSent(teamId, sessionId, playerId, claimId);
-        if (!markedSent) continue;
+        const candidateUserIds = await getPracticePacketReminderTargetUserIds(teamId, playerId, player);
+        if (!candidateUserIds.length) continue;
 
-        results.push({
-          teamId,
-          sessionId,
-          playerId,
-          targetCount: parentTargets.length
-        });
-      } catch (error) {
-        await clearPracticePacketReminderClaim(teamId, sessionId, playerId, claimId, error);
-        functions.logger.error('Failed to send practice packet due tomorrow reminder.', {
-          teamId,
-          sessionId,
-          playerId,
-          error: error?.message || error
-        });
+        const candidateUserIdSet = new Set(candidateUserIds);
+        const parentTargets = practiceTargets.filter((target) => candidateUserIdSet.has(target.uid));
+        if (!parentTargets.length) continue;
+
+        const claimId = await claimPracticePacketReminder(teamId, sessionId, playerId, now);
+        if (!claimId) continue;
+
+        try {
+          await sendDirectTargetsNotification({
+            targets: parentTargets,
+            category: 'practice',
+            title: `Reminder: ${packetTitle} is due tomorrow`,
+            body: `${String(player.name || 'Your player').trim() || 'Your player'} has not completed the ${getPracticePacketNotificationLabel(session)} yet.`,
+            teamId,
+            eventId: sessionId,
+            linkOverride: destination.link,
+            appRouteOverride: destination.appRoute
+          });
+
+          const markedSent = await markPracticePacketReminderSent(teamId, sessionId, playerId, claimId);
+          if (!markedSent) continue;
+
+          results.push({
+            teamId,
+            sessionId,
+            playerId,
+            targetCount: parentTargets.length
+          });
+        } catch (error) {
+          await clearPracticePacketReminderClaim(teamId, sessionId, playerId, claimId, error);
+          functions.logger.error('Failed to send practice packet due tomorrow reminder.', {
+            teamId,
+            sessionId,
+            playerId,
+            error: error?.message || error
+          });
+        }
       }
     }
-  }
+
+    lastSessionDoc = sessionSnap.docs.length === PRACTICE_PACKET_REMINDER_PAGE_SIZE
+      ? sessionSnap.docs[sessionSnap.docs.length - 1]
+      : null;
+  } while (lastSessionDoc);
 
   return results;
 }

--- a/tests/unit/app-schedule-packets-service.test.js
+++ b/tests/unit/app-schedule-packets-service.test.js
@@ -306,9 +306,7 @@ describe('React app practice packet service', () => {
             eventType: 'practice',
             sourcePage: 'app-schedule',
             homePacketGenerated: true,
-            homePacketReminderDueAt: expect.objectContaining({
-                toDate: expect.any(Function)
-            }),
+            homePacketReminderDueAt: expect.any(Date),
             homePacketContent: expect.objectContaining({
                 packetTitle: 'Weekend touches',
                 dueDate: expect.stringContaining('2026-05-24'),
@@ -318,7 +316,7 @@ describe('React app practice packet service', () => {
         }));
         const packetContent = dbMocks.upsertPracticeSessionForEvent.mock.calls[0][2].homePacketContent;
         const reminderDueAt = dbMocks.upsertPracticeSessionForEvent.mock.calls[0][2].homePacketReminderDueAt;
-        expect(reminderDueAt.toDate().toISOString()).toContain('2026-05-24');
+        expect(reminderDueAt.toISOString()).toContain('2026-05-24');
         expect(packetContent.blocks).toEqual([
             expect.objectContaining({ drillTitle: 'Ball Mastery', duration: 12, notes: 'Both feet' }),
             expect.objectContaining({ drillTitle: 'Home Drill 2', duration: 8 })
@@ -344,13 +342,37 @@ describe('React app practice packet service', () => {
 
         expect(dbMocks.updatePracticeSession).toHaveBeenCalledWith('team-1', 'session-1', expect.objectContaining({
             homePacketGenerated: true,
-            homePacketReminderDueAt: expect.objectContaining({
-                toDate: expect.any(Function)
-            })
+            homePacketReminderDueAt: expect.any(Date)
         }));
         const reminderDueAt = dbMocks.updatePracticeSession.mock.calls[0][2].homePacketReminderDueAt;
-        expect(reminderDueAt.toDate()).toEqual(new Date('2026-05-22T19:00:00.000Z'));
+        expect(reminderDueAt).toEqual(new Date('2026-05-22T19:00:00.000Z'));
         expect(dbMocks.upsertPracticeSessionForEvent).not.toHaveBeenCalled();
+    });
+
+    it('encodes the reminder due time as a Firestore timestamp in the native REST fallback', async () => {
+        installWindow('capacitor:');
+        authMocks.getNativeAuthIdToken.mockResolvedValue('native-token');
+        dbMocks.updatePracticeSession.mockRejectedValue(new Error('Firestore save unavailable'));
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            json: vi.fn().mockResolvedValue({})
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await saveStaffPracticePacket(practiceEvent({
+            isTeamAdmin: true,
+            practiceSessionId: 'session-1'
+        }), user({ uid: 'coach-1', roles: ['coach'] }), {
+            packetTitle: 'Weekend touches',
+            dueDate: '2026-05-24',
+            blocks: [{ drillTitle: 'Ball Mastery', type: 'Technical', duration: 12 }]
+        });
+
+        const [, request] = fetchMock.mock.calls[0];
+        const body = JSON.parse(request.body);
+        expect(body.fields.homePacketReminderDueAt).toEqual({
+            timestampValue: expect.stringContaining('2026-05-24')
+        });
     });
 
     it('carries packet data from practice sessions into parent schedule events', async () => {

--- a/tests/unit/app-schedule-packets-service.test.js
+++ b/tests/unit/app-schedule-packets-service.test.js
@@ -306,6 +306,9 @@ describe('React app practice packet service', () => {
             eventType: 'practice',
             sourcePage: 'app-schedule',
             homePacketGenerated: true,
+            homePacketReminderDueAt: expect.objectContaining({
+                toDate: expect.any(Function)
+            }),
             homePacketContent: expect.objectContaining({
                 packetTitle: 'Weekend touches',
                 dueDate: expect.stringContaining('2026-05-24'),
@@ -314,6 +317,8 @@ describe('React app practice packet service', () => {
             })
         }));
         const packetContent = dbMocks.upsertPracticeSessionForEvent.mock.calls[0][2].homePacketContent;
+        const reminderDueAt = dbMocks.upsertPracticeSessionForEvent.mock.calls[0][2].homePacketReminderDueAt;
+        expect(reminderDueAt.toDate().toISOString()).toContain('2026-05-24');
         expect(packetContent.blocks).toEqual([
             expect.objectContaining({ drillTitle: 'Ball Mastery', duration: 12, notes: 'Both feet' }),
             expect.objectContaining({ drillTitle: 'Home Drill 2', duration: 8 })
@@ -323,6 +328,29 @@ describe('React app practice packet service', () => {
             packetTitle: 'Weekend touches',
             totalMinutes: 20
         });
+    });
+
+    it('persists the session date as reminder due time on linked-session updates without an explicit due date', async () => {
+        const coach = user({ uid: 'coach-1', roles: ['coach'] });
+
+        await saveStaffPracticePacket(practiceEvent({
+            isTeamAdmin: true,
+            practiceSessionId: 'session-1'
+        }), coach, {
+            packetTitle: 'Practice follow-up',
+            dueDate: null,
+            blocks: [{ drillTitle: 'Ball Mastery', type: 'Technical', duration: 12 }]
+        });
+
+        expect(dbMocks.updatePracticeSession).toHaveBeenCalledWith('team-1', 'session-1', expect.objectContaining({
+            homePacketGenerated: true,
+            homePacketReminderDueAt: expect.objectContaining({
+                toDate: expect.any(Function)
+            })
+        }));
+        const reminderDueAt = dbMocks.updatePracticeSession.mock.calls[0][2].homePacketReminderDueAt;
+        expect(reminderDueAt.toDate()).toEqual(new Date('2026-05-22T19:00:00.000Z'));
+        expect(dbMocks.upsertPracticeSessionForEvent).not.toHaveBeenCalled();
     });
 
     it('carries packet data from practice sessions into parent schedule events', async () => {

--- a/tests/unit/backfill-practice-packet-reminder-due-at.test.js
+++ b/tests/unit/backfill-practice-packet-reminder-due-at.test.js
@@ -12,6 +12,7 @@ function makeHarness(records) {
     }));
     const queryCalls = [];
     const writes = [];
+    const migrationStateWrites = [];
 
     function buildQuery(cursor = null, pageSize = docs.length) {
         return {
@@ -40,6 +41,9 @@ function makeHarness(records) {
 
     const db = {
         collectionGroup: vi.fn(() => buildQuery()),
+        doc: vi.fn((path) => ({
+            set: vi.fn(async (value, options) => migrationStateWrites.push({ path, value, options }))
+        })),
         batch: vi.fn(() => ({
             update: vi.fn((ref, value) => writes.push({ path: ref.path, value })),
             commit: vi.fn(async () => undefined)
@@ -49,7 +53,7 @@ function makeHarness(records) {
         fromDate: vi.fn((date) => ({ millis: date.getTime() }))
     };
 
-    return { db, Timestamp, queryCalls, writes };
+    return { db, Timestamp, queryCalls, writes, migrationStateWrites };
 }
 
 describe('practice packet reminder due-at backfill', () => {
@@ -130,5 +134,10 @@ describe('practice packet reminder due-at backfill', () => {
                 value: { homePacketReminderDueAt: { millis: Date.parse('2026-07-23T18:00:00.000Z') } }
             }
         ]);
+        expect(harness.migrationStateWrites).toEqual([{
+            path: 'systemMigrations/practicePacketReminderDueAt',
+            value: { completed: true },
+            options: { merge: true }
+        }]);
     });
 });

--- a/tests/unit/backfill-practice-packet-reminder-due-at.test.js
+++ b/tests/unit/backfill-practice-packet-reminder-due-at.test.js
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    backfillPracticePacketReminderDueAt,
+    derivePracticePacketReminderDueAt
+} from '../../_migration/backfill-practice-packet-reminder-due-at.js';
+
+function makeHarness(records) {
+    const docs = records.map(({ path, data }) => ({
+        id: path.split('/').pop(),
+        ref: { path },
+        data: () => data
+    }));
+    const queryCalls = [];
+    const writes = [];
+
+    function buildQuery(cursor = null, pageSize = docs.length) {
+        return {
+            orderBy(field) {
+                queryCalls.push(['orderBy', field]);
+                return this;
+            },
+            limit(value) {
+                pageSize = value;
+                queryCalls.push(['limit', value]);
+                return this;
+            },
+            startAfter(docSnap) {
+                cursor = docSnap;
+                queryCalls.push(['startAfter', docSnap.ref.path]);
+                return this;
+            },
+            async get() {
+                const startIndex = cursor
+                    ? docs.findIndex((docSnap) => docSnap.ref.path === cursor.ref.path) + 1
+                    : 0;
+                return { docs: docs.slice(startIndex, startIndex + pageSize) };
+            }
+        };
+    }
+
+    const db = {
+        collectionGroup: vi.fn(() => buildQuery()),
+        batch: vi.fn(() => ({
+            update: vi.fn((ref, value) => writes.push({ path: ref.path, value })),
+            commit: vi.fn(async () => undefined)
+        }))
+    };
+    const Timestamp = {
+        fromDate: vi.fn((date) => ({ millis: date.getTime() }))
+    };
+
+    return { db, Timestamp, queryCalls, writes };
+}
+
+describe('practice packet reminder due-at backfill', () => {
+    it('derives explicit packet dueAt before falling back to the session date', () => {
+        expect(derivePracticePacketReminderDueAt({
+            date: '2026-07-22T18:00:00.000Z',
+            homePacketContent: { dueAt: '2026-07-20T09:00:00.000Z' }
+        })).toEqual(new Date('2026-07-20T09:00:00.000Z'));
+        expect(derivePracticePacketReminderDueAt({
+            date: '2026-07-22T18:00:00.000Z',
+            homePacketContent: {}
+        })).toEqual(new Date('2026-07-22T18:00:00.000Z'));
+        expect(derivePracticePacketReminderDueAt({
+            date: 'invalid',
+            homePacketContent: { dueAt: 'also-invalid' }
+        })).toBeNull();
+    });
+
+    it('paginates all sessions and skips already-migrated or malformed documents on restart', async () => {
+        const harness = makeHarness([
+            {
+                path: 'teams/team-1/practiceSessions/explicit',
+                data: {
+                    homePacketGenerated: true,
+                    date: '2026-07-22T18:00:00.000Z',
+                    homePacketContent: { dueAt: '2026-07-20T09:00:00.000Z' }
+                }
+            },
+            {
+                path: 'teams/team-1/practiceSessions/fallback',
+                data: {
+                    homePacketGenerated: true,
+                    date: '2026-07-23T18:00:00.000Z',
+                    homePacketContent: {}
+                }
+            },
+            {
+                path: 'teams/team-2/practiceSessions/malformed',
+                data: {
+                    homePacketGenerated: true,
+                    date: 'invalid',
+                    homePacketContent: { dueAt: 'invalid' }
+                }
+            },
+            {
+                path: 'teams/team-2/practiceSessions/already-migrated',
+                data: {
+                    homePacketGenerated: true,
+                    homePacketReminderDueAt: { millis: 123 },
+                    homePacketContent: { dueAt: '2026-07-24T09:00:00.000Z' }
+                }
+            }
+        ]);
+
+        const result = await backfillPracticePacketReminderDueAt({
+            db: harness.db,
+            Timestamp: harness.Timestamp,
+            pageSize: 2
+        });
+
+        expect(result).toEqual({ scanned: 4, updated: 2, skipped: 1, malformed: 1 });
+        expect(harness.queryCalls.filter(([name]) => name === 'limit')).toEqual([
+            ['limit', 2],
+            ['limit', 2],
+            ['limit', 2]
+        ]);
+        expect(harness.queryCalls.filter(([name]) => name === 'startAfter')).toEqual([
+            ['startAfter', 'teams/team-1/practiceSessions/fallback'],
+            ['startAfter', 'teams/team-2/practiceSessions/already-migrated']
+        ]);
+        expect(harness.writes).toEqual([
+            {
+                path: 'teams/team-1/practiceSessions/explicit',
+                value: { homePacketReminderDueAt: { millis: Date.parse('2026-07-20T09:00:00.000Z') } }
+            },
+            {
+                path: 'teams/team-1/practiceSessions/fallback',
+                value: { homePacketReminderDueAt: { millis: Date.parse('2026-07-23T18:00:00.000Z') } }
+            }
+        ]);
+    });
+});

--- a/tests/unit/drills-access-control.test.js
+++ b/tests/unit/drills-access-control.test.js
@@ -17,6 +17,7 @@ describe('drills planning access control', () => {
     });
 
     it('persists the session-date reminder timestamp when saving legacy home packets', () => {
+        expect(drillsHtml).toContain('data.homePacketReminderDueAt = data.date;');
         expect(drillsHtml).toContain("const homePacketReminderDueAt = new Date(document.getElementById('session-date').value);");
         expect(drillsHtml).toContain('homePacketReminderDueAt,\n                homePacketContent: {');
     });

--- a/tests/unit/drills-access-control.test.js
+++ b/tests/unit/drills-access-control.test.js
@@ -16,6 +16,11 @@ describe('drills planning access control', () => {
         expect(drillsHtml).toContain("if (!requireFullPlanningAccess('Home packets')) return;");
     });
 
+    it('persists the session-date reminder timestamp when saving legacy home packets', () => {
+        expect(drillsHtml).toContain("const homePacketReminderDueAt = new Date(document.getElementById('session-date').value);");
+        expect(drillsHtml).toContain('homePacketReminderDueAt,\n                homePacketContent: {');
+    });
+
     it('hides admin-only controls for read-only users', () => {
         expect(drillsHtml).toContain("document.getElementById('btn-new-drill').classList.add('hidden');");
         expect(drillsHtml).toContain("document.getElementById('session-meta-bar').classList.add('hidden');");

--- a/tests/unit/practice-packet-due-reminders.test.js
+++ b/tests/unit/practice-packet-due-reminders.test.js
@@ -72,6 +72,7 @@ function buildHarness({
     });
 
     const queryCalls = [];
+    const indexedPageFetchDeliveryCounts = [];
     const sessionDocs = sessions.map((session) => {
         const ref = { path: session.path, id: session.path.split('/').pop() };
         return makeDocSnapshot(ref, session.data, true);
@@ -103,7 +104,11 @@ function buildHarness({
                 return this;
             },
             async get() {
-                if (indexedQueryError && constraints.some(({ field }) => field === 'homePacketReminderDueAt')) {
+                const isIndexedQuery = constraints.some(({ field }) => field === 'homePacketReminderDueAt');
+                if (isIndexedQuery) {
+                    indexedPageFetchDeliveryCounts.push(sendDirectTargetsNotification.mock.calls.length);
+                }
+                if (indexedQueryError && isIndexedQuery) {
                     throw indexedQueryError;
                 }
                 const matches = sessionDocs
@@ -249,7 +254,8 @@ function buildHarness({
         getTeamFeeRecipientTargetUserIds,
         sendDirectTargetsNotification,
         reminderDocStore,
-        queryCalls
+        queryCalls,
+        indexedPageFetchDeliveryCounts
     };
 }
 
@@ -407,7 +413,7 @@ describe('sendPracticePacketDueTomorrowReminders', () => {
         }));
     });
 
-    it('uses bounded cursor pages and excludes historical and future packets', async () => {
+    it('processes bounded cursor pages before fetching the next page and excludes out-of-window packets', async () => {
         const makeSession = (id, dueAt) => ({
             path: `teams/team-1/practiceSessions/${id}`,
             data: {
@@ -444,6 +450,7 @@ describe('sendPracticePacketDueTomorrowReminders', () => {
 
         expect(result.map(({ sessionId }) => sessionId)).toEqual(['due-1', 'due-2', 'due-3']);
         expect(harness.sendDirectTargetsNotification).toHaveBeenCalledTimes(3);
+        expect(harness.indexedPageFetchDeliveryCounts).toEqual([0, 2]);
         expect(harness.queryCalls.filter(([name]) => name === 'limit')).toEqual([
             ['limit', 2],
             ['limit', 2]

--- a/tests/unit/practice-packet-due-reminders.test.js
+++ b/tests/unit/practice-packet-due-reminders.test.js
@@ -49,7 +49,8 @@ function buildHarness({
     privateProfiles = {},
     practiceTargetsByTeam = {},
     existingReminderDocs = {},
-    pageSize = 100
+    pageSize = 100,
+    indexedQueryError = null
 } = {}) {
     const reminderDocStore = new Map(Object.entries(existingReminderDocs));
     const sendDirectTargetsNotification = vi.fn(async () => ({ successCount: 1, failureCount: 0 }));
@@ -79,6 +80,7 @@ function buildHarness({
         const constraints = [];
         let limitValue = sessionDocs.length;
         let cursor = null;
+        let orderByField = null;
         return {
             where(field, operator, value) {
                 constraints.push({ field, operator, value });
@@ -86,6 +88,7 @@ function buildHarness({
                 return this;
             },
             orderBy(field) {
+                orderByField = field;
                 queryCalls.push(['orderBy', field]);
                 return this;
             },
@@ -100,6 +103,9 @@ function buildHarness({
                 return this;
             },
             async get() {
+                if (indexedQueryError && constraints.some(({ field }) => field === 'homePacketReminderDueAt')) {
+                    throw indexedQueryError;
+                }
                 const matches = sessionDocs
                     .filter((docSnap) => constraints.every(({ field, operator, value }) => {
                         const actual = docSnap.data()?.[field];
@@ -111,6 +117,9 @@ function buildHarness({
                         throw new Error(`Unexpected operator ${operator}`);
                     }))
                     .sort((left, right) => {
+                        if (orderByField === '__name__') {
+                            return left.ref.path.localeCompare(right.ref.path);
+                        }
                         const dueDifference = new Date(left.data().homePacketReminderDueAt).getTime()
                             - new Date(right.data().homePacketReminderDueAt).getTime();
                         return dueDifference || left.ref.path.localeCompare(right.ref.path);
@@ -189,6 +198,9 @@ function buildHarness({
         firestore: {
             Timestamp: {
                 fromDate: (date) => new Date(date)
+            },
+            FieldPath: {
+                documentId: () => '__name__'
             },
             FieldValue: {
                 serverTimestamp: () => ({ __serverTimestamp: true })
@@ -422,6 +434,9 @@ describe('sendPracticePacketDueTomorrowReminders', () => {
             },
             practiceTargetsByTeam: {
                 'team-1': [{ uid: 'parent-1', token: 'parent-token', teamId: 'team-1' }]
+            },
+            existingReminderDocs: {
+                'systemMigrations/practicePacketReminderDueAt': { completed: true }
             }
         });
 
@@ -447,6 +462,73 @@ describe('sendPracticePacketDueTomorrowReminders', () => {
             ['orderBy', 'homePacketReminderDueAt'],
             ['orderBy', 'homePacketReminderDueAt']
         ]);
+    });
+
+    it('delivers reminders for due-tomorrow packets that have not been backfilled yet', async () => {
+        const harness = buildHarness({
+            sessions: [{
+                path: 'teams/team-1/practiceSessions/legacy-session',
+                data: {
+                    title: 'Legacy packet',
+                    homePacketGenerated: true,
+                    homePacketContent: {
+                        blocks: [{ id: 'block-1' }],
+                        dueAt: '2026-06-21T09:00:00.000Z'
+                    }
+                }
+            }],
+            playersByTeam: {
+                'team-1': [{ id: 'player-1', data: { name: 'Pat', parents: [{ userId: 'parent-1' }] } }]
+            },
+            practiceTargetsByTeam: {
+                'team-1': [{ uid: 'parent-1', token: 'parent-token', teamId: 'team-1' }]
+            }
+        });
+
+        const result = await harness.sendPracticePacketDueTomorrowReminders(harness.now);
+
+        expect(result).toEqual([
+            { teamId: 'team-1', sessionId: 'legacy-session', playerId: 'player-1', targetCount: 1 }
+        ]);
+        expect(harness.queryCalls).toContainEqual(['orderBy', '__name__']);
+        expect(harness.queryCalls).toContainEqual(['limit', 100]);
+    });
+
+    it('uses the compatibility scan while the new composite index is still building', async () => {
+        const harness = buildHarness({
+            indexedQueryError: new Error('The query requires an index'),
+            sessions: [{
+                path: 'teams/team-1/practiceSessions/indexed-session',
+                data: {
+                    title: 'Indexed packet',
+                    homePacketGenerated: true,
+                    homePacketReminderDueAt: new Date('2026-06-21T09:00:00.000Z'),
+                    homePacketContent: {
+                        blocks: [{ id: 'block-1' }],
+                        dueAt: '2026-06-21T09:00:00.000Z'
+                    }
+                }
+            }],
+            playersByTeam: {
+                'team-1': [{ id: 'player-1', data: { name: 'Pat', parents: [{ userId: 'parent-1' }] } }]
+            },
+            practiceTargetsByTeam: {
+                'team-1': [{ uid: 'parent-1', token: 'parent-token', teamId: 'team-1' }]
+            },
+            existingReminderDocs: {
+                'systemMigrations/practicePacketReminderDueAt': { completed: true }
+            }
+        });
+
+        const result = await harness.sendPracticePacketDueTomorrowReminders(harness.now);
+
+        expect(result).toEqual([
+            { teamId: 'team-1', sessionId: 'indexed-session', playerId: 'player-1', targetCount: 1 }
+        ]);
+        expect(harness.functions.logger.error).toHaveBeenCalledWith(
+            'Practice packet reminder indexed query unavailable; using migration compatibility scan.',
+            { error: 'The query requires an index' }
+        );
     });
 
     it('logs and exits when practice notifications are unavailable', async () => {

--- a/tests/unit/practice-packet-due-reminders.test.js
+++ b/tests/unit/practice-packet-due-reminders.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 
 const functionsSource = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
+const firestoreIndexes = JSON.parse(readFileSync(new URL('../../firestore.indexes.json', import.meta.url), 'utf8'));
 
 function extractChunk(startMarker, endMarker) {
     const start = functionsSource.indexOf(startMarker);
@@ -15,7 +16,7 @@ function extractChunk(startMarker, endMarker) {
 function extractReminderSource() {
     return [
         extractChunk('function buildPracticePacketNotificationDestination(', 'function buildNotificationLink'),
-        extractChunk('function getPracticePacketReminderDueDate(', 'function getFeeReminderPlayerKey')
+        extractChunk('function getTomorrowDateRange(', 'function getFeeReminderPlayerKey')
     ].join('\n');
 }
 
@@ -47,7 +48,8 @@ function buildHarness({
     completionsBySessionPath = {},
     privateProfiles = {},
     practiceTargetsByTeam = {},
-    existingReminderDocs = {}
+    existingReminderDocs = {},
+    pageSize = 100
 } = {}) {
     const reminderDocStore = new Map(Object.entries(existingReminderDocs));
     const sendDirectTargetsNotification = vi.fn(async () => ({ successCount: 1, failureCount: 0 }));
@@ -68,19 +70,65 @@ function buildHarness({
         return [...new Set(ids.map((value) => String(value || '').trim()).filter(Boolean))];
     });
 
+    const queryCalls = [];
+    const sessionDocs = sessions.map((session) => {
+        const ref = { path: session.path, id: session.path.split('/').pop() };
+        return makeDocSnapshot(ref, session.data, true);
+    });
+    function buildSessionQuery() {
+        const constraints = [];
+        let limitValue = sessionDocs.length;
+        let cursor = null;
+        return {
+            where(field, operator, value) {
+                constraints.push({ field, operator, value });
+                queryCalls.push(['where', field, operator, value]);
+                return this;
+            },
+            orderBy(field) {
+                queryCalls.push(['orderBy', field]);
+                return this;
+            },
+            limit(value) {
+                limitValue = value;
+                queryCalls.push(['limit', value]);
+                return this;
+            },
+            startAfter(docSnap) {
+                cursor = docSnap;
+                queryCalls.push(['startAfter', docSnap.ref.path]);
+                return this;
+            },
+            async get() {
+                const matches = sessionDocs
+                    .filter((docSnap) => constraints.every(({ field, operator, value }) => {
+                        const actual = docSnap.data()?.[field];
+                        if (operator === '==') return actual === value;
+                        const actualMillis = actual instanceof Date ? actual.getTime() : new Date(actual).getTime();
+                        const expectedMillis = value instanceof Date ? value.getTime() : new Date(value).getTime();
+                        if (operator === '>=') return actualMillis >= expectedMillis;
+                        if (operator === '<') return actualMillis < expectedMillis;
+                        throw new Error(`Unexpected operator ${operator}`);
+                    }))
+                    .sort((left, right) => {
+                        const dueDifference = new Date(left.data().homePacketReminderDueAt).getTime()
+                            - new Date(right.data().homePacketReminderDueAt).getTime();
+                        return dueDifference || left.ref.path.localeCompare(right.ref.path);
+                    });
+                const startIndex = cursor
+                    ? matches.findIndex((docSnap) => docSnap.ref.path === cursor.ref.path) + 1
+                    : 0;
+                return makeQuerySnapshot(matches.slice(startIndex, startIndex + limitValue));
+            }
+        };
+    }
+
     const firestore = {
         collectionGroup: vi.fn((name) => {
             if (name !== 'practiceSessions') {
                 throw new Error(`Unexpected collectionGroup ${name}`);
             }
-            return {
-                where: vi.fn(() => ({
-                    get: vi.fn(async () => makeQuerySnapshot(sessions.map((session) => {
-                        const ref = { path: session.path, id: session.path.split('/').pop() };
-                        return makeDocSnapshot(ref, session.data, true);
-                    })))
-                }))
-            };
+            return buildSessionQuery();
         }),
         collection: vi.fn((path) => ({
             get: vi.fn(async () => {
@@ -139,6 +187,9 @@ function buildHarness({
     };
     const admin = {
         firestore: {
+            Timestamp: {
+                fromDate: (date) => new Date(date)
+            },
             FieldValue: {
                 serverTimestamp: () => ({ __serverTimestamp: true })
             }
@@ -158,7 +209,10 @@ function buildHarness({
         'getTeamFeeRecipientTargetUserIds',
         'sendDirectTargetsNotification',
         'crypto',
-        `${extractReminderSource()}\nreturn { trigger: exports.sendPracticePacketDueTomorrowReminders, sendPracticePacketDueTomorrowReminders };`
+        `${extractReminderSource().replace(
+            'const PRACTICE_PACKET_REMINDER_PAGE_SIZE = 100;',
+            `const PRACTICE_PACKET_REMINDER_PAGE_SIZE = ${pageSize};`
+        )}\nreturn { trigger: exports.sendPracticePacketDueTomorrowReminders, sendPracticePacketDueTomorrowReminders };`
     );
 
     const built = factory(
@@ -182,11 +236,23 @@ function buildHarness({
         getTargetsForCategory,
         getTeamFeeRecipientTargetUserIds,
         sendDirectTargetsNotification,
-        reminderDocStore
+        reminderDocStore,
+        queryCalls
     };
 }
 
 describe('sendPracticePacketDueTomorrowReminders', () => {
+    it('declares the collection-group composite index for generated packet due-time queries', () => {
+        expect(firestoreIndexes.indexes).toContainEqual({
+            collectionGroup: 'practiceSessions',
+            queryScope: 'COLLECTION_GROUP',
+            fields: [
+                { fieldPath: 'homePacketGenerated', order: 'ASCENDING' },
+                { fieldPath: 'homePacketReminderDueAt', order: 'ASCENDING' }
+            ]
+        });
+    });
+
     it('sends one practice reminder only for incomplete players with enabled parent targets, including private-profile caregivers', async () => {
         const harness = buildHarness({
             sessions: [
@@ -196,6 +262,7 @@ describe('sendPracticePacketDueTomorrowReminders', () => {
                         title: 'Thursday Practice',
                         eventId: 'practice-44',
                         homePacketGenerated: true,
+                        homePacketReminderDueAt: new Date('2026-06-21T09:00:00.000Z'),
                         homePacketContent: {
                             blocks: [{ id: 'block-1' }],
                             dueDate: '2026-06-21T09:00:00.000Z'
@@ -268,6 +335,7 @@ describe('sendPracticePacketDueTomorrowReminders', () => {
                     data: {
                         title: 'Thursday Practice',
                         homePacketGenerated: true,
+                        homePacketReminderDueAt: new Date('2026-06-21T09:00:00.000Z'),
                         homePacketContent: {
                             blocks: [{ id: 'block-1' }],
                             dueDate: '2026-06-21T09:00:00.000Z'
@@ -325,6 +393,60 @@ describe('sendPracticePacketDueTomorrowReminders', () => {
             deliveryClaimedAt: null,
             lastError: null
         }));
+    });
+
+    it('uses bounded cursor pages and excludes historical and future packets', async () => {
+        const makeSession = (id, dueAt) => ({
+            path: `teams/team-1/practiceSessions/${id}`,
+            data: {
+                title: id,
+                homePacketGenerated: true,
+                homePacketReminderDueAt: new Date(dueAt),
+                homePacketContent: {
+                    blocks: [{ id: 'block-1' }],
+                    dueAt
+                }
+            }
+        });
+        const harness = buildHarness({
+            pageSize: 2,
+            sessions: [
+                makeSession('historical', '2026-06-20T09:00:00.000Z'),
+                makeSession('due-1', '2026-06-21T08:00:00.000Z'),
+                makeSession('due-2', '2026-06-21T09:00:00.000Z'),
+                makeSession('due-3', '2026-06-21T10:00:00.000Z'),
+                makeSession('future', '2026-06-22T09:00:00.000Z')
+            ],
+            playersByTeam: {
+                'team-1': [{ id: 'player-1', data: { name: 'Pat', parents: [{ userId: 'parent-1' }] } }]
+            },
+            practiceTargetsByTeam: {
+                'team-1': [{ uid: 'parent-1', token: 'parent-token', teamId: 'team-1' }]
+            }
+        });
+
+        const result = await harness.sendPracticePacketDueTomorrowReminders(harness.now);
+
+        expect(result.map(({ sessionId }) => sessionId)).toEqual(['due-1', 'due-2', 'due-3']);
+        expect(harness.sendDirectTargetsNotification).toHaveBeenCalledTimes(3);
+        expect(harness.queryCalls.filter(([name]) => name === 'limit')).toEqual([
+            ['limit', 2],
+            ['limit', 2]
+        ]);
+        expect(harness.queryCalls.filter(([name]) => name === 'startAfter')).toEqual([
+            ['startAfter', 'teams/team-1/practiceSessions/due-2']
+        ]);
+        expect(harness.queryCalls.filter(([name, field]) => name === 'where' && field === 'homePacketReminderDueAt'))
+            .toEqual([
+                ['where', 'homePacketReminderDueAt', '>=', new Date('2026-06-21T00:00:00.000Z')],
+                ['where', 'homePacketReminderDueAt', '<', new Date('2026-06-22T00:00:00.000Z')],
+                ['where', 'homePacketReminderDueAt', '>=', new Date('2026-06-21T00:00:00.000Z')],
+                ['where', 'homePacketReminderDueAt', '<', new Date('2026-06-22T00:00:00.000Z')]
+            ]);
+        expect(harness.queryCalls.filter(([name]) => name === 'orderBy')).toEqual([
+            ['orderBy', 'homePacketReminderDueAt'],
+            ['orderBy', 'homePacketReminderDueAt']
+        ]);
     });
 
     it('logs and exits when practice notifications are unavailable', async () => {


### PR DESCRIPTION
Closes #4003

## What changed
- Persist `homePacketReminderDueAt` from the explicit packet due date or session-date fallback across app and legacy save paths.
- Query only tomorrow's indexed timestamp range in fixed-size cursor pages.
- Add the required collection-group index.
- Add a paginated, restart-safe backfill for existing generated packets.
- Preserve recipient filtering, completion checks, idempotency claims, retries, and notification content.

## Root Cause
Reminder eligibility existed only inside `homePacketContent` and was evaluated after an unbounded collection-group read. Every daily run therefore loaded all historical generated packets before identifying tomorrow's candidates.

## Prevention / Learning
Materialize indexed scheduling timestamps at every write path. Recurring collection-group jobs must use bounded time ranges and cursor pagination, with regression tests covering cardinality and page draining.

## Regression Tests
- 19 focused Vitest tests covering bounded queries, pagination, delivery behavior, app and legacy persistence, and migration behavior.
- Firebase rules/index configuration validation.
- Node syntax checks for the function and migration scripts.
- `git diff --check`.

## Recurrence Risk
Low. All packet save paths materialize the indexed timestamp, historical documents have a restart-safe backfill, and tests enforce the bounded query and required index.