### PR TITLE
Reset chat layout state when switching teams

### DIFF
--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -252,6 +252,10 @@ export function getChatComposerDraftKey(teamId: string, conversationId: string |
   return `${encodeURIComponent(String(teamId || '').trim())}|${encodeURIComponent(normalizeConversationId(conversationId))}`;
 }
 
+export function getChatThreadLayoutKey(teamId: string, conversationId: string | null | undefined) {
+  return `${encodeURIComponent(String(teamId || '').trim())}|${encodeURIComponent(normalizeConversationId(conversationId))}`;
+}
+
 export function isSelectedConversation(conversationId: string, selectedConversationId: string) {
   return conversationId === selectedConversationId;
 }
@@ -407,6 +411,7 @@ export function ChatWindow({
     onTeamReset: resetChatSelectionState
   });
   const effectiveConversationId = normalizeConversationId(selectedConversationId);
+  const activeThreadLayoutKey = getChatThreadLayoutKey(teamId, effectiveConversationId);
   const activeComposerDraftKey = getChatComposerDraftKey(teamId, effectiveConversationId);
   const activeComposerDraftKeyRef = useRef(activeComposerDraftKey);
   const latestComposerDraftRef = useRef<ChatComposerDraft>({
@@ -850,7 +855,7 @@ export function ChatWindow({
     setMeasuredMessageHeights({});
     setMessageViewportState({ scrollTop: 0, viewportHeight: 0 });
     olderLoadAnchorRef.current = null;
-  }, [effectiveConversationId]);
+  }, [activeThreadLayoutKey]);
 
   useEffect(() => {
     setIsMuted(resolveMutedState(teamId, effectiveConversationId, inboxTeam, profile));

--- a/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
@@ -13,6 +13,7 @@ import {
   getMessageRevisionSignature,
   getSafeMessageAttachments,
   getChatComposerDraftKey,
+  getChatThreadLayoutKey,
   buildVirtualizedChatLayout,
   buildVirtualizedChatWindow,
   buildVirtualizedChatWindowFromLayout
@@ -97,6 +98,7 @@ const olderPage = Array.from({ length: 50 }, (_, index) => buildMessage(`older-$
 
 let scrollHeightValue = 2400;
 let contentScrollHeightValue = 2400;
+let olderLoadGate: { promise: Promise<void>; resolve: () => void } | null = null;
 
 function buildMessage(id: string, seconds: number): ChatMessage {
   return {
@@ -282,7 +284,7 @@ vi.mock('../hooks/useChatMessages', async () => {
           setLoadingOlder(true);
           scrollHeightValue = 3000;
           contentScrollHeightValue = 3000;
-          await Promise.resolve();
+          await (olderLoadGate?.promise || Promise.resolve());
           setOlderMessages(olderPage);
           setLoadingOlder(false);
         },
@@ -357,6 +359,7 @@ class MockResizeObserver {
 beforeEach(() => {
   useStatefulChatSheets = false;
   mockThreadLoadScenario = 'normal';
+  olderLoadGate = null;
   mockRouter.navigate.mockReset();
   mockShellLayoutState.isDesktopWeb = false;
   mockChatSheetsState.showConversationSheet = false;
@@ -538,6 +541,11 @@ describe('ChatWindow virtualization', () => {
     stringifySpy.mockRestore();
   });
 
+  it('scopes thread layout identity by team and normalized conversation', () => {
+    expect(getChatThreadLayoutKey('team-1', 'team')).toBe(getChatThreadLayoutKey('team-1', ''));
+    expect(getChatThreadLayoutKey('team-1', 'team')).not.toBe(getChatThreadLayoutKey('team-2', 'team'));
+  });
+
   it('includes attachment fields in the message revision signature', () => {
     const message = {
       ...buildMessage('message-with-attachment', 10),
@@ -667,6 +675,41 @@ describe('ChatWindow virtualization', () => {
     expect(bubbleCount).toBeGreaterThan(0);
     expect(bubbleCount).toBeLessThan(100);
     expect(bubbleCount).toBeLessThan(liveMessages.length);
+  });
+
+  it('clears pending older-history layout state when switching teams on the default conversation', async () => {
+    let releaseOlderLoad = () => {};
+    olderLoadGate = {
+      promise: new Promise<void>((resolve) => {
+        releaseOlderLoad = resolve;
+      }),
+      resolve: () => releaseOlderLoad()
+    };
+    const view = render(
+      <MemoryRouter>
+        <ChatWindow auth={auth} teamId="team-1" />
+      </MemoryRouter>
+    );
+    const thread = view.container.querySelector('.chat-messages-scroll') as HTMLDivElement;
+    thread.scrollTop = 120;
+    fireEvent.scroll(thread);
+    fireEvent.click(view.getByRole('button', { name: 'Load older messages' }));
+    await waitFor(() => expect(view.getByRole('button', { name: 'Load older messages' })).toBeDisabled());
+
+    view.rerender(
+      <MemoryRouter>
+        <ChatWindow auth={auth} teamId="team-2" />
+      </MemoryRouter>
+    );
+    olderLoadGate.resolve();
+
+    await waitFor(() => {
+      expect(view.getByRole('button', { name: 'Load older messages' })).toBeEnabled();
+      expect(thread.scrollTop).toBe(120);
+      const bubbleCount = view.container.querySelectorAll('.message-bubble').length;
+      expect(bubbleCount).toBeGreaterThan(0);
+      expect(bubbleCount).toBeLessThan(100);
+    });
   });
 
   it('offers in-place retry for a failed message subscription and keeps back navigation available', async () => {


### PR DESCRIPTION
Closes #4005

## What changed
- Added a normalized thread-layout identity composed of team ID and effective conversation ID.
- Reset measured message heights, viewport state, and older-history anchors whenever either identity component changes.
- Added cross-team default-conversation regression coverage while retaining existing virtualization and anchoring coverage.

## Root Cause
ChatWindow keyed its virtualization reset only by effectiveConversationId. Because the desktop two-pane view reuses the component and different teams share the default `team` conversation ID, team switches retained the previous team's measurements, viewport state, and older-history anchor.

## Prevention / Learning
Any component state derived from team-scoped conversation data must use the complete thread identity, including both team ID and normalized conversation ID, for cache ownership and reset dependencies.

## Regression Tests
- Verifies identical conversation IDs under different team IDs produce different layout keys.
- Rerenders the same ChatWindow instance across teams while an older-history load is pending and verifies the stale anchor is not applied.
- Verifies mounted message bubbles remain bounded.
- Focused virtualization suite: 33 tests passed.

## Recurrence Risk
Low. The reset now uses the same complete identity boundary as the underlying chat data, with focused unit and integration regression coverage.