### PR TITLE
Make paid checkout fulfillment server-authoritative

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2969,11 +2969,15 @@ service cloud.firestore {
               'providerCustomerId', 'providerSubscriptionId', 'billingEmail'
             ])
           );
+        // Team admins may stage or deactivate non-active records, but only a
+        // trusted Admin SDK path (for example the verified Stripe webhook) may
+        // create or preserve an active paid entitlement. Admin SDK writes
+        // bypass these client rules; existing active entitlements remain readable.
         allow create, update: if isTeamOwnerOrAdmin(teamId) &&
           request.resource.data.teamId == teamId &&
           request.resource.data.seasonId is string &&
           request.resource.data.tier == 'team-pass' &&
-          request.resource.data.status in ['active', 'inactive', 'expired', 'cancelled'];
+          request.resource.data.status in ['inactive', 'expired', 'cancelled'];
         allow delete: if isTeamOwnerOrAdmin(teamId);
       }
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -30,6 +30,10 @@ const {
   buildTeamFeePaidUpdate,
   buildTeamFeeStripeRefundUpdate
 } = require('./team-fees-core.cjs');
+const {
+  getRegistrationPaidCheckoutGuardFailure,
+  normalizeRegistrationCheckoutCurrency
+} = require('./registration-payment-webhook-core.cjs');
 const { createFirestoreFixedWindowRateLimiter, createInMemoryRateLimiter, getRequestIp } = require('./rate-limit.cjs');
 const { buildPublicGamesIcs, canExposeEmptyPublicFeed, isPublicFanGame } = require('./public-calendar-core.cjs');
 const { buildCalendarFeedGamesQuery } = require('./calendar-feed-window-core.cjs');
@@ -1140,6 +1144,15 @@ function getRegistrationCheckoutAmountCents(registration = {}, form = null) {
     return Math.max(0, Math.round(Number(installmentState.currentInstallment?.amountCents || 0) || 0));
   }
   return Math.max(0, Math.round(Number(registration.feeSnapshot?.finalAmountDueCents ?? registration.feeAmountCents ?? 0)));
