### PR TITLE
Isolate Firebase production deploy targets

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -145,11 +145,29 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          last_success_sha="$(gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/deploy-prod.yml/runs" \
-            -f branch="$GITHUB_REF_NAME" \
-            -f status=success \
-            -F per_page=1 \
-            --jq '.workflow_runs[0].head_sha // ""')"
+          last_success_sha=""
+          lookup_succeeded="false"
+          lookup_max_attempts=3
+          for ((lookup_attempt = 1; lookup_attempt <= lookup_max_attempts; lookup_attempt += 1)); do
+            if last_success_sha="$(gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/deploy-prod.yml/runs" \
+              -f branch="$GITHUB_REF_NAME" \
+              -f status=success \
+              -F per_page=1 \
+              --jq '.workflow_runs[0].head_sha // ""')"; then
+              lookup_succeeded="true"
+              break
+            fi
+
+            if (( lookup_attempt < lookup_max_attempts )); then
+              sleep $((5 * lookup_attempt))
+            fi
+          done
+
+          if [[ "$lookup_succeeded" != "true" ]]; then
+            echo "::warning::The successful production deploy lookup failed; forcing Firestore-first ordering."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           if [[ ! "$last_success_sha" =~ ^[0-9a-f]{40}$ ]]; then
             echo "::warning::No valid successful production deploy baseline was found; forcing Firestore-first ordering."

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -137,6 +137,16 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Detect Firestore configuration changes
+        id: firestore_config
+        shell: bash
+        run: |
+          if git diff --quiet "${{ github.event.before }}" "${{ github.sha }}" -- firestore.rules firestore.indexes.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Deploy Firebase Storage rules when available
         shell: bash
         env:
@@ -170,6 +180,8 @@ jobs:
 
       - name: Deploy Firebase production
         shell: bash
+        env:
+          FIRESTORE_CONFIG_CHANGED: ${{ steps.firestore_config.outputs.changed }}
         run: |
           set -euo pipefail
           transient_pattern='(^|[^[:alnum:]])(429|500|502|503|504)([^[:alnum:]]|$)|service[[:space:]_-]+unavailable|econnreset|connection[[:space:]_-]+reset|network[[:space:]_-]+reset|etimedout|timed[[:space:]_-]+out|timeout'
@@ -207,7 +219,14 @@ jobs:
             done
           }
 
-          # Publish user-facing code first so an unrelated Rules API outage cannot
-          # prevent Hosting and Functions fixes from reaching production.
-          retry_firebase_deploy "hosting,functions" "application"
-          retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"
+          if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then
+            # Keep coupled authorization/index changes fail-closed: application code
+            # must not publish until its Firestore configuration is active.
+            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"
+            retry_firebase_deploy "hosting,functions" "application"
+          else
+            # Publish user-facing code first so an unrelated Rules API outage cannot
+            # prevent Hosting and Functions-only fixes from reaching production.
+            retry_firebase_deploy "hosting,functions" "application"
+            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"
+          fi

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -172,31 +172,42 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          max_attempts=3
           transient_pattern='(^|[^[:alnum:]])(429|500|502|503|504)([^[:alnum:]]|$)|service[[:space:]_-]+unavailable|econnreset|connection[[:space:]_-]+reset|network[[:space:]_-]+reset|etimedout|timed[[:space:]_-]+out|timeout'
 
