### PR TITLE
Fix production Storage deploy guard

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -153,15 +153,17 @@ jobs:
             exit 0
           fi
 
+          storage_plain_log="$RUNNER_TEMP/firebase-storage-deploy.plain.log"
+          sed -E 's/\x1B\[[0-9;]*[[:alpha:]]//g' "$storage_log" > "$storage_plain_log"
           storage_not_configured="Firebase Storage has not been set up on project 'game-flow-c6311'"
-          if grep -Fq "$storage_not_configured" "$storage_log" && [[ "$STORAGE_RULES_CHANGED" != "true" ]]; then
+          if grep -Fq "$storage_not_configured" "$storage_plain_log" && [[ "$STORAGE_RULES_CHANGED" != "true" ]]; then
             echo "::warning::Firebase Storage is not initialized; no Storage surface exists yet. Rules were unchanged, so the rest of production deployment can continue."
             echo "### Firebase Storage rules" >> "$GITHUB_STEP_SUMMARY"
             echo "Skipped because Storage is not initialized and storage.rules was unchanged." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
-          if grep -Fq "$storage_not_configured" "$storage_log"; then
+          if grep -Fq "$storage_not_configured" "$storage_plain_log"; then
             echo "::error::storage.rules changed, but Firebase Storage is not initialized. Refusing to deploy other production changes with stale Storage authorization rules."
           fi
           exit "$storage_status"

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -80,6 +80,7 @@ export function validateProductionDeployCommand(deployProd) {
     assertIncludes(deployProd, 'fetch-depth: 0', 'Production Storage rules change history');
     assertIncludes(deployProd, 'git diff --quiet "${{ github.event.before }}" "${{ github.sha }}" -- storage.rules', 'Production Storage rules change detection');
     assertIncludes(deployProd, 'STORAGE_RULES_CHANGED: ${{ steps.storage_rules.outputs.changed }}', 'Production Storage rules change output');
+    assertIncludes(deployProd, "sed -E 's/\\x1B\\[[0-9;]*[[:alpha:]]//g' \"$storage_log\" > \"$storage_plain_log\"", 'Production Storage rules ANSI log normalization');
     assertIncludes(deployProd, '[[ "$STORAGE_RULES_CHANGED" != "true" ]]', 'Production Storage rules unchanged-only skip');
     assertIncludes(deployProd, 'exit "$storage_status"', 'Production Storage rules changed failure');
     assertMatches(deployCommand, /(?:^|\s)--project game-flow-c6311(?:\s|$)/, 'Production Firebase deploy project');

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -75,6 +75,7 @@ service firebase.storage {
           STORAGE_RULES_CHANGED: \${{ steps.storage_rules.outputs.changed }}
         run: |
           npx firebase-tools@14.25.0 deploy --only storage --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive
+          sed -E 's/\\x1B\\[[0-9;]*[[:alpha:]]//g' "$storage_log" > "$storage_plain_log"
           if [[ "$STORAGE_RULES_CHANGED" != "true" ]]; then exit 0; fi
           exit "$storage_status"
             npx firebase-tools@14.25.0 deploy --only hosting,firestore:rules,firestore:indexes,functions --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive
@@ -83,6 +84,9 @@ service firebase.storage {
         expect(() => validateProductionDeployCommand(validDeployCommand)).not.toThrow();
         expect(() => validateProductionDeployCommand(validDeployCommand.replace('[[ "$STORAGE_RULES_CHANGED" != "true" ]]', '[[ true ]]'))).toThrow(
             'Production Storage rules unchanged-only skip'
+        );
+        expect(() => validateProductionDeployCommand(validDeployCommand.replace("sed -E 's/\\x1B\\[[0-9;]*[[:alpha:]]//g' \"$storage_log\" > \"$storage_plain_log\"", ''))).toThrow(
+            'Production Storage rules ANSI log normalization'
         );
     });
 


### PR DESCRIPTION
## Summary

- Strip Firebase CLI ANSI color codes before classifying the uninitialized-Storage error.
- Continue production deployment only when `storage.rules` is unchanged.
- Keep changed Storage rules fail-closed and add a validator regression for log normalization.

## Why

Production run [29619343595](https://github.com/pauljsnider/allplays/actions/runs/29619343595) failed because Firebase CLI colorized `game-flow-c6311`, so the exact error classifier did not match the known uninitialized-Storage response.

## Validation

- `npx vitest run tests/unit/validate-firebase-rules-ci.test.js --reporter=verbose`
- `node scripts/validate-firebase-rules-ci.mjs`
- Production workflow YAML parsed successfully.
- A colorized Firebase error sample normalizes and matches the expected message.