+}
+
+function getRegistrationCheckoutCurrency(registration = {}, form = null) {
+  return normalizeRegistrationCheckoutCurrency(
+    form?.currency
+      || registration.feeSnapshot?.currency
+      || registration.currency
+      || 'usd'
+  ) || 'usd';
 }
 
 function getRegistrationCustomerEmail(registration = {}) {
@@ -4211,9 +4224,7 @@ exports.createStripeRegistrationCheckout = functions.https.onCall(async (data) =
   if (!Number.isFinite(amountCents) || amountCents <= 0) {
     throw new functions.https.HttpsError('failed-precondition', 'This registration does not have a payment due.');
   }
-  const currency = String(
-    form.currency || registration.feeSnapshot?.currency || registration.currency || 'usd'
-  ).trim().toLowerCase() || 'usd';
+  const currency = getRegistrationCheckoutCurrency(registration, form);
   if (!registrationCheckoutAuthorityMatches(registration, resolvedInput)) {
     throw new functions.https.HttpsError('failed-precondition', 'Current public checkout capability is required.');
   }
@@ -4344,6 +4355,7 @@ exports.createStripeRegistrationCheckout = functions.https.onCall(async (data) =
       stripeCheckoutSessionId: session.id,
       stripePaymentStatus: session.payment_status || 'unpaid',
       checkoutAmountCents: amountCents,
+      checkoutCurrency: currency,
       checkoutAttemptToken: input.checkoutAttemptToken || null,
       publicCheckoutCapabilityHash: hashPublicCheckoutCapability(issuedPublicCheckoutCapability),
       checkoutCreatedAt: now,
@@ -4431,6 +4443,26 @@ exports.stripeTeamPassWebhook = functions.https.onRequest(async (req, res) => {
         const form = formSnap.data() || {};
         const registration = registrationSnap.data() || {};
         if (shouldMarkRegistrationPaidFromEvent(event)) {
+          const paidCheckoutGuardFailure = getRegistrationPaidCheckoutGuardFailure({
+            registration,
+            session,
+            authorityMatches: registrationCheckoutAuthorityMatches(registration, registrationInput),
+            expectedCurrency: getRegistrationCheckoutCurrency(registration, form)
+          });
+          if (paidCheckoutGuardFailure) {
+            transaction.set(eventRef, {
+              provider: 'stripe',
+              product: 'registration',
+              type: event.type,
+              checkoutSessionId: session.id || null,
+              registrationPath: registrationRef.path,
+              ignored: true,
+              ignoredReason: paidCheckoutGuardFailure,
+              receivedAt
+            });
+            return;
+          }
+
           if (registration.paymentPlan?.id === 'installments' && form.installmentPlan?.enabled === true) {
             const nextPaidInstallmentCount = getRegistrationPaymentPlanPaidInstallmentCount(registration) + 1;
             const installmentState = buildRegistrationInstallmentPaymentState(registration, form, nextPaidInstallmentCount);
@@ -4445,6 +4477,7 @@ exports.stripeTeamPassWebhook = functions.https.onRequest(async (req, res) => {
               stripePaymentIntentId: session.payment_intent || null,
               stripePaymentStatus: session.payment_status || 'paid',
               stripeEventId: event.id,
+              lastPaidStripeCheckoutSessionId: session.id,
               paymentPlan: {
                 ...registration.paymentPlan,
                 totalBalanceDueCents: installmentState.totalBalanceDueCents,
@@ -4469,6 +4502,7 @@ exports.stripeTeamPassWebhook = functions.https.onRequest(async (req, res) => {
               stripePaymentIntentId: session.payment_intent || null,
               stripePaymentStatus: session.payment_status || 'paid',
               stripeEventId: event.id,
+              lastPaidStripeCheckoutSessionId: session.id,
               updatedAt: receivedAt
             }, { merge: true });
             transaction.update(registrationRef, buildRegistrationReminderStopUpdate({ reason: 'paid', nowIso: queuedAtIso }));

--- a/functions/registration-payment-webhook-core.cjs
+++ b/functions/registration-payment-webhook-core.cjs
@@ -1,0 +1,64 @@
+'use strict';
+
+function normalizeString(value) {
+    return String(value || '').trim();
+}
+
+function normalizeCurrency(value) {
+    return normalizeString(value).toLowerCase();
+}
+
+function normalizePositiveInteger(value) {
+    const normalized = Number(value);
+    return Number.isSafeInteger(normalized) && normalized > 0 ? normalized : 0;
+}
+
+/**
+ * Returns a stable ignored reason when a signed Stripe paid event is not the
+ * authoritative, still-open checkout for the registration.
+ *
+ * Stripe signatures prove who sent an event, not that the Checkout Session is
+ * the registration's current payment attempt. Session, authority, amount, and
+ * currency are therefore checked against server-persisted checkout state before
+ * any paid/installment mutation is applied.
+ */
+function getRegistrationPaidCheckoutGuardFailure({
+    registration = {},
+    session = {},
+    authorityMatches = false,
+    expectedCurrency = ''
+} = {}) {
+    const activeSessionId = normalizeString(registration.stripeCheckoutSessionId);
+    const sessionId = normalizeString(session.id);
+    if (!activeSessionId || !sessionId || activeSessionId !== sessionId) {
+        return 'checkout_session_mismatch';
+    }
+
+    const lastPaidSessionId = normalizeString(registration.lastPaidStripeCheckoutSessionId);
+    if (lastPaidSessionId === sessionId || registration.checkoutStatus === 'complete' || registration.paymentStatus === 'paid') {
+        return 'checkout_session_already_processed';
+    }
+
+    if (authorityMatches !== true) {
+        return 'checkout_attempt_mismatch';
+    }
+
+    const expectedAmountCents = normalizePositiveInteger(registration.checkoutAmountCents);
+    const paidAmountCents = normalizePositiveInteger(session.amount_total);
+    if (!expectedAmountCents || !paidAmountCents || paidAmountCents !== expectedAmountCents) {
+        return 'checkout_amount_mismatch';
+    }
+
+    const storedCurrency = normalizeCurrency(registration.checkoutCurrency || expectedCurrency);
+    const paidCurrency = normalizeCurrency(session.currency);
+    if (!storedCurrency || !paidCurrency || storedCurrency !== paidCurrency) {
+        return 'checkout_currency_mismatch';
+    }
+
+    return '';
+}
+
+module.exports = {
+    getRegistrationPaidCheckoutGuardFailure,
+    normalizeRegistrationCheckoutCurrency: normalizeCurrency
+};

--- a/functions/test/public-registration-submission.test.cjs
+++ b/functions/test/public-registration-submission.test.cjs
@@ -810,6 +810,7 @@ test('records installment payment progress after Stripe marks the first installm
                 payment_status: 'paid',
                 payment_intent: 'pi_test_1',
                 amount_total: 4166,
+                currency: 'usd',
                 metadata: {
                     product: 'registration',
                     teamId: 'team-1',
@@ -838,6 +839,124 @@ test('records installment payment progress after Stripe marks the first installm
     assert.equal(registration.paymentPlan.paidInstallmentCount, 1);
     assert.equal(registration.paymentPlan.remainingBalanceCents, 8334);
     assert.equal(registration.paymentPlan.nextDueDate, '2026-07-31');
+});
+
+async function createInstallmentCheckoutFixture() {
+    const fixture = loadFunctionsModule(buildSeedState({
+        feeAmountCents: 12500,
+        paymentSettings: { offlinePaymentEnabled: true, onlineCheckoutEnabled: true },
+        installmentPlan: {
+            enabled: true,
+            title: 'Monthly installments',
+            installmentCount: 3,
+            firstDueDate: '2026-07-01',
+            intervalDays: 30
+        }
+    }));
+    const submission = await fixture.mod.submitPublicRegistration(buildSubmission({
+        selectedPaymentPlanId: 'installments',
+        checkoutAttemptToken: 'checkouttoken123456'
+    }), context);
+    await fixture.mod.createStripeRegistrationCheckout({
+        teamId: 'team-1',
+        formId: 'form-1',
+        registrationId: submission.registrationId,
+        checkoutAttemptToken: 'checkouttoken123456'
+    });
+    return {
+        ...fixture,
+        submission,
+        registrationPath: `teams/team-1/registrationForms/form-1/registrations/${submission.registrationId}`
+    };
+}
+
+function buildPaidInstallmentWebhookEvent({ eventId, registrationId, sessionId = 'cs_test_1', amountTotal = 4166, currency = 'usd' }) {
+    return {
+        id: eventId,
+        type: 'checkout.session.completed',
+        data: {
+            object: {
+                id: sessionId,
+                payment_status: 'paid',
+                payment_intent: `pi_${eventId}`,
+                amount_total: amountTotal,
+                currency,
+                metadata: {
+                    product: 'registration',
+                    teamId: 'team-1',
+                    formId: 'form-1',
+                    registrationId,
+                    checkoutAttemptToken: 'checkouttoken123456'
+                }
+            }
+        }
+    };
+}
+
+async function deliverStripeWebhook(mod) {
+    const response = createMockResponse();
+    await mod.stripeTeamPassWebhook({
+        method: 'POST',
+        rawBody: Buffer.from('event'),
+        headers: { 'stripe-signature': 'sig_test' }
+    }, response);
+    return response;
+}
+
+test('ignores a signed stale registration checkout success without advancing installments', async () => {
+    const { firestore, stripeState, mod, submission, registrationPath } = await createInstallmentCheckoutFixture();
+    stripeState.webhookEvent = buildPaidInstallmentWebhookEvent({
+        eventId: 'evt_installment_stale',
+        registrationId: submission.registrationId,
+        sessionId: 'cs_stale'
+    });
+
+    const response = await deliverStripeWebhook(mod);
+
+    assert.equal(response.statusCode, 200);
+    const registration = firestore.snapshot(registrationPath);
+    assert.equal(registration.paymentStatus, 'checkout_open');
+    assert.equal(Number(registration.paymentPlan.paidInstallmentCount || 0), 0);
+    assert.equal(registration.stripeCheckoutSessionId, 'cs_test_1');
+    assert.equal(firestore.snapshot('stripeEvents/evt_installment_stale').ignoredReason, 'checkout_session_mismatch');
+});
+
+test('ignores a signed registration checkout success with the wrong amount', async () => {
+    const { firestore, stripeState, mod, submission, registrationPath } = await createInstallmentCheckoutFixture();
+    stripeState.webhookEvent = buildPaidInstallmentWebhookEvent({
+        eventId: 'evt_installment_wrong_amount',
+        registrationId: submission.registrationId,
+        amountTotal: 1
+    });
+
+    const response = await deliverStripeWebhook(mod);
+
+    assert.equal(response.statusCode, 200);
+    const registration = firestore.snapshot(registrationPath);
+    assert.equal(registration.paymentStatus, 'checkout_open');
+    assert.equal(Number(registration.paymentPlan.paidInstallmentCount || 0), 0);
+    assert.equal(firestore.snapshot('stripeEvents/evt_installment_wrong_amount').ignoredReason, 'checkout_amount_mismatch');
+});
+
+test('deduplicates distinct paid events for one registration checkout session', async () => {
+    const { firestore, stripeState, mod, submission, registrationPath } = await createInstallmentCheckoutFixture();
+    stripeState.webhookEvent = buildPaidInstallmentWebhookEvent({
+        eventId: 'evt_installment_first_delivery',
+        registrationId: submission.registrationId
+    });
+    assert.equal((await deliverStripeWebhook(mod)).statusCode, 200);
+
+    stripeState.webhookEvent = buildPaidInstallmentWebhookEvent({
+        eventId: 'evt_installment_replay_distinct_event',
+        registrationId: submission.registrationId
+    });
+    assert.equal((await deliverStripeWebhook(mod)).statusCode, 200);
+
+    const registration = firestore.snapshot(registrationPath);
+    assert.equal(registration.paymentStatus, 'installment_in_progress');
+    assert.equal(registration.paymentPlan.paidInstallmentCount, 1);
+    assert.equal(registration.lastPaidStripeCheckoutSessionId, 'cs_test_1');
+    assert.equal(firestore.snapshot('stripeEvents/evt_installment_replay_distinct_event').ignoredReason, 'checkout_session_already_processed');
 });
 
 test('keeps capacity reserved when a later installment payment fails', async () => {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "vitest run tests/unit",
     "test:unit": "vitest run tests/unit",
     "test:unit:ci": "vitest run tests/unit --reporter=dot && npm run test:storage-rules:ci",
-    "test:storage-rules:ci": "firebase emulators:exec --only firestore,storage --project demo-allplays \"vitest run tests/unit/storage-rules-team-boundary.test.js tests/unit/player-rules-privacy.test.js tests/unit/private-ai-rules.test.js tests/unit/team-entitlement-rules.test.js tests/unit/team-email-send-rules.test.js --reporter=dot\"",
+    "test:storage-rules:ci": "firebase emulators:exec --only firestore,storage --project demo-allplays \"vitest run tests/unit/storage-rules-team-boundary.test.js tests/unit/player-rules-privacy.test.js tests/unit/private-ai-rules.test.js tests/unit/team-entitlement-rules.test.js tests/unit/team-email-send-rules.test.js --reporter=dot --maxWorkers=1\"",
     "test:coverage-map": "node scripts/report-test-coverage-map.mjs --check",
     "test:functions:notifications": "npm run test:notifications --prefix functions",
     "test:functions:auth-email": "node --test functions/test/auth-email-*.test.cjs",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "vitest run tests/unit",
     "test:unit": "vitest run tests/unit",
     "test:unit:ci": "vitest run tests/unit --reporter=dot && npm run test:storage-rules:ci",
-    "test:storage-rules:ci": "firebase emulators:exec --only firestore,storage --project demo-allplays \"vitest run tests/unit/storage-rules-team-boundary.test.js tests/unit/player-rules-privacy.test.js tests/unit/private-ai-rules.test.js tests/unit/team-email-send-rules.test.js --reporter=dot\"",
+    "test:storage-rules:ci": "firebase emulators:exec --only firestore,storage --project demo-allplays \"vitest run tests/unit/storage-rules-team-boundary.test.js tests/unit/player-rules-privacy.test.js tests/unit/private-ai-rules.test.js tests/unit/team-entitlement-rules.test.js tests/unit/team-email-send-rules.test.js --reporter=dot\"",
     "test:coverage-map": "node scripts/report-test-coverage-map.mjs --check",
     "test:functions:notifications": "npm run test:notifications --prefix functions",
     "test:functions:auth-email": "node --test functions/test/auth-email-*.test.cjs",

--- a/tests/unit/registration-flow.test.js
+++ b/tests/unit/registration-flow.test.js
@@ -774,14 +774,14 @@ describe('public registration flow', () => {
         expect(functionsSource).toContain("params.set('retryPayment', '1');");
         expect(functionsSource).toContain('reserveRegistrationCheckoutCapacityForRetry');
         expect(functionsSource).toContain('const amountCents = expectedAmountCents');
-        expect(functionsSource).toContain('form.currency || registration.feeSnapshot?.currency || registration.currency');
+        expect(functionsSource).toContain('form?.currency\n      || registration.feeSnapshot?.currency');
         expect(functionsSource).toContain("Current public checkout capability is required to retry this payment.");
         expect(functionsSource).toContain("This registration option is no longer available. Please restart registration or contact the organizer.");
         expect(functionsSource).toContain("Registration is currently unavailable. No registration options are available.");
         expect(functionsSource).toContain("reason: 'no-options-available'");
         expect(functionsSource).toContain("registrationCapacityReleased: false");
         expect(functionsSource).toContain("capacityReleasedAt: admin.firestore.FieldValue.delete()");
-        expect(functionsSource).toContain("const currency = String(");
+        expect(functionsSource).toContain('const currency = getRegistrationCheckoutCurrency(registration, form)');
         expect(functionsSource).toContain("form.paymentSettings?.onlineCheckoutEnabled !== true");
         expect(functionsSource).toContain("checkoutStatus: 'open'");
         expect(functionsSource).toContain("paymentStatus: 'checkout_open'");

--- a/tests/unit/registration-payment-webhook.test.js
+++ b/tests/unit/registration-payment-webhook.test.js
@@ -1,0 +1,97 @@
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const {
+    getRegistrationPaidCheckoutGuardFailure,
+    normalizeRegistrationCheckoutCurrency
+} = require('../../functions/registration-payment-webhook-core.cjs');
+
+const functionsSource = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
+
+function currentCheckout(overrides = {}) {
+    return {
+        registration: {
+            stripeCheckoutSessionId: 'cs_current',
+            checkoutStatus: 'open',
+            paymentStatus: 'checkout_open',
+            checkoutAmountCents: 7500,
+            checkoutCurrency: 'usd',
+            ...overrides.registration
+        },
+        session: {
+            id: 'cs_current',
+            amount_total: 7500,
+            currency: 'usd',
+            ...overrides.session
+        },
+        authorityMatches: overrides.authorityMatches ?? true,
+        expectedCurrency: overrides.expectedCurrency ?? 'usd'
+    };
+}
+
+describe('registration paid webhook guard', () => {
+    it('accepts only the current authoritative checkout with the exact recorded amount and currency', () => {
+        expect(getRegistrationPaidCheckoutGuardFailure(currentCheckout())).toBe('');
+    });
+
+    it('rejects stale sessions even when their signed metadata still has valid attempt authority', () => {
+        expect(getRegistrationPaidCheckoutGuardFailure(currentCheckout({
+            session: { id: 'cs_stale' }
+        }))).toBe('checkout_session_mismatch');
+    });
+
+    it('rejects replayed sessions before another installment can be advanced', () => {
+        expect(getRegistrationPaidCheckoutGuardFailure(currentCheckout({
+            registration: { lastPaidStripeCheckoutSessionId: 'cs_current' }
+        }))).toBe('checkout_session_already_processed');
+        expect(getRegistrationPaidCheckoutGuardFailure(currentCheckout({
+            registration: { checkoutStatus: 'complete' }
+        }))).toBe('checkout_session_already_processed');
+    });
+
+    it('rejects current sessions whose attempt authority no longer matches', () => {
+        expect(getRegistrationPaidCheckoutGuardFailure(currentCheckout({
+            authorityMatches: false
+        }))).toBe('checkout_attempt_mismatch');
+    });
+
+    it('rejects missing, non-integer, and mismatched paid amounts', () => {
+        expect(getRegistrationPaidCheckoutGuardFailure(currentCheckout({
+            session: { amount_total: 7400 }
+        }))).toBe('checkout_amount_mismatch');
+        expect(getRegistrationPaidCheckoutGuardFailure(currentCheckout({
+            session: { amount_total: 7500.5 }
+        }))).toBe('checkout_amount_mismatch');
+        expect(getRegistrationPaidCheckoutGuardFailure(currentCheckout({
+            registration: { checkoutAmountCents: null }
+        }))).toBe('checkout_amount_mismatch');
+    });
+
+    it('rejects missing or mismatched currency while supporting legacy records through the server-derived fallback', () => {
+        expect(getRegistrationPaidCheckoutGuardFailure(currentCheckout({
+            session: { currency: 'eur' }
+        }))).toBe('checkout_currency_mismatch');
+        expect(getRegistrationPaidCheckoutGuardFailure(currentCheckout({
+            session: { currency: null }
+        }))).toBe('checkout_currency_mismatch');
+        expect(getRegistrationPaidCheckoutGuardFailure(currentCheckout({
+            registration: { checkoutCurrency: null },
+            expectedCurrency: 'USD'
+        }))).toBe('');
+        expect(normalizeRegistrationCheckoutCurrency(' USD ')).toBe('usd');
+    });
+
+    it('wires the guard before registration installment or paid state mutations and persists checkout currency', () => {
+        const paidBranchStart = functionsSource.indexOf('if (shouldMarkRegistrationPaidFromEvent(event)) {');
+        const installmentMutation = functionsSource.indexOf('const nextPaidInstallmentCount', paidBranchStart);
+        const guardCall = functionsSource.indexOf('getRegistrationPaidCheckoutGuardFailure({', paidBranchStart);
+
+        expect(paidBranchStart).toBeGreaterThanOrEqual(0);
+        expect(guardCall).toBeGreaterThan(paidBranchStart);
+        expect(guardCall).toBeLessThan(installmentMutation);
+        expect(functionsSource).toContain('checkoutCurrency: currency,');
+        expect(functionsSource).toContain('lastPaidStripeCheckoutSessionId: session.id,');
+    });
+});

--- a/tests/unit/stripe-registration-fee-recompute.test.js
+++ b/tests/unit/stripe-registration-fee-recompute.test.js
@@ -146,9 +146,11 @@ describe('server-side registration fee recomputation (issue #2243)', () => {
         expect(source).not.toContain('input.amountCents ?? expectedAmountCents');
     });
 
-    it('currency is taken from the authoritative form document, not from client-submitted feeSnapshot', () => {
-        // currency should prefer form.currency over client-side feeSnapshot.currency
-        expect(source).toContain('form.currency || registration.feeSnapshot?.currency || registration.currency');
+    it('currency is taken from the authoritative form and recorded for webhook verification', () => {
+        expect(source).toContain('form?.currency\n      || registration.feeSnapshot?.currency');
+        expect(source).toContain('const currency = getRegistrationCheckoutCurrency(registration, form)');
+        expect(source).toContain('checkoutCurrency: currency,');
+        expect(source).not.toContain('input.currency ||');
     });
 
     it('the server-side fee helper recomputes the same amount as the client-side helper when the form has no discounts', () => {

--- a/tests/unit/team-entitlement-rules.test.js
+++ b/tests/unit/team-entitlement-rules.test.js
@@ -1,0 +1,98 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import {
+    assertFails,
+    assertSucceeds,
+    initializeTestEnvironment
+} from '@firebase/rules-unit-testing';
+import {
+    doc,
+    getDoc,
+    setDoc,
+    updateDoc
+} from 'firebase/firestore';
+
+const rules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
+
+function entitlementPayload(overrides = {}) {
+    return {
+        teamId: 'team-a',
+        seasonId: '2026',
+        tier: 'team-pass',
+        status: 'active',
+        ...overrides
+    };
+}
+
+describe('team entitlement Firestore rules', () => {
+    it('allows client management only when the resulting entitlement is not active', () => {
+        expect(rules).toContain("request.resource.data.status in ['inactive', 'expired', 'cancelled']");
+        expect(rules).not.toContain("request.resource.data.status in ['active', 'inactive', 'expired', 'cancelled']");
+    });
+
+    describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('emulator authorization coverage', () => {
+        let testEnv;
+
+        beforeAll(async () => {
+            testEnv = await initializeTestEnvironment({
+                projectId: `allplays-team-entitlements-${Date.now()}`,
+                firestore: { rules }
+            });
+        }, 30000);
+
+        beforeEach(async () => {
+            await testEnv.clearFirestore();
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                const firestore = context.firestore();
+                await setDoc(doc(firestore, 'teams/team-a'), {
+                    ownerId: 'owner-a',
+                    adminEmails: ['admin-a@example.com']
+                });
+                await setDoc(
+                    doc(firestore, 'teams/team-a/entitlements/server-active'),
+                    entitlementPayload({ provider: 'stripe' })
+                );
+            });
+        });
+
+        afterAll(async () => {
+            await testEnv?.cleanup();
+        });
+
+        it('preserves reads of existing server-created active entitlements', async () => {
+            const ownerDb = testEnv.authenticatedContext('owner-a').firestore();
+            const publicDb = testEnv.unauthenticatedContext().firestore();
+
+            await assertSucceeds(getDoc(doc(ownerDb, 'teams/team-a/entitlements/server-active')));
+            await assertSucceeds(getDoc(doc(publicDb, 'teams/team-a/entitlements/server-active')));
+        });
+
+        it('denies client activation on create and update, including active-record edits', async () => {
+            const ownerDb = testEnv.authenticatedContext('owner-a').firestore();
+            const activeCreateRef = doc(ownerDb, 'teams/team-a/entitlements/client-active');
+            const stagedRef = doc(ownerDb, 'teams/team-a/entitlements/client-staged');
+            const existingActiveRef = doc(ownerDb, 'teams/team-a/entitlements/server-active');
+
+            await assertFails(setDoc(activeCreateRef, entitlementPayload()));
+            await assertSucceeds(setDoc(stagedRef, entitlementPayload({ status: 'inactive' })));
+            await assertFails(updateDoc(stagedRef, { status: 'active' }));
+            await assertFails(updateDoc(existingActiveRef, { expiresAt: '2099-01-01T00:00:00.000Z' }));
+        });
+
+        it('allows team admins to deactivate an active entitlement but not reactivate it', async () => {
+            const adminDb = testEnv.authenticatedContext('admin-a', { email: 'admin-a@example.com' }).firestore();
+            const activeRef = doc(adminDb, 'teams/team-a/entitlements/server-active');
+
+            await assertSucceeds(updateDoc(activeRef, { status: 'cancelled' }));
+            await assertFails(updateDoc(activeRef, { status: 'active' }));
+        });
+
+        it('keeps non-admin clients from staging entitlement records', async () => {
+            const unrelatedDb = testEnv.authenticatedContext('unrelated').firestore();
+            await assertFails(setDoc(
+                doc(unrelatedDb, 'teams/team-a/entitlements/unrelated-staged'),
+                entitlementPayload({ status: 'inactive' })
+            ));
+        });
+    });
+});

--- a/tests/unit/team-entitlements.test.js
+++ b/tests/unit/team-entitlements.test.js
@@ -65,12 +65,14 @@ describe('team entitlement helpers', () => {
         expect(html).toContain('Team Pass required');
     });
 
-    it('documents security rules for entitlement writes', () => {
+    it('routes active entitlement writes through trusted server paths', () => {
         const rules = readRepoFile('firestore.rules');
 
         expect(rules).toContain('match /entitlements/{entitlementId}');
         expect(rules).toContain('allow create, update: if isTeamOwnerOrAdmin(teamId)');
         expect(rules).toContain("request.resource.data.tier == 'team-pass'");
+        expect(rules).toContain("request.resource.data.status in ['inactive', 'expired', 'cancelled']");
+        expect(rules).not.toContain("request.resource.data.status in ['active', 'inactive', 'expired', 'cancelled']");
         expect(rules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId);');
     });
 });


### PR DESCRIPTION
## Summary\n\n- reject stale, replayed, wrong-authority, wrong-amount, and wrong-currency Stripe registration events before any payment or installment mutation\n- persist server-authoritative checkout currency and the last fulfilled Checkout Session\n- record ignored signed events idempotently with stable reasons for operations visibility\n- prevent clients from creating, reactivating, or editing active team-pass entitlements; verified server/webhook Admin SDK writes remain supported\n- preserve reads of existing active entitlements and allow owners/admins to deactivate them\n\n## Security impact\n\nA valid Stripe signature proves event origin, but did not prove that the session was the registration current checkout attempt. This closes that trust gap and prevents distinct valid event IDs for one session from advancing multiple installments. It also removes direct client minting of paid entitlements.\n\n## Validation\n\n- root Vitest: 4,303 passed, 62 skipped\n- focused payment/entitlement tests: 52 passed\n- registration function tests: 35/35 passed\n- Firebase rules static validation passed\n- Functions syntax checks passed\n- entitlement emulator authorization coverage is wired into CI\n\n## Compatibility\n\n- existing valid active entitlements remain readable and effective\n- server-created entitlements and verified webhook writes are unchanged\n- client owners/admins retain deactivation and deletion paths\n- legacy registration currency falls back to the authoritative form/registration currency