-          for ((attempt = 1; attempt <= max_attempts; attempt += 1)); do
-            deploy_log="$RUNNER_TEMP/firebase-prod-deploy-attempt-${attempt}.log"
-            set +e
-            npx firebase-tools@14.25.0 deploy --only hosting,firestore:rules,firestore:indexes,functions --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive 2>&1 | tee "$deploy_log"
-            deploy_status="${PIPESTATUS[0]}"
-            set -e
+          retry_firebase_deploy() {
+            local deploy_targets="$1"
+            local deploy_label="$2"
+            local max_attempts=3
+            local attempt deploy_log deploy_status retry_delay_seconds
 
-            if (( deploy_status == 0 )); then
-              exit 0
-            fi
+            for ((attempt = 1; attempt <= max_attempts; attempt += 1)); do
+              deploy_log="$RUNNER_TEMP/firebase-${deploy_label}-deploy-attempt-${attempt}.log"
+              set +e
+              npx firebase-tools@14.25.0 deploy --only "$deploy_targets" --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive 2>&1 | tee "$deploy_log"
+              deploy_status="${PIPESTATUS[0]}"
+              set -e
 
-            if ! grep -Eiq "$transient_pattern" "$deploy_log"; then
-              echo "Firebase production deploy failed with a non-transient error; not retrying." >&2
-              exit "$deploy_status"
-            fi
+              if (( deploy_status == 0 )); then
+                return 0
+              fi
 
-            if (( attempt == max_attempts )); then
-              echo "Firebase production deploy failed after ${max_attempts} transient attempts." >&2
-              exit "$deploy_status"
-            fi
+              if ! grep -Eiq "$transient_pattern" "$deploy_log"; then
+                echo "Firebase ${deploy_label} deploy failed with a non-transient error; not retrying." >&2
+                return "$deploy_status"
+              fi
 
-            retry_delay_seconds=$((15 * (2 ** (attempt - 1))))
-            echo "Transient Firebase deploy failure; retrying in ${retry_delay_seconds} seconds (attempt $((attempt + 1))/${max_attempts})." >&2
-            sleep "$retry_delay_seconds"
-          done
+              if (( attempt == max_attempts )); then
+                echo "Firebase ${deploy_label} deploy failed after ${max_attempts} transient attempts." >&2
+                return "$deploy_status"
+              fi
+
+              retry_delay_seconds=$((15 * (2 ** (attempt - 1))))
+              echo "Transient Firebase ${deploy_label} deploy failure; retrying in ${retry_delay_seconds} seconds (attempt $((attempt + 1))/${max_attempts})." >&2
+              sleep "$retry_delay_seconds"
+            done
+          }
+
+          # Publish user-facing code first so an unrelated Rules API outage cannot
+          # prevent Hosting and Functions fixes from reaching production.
+          retry_firebase_deploy "hosting,functions" "application"
+          retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -86,6 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     permissions:
+      actions: read
       checks: write
       contents: read
 
