### PR TITLE
Expose Family workflows in signed-in navigation

### DIFF
--- a/apps/app/src/components/AppShell.test.tsx
+++ b/apps/app/src/components/AppShell.test.tsx
@@ -180,6 +180,49 @@ describe('AppShell', () => {
     expect(searchButton.getAttribute('data-testid')).toBe('app-shell-search-trigger');
   });
 
+  it('adds Family to signed-in desktop navigation and marks nested tools active', () => {
+    render(
+      <MemoryRouter initialEntries={['/parent-tools/fees']}>
+        <Routes>
+          <Route path="/parent-tools/fees" element={<AppShell auth={signedInAuth}><div>Family fees</div></AppShell>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const primaryNav = screen.getByRole('navigation', { name: 'Primary navigation' });
+    const familyLink = within(primaryNav).getByRole('link', { name: 'Family' });
+    expect(familyLink.getAttribute('href')).toBe('/parent-tools');
+    expect(familyLink.className).toContain('bg-primary-50');
+  });
+
+  it('keeps the mobile bottom navigation at six items and routes Family through Profile', () => {
+    useShellLayoutMock.mockReturnValue({ isDesktopWeb: false });
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route path="/home" element={<AppShell auth={signedInAuth}><div>Home</div></AppShell>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const primaryNav = screen.getByRole('navigation', { name: 'Primary navigation' });
+    expect(within(primaryNav).getAllByRole('link')).toHaveLength(6);
+    expect(within(primaryNav).queryByRole('link', { name: 'Family' })).toBeNull();
+    expect(within(primaryNav).getByRole('link', { name: 'Profile' })).toBeTruthy();
+  });
+
+  it('does not add Family to signed-out navigation', () => {
+    render(
+      <MemoryRouter initialEntries={['/discover']}>
+        <Routes>
+          <Route path="/discover" element={<AppShell auth={{ ...auth, roles: [] }}><div>Discover</div></AppShell>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByRole('link', { name: 'Family' })).toBeNull();
+  });
+
   it('announces notification count changes through a live region', () => {
     render(
       <MemoryRouter initialEntries={['/home']}>

--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -53,6 +53,13 @@ const navItems: NavItem[] = [
   { label: 'Profile', path: '/profile', icon: UserCircle }
 ];
 
+const familyNavItem: NavItem = { label: 'Family', path: '/parent-tools', icon: UsersRound };
+const desktopNavItems: NavItem[] = [
+  ...navItems.slice(0, -1),
+  familyNavItem,
+  navItems[navItems.length - 1]
+];
+
 const publicNavItems: NavItem[] = [
   { label: 'Discover', path: '/discover', icon: Compass },
   { label: 'Find Teams', path: '/teams/browse', icon: Users },
@@ -264,6 +271,7 @@ export function AppShell({ auth, children }: AppShellProps) {
   const addWorkflows = buildAddWorkflows();
   const hasSignedInSession = Boolean(auth.user || auth.roles.length);
   const activeNavItems = hasSignedInSession ? navItems : publicNavItems;
+  const activeDesktopNavItems = hasSignedInSession ? desktopNavItems : publicNavItems;
   const commonAddWorkflows = commonAddWorkflowIds
     .map((id) => addWorkflows.find((workflow) => workflow.id === id))
     .filter((workflow): workflow is AddWorkflow => workflow !== undefined);
@@ -405,7 +413,7 @@ export function AppShell({ auth, children }: AppShellProps) {
           <div className={`mx-auto grid max-w-7xl grid-cols-[236px_minmax(0,1fr)] gap-6 px-6 py-6 ${isDesktopMessages ? 'desktop-shell-grid-messages' : ''}`}>
             <aside className="sticky top-[84px] h-[calc(100vh-108px)] self-start rounded-2xl border border-gray-200 bg-white p-3 shadow-app">
               <nav className="space-y-1" aria-label="Primary navigation">
-                {activeNavItems.map((item) => {
+                {activeDesktopNavItems.map((item) => {
                   const Icon = item.icon;
                   const isActive = location.pathname === item.path || (item.path !== '/home' && location.pathname.startsWith(item.path + '/'));
 

--- a/apps/app/src/pages/Profile.test.tsx
+++ b/apps/app/src/pages/Profile.test.tsx
@@ -216,6 +216,15 @@ describe('Profile', () => {
     expect(sectionGrid?.className).not.toContain('min-w-max');
   });
 
+  it('exposes Family workflows from the mobile profile surface', async () => {
+    renderProfile();
+
+    expect(await screen.findByRole('heading', { name: 'Your Account' })).toBeTruthy();
+    const familyLink = screen.getByRole('link', { name: 'Open Family workflows' });
+    expect(familyLink.getAttribute('href')).toBe('/parent-tools');
+    expect(familyLink.textContent).toContain('Player access, household, fees, calendars, sharing, registration, and awards.');
+  });
+
   it('disables account merge while parent team eligibility is loading', async () => {
     const parentTeamsRequest = createDeferredPromise<Array<{ id: string; name: string }>>();
     profileServiceMocks.loadParentTeams.mockImplementation(() => parentTeamsRequest.promise);

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -1277,6 +1277,23 @@ export function Profile({ auth }: { auth: AuthState }) {
         </div>
       </div>
 
+      {!isDesktopWeb ? (
+        <Link
+          to="/parent-tools"
+          className="app-card flex items-center gap-3 p-4 transition hover:border-primary-200 hover:shadow-app-lg"
+          aria-label="Open Family workflows"
+        >
+          <span className="flex h-11 w-11 flex-none items-center justify-center rounded-xl bg-violet-50 text-violet-700">
+            <UserCircle className="h-5 w-5" aria-hidden="true" />
+          </span>
+          <span className="min-w-0 flex-1">
+            <span className="block text-sm font-black text-gray-950">Family workflows</span>
+            <span className="mt-0.5 block text-xs font-semibold leading-5 text-gray-600">Player access, household, fees, calendars, sharing, registration, and awards.</span>
+          </span>
+          <span className="text-sm font-black text-primary-700" aria-hidden="true">Open</span>
+        </Link>
+      ) : null}
+
       {activeProfileSection === 'account' ? (
       <section className="app-card p-4">
         <div className="flex items-center justify-between gap-3">

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -778,6 +778,23 @@ test('profile exposes account, notification, invite, verification, password, upl
     });
 });
 
+test('mobile profile exposes a persistent shortcut to Family workflows', async ({ page, baseURL }) => {
+    const user = {
+        uid: 'user-1',
+        email: 'parent@example.com',
+        displayName: 'Pat Parent',
+        roles: ['parent'],
+        parentOf: [{ teamId: 'team-1', playerId: 'player-1' }]
+    };
+    await mockAppModules(page, { user });
+    await page.goto(appUrl(baseURL, '/profile'), { waitUntil: 'domcontentloaded' });
+
+    const familyShortcut = page.getByRole('link', { name: 'Open Family workflows' });
+    await expect(familyShortcut).toBeVisible();
+    await familyShortcut.click();
+    await expect(page.getByRole('heading', { name: 'Family workflows' })).toBeVisible();
+});
+
 test('profile keeps destructive alert actions disabled until a failed team load retries successfully', async ({ page, baseURL }) => {
     const user = {
         uid: 'user-1',

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -612,6 +612,25 @@ test('parent tools hub completes access, fees, calendars, share, registration, a
     await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
 });
 
+test.describe('desktop Family navigation', () => {
+    test.use({ viewport: { width: 1280, height: 900 }, hasTouch: false });
+
+    test('keeps Family in persistent navigation and active for nested tools', async ({ page, baseURL }) => {
+        await mockParentToolsModules(page);
+        await page.goto(appUrl(baseURL, '/parent-tools/fees'), { waitUntil: 'domcontentloaded' });
+
+        const primaryNav = page.getByRole('navigation', { name: 'Primary navigation' });
+        const familyLink = primaryNav.getByRole('link', { name: 'Family' });
+        await expect(familyLink).toBeVisible();
+        await expect(familyLink).toHaveClass(/bg-primary-50/);
+
+        await primaryNav.getByRole('link', { name: 'My Teams' }).click();
+        await expect(page).toHaveURL(/#\/teams$/);
+        await primaryNav.getByRole('link', { name: 'Family' }).click();
+        await expect(page.getByRole('heading', { name: 'Family workflows' })).toBeVisible();
+    });
+});
+
 test('parent fees workflow renders payment states and blocks overlapping checkout', async ({ page, baseURL }) => {
     await mockParentToolsModules(page);
     await page.addInitScript(() => {


### PR DESCRIPTION
## What changed
- adds a persistent **Family** destination to the signed-in desktop navigation
- keeps the compact six-item mobile bottom bar and exposes Family workflows through a persistent Profile shortcut
- keeps Family active while visiting nested tools such as fees, calendars, sharing, registration, and awards
- leaves signed-out navigation unchanged

## Why
Parents currently have to discover Family workflows indirectly. This creates a predictable desktop entry point without overcrowding mobile navigation.

## QA
- `cd apps/app && npx vitest run src/components/AppShell.test.tsx src/pages/Profile.test.tsx src/pages/ParentTools.test.tsx --reporter=dot` (88 passed)
- affected root Profile suites (34 passed)
- remaining notification-function suites after installing function dependencies (10 passed)
- `npm run app:build`
- Playwright Family navigation smoke scenarios (2 passed)
- full root suite reached 4,251 passes before identifying the strict icon-mock issue and missing isolated-worktree function dependency; both causes were corrected and their affected suites pass

Closes #4016