### PR TITLE
Stream Home data as it loads

### DIFF
--- a/apps/app/src/lib/homeService.ts
+++ b/apps/app/src/lib/homeService.ts
@@ -29,6 +29,20 @@ const homeSecondaryTtlMs = 30 * 1000;
 const teamsSummaryTtlMs = 30 * 1000;
 const logger = createLogger('home');
 
+type ParentHomeSummaryBootstrapResult = {
+  home: ParentHomeModel;
+  schedule: ParentScheduleLoadResult;
+};
+
+type ParentHomeSummaryOptions = {
+  force?: boolean;
+  scheduleScope?: ParentScheduleScope;
+};
+
+type ParentHomeSummaryBootstrapOptions = ParentHomeSummaryOptions & {
+  onPartial?: (result: ParentHomeSummaryBootstrapResult) => void;
+};
+
 function rethrowIfPermissionError(error: unknown, fallbackMessage: string) {
   const appError = toAppServiceError(error, fallbackMessage);
   if (appError.type === 'permission') {
@@ -68,7 +82,7 @@ export async function loadParentHome(user: AuthUser | null): Promise<ParentHomeM
 
 export async function loadParentHomeSummary(
   user: AuthUser | null,
-  options: { force?: boolean; scheduleScope?: ParentScheduleScope } = {}
+  options: ParentHomeSummaryOptions = {}
 ): Promise<ParentHomeModel> {
   const summary = await loadParentHomeSummaryBootstrap(user, options);
   return summary.home;
@@ -76,8 +90,8 @@ export async function loadParentHomeSummary(
 
 export async function loadParentHomeSummaryBootstrap(
   user: AuthUser | null,
-  options: { force?: boolean; scheduleScope?: ParentScheduleScope } = {}
-): Promise<{ home: ParentHomeModel; schedule: ParentScheduleLoadResult }> {
+  options: ParentHomeSummaryBootstrapOptions = {}
+): Promise<ParentHomeSummaryBootstrapResult> {
   if (!user?.uid) {
     const schedule = { children: [], events: [] };
     return {
@@ -86,16 +100,23 @@ export async function loadParentHomeSummaryBootstrap(
     };
   }
 
-  const schedule = await loadParentScheduleSummary(user, options);
-  return {
+  const toBootstrapResult = (schedule: ParentScheduleLoadResult): ParentHomeSummaryBootstrapResult => ({
     home: buildParentHomeModel({
       children: schedule.children,
       events: schedule.events,
-      inboxTeams: [],
+      inboxTeams: normalizeStaffTeams(schedule),
       fees: []
     }),
     schedule
-  };
+  });
+  const schedule = await loadParentScheduleSummary(user, {
+    force: options.force,
+    scheduleScope: options.scheduleScope,
+    ...(options.onPartial ? {
+      onPartial: (partialSchedule) => options.onPartial?.(toBootstrapResult(partialSchedule))
+    } : {})
+  });
+  return toBootstrapResult(schedule);
 }
 
 export async function loadParentTeamsSummary(user: AuthUser | null, options: { force?: boolean } = {}): Promise<ParentHomeModel> {
@@ -238,7 +259,7 @@ export async function loadParentHomeWithSecondaryData(
 
 export async function loadParentScheduleSummary(
   user: AuthUser | null,
-  options: { force?: boolean; scheduleScope?: ParentScheduleScope } = {}
+  options: ParentHomeSummaryOptions & { onPartial?: (schedule: ParentScheduleLoadResult) => void } = {}
 ): Promise<ParentScheduleLoadResult> {
   if (!user?.uid) return { children: [], events: [] };
   return loadCachedAppData(
@@ -246,7 +267,8 @@ export async function loadParentScheduleSummary(
     () => loadParentSchedule(user, {
       hydrateDetails: false,
       expandStaffPlayers: false,
-      parentScope: options.scheduleScope
+      parentScope: options.scheduleScope,
+      ...(options.onPartial ? { onPartial: options.onPartial } : {})
     }),
     {
       ttlMs: homeSummaryTtlMs,
@@ -254,6 +276,15 @@ export async function loadParentScheduleSummary(
       shouldCache: (result) => result?.isPartial !== true
     }
   );
+}
+
+function normalizeStaffTeams(schedule: ParentScheduleLoadResult): ParentHomeInboxTeam[] {
+  return (schedule.staffTeams || []).map((team) => ({
+    id: team.teamId,
+    name: team.teamName,
+    role: 'Coach',
+    unreadCount: 0
+  }));
 }
 
 function normalizeInboxTeams(teams: any[]): ParentHomeInboxTeam[] {

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -3198,6 +3198,35 @@ describe('partial parent schedule team failures (#3021)', () => {
     expect(result.isPartial).toBe(true);
   });
 
+  it('streams the player/team shell before every team schedule finishes', async () => {
+    vi.mocked(getGames).mockImplementation(async (teamId: string) => ([{
+      id: `game-${teamId}`,
+      type: 'game',
+      date: new Date(teamId === 'team-1' ? '2100-06-25T18:00:00.000Z' : '2100-06-26T18:00:00.000Z'),
+      opponent: teamId === 'team-1' ? 'Tigers' : 'Lions',
+      location: 'Main Gym'
+    }] as any));
+    const partials: any[] = [];
+
+    const result = await loadParentSchedule(parentUser, {
+      hydrateDetails: false,
+      expandStaffPlayers: false,
+      onPartial: (partial) => partials.push(partial)
+    });
+
+    expect(partials[0]).toMatchObject({
+      children: [
+        expect.objectContaining({ teamId: 'team-1', playerId: 'p1' }),
+        expect.objectContaining({ teamId: 'team-2', playerId: 'p2' })
+      ],
+      events: [],
+      isPartial: true
+    });
+    expect(partials.some((partial) => partial.events.length === 1)).toBe(true);
+    expect(partials[partials.length - 1]?.events).toHaveLength(2);
+    expect(result.events).toHaveLength(2);
+  });
+
   it('rethrows a typed schedule load error when every team schedule load fails', async () => {
     vi.mocked(getGames).mockRejectedValue(new Error('permission-denied'));
 

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -240,6 +240,8 @@ export type ParentScheduleLoadOptions = {
   includePastGames?: boolean;
   scheduleRangeByTeam?: ScheduleDateRangeByTeam;
   parentScope?: ParentScheduleScope;
+  /** Stream the resolved player/team shell and completed team schedules while the full load continues. */
+  onPartial?: (result: ParentScheduleLoadResult) => void;
 };
 
 export type OfficialAssignmentsAccess = {
@@ -4043,11 +4045,48 @@ export async function loadParentSchedule(user: AuthUser | null, options: ParentS
       expandStaffPlayers,
       parentScope: canReuseParentScope ? options.parentScope : undefined
     });
+    const staffTeamSummaries = staffTeams
+      .map((team: any) => {
+        const teamId = compactString(team?.id);
+        return teamId ? { teamId, teamName: compactString(team?.name) || teamId } : null;
+      })
+      .filter(Boolean) as ParentScheduleStaffTeam[];
+
+    const completedTeamResults: Array<{
+      teamId: string;
+      events: ParentScheduleEvent[];
+      error: ReturnType<typeof toAppServiceError> | null;
+    }> = [];
+    const emitPartial = () => {
+      if (!options.onPartial) return;
+      const partialEvents = completedTeamResults
+        .flatMap((result) => result.events)
+        .sort((a, b) => a.date.getTime() - b.date.getTime());
+      try {
+        options.onPartial({
+          children,
+          events: partialEvents,
+          staffTeams: staffTeamSummaries,
+          isPartial: true
+        });
+      } catch (error) {
+        logScheduleWarning('Parent schedule partial callback failed.', 'parent-schedule-partial-callback', error);
+      }
+    };
+
+    // The Home page can render its player/team shell as soon as access scope is
+    // known, without waiting for every team's games and practices to finish.
+    emitPartial();
 
     const teamEntries = [...byTeam.entries()];
     const teamResults = await mapWithConcurrency(teamEntries, parentScheduleTeamConcurrency, async ([teamId, teamChildren]) => {
+      let result: {
+        teamId: string;
+        events: ParentScheduleEvent[];
+        error: ReturnType<typeof toAppServiceError> | null;
+      };
       try {
-        return {
+        result = {
           teamId,
           events: await buildTeamSchedule(teamId, teamChildren, user, {
             includePastGames,
@@ -4058,12 +4097,15 @@ export async function loadParentSchedule(user: AuthUser | null, options: ParentS
       } catch (error) {
         const appError = toAppServiceError(error, 'Unable to load schedule.');
         logScheduleWarning('Failed to load team schedule.', 'team-schedule-load', error, { teamId });
-        return {
+        result = {
           teamId,
           events: [] as ParentScheduleEvent[],
           error: appError
         };
       }
+      completedTeamResults.push(result);
+      emitPartial();
+      return result;
     });
 
     const failedTeamLoads = teamResults.filter((result) => result.error);
@@ -4082,12 +4124,6 @@ export async function loadParentSchedule(user: AuthUser | null, options: ParentS
     if (hydrateDetails) {
       await hydrateEventDetails(events, user);
     }
-    const staffTeamSummaries = staffTeams
-      .map((team: any) => {
-        const teamId = compactString(team?.id);
-        return teamId ? { teamId, teamName: compactString(team?.name) || teamId } : null;
-      })
-      .filter(Boolean) as ParentScheduleStaffTeam[];
     const isPartial = failedTeamLoads.length > 0;
     timer.end({
       hydrateDetails,

--- a/apps/app/src/pages/Home.test.tsx
+++ b/apps/app/src/pages/Home.test.tsx
@@ -350,7 +350,7 @@ describe('Home', () => {
     cleanup();
   });
 
-  it('waits for the initial secondary Home load to finish before recording first meaningful render', async () => {
+  it('records first meaningful render when the Home summary is available', async () => {
     let resolveBootstrap!: (value: { home: typeof baseHome; schedule: [] }) => void;
     let resolveSecondary!: (value: typeof baseHome) => void;
     homeServiceMocks.loadParentHomeSummaryBootstrap.mockImplementationOnce(() => new Promise((resolve) => {
@@ -367,13 +367,26 @@ describe('Home', () => {
     resolveBootstrap({ home: baseHome, schedule: [] });
 
     expect(await screen.findByRole('heading', { name: 'Today for your players' })).toBeTruthy();
-    expect(uxTimingMocks.recordFirstMeaningfulRender).not.toHaveBeenCalled();
-
-    resolveSecondary(baseHome);
-
     await waitFor(() => {
       expect(uxTimingMocks.recordFirstMeaningfulRender).toHaveBeenCalledWith('home');
     });
+
+    resolveSecondary(baseHome);
+    expect(uxTimingMocks.recordFirstMeaningfulRender).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a progressive Home preview while the full schedule summary is still pending', async () => {
+    homeServiceMocks.loadParentHomeSummaryBootstrap.mockImplementationOnce((_user: unknown, options: any) => {
+      options?.onPartial?.({ home: baseHome, schedule: { children: [], events: [], isPartial: true } });
+      return new Promise(() => {});
+    });
+
+    renderHome(signedInAuth);
+
+    expect(await screen.findByRole('heading', { name: 'Today for your players' })).toBeTruthy();
+    expect(screen.getByText('Checking responses…')).toBeTruthy();
+    expect(screen.queryByText('Loading Home')).toBeNull();
+    expect(uxTimingMocks.recordFirstMeaningfulRender).toHaveBeenCalledWith('home');
   });
 
   it('renders the feed for signed-out users without crashing', async () => {
@@ -438,14 +451,15 @@ describe('Home', () => {
     expect(screen.getByText('Check your connection and try loading Home again.')).toBeTruthy();
   });
 
-  it('shows retryable Home error UI when the initial secondary load fails', async () => {
+  it('keeps the summary visible when the initial secondary load fails', async () => {
     homeServiceMocks.loadParentHomeWithSecondaryData.mockRejectedValueOnce(new TypeError('Failed to fetch'));
 
     renderHome(signedInAuth);
 
-    expect(await screen.findByText('Home could not connect')).toBeTruthy();
-    expect(screen.getByText('Check your connection and try loading Home again.')).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Retry loading Home' })).toBeTruthy();
+    expect(await screen.findByText('Home details could not refresh while offline.')).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Today for your players' })).toBeTruthy();
+    expect(screen.queryByText('Home could not connect')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Retry loading Home' })).toBeNull();
   });
 
   it('shows first-run access actions instead of an empty Today dashboard when no players or teams are linked', async () => {
@@ -586,7 +600,7 @@ describe('Home', () => {
     expect(capturedOnPartial).toBeTypeOf('function');
   });
 
-  it('renders secondary Home details before social data finishes loading', async () => {
+  it('records meaningful Home render without waiting for social data', async () => {
     const largeHome = buildLargeHomeModel();
     let resolveSocial!: (value: typeof baseSocial) => void;
     homeServiceMocks.loadParentHomeWithSecondaryData.mockResolvedValueOnce(largeHome);
@@ -598,12 +612,12 @@ describe('Home', () => {
 
     expect(await screen.findByText('Falcons')).toBeTruthy();
     expect(socialServiceMocks.loadSocialHome).toHaveBeenCalledWith(signedInAuth.user, largeHome);
-    expect(uxTimingMocks.recordFirstMeaningfulRender).not.toHaveBeenCalled();
+    expect(uxTimingMocks.recordFirstMeaningfulRender).toHaveBeenCalledWith('home');
 
     resolveSocial(baseSocial);
 
     await waitFor(() => {
-      expect(uxTimingMocks.recordFirstMeaningfulRender).toHaveBeenCalledWith('home');
+      expect(uxTimingMocks.recordFirstMeaningfulRender).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -178,6 +178,7 @@ export function Home({ auth }: { auth: AuthState }) {
   const [socialStatus, setSocialStatus] = useState<{ tone: 'error' | 'success'; message: string } | null>(null);
   const [composerOpen, setComposerOpen] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
+  const [previewHomeUserId, setPreviewHomeUserId] = useState<string | null>(null);
   const [loadedHomeDetailsUserId, setLoadedHomeDetailsUserId] = useState<string | null>(null);
   const [homeLoadError, setHomeLoadError] = useState<AppServiceError | null>(null);
   const { loading, error, clearError, run: runPrimaryLoad } = useAsyncOperation();
@@ -185,11 +186,13 @@ export function Home({ auth }: { auth: AuthState }) {
   const hasStartedInitialHomeLoadRef = useRef(false);
 
   const authUserId = auth.user?.uid || null;
+  const hasHomePreview = Boolean(authUserId) && authUserId === previewHomeUserId;
   const hasLoadedHomeDetails = Boolean(authUserId) && authUserId === loadedHomeDetailsUserId;
 
   const refreshHome = async ({ force = false }: { force?: boolean } = {}) => {
     const user = auth.user;
     if (!user) return;
+    let receivedHomePreview = false;
     const hasExistingHome = loadedHomeDetailsUserId === user.uid;
     clearError();
     setHomeLoadError(null);
@@ -200,8 +203,18 @@ export function Home({ auth }: { auth: AuthState }) {
     });
     return runPrimaryLoad(
       async () => {
-        const summary = await loadParentHomeSummaryBootstrap(user, { force });
+        const summary = await loadParentHomeSummaryBootstrap(user, {
+          force,
+          onPartial: (partial) => {
+            receivedHomePreview = true;
+            setHome(partial.home);
+            setPreviewHomeUserId(user.uid);
+            setHomeLoadError(null);
+          }
+        });
+        receivedHomePreview = true;
         setHome(summary.home);
+        setPreviewHomeUserId(user.uid);
         setHomeLoadError(null);
 
         void runSecondaryLoad(
@@ -247,6 +260,7 @@ export function Home({ auth }: { auth: AuthState }) {
                 setHomeLoadError(appError);
                 setLoadedHomeDetailsUserId(null);
                 setSocial(emptySocialHome());
+                setSocialStatus({ tone: 'error', message: getHomeSecondaryErrorMessage(appError) });
                 return;
               }
               setSocialStatus({ tone: 'error', message: getHomeSecondaryErrorMessage(appError) });
@@ -257,7 +271,7 @@ export function Home({ auth }: { auth: AuthState }) {
         return summary;
       },
       {
-        getErrorMessage: (loadError) => getHomeLoadErrorMessage(toAppServiceError(loadError, 'Unable to load Home.'), hasExistingHome),
+        getErrorMessage: (loadError) => getHomeLoadErrorMessage(toAppServiceError(loadError, 'Unable to load Home.'), hasExistingHome || receivedHomePreview),
         rethrow: false,
         onError: (loadError) => {
           const appError = toAppServiceError(loadError, 'Unable to load Home.');
@@ -266,10 +280,12 @@ export function Home({ auth }: { auth: AuthState }) {
             hydrated: false,
             error: appError.message
           });
-          if (!hasExistingHome) {
+          if (!hasExistingHome && !receivedHomePreview) {
             setHome(emptyHome());
             setSocial(emptySocialHome());
+            setPreviewHomeUserId(null);
             setLoadedHomeDetailsUserId(null);
+            return;
           }
         }
       }
@@ -289,13 +305,13 @@ export function Home({ auth }: { auth: AuthState }) {
   useRefreshOnResume(() => { void refreshHome({ force: true }); }, { enabled: Boolean(auth.user?.uid) });
 
   useEffect(() => {
-    if (!hasStartedInitialHomeLoadRef.current || loading || socialLoading) {
+    if (!hasStartedInitialHomeLoadRef.current) {
       return;
     }
-    if (hasLoadedHomeDetails || homeLoadError) {
+    if (hasHomePreview || homeLoadError) {
       recordFirstMeaningfulRender('home');
     }
-  }, [hasLoadedHomeDetails, homeLoadError, loading, socialLoading]);
+  }, [hasHomePreview, homeLoadError]);
 
   useEffect(() => {
     let cancelled = false;
@@ -328,7 +344,10 @@ export function Home({ auth }: { auth: AuthState }) {
   }, [searchParams]);
 
   const topAction = home.actionItems[0] || null;
-  const showBlockingErrorState = !loading && !hasLoadedHomeDetails && Boolean(homeLoadError);
+  const hasRenderableHome = !authUserId || hasHomePreview || hasLoadedHomeDetails;
+  const showBlockingErrorState = !loading && !hasRenderableHome && Boolean(homeLoadError);
+  const showInitialHomeSkeleton = loading && !hasRenderableHome;
+  const canRenderHomeSections = !loading || hasRenderableHome;
   const displayName = auth.user?.displayName || auth.user?.email || 'ALL PLAYS User';
   const openCount = home.metrics.rsvpNeeded + home.metrics.packetsReady + home.metrics.unreadMessages + home.fees.length + social.metrics.incomingRequests;
   const today = new Date();
@@ -490,11 +509,11 @@ export function Home({ auth }: { auth: AuthState }) {
       {error ? <Status tone="error" message={error} /> : null}
       {socialStatus ? <Status tone={socialStatus.tone} message={socialStatus.message} /> : null}
 
-      {loading ? <HomePageSkeleton /> : null}
+      {showInitialHomeSkeleton ? <HomePageSkeleton /> : null}
 
       {showBlockingErrorState ? <HomeLoadErrorState error={homeLoadError} onRetry={() => refreshHome({ force: true })} retrying={loading} /> : null}
 
-      {!loading && !showBlockingErrorState && activeSection === 'today' ? (
+      {canRenderHomeSections && !showBlockingErrorState && activeSection === 'today' ? (
         <TodaySection
           home={home}
           social={social}
@@ -504,7 +523,7 @@ export function Home({ auth }: { auth: AuthState }) {
           officialsAccess={resolvedOfficialsAccess}
         />
       ) : null}
-      {!loading && !showBlockingErrorState && activeSection === 'feed' ? (
+      {canRenderHomeSections && !showBlockingErrorState && activeSection === 'feed' ? (
         <FeedSection
           social={social}
           loading={socialLoading}
@@ -515,9 +534,9 @@ export function Home({ auth }: { auth: AuthState }) {
           onStatus={setSocialStatus}
         />
       ) : null}
-      {!loading && !showBlockingErrorState && activeSection === 'players' ? <PlayersSection players={home.players} /> : null}
-      {!loading && !showBlockingErrorState && activeSection === 'teams' ? <TeamsSection teams={home.teams} /> : null}
-      {!loading && !showBlockingErrorState && activeSection === 'friends' ? (
+      {canRenderHomeSections && !showBlockingErrorState && activeSection === 'players' ? <PlayersSection players={home.players} /> : null}
+      {canRenderHomeSections && !showBlockingErrorState && activeSection === 'teams' ? <TeamsSection teams={home.teams} /> : null}
+      {canRenderHomeSections && !showBlockingErrorState && activeSection === 'friends' ? (
         <FriendsSection
           auth={auth}
           home={home}

--- a/tests/unit/app-async-operation-initiative-source-contract.test.js
+++ b/tests/unit/app-async-operation-initiative-source-contract.test.js
@@ -48,7 +48,7 @@ describe('app async operation initiative source contract', () => {
         expect(homeSource).toContain("import { useAsyncOperation } from '../lib/useAsyncOperation';");
         expect(homeSource).toContain('const { loading, error, clearError, run: runPrimaryLoad } = useAsyncOperation();');
         expect(homeSource).toContain('const { loading: socialLoading, run: runSecondaryLoad } = useAsyncOperation();');
-        expect(homeSource).toContain('getHomeLoadErrorMessage(toAppServiceError(loadError, \'Unable to load Home.\'), hasExistingHome)');
+        expect(homeSource).toContain('getHomeLoadErrorMessage(toAppServiceError(loadError, \'Unable to load Home.\'), hasExistingHome || receivedHomePreview)');
 
         expect(scheduleSource).toContain("import { toAppServiceError, type AppServiceError } from '../lib/appErrors';");
         expect(scheduleSource).toContain("import { useAsyncOperation } from '../lib/useAsyncOperation';");

--- a/tests/unit/app-home-async-operation-contract.test.js
+++ b/tests/unit/app-home-async-operation-contract.test.js
@@ -35,12 +35,14 @@ describe('Home async operation contract', () => {
 
         expect(refreshHomeSource).toContain('const hasExistingHome = loadedHomeDetailsUserId === user.uid;');
         expect(refreshHomeSource).toContain("const timer = startScreenMountTimer('home', {");
-        expect(refreshHomeSource).toContain('const summary = await loadParentHomeSummaryBootstrap(user, { force });');
+        expect(refreshHomeSource).toContain('const summary = await loadParentHomeSummaryBootstrap(user, {');
+        expect(refreshHomeSource).toContain('onPartial: (partial) => {');
+        expect(refreshHomeSource).toContain('setPreviewHomeUserId(user.uid);');
         expect(refreshHomeSource).toContain('setHome(summary.home);');
         expect(refreshHomeSource).toContain('const secondaryHome = await loadParentHomeWithSecondaryData(user, {');
         expect(refreshHomeSource).toContain('schedule: summary.schedule');
         expect(refreshHomeSource).toContain('onPartial: (partial) => setHome(partial)');
-        expect(refreshHomeSource).toContain("getErrorMessage: (loadError) => getHomeLoadErrorMessage(toAppServiceError(loadError, 'Unable to load Home.'), hasExistingHome)");
+        expect(refreshHomeSource).toContain("getErrorMessage: (loadError) => getHomeLoadErrorMessage(toAppServiceError(loadError, 'Unable to load Home.'), hasExistingHome || receivedHomePreview)");
         expect(refreshHomeSource).toContain("const appError = toAppServiceError(loadError, 'Unable to load Home.');");
         expect(refreshHomeSource).toContain('if (!hasExistingHome) {');
         expect(refreshHomeSource).toContain('setHome(emptyHome());');

--- a/tests/unit/app-home-service.test.js
+++ b/tests/unit/app-home-service.test.js
@@ -419,6 +419,52 @@ describe('React app Home service', () => {
         expect(home.fees).toEqual([]);
     });
 
+    it('maps progressive schedule results into renderable Home previews', async () => {
+        scheduleMocks.loadParentSchedule.mockImplementationOnce(async (_user, options = {}) => {
+            options.onPartial?.({
+                children: [{
+                    teamId: 'team-1',
+                    teamName: 'Bears',
+                    playerId: 'player-1',
+                    playerName: 'Pat Star'
+                }],
+                events: [],
+                staffTeams: [{ teamId: 'team-coach', teamName: 'Coach Team' }],
+                isPartial: true
+            });
+            return {
+                children: [{
+                    teamId: 'team-1',
+                    teamName: 'Bears',
+                    playerId: 'player-1',
+                    playerName: 'Pat Star'
+                }],
+                events: [event()],
+                staffTeams: [{ teamId: 'team-coach', teamName: 'Coach Team' }]
+            };
+        });
+        const onPartial = vi.fn();
+        const { loadParentHomeSummaryBootstrap } = await import('../../apps/app/src/lib/homeService.ts');
+
+        const summary = await loadParentHomeSummaryBootstrap(user, { force: true, onPartial });
+
+        expect(onPartial).toHaveBeenCalledWith(expect.objectContaining({
+            home: expect.objectContaining({
+                players: [expect.objectContaining({ playerId: 'player-1' })],
+                teams: expect.arrayContaining([
+                    expect.objectContaining({ teamId: 'team-1' }),
+                    expect.objectContaining({ teamId: 'team-coach', role: 'Coach' })
+                ]),
+                upcomingEvents: []
+            }),
+            schedule: expect.objectContaining({ isPartial: true })
+        }));
+        expect(summary.home.upcomingEvents).toHaveLength(1);
+        expect(summary.home.teams).toEqual(expect.arrayContaining([
+            expect.objectContaining({ teamId: 'team-coach', role: 'Coach' })
+        ]));
+    });
+
     it('reuses one base schedule load across summary and secondary Home refresh', async () => {
         scheduleMocks.loadParentSchedule.mockImplementation((_, options = {}) => Promise.resolve({
             children: [

--- a/tests/unit/app-performance-baseline-contract.test.js
+++ b/tests/unit/app-performance-baseline-contract.test.js
@@ -73,12 +73,13 @@ describe('app performance baseline contract', () => {
         expect(telemetry).toContain("captureHandledAppError(label, error, {");
 
         expect(home).toContain("const timer = startScreenMountTimer('home', {");
-        expect(home).toContain('const summary = await loadParentHomeSummaryBootstrap(user, { force });');
+        expect(home).toContain('const summary = await loadParentHomeSummaryBootstrap(user, {');
+        expect(home).toContain('onPartial: (partial) => {');
         expect(home).toContain('const secondaryHome = await loadParentHomeWithSecondaryData(user, {');
         expect(home).toContain('timer.end({');
         expect(home).toContain('hydrated: true');
         expect(home).toContain('playerCount: secondaryHome.players.length');
-        expect(home).toContain("getErrorMessage: (loadError) => getHomeLoadErrorMessage(toAppServiceError(loadError, 'Unable to load Home.'), hasExistingHome)");
+        expect(home).toContain("getErrorMessage: (loadError) => getHomeLoadErrorMessage(toAppServiceError(loadError, 'Unable to load Home.'), hasExistingHome || receivedHomePreview)");
         expect(home).toContain('onError: (loadError) => {');
         expect(home).toContain('timer.end({\n            hydrated: false,\n            error: appError.message\n          });');
 


### PR DESCRIPTION
## What changed

- Stream the player/team shell before every team schedule request completes.
- Add each completed team schedule to Home incrementally while chat, fees, RSVP, and social hydration continue.
- Keep available Home content visible when a later data slice fails, with inline error messaging.
- Include coach-managed teams in early summary previews.

## Why

Home previously kept the main dashboard behind the complete schedule summary. One slow team or Firebase read could make the page appear stuck even though useful account data was ready.

## User impact

Home becomes usable progressively, and a degraded data slice no longer replaces content that has already loaded.

## Validation

- Focused Home and schedule tests: 161 passed.
- Full unit suite: 4,295 passed, 58 skipped.
- `npm run app:build`