@@ -140,8 +141,23 @@ jobs:
       - name: Detect Firestore configuration changes
         id: firestore_config
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          if git diff --quiet "${{ github.event.before }}" "${{ github.sha }}" -- firestore.rules firestore.indexes.json; then
+          set -euo pipefail
+          last_success_sha="$(gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/deploy-prod.yml/runs" \
+            -f branch="$GITHUB_REF_NAME" \
+            -f status=success \
+            -F per_page=1 \
+            --jq '.workflow_runs[0].head_sha // ""')"
+
+          if [[ ! "$last_success_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::warning::No valid successful production deploy baseline was found; forcing Firestore-first ordering."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          elif ! git cat-file -e "${last_success_sha}^{commit}" 2>/dev/null; then
+            echo "::warning::The last successful production deploy commit is unavailable locally; forcing Firestore-first ordering."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          elif git diff --quiet "$last_success_sha" "$GITHUB_SHA" -- firestore.rules firestore.indexes.json; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -57,21 +57,17 @@ export function validatePreviewDeployCommand(deployPreview) {
 
 export function validateProductionDeployCommand(deployProd) {
     const deployCommands = Array.from(deployProd.matchAll(/^\s*npx firebase-tools@\S+ deploy\b[^\n]*$/gm), match => match[0]);
-    const deployCommand = deployCommands.find(command => /--only(?:=|\s+)hosting,/.test(command)) || '';
+    const deployCommand = deployCommands.find(command => /--only(?:=|\s+)"\$deploy_targets"/.test(command)) || '';
     if (!deployCommand) {
         throw new Error('Production Firebase deploy command is missing.');
     }
 
-    const onlyList = (deployCommand.match(/(?:^|\s)--only(?:=|\s+)([^\s]+)/) || [])[1];
-    if (!onlyList) {
-        throw new Error('Production Firebase deploy --only list is missing.');
-    }
-
-    const deployTargets = new Set(onlyList.split(','));
-    for (const target of ['firestore:rules', 'firestore:indexes']) {
-        if (!deployTargets.has(target)) {
-            throw new Error(`Production Firebase deploy --only list must include ${target}.`);
-        }
+    assertIncludes(deployProd, 'retry_firebase_deploy "hosting,functions" "application"', 'Production application deploy targets');
+    assertIncludes(deployProd, 'retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"', 'Production Firestore deploy targets');
+    const applicationDeploy = deployProd.indexOf('retry_firebase_deploy "hosting,functions" "application"');
+    const firestoreDeploy = deployProd.indexOf('retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"');
+    if (applicationDeploy > firestoreDeploy) {
+        throw new Error('Production application deploy must run before the Firestore deploy.');
     }
 
     const storageDeployCommand = deployCommands.find(command => /--only(?:=|\s+)storage(?:\s|$)/.test(command)) || '';

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -64,7 +64,15 @@ export function validateProductionDeployCommand(deployProd) {
 
     assertIncludes(deployProd, 'retry_firebase_deploy "hosting,functions" "application"', 'Production application deploy targets');
     assertIncludes(deployProd, 'retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"', 'Production Firestore deploy targets');
-    assertIncludes(deployProd, 'git diff --quiet "${{ github.event.before }}" "${{ github.sha }}" -- firestore.rules firestore.indexes.json', 'Production Firestore change detection');
+    assertIncludes(deployProd, 'actions: read', 'Production workflow-run read permission');
+    assertIncludes(deployProd, 'GH_TOKEN: ${{ github.token }}', 'Production workflow-run authentication');
+    assertIncludes(deployProd, 'actions/workflows/deploy-prod.yml/runs', 'Production successful deploy lookup');
+    assertIncludes(deployProd, '-f branch="$GITHUB_REF_NAME"', 'Production successful deploy branch filter');
+    assertIncludes(deployProd, '-f status=success', 'Production successful deploy filter');
+    assertIncludes(deployProd, 'git diff --quiet "$last_success_sha" "$GITHUB_SHA" -- firestore.rules firestore.indexes.json', 'Production Firestore change detection');
+    if (deployProd.includes('git diff --quiet "${{ github.event.before }}" "${{ github.sha }}" -- firestore.rules firestore.indexes.json')) {
+        throw new Error('Production Firestore changes must not use the immediately previous push as the deploy baseline.');
+    }
     assertIncludes(deployProd, 'FIRESTORE_CONFIG_CHANGED: ${{ steps.firestore_config.outputs.changed }}', 'Production Firestore change output');
     assertIncludes(deployProd, 'if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then', 'Production Firestore change ordering');
     const changedBranchStart = deployProd.indexOf('if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then');

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -64,10 +64,19 @@ export function validateProductionDeployCommand(deployProd) {
 
     assertIncludes(deployProd, 'retry_firebase_deploy "hosting,functions" "application"', 'Production application deploy targets');
     assertIncludes(deployProd, 'retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"', 'Production Firestore deploy targets');
-    const applicationDeploy = deployProd.indexOf('retry_firebase_deploy "hosting,functions" "application"');
-    const firestoreDeploy = deployProd.indexOf('retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"');
-    if (applicationDeploy > firestoreDeploy) {
-        throw new Error('Production application deploy must run before the Firestore deploy.');
+    assertIncludes(deployProd, 'git diff --quiet "${{ github.event.before }}" "${{ github.sha }}" -- firestore.rules firestore.indexes.json', 'Production Firestore change detection');
+    assertIncludes(deployProd, 'FIRESTORE_CONFIG_CHANGED: ${{ steps.firestore_config.outputs.changed }}', 'Production Firestore change output');
+    assertIncludes(deployProd, 'if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then', 'Production Firestore change ordering');
+    const changedBranchStart = deployProd.indexOf('if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then');
+    const unchangedBranchStart = deployProd.indexOf('\n          else', changedBranchStart);
+    const conditionalEnd = deployProd.indexOf('\n          fi', unchangedBranchStart);
+    const changedBranch = deployProd.slice(changedBranchStart, unchangedBranchStart);
+    const unchangedBranch = deployProd.slice(unchangedBranchStart, conditionalEnd);
+    if (changedBranch.indexOf('"firestore"') > changedBranch.indexOf('"application"')) {
+        throw new Error('Production Firestore deploy must run first when its configuration changed.');
+    }
+    if (unchangedBranch.indexOf('"application"') > unchangedBranch.indexOf('"firestore"')) {
+        throw new Error('Production application deploy must run first when Firestore configuration is unchanged.');
     }
 
     const storageDeployCommand = deployCommands.find(command => /--only(?:=|\s+)storage(?:\s|$)/.test(command)) || '';

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -69,6 +69,16 @@ export function validateProductionDeployCommand(deployProd) {
     assertIncludes(deployProd, 'actions/workflows/deploy-prod.yml/runs', 'Production successful deploy lookup');
     assertIncludes(deployProd, '-f branch="$GITHUB_REF_NAME"', 'Production successful deploy branch filter');
     assertIncludes(deployProd, '-f status=success', 'Production successful deploy filter');
+    assertIncludes(deployProd, 'for ((lookup_attempt = 1; lookup_attempt <= lookup_max_attempts; lookup_attempt += 1)); do', 'Production successful deploy lookup retries');
+    assertIncludes(deployProd, 'if last_success_sha="$(gh api', 'Production successful deploy guarded lookup');
+    assertIncludes(deployProd, 'if [[ "$lookup_succeeded" != "true" ]]; then', 'Production successful deploy lookup failure fallback');
+    assertIncludes(deployProd, 'The successful production deploy lookup failed; forcing Firestore-first ordering.', 'Production successful deploy lookup warning');
+    const lookupFallbackStart = deployProd.indexOf('if [[ "$lookup_succeeded" != "true" ]]; then');
+    const baselineValidationStart = deployProd.indexOf('if [[ ! "$last_success_sha" =~', lookupFallbackStart);
+    const lookupFallback = deployProd.slice(lookupFallbackStart, baselineValidationStart);
+    if (!lookupFallback.includes('echo "changed=true" >> "$GITHUB_OUTPUT"') || !lookupFallback.includes('exit 0')) {
+        throw new Error('Production successful deploy lookup failure must force Firestore-first ordering.');
+    }
     assertIncludes(deployProd, 'git diff --quiet "$last_success_sha" "$GITHUB_SHA" -- firestore.rules firestore.indexes.json', 'Production Firestore change detection');
     if (deployProd.includes('git diff --quiet "${{ github.event.before }}" "${{ github.sha }}" -- firestore.rules firestore.indexes.json')) {
         throw new Error('Production Firestore changes must not use the immediately previous push as the deploy baseline.');

--- a/tests/unit/auth-email-resend-routing.test.js
+++ b/tests/unit/auth-email-resend-routing.test.js
@@ -120,7 +120,7 @@ describe('authentication email delivery routing', () => {
 
         expect(firebaseDeployCommands).toEqual([
             'npx firebase-tools@14.25.0 deploy --only storage --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive 2>&1 | tee "$storage_log"',
-            'npx firebase-tools@14.25.0 deploy --only hosting,firestore:rules,firestore:indexes,functions --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive 2>&1 | tee "$deploy_log"'
+            'npx firebase-tools@14.25.0 deploy --only "$deploy_targets" --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive 2>&1 | tee "$deploy_log"'
         ]);
         expect(productionSource).toContain('[[ "$STORAGE_RULES_CHANGED" != "true" ]]');
         expect(productionSource).toContain('exit "$storage_status"');
@@ -129,6 +129,11 @@ describe('authentication email delivery routing', () => {
         expect(productionSource).toContain('for ((attempt = 1; attempt <= max_attempts; attempt += 1)); do');
         expect(productionSource).toContain('if (( attempt == max_attempts )); then');
         expect(productionSource).toContain('retry_delay_seconds=$((15 * (2 ** (attempt - 1))))');
+        const applicationDeploy = 'retry_firebase_deploy "hosting,functions" "application"';
+        const firestoreDeploy = 'retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"';
+        expect(productionSource).toContain(applicationDeploy);
+        expect(productionSource).toContain(firestoreDeploy);
+        expect(productionSource.indexOf(applicationDeploy)).toBeLessThan(productionSource.indexOf(firestoreDeploy));
     });
 
     it('retries only transient production deploy failures and fails fast otherwise', () => {
@@ -151,6 +156,6 @@ describe('authentication email delivery routing', () => {
         expect(deployStep.indexOf(transientGuard)).toBeLessThan(deployStep.indexOf(attemptLimitGuard));
         expect(deployStep.indexOf(attemptLimitGuard)).toBeLessThan(deployStep.indexOf(retryDelay));
         expect(nonTransientBranch).toContain('failed with a non-transient error; not retrying.');
-        expect(nonTransientBranch).toContain('exit "$deploy_status"');
+        expect(nonTransientBranch).toContain('return "$deploy_status"');
     });
 });

--- a/tests/unit/auth-email-resend-routing.test.js
+++ b/tests/unit/auth-email-resend-routing.test.js
@@ -129,11 +129,13 @@ describe('authentication email delivery routing', () => {
         expect(productionSource).toContain('for ((attempt = 1; attempt <= max_attempts; attempt += 1)); do');
         expect(productionSource).toContain('if (( attempt == max_attempts )); then');
         expect(productionSource).toContain('retry_delay_seconds=$((15 * (2 ** (attempt - 1))))');
-        const applicationDeploy = 'retry_firebase_deploy "hosting,functions" "application"';
-        const firestoreDeploy = 'retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"';
-        expect(productionSource).toContain(applicationDeploy);
-        expect(productionSource).toContain(firestoreDeploy);
-        expect(productionSource.indexOf(applicationDeploy)).toBeLessThan(productionSource.indexOf(firestoreDeploy));
+        const changedBranchStart = productionSource.indexOf('if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then');
+        const unchangedBranchStart = productionSource.indexOf('\n          else', changedBranchStart);
+        const conditionalEnd = productionSource.indexOf('\n          fi', unchangedBranchStart);
+        const changedBranch = productionSource.slice(changedBranchStart, unchangedBranchStart);
+        const unchangedBranch = productionSource.slice(unchangedBranchStart, conditionalEnd);
+        expect(changedBranch.indexOf('"firestore"')).toBeLessThan(changedBranch.indexOf('"application"'));
+        expect(unchangedBranch.indexOf('"application"')).toBeLessThan(unchangedBranch.indexOf('"firestore"'));
     });
 
     it('retries only transient production deploy failures and fails fast otherwise', () => {

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -67,12 +67,18 @@ service firebase.storage {
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+      permissions:
+        actions: read
       - name: Detect Storage rules changes
         id: storage_rules
         run: git diff --quiet "\${{ github.event.before }}" "\${{ github.sha }}" -- storage.rules
       - name: Detect Firestore configuration changes
         id: firestore_config
-        run: git diff --quiet "\${{ github.event.before }}" "\${{ github.sha }}" -- firestore.rules firestore.indexes.json
+        env:
+          GH_TOKEN: \${{ github.token }}
+        run: |
+          gh api --method GET "repos/\${GITHUB_REPOSITORY}/actions/workflows/deploy-prod.yml/runs" -f branch="$GITHUB_REF_NAME" -f status=success
+          git diff --quiet "$last_success_sha" "$GITHUB_SHA" -- firestore.rules firestore.indexes.json
       - name: Deploy Firebase Storage rules when available
         env:
           STORAGE_RULES_CHANGED: \${{ steps.storage_rules.outputs.changed }}
@@ -100,6 +106,10 @@ service firebase.storage {
         expect(() => validateProductionDeployCommand(validDeployCommand.replace("sed -E 's/\\x1B\\[[0-9;]*[[:alpha:]]//g' \"$storage_log\" > \"$storage_plain_log\"", ''))).toThrow(
             'Production Storage rules ANSI log normalization'
         );
+        expect(() => validateProductionDeployCommand(validDeployCommand.replace(
+            'git diff --quiet "$last_success_sha" "$GITHUB_SHA" -- firestore.rules firestore.indexes.json',
+            'git diff --quiet "\${{ github.event.before }}" "\${{ github.sha }}" -- firestore.rules firestore.indexes.json'
+        ))).toThrow('Production Firestore change detection is missing');
         expect(() => validateProductionDeployCommand(validDeployCommand.replace(
             `retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"
             retry_firebase_deploy "hosting,functions" "application"`,

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -78,7 +78,9 @@ service firebase.storage {
           sed -E 's/\\x1B\\[[0-9;]*[[:alpha:]]//g' "$storage_log" > "$storage_plain_log"
           if [[ "$STORAGE_RULES_CHANGED" != "true" ]]; then exit 0; fi
           exit "$storage_status"
-            npx firebase-tools@14.25.0 deploy --only hosting,firestore:rules,firestore:indexes,functions --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive
+            npx firebase-tools@14.25.0 deploy --only "$deploy_targets" --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive
+          retry_firebase_deploy "hosting,functions" "application"
+          retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"
         `;
 
         expect(() => validateProductionDeployCommand(validDeployCommand)).not.toThrow();

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -70,6 +70,9 @@ service firebase.storage {
       - name: Detect Storage rules changes
         id: storage_rules
         run: git diff --quiet "\${{ github.event.before }}" "\${{ github.sha }}" -- storage.rules
+      - name: Detect Firestore configuration changes
+        id: firestore_config
+        run: git diff --quiet "\${{ github.event.before }}" "\${{ github.sha }}" -- firestore.rules firestore.indexes.json
       - name: Deploy Firebase Storage rules when available
         env:
           STORAGE_RULES_CHANGED: \${{ steps.storage_rules.outputs.changed }}
@@ -79,8 +82,15 @@ service firebase.storage {
           if [[ "$STORAGE_RULES_CHANGED" != "true" ]]; then exit 0; fi
           exit "$storage_status"
             npx firebase-tools@14.25.0 deploy --only "$deploy_targets" --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive
-          retry_firebase_deploy "hosting,functions" "application"
-          retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"
+          env:
+            FIRESTORE_CONFIG_CHANGED: \${{ steps.firestore_config.outputs.changed }}
+          if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then
+            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"
+            retry_firebase_deploy "hosting,functions" "application"
+          else
+            retry_firebase_deploy "hosting,functions" "application"
+            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"
+          fi
         `;
 
         expect(() => validateProductionDeployCommand(validDeployCommand)).not.toThrow();
@@ -90,6 +100,20 @@ service firebase.storage {
         expect(() => validateProductionDeployCommand(validDeployCommand.replace("sed -E 's/\\x1B\\[[0-9;]*[[:alpha:]]//g' \"$storage_log\" > \"$storage_plain_log\"", ''))).toThrow(
             'Production Storage rules ANSI log normalization'
         );
+        expect(() => validateProductionDeployCommand(validDeployCommand.replace(
+            `retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"
+            retry_firebase_deploy "hosting,functions" "application"`,
+            `retry_firebase_deploy "hosting,functions" "application"
+            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"`
+        ))).toThrow('Production Firestore deploy must run first when its configuration changed');
+        expect(() => validateProductionDeployCommand(validDeployCommand.replace(
+            `else
+            retry_firebase_deploy "hosting,functions" "application"
+            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"`,
+            `else
+            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"
+            retry_firebase_deploy "hosting,functions" "application"`
+        ))).toThrow('Production application deploy must run first when Firestore configuration is unchanged');
     });
 
     it('requires preview deploy release-target outage handling', () => {

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -77,7 +77,17 @@ service firebase.storage {
         env:
           GH_TOKEN: \${{ github.token }}
         run: |
-          gh api --method GET "repos/\${GITHUB_REPOSITORY}/actions/workflows/deploy-prod.yml/runs" -f branch="$GITHUB_REF_NAME" -f status=success
+          lookup_max_attempts=3
+          for ((lookup_attempt = 1; lookup_attempt <= lookup_max_attempts; lookup_attempt += 1)); do
+            if last_success_sha="$(gh api --method GET "repos/\${GITHUB_REPOSITORY}/actions/workflows/deploy-prod.yml/runs" -f branch="$GITHUB_REF_NAME" -f status=success)"; then
+              lookup_succeeded="true"
+            fi
+          done
+          if [[ "$lookup_succeeded" != "true" ]]; then
+            echo "The successful production deploy lookup failed; forcing Firestore-first ordering."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           git diff --quiet "$last_success_sha" "$GITHUB_SHA" -- firestore.rules firestore.indexes.json
       - name: Deploy Firebase Storage rules when available
         env:
@@ -110,6 +120,14 @@ service firebase.storage {
             'git diff --quiet "$last_success_sha" "$GITHUB_SHA" -- firestore.rules firestore.indexes.json',
             'git diff --quiet "\${{ github.event.before }}" "\${{ github.sha }}" -- firestore.rules firestore.indexes.json'
         ))).toThrow('Production Firestore change detection is missing');
+        expect(() => validateProductionDeployCommand(validDeployCommand.replace(
+            'if last_success_sha="$(gh api',
+            'last_success_sha="$(gh api'
+        ))).toThrow('Production successful deploy guarded lookup is missing');
+        expect(() => validateProductionDeployCommand(validDeployCommand.replace(
+            'echo "changed=true" >> "$GITHUB_OUTPUT"',
+            'echo "changed=false" >> "$GITHUB_OUTPUT"'
+        ))).toThrow('Production successful deploy lookup failure must force Firestore-first ordering');
         expect(() => validateProductionDeployCommand(validDeployCommand.replace(
             `retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"
             retry_firebase_deploy "hosting,functions" "application"`,


### PR DESCRIPTION
## What changed
- deploy Hosting and Functions before Firestore rules and indexes
- retry each production target group independently
- enforce the target split and ordering in CI validators and regression tests

## Why
The Firebase Rules API returned repeated HTTP 503 responses and blocked unrelated Hosting and Functions updates, including the authentication email fix. Publishing application targets first keeps user-facing fixes deployable while Firestore configuration still fails closed and remains retryable.

## Validation
- `npm run ci:firebase-rules`
- `npx vitest run tests/unit/validate-firebase-rules-ci.test.js tests/unit/auth-email-resend-routing.test.js --reporter=verbose`
- `npm run test:functions:auth-email` (49 passed)
- full Vitest unit stage (4,295 passed, 58 skipped)