### PR TITLE
Add deploy-safe public team projections

### DIFF
--- a/_migration/MIGRATION-README.md
+++ b/_migration/MIGRATION-README.md
@@ -36,9 +36,12 @@ Safe rollout order:
 1. Deploy the projection rules, Functions sync trigger/callable fallbacks, and
    projection-first frontend readers while retaining legacy source reads.
 2. Run and review this backfill's dry run, then apply it.
-3. The full apply records `systemMigrations/publicTeamProfilesBackfill` only
-   after every source team is processed; browse then switches atomically from
-   the compatibility source query to the strict projection indexes.
+3. A full apply first sets `systemMigrations/publicTeamProfilesBackfill.completed`
+   to `false`, keeping browse on the compatibility source query. After the
+   initial pass it repeatedly reconciles current source teams and orphaned
+   projections until two source snapshots match. Only that fixed point records
+   `completed: true`; sustained concurrent changes abort without enabling the
+   projection-only path.
 4. Verify old source-team readers and new projection readers in production.
 
 Public browse and detail reads retain allow-listed callable fallbacks during

--- a/_migration/MIGRATION-README.md
+++ b/_migration/MIGRATION-README.md
@@ -1,7 +1,8 @@
 # Migration Scripts
 
 One-off Node.js scripts for Firestore data fixes and migrations. They run with
-the `firebase-admin` SDK against production using a service account key.
+the `firebase-admin` SDK against production using Application Default
+Credentials or an explicitly supplied service account key.
 
 ## Requirements
 
@@ -16,6 +17,29 @@ the `firebase-admin` SDK against production using a service account key.
   reviewed before applying.
 
 ## Scripts
+
+### backfill-public-team-profiles.js
+
+Creates or refreshes the strict `publicTeamProfiles/{teamId}` projection for
+active public teams and removes stale projections for private/inactive teams.
+It does not modify source team documents, so it is safe to deploy while legacy
+clients continue reading public `teams` documents. Dry run is the default:
+
+```bash
+node _migration/backfill-public-team-profiles.js
+node _migration/backfill-public-team-profiles.js --team TEAM_ID
+node _migration/backfill-public-team-profiles.js --apply
+```
+
+Safe rollout order:
+
+1. Deploy the projection rules, Functions sync trigger/callable fallbacks, and
+   projection-first frontend readers while retaining legacy source reads.
+2. Run and review this backfill's dry run, then apply it.
+3. Verify old source-team readers and new projection readers in production.
+
+Public browse and detail reads retain allow-listed callable fallbacks during
+the backfill window, including when there are zero projection documents.
 
 ### fix-orphaned-invite-redemptions.js
 

--- a/_migration/MIGRATION-README.md
+++ b/_migration/MIGRATION-README.md
@@ -36,7 +36,10 @@ Safe rollout order:
 1. Deploy the projection rules, Functions sync trigger/callable fallbacks, and
    projection-first frontend readers while retaining legacy source reads.
 2. Run and review this backfill's dry run, then apply it.
-3. Verify old source-team readers and new projection readers in production.
+3. The full apply records `systemMigrations/publicTeamProfilesBackfill` only
+   after every source team is processed; browse then switches atomically from
+   the compatibility source query to the strict projection indexes.
+4. Verify old source-team readers and new projection readers in production.
 
 Public browse and detail reads retain allow-listed callable fallbacks during
 the backfill window, including when there are zero projection documents.

--- a/_migration/backfill-public-team-profiles.js
+++ b/_migration/backfill-public-team-profiles.js
@@ -15,6 +15,7 @@ const {
     buildPublicTeamProfile,
     isPublicTeamProfileSchemaValid
 } = require('../functions/public-team-profile-core.cjs');
+const PUBLIC_TEAM_PROFILE_MIGRATION_STATE_PATH = 'systemMigrations/publicTeamProfilesBackfill';
 
 function readFlag(argv, flag) {
     const index = argv.indexOf(flag);
@@ -56,7 +57,8 @@ export async function runPublicTeamProfileBackfill(options = parsePublicTeamBack
         dryRun: !options.apply,
         teamsScanned: teamDocs.length,
         projectionsUpserted: 0,
-        projectionsDeleted: 0
+        projectionsDeleted: 0,
+        migrationCompletionRecorded: false
     };
 
     for (const teamSnap of teamDocs) {
@@ -74,6 +76,11 @@ export async function runPublicTeamProfileBackfill(options = parsePublicTeamBack
         }
         summary.projectionsUpserted += 1;
         if (options.apply) await profileRef.set(profile);
+    }
+
+    if (options.apply && !options.teamId) {
+        await db.doc(PUBLIC_TEAM_PROFILE_MIGRATION_STATE_PATH).set({ completed: true }, { merge: true });
+        summary.migrationCompletionRecorded = true;
     }
 
     console.log(JSON.stringify(summary, null, 2));

--- a/_migration/backfill-public-team-profiles.js
+++ b/_migration/backfill-public-team-profiles.js
@@ -16,6 +16,7 @@ const {
     isPublicTeamProfileSchemaValid
 } = require('../functions/public-team-profile-core.cjs');
 const PUBLIC_TEAM_PROFILE_MIGRATION_STATE_PATH = 'systemMigrations/publicTeamProfilesBackfill';
+const PUBLIC_TEAM_PROFILE_RECONCILIATION_MAX_PASSES = 5;
 
 function readFlag(argv, flag) {
     const index = argv.indexOf(flag);
@@ -49,6 +50,34 @@ async function listTeams(db, teamId) {
     return teamSnap.exists ? [teamSnap] : [];
 }
 
+async function listPublicTeamProfiles(db) {
+    return (await db.collection('publicTeamProfiles').get()).docs;
+}
+
+function stableSnapshotValue(value) {
+    if (value === null || value === undefined) return value ?? null;
+    if (Array.isArray(value)) return value.map(stableSnapshotValue);
+    if (value instanceof Date) return { __date: value.toISOString() };
+    if (typeof value?.toMillis === 'function') return { __timestampMillis: value.toMillis() };
+    if (typeof value === 'object') {
+        return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stableSnapshotValue(value[key])]));
+    }
+    return value;
+}
+
+function getTeamSnapshotFingerprint(teamDocs) {
+    return teamDocs
+        .map((teamSnap) => {
+            const updateTime = teamSnap.updateTime;
+            const version = typeof updateTime?.toMillis === 'function'
+                ? updateTime.toMillis()
+                : JSON.stringify(stableSnapshotValue(teamSnap.data() || {}));
+            return `${teamSnap.id}:${version}`;
+        })
+        .sort()
+        .join('|');
+}
+
 async function applyCurrentPublicTeamProfile(db, teamId) {
     const teamRef = db.doc(`teams/${teamId}`);
     const profileRef = db.doc(`publicTeamProfiles/${teamId}`);
@@ -74,15 +103,54 @@ async function applyCurrentPublicTeamProfile(db, teamId) {
     });
 }
 
+async function reconcilePublicTeamProfilesToFixedPoint(db) {
+    for (let pass = 1; pass <= PUBLIC_TEAM_PROFILE_RECONCILIATION_MAX_PASSES; pass += 1) {
+        const [beforeTeamDocs, profileDocs] = await Promise.all([
+            listTeams(db, ''),
+            listPublicTeamProfiles(db)
+        ]);
+        const reconciliationIds = new Set([
+            ...beforeTeamDocs.map((teamSnap) => teamSnap.id),
+            ...profileDocs.map((profileSnap) => profileSnap.id)
+        ]);
+
+        for (const teamId of reconciliationIds) {
+            await applyCurrentPublicTeamProfile(db, teamId);
+        }
+
+        const afterTeamDocs = await listTeams(db, '');
+        if (getTeamSnapshotFingerprint(beforeTeamDocs) === getTeamSnapshotFingerprint(afterTeamDocs)) {
+            return {
+                passes: pass,
+                teamsReconciled: reconciliationIds.size
+            };
+        }
+    }
+
+    throw new Error(
+        `Teams kept changing during ${PUBLIC_TEAM_PROFILE_RECONCILIATION_MAX_PASSES} reconciliation passes; ` +
+        'migration completion was not recorded.'
+    );
+}
+
 export async function runPublicTeamProfileBackfill(options = parsePublicTeamBackfillArgs(), dependencies = {}) {
     if (!dependencies.db) initializeAdmin(options);
     const db = dependencies.db || getFirestore();
+    const migrationStateRef = db.doc(PUBLIC_TEAM_PROFILE_MIGRATION_STATE_PATH);
+    if (options.apply && !options.teamId) {
+        // A rerun must fail safe to the source compatibility path until a fresh
+        // fixed point is proven. If the process exits early, completed remains
+        // false and public discovery does not switch to a partial projection.
+        await migrationStateRef.set({ completed: false }, { merge: true });
+    }
     const teamDocs = await listTeams(db, options.teamId);
     const summary = {
         dryRun: !options.apply,
         teamsScanned: teamDocs.length,
         projectionsUpserted: 0,
         projectionsDeleted: 0,
+        reconciliationPasses: 0,
+        teamsReconciled: 0,
         migrationCompletionRecorded: false
     };
 
@@ -109,17 +177,10 @@ export async function runPublicTeamProfileBackfill(options = parsePublicTeamBack
     }
 
     if (options.apply && !options.teamId) {
-        // Re-list and re-apply every team before publishing completion. This
-        // closes the window where a team can be created or made public after
-        // the initial collection snapshot but before clients switch sources.
-        const reconciliationTeamDocs = await listTeams(db, '');
-        summary.teamsScanned += reconciliationTeamDocs.length;
-        for (const teamSnap of reconciliationTeamDocs) {
-            const result = await applyCurrentPublicTeamProfile(db, teamSnap.id);
-            if (result === 'upserted') summary.projectionsUpserted += 1;
-            if (result === 'deleted') summary.projectionsDeleted += 1;
-        }
-        await db.doc(PUBLIC_TEAM_PROFILE_MIGRATION_STATE_PATH).set({ completed: true }, { merge: true });
+        const reconciliation = await reconcilePublicTeamProfilesToFixedPoint(db);
+        summary.reconciliationPasses = reconciliation.passes;
+        summary.teamsReconciled = reconciliation.teamsReconciled;
+        await migrationStateRef.set({ completed: true }, { merge: true });
         summary.migrationCompletionRecorded = true;
     }
 

--- a/_migration/backfill-public-team-profiles.js
+++ b/_migration/backfill-public-team-profiles.js
@@ -49,9 +49,34 @@ async function listTeams(db, teamId) {
     return teamSnap.exists ? [teamSnap] : [];
 }
 
-export async function runPublicTeamProfileBackfill(options = parsePublicTeamBackfillArgs()) {
-    initializeAdmin(options);
-    const db = getFirestore();
+async function applyCurrentPublicTeamProfile(db, teamId) {
+    const teamRef = db.doc(`teams/${teamId}`);
+    const profileRef = db.doc(`publicTeamProfiles/${teamId}`);
+
+    return db.runTransaction(async (transaction) => {
+        // Read the source inside the write transaction so a visibility change
+        // cannot commit between projection generation and the projection write.
+        const currentTeamSnap = await transaction.get(teamRef);
+        const profile = currentTeamSnap.exists
+            ? buildPublicTeamProfile(currentTeamSnap.data() || {})
+            : null;
+        if (!profile) {
+            const existing = await transaction.get(profileRef);
+            if (!existing.exists) return 'unchanged';
+            transaction.delete(profileRef);
+            return 'deleted';
+        }
+        if (!isPublicTeamProfileSchemaValid(profile)) {
+            throw new Error(`Invalid generated public team profile for ${teamId}.`);
+        }
+        transaction.set(profileRef, profile);
+        return 'upserted';
+    });
+}
+
+export async function runPublicTeamProfileBackfill(options = parsePublicTeamBackfillArgs(), dependencies = {}) {
+    if (!dependencies.db) initializeAdmin(options);
+    const db = dependencies.db || getFirestore();
     const teamDocs = await listTeams(db, options.teamId);
     const summary = {
         dryRun: !options.apply,
@@ -62,20 +87,25 @@ export async function runPublicTeamProfileBackfill(options = parsePublicTeamBack
     };
 
     for (const teamSnap of teamDocs) {
+        if (options.apply) {
+            const result = await applyCurrentPublicTeamProfile(db, teamSnap.id);
+            if (result === 'upserted') summary.projectionsUpserted += 1;
+            if (result === 'deleted') summary.projectionsDeleted += 1;
+            continue;
+        }
+
         const profileRef = db.doc(`publicTeamProfiles/${teamSnap.id}`);
         const profile = buildPublicTeamProfile(teamSnap.data() || {});
         if (!profile) {
             const existing = await profileRef.get();
             if (!existing.exists) continue;
             summary.projectionsDeleted += 1;
-            if (options.apply) await profileRef.delete();
             continue;
         }
         if (!isPublicTeamProfileSchemaValid(profile)) {
             throw new Error(`Invalid generated public team profile for ${teamSnap.id}.`);
         }
         summary.projectionsUpserted += 1;
-        if (options.apply) await profileRef.set(profile);
     }
 
     if (options.apply && !options.teamId) {

--- a/_migration/backfill-public-team-profiles.js
+++ b/_migration/backfill-public-team-profiles.js
@@ -109,6 +109,16 @@ export async function runPublicTeamProfileBackfill(options = parsePublicTeamBack
     }
 
     if (options.apply && !options.teamId) {
+        // Re-list and re-apply every team before publishing completion. This
+        // closes the window where a team can be created or made public after
+        // the initial collection snapshot but before clients switch sources.
+        const reconciliationTeamDocs = await listTeams(db, '');
+        summary.teamsScanned += reconciliationTeamDocs.length;
+        for (const teamSnap of reconciliationTeamDocs) {
+            const result = await applyCurrentPublicTeamProfile(db, teamSnap.id);
+            if (result === 'upserted') summary.projectionsUpserted += 1;
+            if (result === 'deleted') summary.projectionsDeleted += 1;
+        }
         await db.doc(PUBLIC_TEAM_PROFILE_MIGRATION_STATE_PATH).set({ completed: true }, { merge: true });
         summary.migrationCompletionRecorded = true;
     }

--- a/_migration/backfill-public-team-profiles.js
+++ b/_migration/backfill-public-team-profiles.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * Create the publicTeamProfiles projection without changing source team data.
+ * Dry run is the default; pass --apply to write.
+ */
+
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+import { initializeApp, cert, getApps } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+
+const require = createRequire(import.meta.url);
+const {
+    buildPublicTeamProfile,
+    isPublicTeamProfileSchemaValid
+} = require('../functions/public-team-profile-core.cjs');
+
+function readFlag(argv, flag) {
+    const index = argv.indexOf(flag);
+    return index >= 0 ? String(argv[index + 1] || '').trim() : '';
+}
+
+export function parsePublicTeamBackfillArgs(argv = process.argv.slice(2)) {
+    return {
+        apply: argv.includes('--apply'),
+        teamId: readFlag(argv, '--team') || String(process.env.TEAM_ID || '').trim(),
+        projectId: readFlag(argv, '--project') || process.env.FIREBASE_PROJECT_ID || 'game-flow-c6311',
+        serviceAccountPath: readFlag(argv, '--service-account') || process.env.FIREBASE_SERVICE_ACCOUNT || ''
+    };
+}
+
+function initializeAdmin({ projectId, serviceAccountPath }) {
+    if (getApps().length) return;
+    if (serviceAccountPath) {
+        initializeApp({
+            credential: cert(JSON.parse(readFileSync(serviceAccountPath, 'utf8'))),
+            projectId
+        });
+        return;
+    }
+    initializeApp({ projectId });
+}
+
+async function listTeams(db, teamId) {
+    if (!teamId) return (await db.collection('teams').get()).docs;
+    const teamSnap = await db.doc(`teams/${teamId}`).get();
+    return teamSnap.exists ? [teamSnap] : [];
+}
+
+export async function runPublicTeamProfileBackfill(options = parsePublicTeamBackfillArgs()) {
+    initializeAdmin(options);
+    const db = getFirestore();
+    const teamDocs = await listTeams(db, options.teamId);
+    const summary = {
+        dryRun: !options.apply,
+        teamsScanned: teamDocs.length,
+        projectionsUpserted: 0,
+        projectionsDeleted: 0
+    };
+
+    for (const teamSnap of teamDocs) {
+        const profileRef = db.doc(`publicTeamProfiles/${teamSnap.id}`);
+        const profile = buildPublicTeamProfile(teamSnap.data() || {});
+        if (!profile) {
+            const existing = await profileRef.get();
+            if (!existing.exists) continue;
+            summary.projectionsDeleted += 1;
+            if (options.apply) await profileRef.delete();
+            continue;
+        }
+        if (!isPublicTeamProfileSchemaValid(profile)) {
+            throw new Error(`Invalid generated public team profile for ${teamSnap.id}.`);
+        }
+        summary.projectionsUpserted += 1;
+        if (options.apply) await profileRef.set(profile);
+    }
+
+    console.log(JSON.stringify(summary, null, 2));
+    return summary;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    runPublicTeamProfileBackfill()
+        .then(() => process.exit(0))
+        .catch((error) => {
+            console.error(error?.stack || error?.message || error);
+            process.exit(1);
+        });
+}

--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -52,7 +52,12 @@ const {
   }),
   getKnownAppSearchTeamsMock: vi.fn((_user: AuthState['user']): AppSearchTeam[] => []),
   loadAppSearchTeamsMock: vi.fn(async (): Promise<AppSearchTeam[]> => [{ id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }]),
-  searchAppTeamsMock: vi.fn<(query: string, teams: AppSearchTeam[], user: AuthState['user']) => Promise<AppSearchTeam[]>>(),
+  searchAppTeamsMock: vi.fn<(
+    query: string,
+    teams: AppSearchTeam[],
+    user: AuthState['user'],
+    cursor?: unknown | null
+  ) => Promise<AppSearchTeam[] | { teams: AppSearchTeam[]; nextCursor: unknown | null }>>(),
   searchAppPlayersMock: vi.fn<(query: string, teamsById: Map<string, AppSearchTeam>, user: AuthState['user']) => Promise<any[]>>(),
 }));
 
@@ -107,6 +112,7 @@ vi.mock('../lib/searchService', () => ({
   getKnownAppSearchTeams: getKnownAppSearchTeamsMock,
   loadAppSearchTeams: loadAppSearchTeamsMock,
   searchAppTeams: searchAppTeamsMock,
+  searchAppTeamsPage: searchAppTeamsMock,
   searchAppPlayers: searchAppPlayersMock,
 }));
 
@@ -590,6 +596,33 @@ describe('AppSearchDialog', () => {
       expect.objectContaining({ id: 'team-2', name: 'Rockets' })
     ]), null));
     expect(loadAppSearchTeamsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows and consumes the residual cursor instead of reporting capped team search as complete', async () => {
+    const cursor = { kind: 'public-team-callable-v2', lastId: 'middle' };
+    getKnownAppSearchTeamsMock.mockReturnValue([]);
+    loadAppSearchTeamsMock.mockResolvedValue([]);
+    searchAppTeamsMock
+      .mockResolvedValueOnce({ teams: [], nextCursor: cursor })
+      .mockResolvedValueOnce({
+        teams: [{ id: 'team-target', name: 'Target United', sport: 'Soccer' }],
+        nextCursor: null
+      });
+
+    render(
+      <MemoryRouter>
+        <AppSearchDialog auth={auth} open={true} onClose={vi.fn()} />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: 'target' } });
+    const continueButton = await screen.findByRole('button', { name: 'Continue team search' });
+    expect(screen.getByText('No matching teams in this scan yet')).not.toBeNull();
+    fireEvent.click(continueButton);
+
+    await waitFor(() => expect(searchAppTeamsMock).toHaveBeenNthCalledWith(2, 'target', [], null, cursor));
+    expect(await screen.findByRole('button', { name: /Target United/i })).not.toBeNull();
+    expect(screen.queryByRole('button', { name: 'Continue team search' })).toBeNull();
   });
 
   it('waits briefly for hydrated access so the first query runs once with the expanded scope', async () => {

--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -618,6 +618,12 @@ describe('AppSearchDialog', () => {
     fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: 'target' } });
     const continueButton = await screen.findByRole('button', { name: 'Continue team search' });
     expect(screen.getByText('No matching teams in this scan yet')).not.toBeNull();
+    continueButton.focus();
+    fireEvent.keyDown(continueButton, { key: 'Enter' });
+
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(searchAppTeamsMock).toHaveBeenCalledTimes(1);
+
     fireEvent.click(continueButton);
 
     await waitFor(() => expect(searchAppTeamsMock).toHaveBeenNthCalledWith(2, 'target', [], null, cursor));

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -502,6 +502,11 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
                   type="button"
                   className="text-xs font-extrabold text-primary-700 transition hover:text-primary-800 disabled:opacity-60"
                   onClick={() => void continueTeamSearch()}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                      event.stopPropagation();
+                    }
+                  }}
                   disabled={teamsLoading}
                 >
                   {teamsLoading ? 'Continuing...' : 'Continue team search'}

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -12,10 +12,11 @@ import {
   getImmediateAppTeamSearchResults,
   getKnownAppSearchTeams,
   loadAppSearchTeams,
-  searchAppTeams,
+  searchAppTeamsPage,
   searchAppPlayers,
   type AppSearchItem,
   type AppSearchPlayer,
+  type AppSearchTeamsPage,
   type AppSearchTeam
 } from '../lib/searchService';
 import type { AuthState } from '../lib/types';
@@ -36,12 +37,14 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
   const [teams, setTeams] = useState<AppSearchTeam[]>([]);
   const [teamsLoading, setTeamsLoading] = useState(false);
   const [teamsError, setTeamsError] = useState('');
+  const [teamNextCursor, setTeamNextCursor] = useState<unknown | null>(null);
   const [players, setPlayers] = useState<AppSearchPlayer[]>([]);
   const [playersLoading, setPlayersLoading] = useState(false);
   const [playersError, setPlayersError] = useState('');
   const [activeIndex, setActiveIndex] = useState(0);
   const [keyboardInset, setKeyboardInset] = useState(0);
   const searchRequestId = useRef(0);
+  const queryRef = useRef('');
   const playerSearchGenerationRef = useRef(0);
   const playerSearchTimeoutRef = useRef<number | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -51,6 +54,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
   const hydratedTeamsPromiseRef = useRef<Promise<AppSearchTeam[]> | null>(null);
   const navigate = useNavigate();
   const helpRoleFilter = derivePrimaryHelpRole(auth);
+  queryRef.current = query;
 
   const results = useMemo(
     () => computeAppSearchResults({ queryText: query, auth, teams, players, helpRoleFilter }),
@@ -60,7 +64,10 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
   const flatResults = results.flat ?? [...results.actions, ...results.teams, ...helpResults, ...results.players];
 
   useEffect(() => {
-    if (!open) return;
+    if (!open) {
+      searchRequestId.current += 1;
+      return;
+    }
     return lockBodyScroll();
   }, [open]);
 
@@ -86,6 +93,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
     setActiveIndex(0);
     setTeamsLoading(false);
     setTeamsError('');
+    setTeamNextCursor(null);
   }, [auth.user, open]);
 
   useEffect(() => {
@@ -99,6 +107,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
       setTeams(baseTeamsRef.current);
       setTeamsLoading(false);
       setTeamsError('');
+      setTeamNextCursor(null);
       setPlayers([]);
       setPlayersLoading(false);
       setPlayersError('');
@@ -114,6 +123,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
       setTeams(localTeams);
       setTeamsLoading(localTeams.length === 0);
       setTeamsError('');
+      setTeamNextCursor(null);
     };
 
     setImmediateTeamResults(initialAccessibleTeams);
@@ -144,14 +154,17 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
         }, remotePlayerSearchCoalesceMs);
       };
 
-      const applyTeamResults = (teamsResult: PromiseSettledResult<AppSearchTeam[]>) => {
+      const applyTeamResults = (teamsResult: PromiseSettledResult<AppSearchTeamsPage | AppSearchTeam[]>) => {
         if (disposed || requestId !== searchRequestId.current) return;
         if (teamsResult.status === 'fulfilled') {
-          setTeams(teamsResult.value);
+          const page = normalizeAppSearchTeamsPage(teamsResult.value);
+          setTeams(page.teams);
+          setTeamNextCursor(page.nextCursor);
           setTeamsError('');
           return;
         }
         setTeams([]);
+        setTeamNextCursor(null);
         setTeamsError(teamsResult.reason?.message || 'Team search unavailable.');
       };
 
@@ -161,8 +174,8 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
         schedulePlayerSearch(accessibleTeams);
 
         const [teamsResult] = await Promise.allSettled([
-          searchAppTeams(trimmedQuery, accessibleTeams, auth.user)
-        ]) as [PromiseSettledResult<AppSearchTeam[]>];
+          searchAppTeamsPage(trimmedQuery, accessibleTeams, auth.user)
+        ]) as [PromiseSettledResult<AppSearchTeamsPage | AppSearchTeam[]>];
         applyTeamResults(teamsResult);
         if (!disposed && requestId === searchRequestId.current) {
           setTeamsLoading(false);
@@ -225,6 +238,30 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
       clearScheduledPlayerSearch();
     };
   }, [auth.user, open, query]);
+
+  const continueTeamSearch = async () => {
+    const trimmedQuery = query.trim();
+    const cursor = teamNextCursor;
+    if (trimmedQuery.length < 2 || !cursor || teamsLoading) return;
+    const requestId = searchRequestId.current;
+    setTeamsLoading(true);
+    setTeamsError('');
+    try {
+      const page = normalizeAppSearchTeamsPage(
+        await searchAppTeamsPage(trimmedQuery, baseTeamsRef.current, auth.user, cursor)
+      );
+      if (requestId !== searchRequestId.current || trimmedQuery !== queryRef.current.trim()) return;
+      setTeams((current) => mergeSearchTeams(current, page.teams));
+      setTeamNextCursor(page.nextCursor);
+    } catch (error: any) {
+      if (requestId !== searchRequestId.current || trimmedQuery !== queryRef.current.trim()) return;
+      setTeamsError(error?.message || 'Team search unavailable.');
+    } finally {
+      if (requestId === searchRequestId.current && trimmedQuery === queryRef.current.trim()) {
+        setTeamsLoading(false);
+      }
+    }
+  };
 
   useEffect(() => {
     setActiveIndex(0);
@@ -354,7 +391,9 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
       : teamsError
         ? teamsError
         : results.teams.length === 0
-          ? 'No matching teams'
+          ? teamNextCursor
+            ? 'No matching teams in this scan yet'
+            : 'No matching teams'
           : ''
     : teamsError;
   const helpStatus = hasRealQuery && helpResults.length === 0
@@ -401,7 +440,10 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
                   enterKeyHint="search"
                   autoComplete="off"
                   value={query}
-                  onChange={(event) => setQuery(event.target.value)}
+                  onChange={(event) => {
+                    setQuery(event.target.value);
+                    setTeamNextCursor(null);
+                  }}
                   className="min-h-11 w-full rounded-xl border border-gray-200 px-3 pr-11 text-base font-semibold outline-none focus:border-primary-400 focus:ring-2 focus:ring-primary-100"
                   placeholder="Search teams, players, actions, help..."
                   aria-label="Search teams, players, actions, help"
@@ -455,6 +497,16 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
               offset={results.actions.length}
               status={teamsStatus}
               statusTone={teamsError ? 'error' : 'neutral'}
+              headerAccessory={hasRealQuery && teamNextCursor ? (
+                <button
+                  type="button"
+                  className="text-xs font-extrabold text-primary-700 transition hover:text-primary-800 disabled:opacity-60"
+                  onClick={() => void continueTeamSearch()}
+                  disabled={teamsLoading}
+                >
+                  {teamsLoading ? 'Continuing...' : 'Continue team search'}
+                </button>
+              ) : null}
               onOpen={openResult}
               onHover={setActiveResultIndex}
             />
@@ -494,7 +546,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
               onHover={setActiveResultIndex}
             />
 
-            {!teamsLoading && !playersLoading && flatResults.length === 0 ? (
+            {!teamsLoading && !playersLoading && !teamNextCursor && flatResults.length === 0 ? (
               <div className="rounded-xl border border-gray-200 bg-gray-50 px-4 py-6 text-center text-sm font-semibold text-gray-500">
                 No results
               </div>
@@ -600,6 +652,12 @@ function mergeSearchTeams(...teamLists: AppSearchTeam[][]) {
     if (team?.id) teamsById.set(team.id, team);
   });
   return Array.from(teamsById.values());
+}
+
+function normalizeAppSearchTeamsPage(value: AppSearchTeamsPage | AppSearchTeam[]): AppSearchTeamsPage {
+  return Array.isArray(value)
+    ? { teams: value, nextCursor: null }
+    : { teams: value?.teams || [], nextCursor: value?.nextCursor || null };
 }
 
 function haveSameSearchTeamSearchData(left: AppSearchTeam[], right: AppSearchTeam[]) {

--- a/apps/app/src/components/PublicTeamSearch.test.tsx
+++ b/apps/app/src/components/PublicTeamSearch.test.tsx
@@ -279,6 +279,26 @@ describe('PublicTeamSearch', () => {
         expect(screen.queryByText('Atlanta United')).toBeNull();
     });
 
+    it('offers explicit continuation when a bounded scan is empty but resumable', async () => {
+        (getPublicTeamsPage as import('vitest').Mock)
+            .mockResolvedValueOnce({ teams: [], nextCursor: 'scan-cursor-2' })
+            .mockResolvedValueOnce({ teams: [mockTeams[0]], nextCursor: null });
+        renderSearch();
+
+        const searchInput = screen.getByPlaceholderText('Search by team, city, state, or zip');
+        fireEvent.change(searchInput, { target: { value: 'atlanta' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Search public teams' }));
+
+        await waitFor(() => expect(screen.getByText(/No matches in this scan yet/i)).toBeTruthy());
+        expect(screen.queryByText(/No public teams found/i)).toBeNull();
+        fireEvent.click(screen.getByRole('button', { name: /Load more teams/i }));
+
+        await waitFor(() => expect(getPublicTeamsPage).toHaveBeenLastCalledWith({
+            searchText: 'atlanta', cursor: 'scan-cursor-2'
+        }));
+        expect(screen.getByText('Atlanta United')).toBeTruthy();
+    });
+
     it('recovers from an empty filtered search by browsing all public teams', async () => {
         (getPublicTeamsPage as import('vitest').Mock)
             .mockResolvedValueOnce({ teams: [], nextCursor: null })

--- a/apps/app/src/components/PublicTeamSearch.tsx
+++ b/apps/app/src/components/PublicTeamSearch.tsx
@@ -252,12 +252,24 @@ export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = fal
       ) : (
         <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 text-center">
           <div className="text-sm font-semibold text-gray-500">
-            No public teams found {activeSearchQuery ? `for "${activeSearchQuery}"` : ''}. Try a different search or browse all public teams.
+            {nextCursor
+              ? <>No matches in this scan yet {activeSearchQuery ? `for "${activeSearchQuery}"` : ''}. Continue searching to scan more public teams.</>
+              : <>No public teams found {activeSearchQuery ? `for "${activeSearchQuery}"` : ''}. Try a different search or browse all public teams.</>}
           </div>
           <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:justify-center">
+            {nextCursor ? (
+              <button
+                type="button"
+                className="primary-button w-full justify-center !min-h-10 !px-4 text-sm sm:w-auto"
+                onClick={handleLoadMore}
+                disabled={loading}
+              >
+                Load more teams
+              </button>
+            ) : null}
             <button
               type="button"
-              className="primary-button w-full justify-center !min-h-10 !px-4 text-sm sm:w-auto"
+              className={`${nextCursor ? 'ghost-button' : 'primary-button'} w-full justify-center !min-h-10 !px-4 text-sm sm:w-auto`}
               onClick={handleBrowseAll}
               disabled={loading && pendingRequestKey === publicTeamRequestKey(undefined)}
             >

--- a/apps/app/src/lib/publicTeamsService.test.ts
+++ b/apps/app/src/lib/publicTeamsService.test.ts
@@ -195,7 +195,7 @@ describe('publicTeamsService', () => {
         expect(dbMocks.discoverPublicTeams).toHaveBeenCalledWith({ searchText: 'Kansas City', cursor: null, pageSize: 24 });
     });
 
-    it('still matches short text prefixes before treating two-letter searches as state codes', async () => {
+    it('treats a whole two-letter search as an exact state code', async () => {
         dbMocks.discoverPublicTeams.mockResolvedValue({
             teams: [
                 {
@@ -217,14 +217,25 @@ describe('publicTeamsService', () => {
         await expect(getPublicTeamsPage({ searchText: 'be' })).resolves.toEqual({
             teams: [
                 expect.objectContaining({
-                    teamId: 'team-bears-1',
-                    teamName: 'Bears'
-                }),
-                expect.objectContaining({
                     teamId: 'team-state-1',
                     teamName: 'Wildcats'
                 })
             ],
+            nextCursor: null
+        });
+    });
+
+    it('preserves multi-token city and state searches', async () => {
+        dbMocks.discoverPublicTeams.mockResolvedValue({
+            teams: [
+                { id: 'team-kc-1', name: 'Current', city: 'Kansas City', state: 'MO' },
+                { id: 'team-ks-1', name: 'Wildcats', city: 'Wichita', state: 'KS' }
+            ],
+            nextCursor: null
+        });
+
+        await expect(getPublicTeamsPage({ searchText: 'kansas mo' })).resolves.toEqual({
+            teams: [expect.objectContaining({ teamId: 'team-kc-1' })],
             nextCursor: null
         });
     });

--- a/apps/app/src/lib/publicTeamsService.test.ts
+++ b/apps/app/src/lib/publicTeamsService.test.ts
@@ -8,7 +8,7 @@ const dbMocks = vi.hoisted(() => ({
 
 vi.mock('./adapters/legacyPublicTeamsDb', () => dbMocks);
 
-import { getPublicTeamDetail, getPublicTeamsByLocation, getPublicTeamsPage } from './publicTeamsService';
+import { getBoundedPublicTeamSearchPage, getPublicTeamDetail, getPublicTeamsByLocation, getPublicTeamsPage } from './publicTeamsService';
 
 describe('publicTeamsService', () => {
     beforeEach(() => {
@@ -193,6 +193,52 @@ describe('publicTeamsService', () => {
             })
         ]);
         expect(dbMocks.discoverPublicTeams).toHaveBeenCalledWith({ searchText: 'Kansas City', cursor: null, pageSize: 24 });
+    });
+
+    it('continues bounded empty location-search pages and returns a later match', async () => {
+        const firstCursor = { kind: 'public-team-callable-v2', lastId: 'middle' };
+        dbMocks.discoverPublicTeams
+            .mockResolvedValueOnce({ teams: [], nextCursor: firstCursor })
+            .mockResolvedValueOnce({
+                teams: [{ id: 'team-target', name: 'Target Team', city: 'Target', state: 'KS' }],
+                nextCursor: null
+            });
+
+        await expect(getPublicTeamsByLocation('Target')).resolves.toEqual([
+            expect.objectContaining({ teamId: 'team-target', teamName: 'Target Team' })
+        ]);
+        expect(dbMocks.discoverPublicTeams).toHaveBeenNthCalledWith(1, {
+            searchText: 'Target', cursor: null, pageSize: 24
+        });
+        expect(dbMocks.discoverPublicTeams).toHaveBeenNthCalledWith(2, {
+            searchText: 'Target', cursor: firstCursor, pageSize: 24
+        });
+    });
+
+    it('preserves the residual cursor at the single-shot cap and rejects repeated cursors', async () => {
+        const secondCursor = { lastId: 'second' };
+        dbMocks.discoverPublicTeams
+            .mockResolvedValueOnce({ teams: [], nextCursor: { lastId: 'first' } })
+            .mockResolvedValueOnce({ teams: [], nextCursor: secondCursor });
+
+        await expect(getBoundedPublicTeamSearchPage({ searchText: 'Target' })).resolves.toEqual({
+            teams: [],
+            nextCursor: secondCursor
+        });
+        expect(dbMocks.discoverPublicTeams).toHaveBeenCalledTimes(2);
+
+        vi.clearAllMocks();
+        dbMocks.discoverPublicTeams
+            .mockResolvedValueOnce({ teams: [], nextCursor: { lastId: 'first' } })
+            .mockResolvedValueOnce({ teams: [], nextCursor: secondCursor });
+        await expect(getPublicTeamsByLocation('Target')).rejects.toThrow('incomplete');
+        expect(dbMocks.discoverPublicTeams).toHaveBeenCalledTimes(2);
+
+        vi.clearAllMocks();
+        const repeatedCursor = { lastId: 'same' };
+        dbMocks.discoverPublicTeams.mockResolvedValue({ teams: [], nextCursor: repeatedCursor });
+        await expect(getPublicTeamsByLocation('Target')).rejects.toThrow('repeated cursor');
+        expect(dbMocks.discoverPublicTeams).toHaveBeenCalledTimes(2);
     });
 
     it('treats a whole two-letter search as an exact state code', async () => {

--- a/apps/app/src/lib/publicTeamsService.test.ts
+++ b/apps/app/src/lib/publicTeamsService.test.ts
@@ -241,6 +241,35 @@ describe('publicTeamsService', () => {
         expect(dbMocks.discoverPublicTeams).toHaveBeenCalledTimes(2);
     });
 
+    it('preserves the continuation cursor when a bounded page fills exactly', async () => {
+        const nextCursor = { kind: 'public-team-callable-v2', lastId: 'team-20' };
+        dbMocks.discoverPublicTeams.mockResolvedValue({
+            teams: Array.from({ length: 20 }, (_, index) => ({
+                id: `team-${index + 1}`,
+                name: `Target Team ${index + 1}`
+            })),
+            nextCursor
+        });
+
+        await expect(getBoundedPublicTeamSearchPage({
+            searchText: 'Target',
+            pageSize: 20,
+            includeRosterCounts: false
+        })).resolves.toEqual({
+            teams: expect.arrayContaining([
+                expect.objectContaining({ teamId: 'team-1' }),
+                expect.objectContaining({ teamId: 'team-20' })
+            ]),
+            nextCursor
+        });
+        expect(dbMocks.discoverPublicTeams).toHaveBeenCalledTimes(1);
+        expect(dbMocks.discoverPublicTeams).toHaveBeenCalledWith({
+            searchText: 'Target',
+            cursor: null,
+            pageSize: 20
+        });
+    });
+
     it('treats a whole two-letter search as an exact state code', async () => {
         dbMocks.discoverPublicTeams.mockResolvedValue({
             teams: [

--- a/apps/app/src/lib/publicTeamsService.ts
+++ b/apps/app/src/lib/publicTeamsService.ts
@@ -175,17 +175,18 @@ export async function getBoundedPublicTeamSearchPage({
         });
         page.teams.forEach((team) => teamsById.set(team.teamId, team));
         cursor = page.nextCursor || null;
-        if (!cursor || teamsById.size >= resultLimit) break;
+        if (!cursor) break;
         const cursorKey = JSON.stringify(cursor);
         if (seenCursors.has(cursorKey)) {
             throw new Error('Public team search returned a repeated cursor.');
         }
         seenCursors.add(cursorKey);
+        if (teamsById.size >= resultLimit) break;
     }
 
     return {
         teams: Array.from(teamsById.values()),
-        nextCursor: teamsById.size < resultLimit ? cursor : null
+        nextCursor: cursor
     };
 }
 

--- a/apps/app/src/lib/publicTeamsService.ts
+++ b/apps/app/src/lib/publicTeamsService.ts
@@ -116,12 +116,12 @@ function matchesPublicTeamSearch(team: { name?: string | null; city?: string | n
         return normalizedZip.startsWith(normalizedSearchText);
     }
 
-    if (teamFields.some((field) => field.includes(normalizedSearchText))) {
-        return true;
-    }
-
     if (/^[a-z]{2}$/.test(normalizedSearchText)) {
         return normalizedState === normalizedSearchText;
+    }
+
+    if (teamFields.some((field) => field.includes(normalizedSearchText))) {
+        return true;
     }
 
     return searchTokens.every((token) => combinedFields.includes(token));

--- a/apps/app/src/lib/publicTeamsService.ts
+++ b/apps/app/src/lib/publicTeamsService.ts
@@ -2,6 +2,7 @@ import { discoverPublicTeams, getPublicTeamProfile, getPublicTeamRosterCount, ty
 import { type ParentHomeTeam } from './homeLogic';
 
 const PUBLIC_ROSTER_COUNT_CONCURRENCY = 6;
+const SINGLE_SHOT_PUBLIC_TEAM_PAGE_REQUEST_LIMIT = 2;
 
 export type PublicTeamsPage = {
     teams: ParentHomeTeam[];
@@ -146,9 +147,54 @@ export async function getPublicTeamsPage({ searchText, locationFilter, cursor = 
     };
 }
 
+export async function getBoundedPublicTeamSearchPage({
+    searchText,
+    locationFilter,
+    cursor: initialCursor = null,
+    pageSize = 24,
+    includeRosterCounts = true
+}: PublicTeamsPageOptions = {}): Promise<PublicTeamsPage> {
+    const rawResultLimit = Number(pageSize);
+    const resultLimit = Number.isFinite(rawResultLimit)
+        ? Math.min(Math.max(Math.floor(rawResultLimit), 1), 100)
+        : 24;
+    const teamsById = new Map<string, ParentHomeTeam>();
+    const seenCursors = new Set<string>();
+    let cursor: unknown | null = initialCursor;
+    if (cursor) seenCursors.add(JSON.stringify(cursor));
+
+    for (let requestCount = 0;
+        requestCount < SINGLE_SHOT_PUBLIC_TEAM_PAGE_REQUEST_LIMIT && teamsById.size < resultLimit;
+        requestCount += 1) {
+        const page = await getPublicTeamsPage({
+            searchText,
+            locationFilter,
+            cursor,
+            pageSize: resultLimit - teamsById.size,
+            includeRosterCounts
+        });
+        page.teams.forEach((team) => teamsById.set(team.teamId, team));
+        cursor = page.nextCursor || null;
+        if (!cursor || teamsById.size >= resultLimit) break;
+        const cursorKey = JSON.stringify(cursor);
+        if (seenCursors.has(cursorKey)) {
+            throw new Error('Public team search returned a repeated cursor.');
+        }
+        seenCursors.add(cursorKey);
+    }
+
+    return {
+        teams: Array.from(teamsById.values()),
+        nextCursor: teamsById.size < resultLimit ? cursor : null
+    };
+}
+
 export async function getPublicTeamsByLocation(locationFilter?: string): Promise<ParentHomeTeam[]> {
-    const result = await getPublicTeamsPage({ searchText: locationFilter });
-    return result.teams;
+    const page = await getBoundedPublicTeamSearchPage({ searchText: locationFilter });
+    if (page.nextCursor) {
+        throw new Error('Public team location search is incomplete; use paged discovery to continue.');
+    }
+    return page.teams;
 }
 
 export async function getPublicTeamDetail(teamId: string): Promise<PublicTeamProfile> {

--- a/apps/app/src/lib/searchService.test.ts
+++ b/apps/app/src/lib/searchService.test.ts
@@ -17,9 +17,13 @@ const legacySearchDbMocks = vi.hoisted(() => ({
   where: vi.fn()
 }));
 
-const publicTeamsServiceMocks = vi.hoisted(() => ({
-  getPublicTeamsPage: vi.fn()
-}));
+const publicTeamsServiceMocks = vi.hoisted(() => {
+  const getPublicTeamsPage = vi.fn();
+  return {
+    getPublicTeamsPage,
+    getBoundedPublicTeamSearchPage: getPublicTeamsPage
+  };
+});
 
 vi.mock('./adapters/legacySearchDb', () => legacySearchDbMocks);
 vi.mock('./homeService', () => ({
@@ -240,6 +244,7 @@ describe('searchService app search caches', () => {
     expect(publicTeamsServiceMocks.getPublicTeamsPage).toHaveBeenCalledTimes(1);
     expect(publicTeamsServiceMocks.getPublicTeamsPage).toHaveBeenCalledWith({
       searchText: 'Austin',
+      cursor: null,
       pageSize: 20,
       includeRosterCounts: false
     });

--- a/apps/app/src/lib/searchService.ts
+++ b/apps/app/src/lib/searchService.ts
@@ -15,7 +15,7 @@ import {
 } from './adapters/legacySearchDb';
 import { loadParentHomeSummary } from './homeService';
 import { searchHelpKnowledge } from './helpKnowledgeService';
-import { getPublicTeamsPage } from './publicTeamsService';
+import { getBoundedPublicTeamSearchPage } from './publicTeamsService';
 import type { AuthState, AuthUser, UserRole } from './types';
 
 const teamsCacheTtlMs = 10 * 60 * 1000;
@@ -49,7 +49,13 @@ type PlayerSearchCacheEntry = {
 
 type PublicTeamSearchCacheEntry = {
   teams?: AppSearchTeam[];
-  promise?: Promise<AppSearchTeam[]>;
+  nextCursor?: unknown | null;
+  promise?: Promise<AppSearchTeamsPage>;
+};
+
+export type AppSearchTeamsPage = {
+  teams: AppSearchTeam[];
+  nextCursor: unknown | null;
 };
 
 export type AppSearchKind = 'action' | 'team' | 'player' | 'social' | 'help';
@@ -390,17 +396,26 @@ export async function loadAppSearchTeams(user: AuthUser | null): Promise<AppSear
 }
 
 export async function searchAppTeams(queryText: string, appAccessTeams: AppSearchTeam[], user: AuthUser | null): Promise<AppSearchTeam[]> {
+  return (await searchAppTeamsPage(queryText, appAccessTeams, user)).teams;
+}
+
+export async function searchAppTeamsPage(
+  queryText: string,
+  appAccessTeams: AppSearchTeam[],
+  user: AuthUser | null,
+  cursor: unknown | null = null
+): Promise<AppSearchTeamsPage> {
   const rawQuery = String(queryText || '').trim();
   const localTeams = getImmediateAppTeamSearchResults(rawQuery, appAccessTeams);
-  if (rawQuery.length < 2) return localTeams;
+  if (rawQuery.length < 2) return { teams: localTeams, nextCursor: null };
 
   const firstToken = splitSearchTokens(rawQuery)[0] || '';
-  if (!firstToken) return localTeams;
+  if (!firstToken) return { teams: localTeams, nextCursor: null };
 
   try {
-    const publicTeams = await getCachedPublicTeamSearchResults(rawQuery, user);
+    const publicPage = await getCachedPublicTeamSearchResults(rawQuery, user, cursor);
     const localTeamsById = new Map(appAccessTeams.map((team) => [team.id, team]));
-    publicTeams.forEach((team) => {
+    publicPage.teams.forEach((team) => {
       if (canUserDiscoverTeamInAppSearch(team, user)) {
         const existingTeam = localTeamsById.get(team.id);
         localTeamsById.set(team.id, existingTeam?.fromAppAccess
@@ -409,9 +424,12 @@ export async function searchAppTeams(queryText: string, appAccessTeams: AppSearc
       }
     });
 
-    return rankTeamsForQuery(Array.from(localTeamsById.values()), rawQuery).slice(0, teamSearchQueryLimit);
+    return {
+      teams: rankTeamsForQuery(Array.from(localTeamsById.values()), rawQuery).slice(0, teamSearchQueryLimit),
+      nextCursor: publicPage.nextCursor
+    };
   } catch (error) {
-    if (localTeams.length) return localTeams;
+    if (localTeams.length) return { teams: localTeams, nextCursor: cursor };
     throw error;
   }
 }
@@ -618,26 +636,33 @@ export function resetAppSearchCache() {
   publicTeamSearchCache.clear();
 }
 
-async function getCachedPublicTeamSearchResults(queryText: string, user: AuthUser | null): Promise<AppSearchTeam[]> {
+async function getCachedPublicTeamSearchResults(
+  queryText: string,
+  user: AuthUser | null,
+  cursor: unknown | null = null
+): Promise<AppSearchTeamsPage> {
   const normalizedQuery = normalizeSearchQuery(queryText);
-  const cacheKey = `${getAppSearchUserCacheKey(user)}::${normalizedQuery}`;
+  const cursorKey = cursor ? JSON.stringify(cursor) : 'start';
+  const cacheKey = `${getAppSearchUserCacheKey(user)}::${normalizedQuery}::${cursorKey}`;
   const cachedEntry = publicTeamSearchCache.get(cacheKey);
 
   if (cachedEntry?.teams) {
     markSearchCacheEntryRecentlyUsed(publicTeamSearchCache, cacheKey, cachedEntry);
-    return cachedEntry.teams;
+    return { teams: cachedEntry.teams, nextCursor: cachedEntry.nextCursor || null };
   }
   if (cachedEntry?.promise) return cachedEntry.promise;
 
-  const promise = getPublicTeamsPage({
+  const promise = getBoundedPublicTeamSearchPage({
     searchText: queryText,
+    cursor,
     pageSize: teamSearchQueryLimit,
     includeRosterCounts: false
   })
     .then((result) => {
       const teams = normalizePublicTeamSearchResults(result?.teams || []);
-      setBoundedCompletedSearchCacheEntry(publicTeamSearchCache, cacheKey, { teams }, publicTeamSearchCacheMaxEntries);
-      return teams;
+      const page = { teams, nextCursor: result?.nextCursor || null };
+      setBoundedCompletedSearchCacheEntry(publicTeamSearchCache, cacheKey, page, publicTeamSearchCacheMaxEntries);
+      return page;
     })
     .catch((error) => {
       publicTeamSearchCache.delete(cacheKey);

--- a/apps/app/src/pages/parent-tools/AccessTool.test.tsx
+++ b/apps/app/src/pages/parent-tools/AccessTool.test.tsx
@@ -307,6 +307,29 @@ describe('AccessTool manual public team discovery', () => {
         await waitFor(() => expect(accessServiceMocks.loadParentAccessPlayers).toHaveBeenCalledWith('team-b'));
     });
 
+    it('keeps an empty bounded scan resumable without claiming discovery is exhausted', async () => {
+        accessServiceMocks.discoverParentAccessTeams
+            .mockResolvedValueOnce({ teams: [], nextCursor: 'scan-cursor-2' })
+            .mockResolvedValueOnce({
+                teams: [{ id: 'team-b', name: 'Austin Comets', state: 'TX' }],
+                nextCursor: null
+            });
+
+        const view = renderTool('');
+        fireEvent.click(await view.findByRole('button', { name: 'Request access without a code' }));
+        fireEvent.change(view.getByPlaceholderText('Team name, city, state, or zip'), { target: { value: 'Austin' } });
+        fireEvent.click(view.getByRole('button', { name: 'Search' }));
+
+        expect(await view.findByRole('option', { name: 'No matches in this scan yet' })).toBeTruthy();
+        expect(view.queryByRole('option', { name: 'No public teams found' })).toBeNull();
+        fireEvent.click(view.getByRole('button', { name: 'Load more teams' }));
+
+        await waitFor(() => expect(accessServiceMocks.discoverParentAccessTeams).toHaveBeenLastCalledWith({
+            searchText: 'Austin', cursor: 'scan-cursor-2', pageSize: 20
+        }));
+        expect(await view.findByRole('option', { name: 'Austin Comets - TX' })).toBeTruthy();
+    });
+
     it('clears team and player selection when the search text changes', async () => {
         const view = renderTool('');
 

--- a/apps/app/src/pages/parent-tools/AccessTool.tsx
+++ b/apps/app/src/pages/parent-tools/AccessTool.tsx
@@ -438,7 +438,7 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
                                 <div className="min-w-0">
                                     <label className="app-label" htmlFor="parent-access-team">Team</label>
                                     <select id="parent-access-team" aria-label="Team" className="auth-input mt-1" value={selectedTeamId} onChange={(event) => setSelectedTeamId(event.target.value)} disabled={loadingTeams || !teams.length}>
-                                        <option value="">{loadingTeams ? 'Loading public teams...' : teams.length ? 'Choose a team' : teamDiscoveryStarted ? 'No public teams found' : 'Search or browse teams'}</option>
+                                        <option value="">{loadingTeams ? 'Loading public teams...' : teams.length ? 'Choose a team' : teamNextCursor ? 'No matches in this scan yet' : teamDiscoveryStarted ? 'No public teams found' : 'Search or browse teams'}</option>
                                         {teams.map((team) => (
                                             <option key={team.id} value={team.id}>{formatTeamOption(team)}</option>
                                         ))}

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,6 +1,86 @@
 {
   "indexes": [
     {
+      "collectionGroup": "publicTeamProfiles",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "publicSchemaVersion", "order": "ASCENDING" },
+        { "fieldPath": "isPublic", "order": "ASCENDING" },
+        { "fieldPath": "active", "order": "ASCENDING" },
+        { "fieldPath": "publicSearchName", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "publicTeamProfiles",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "publicSchemaVersion", "order": "ASCENDING" },
+        { "fieldPath": "isPublic", "order": "ASCENDING" },
+        { "fieldPath": "active", "order": "ASCENDING" },
+        { "fieldPath": "name", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "publicTeamProfiles",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "publicSchemaVersion", "order": "ASCENDING" },
+        { "fieldPath": "isPublic", "order": "ASCENDING" },
+        { "fieldPath": "active", "order": "ASCENDING" },
+        { "fieldPath": "publicSearchZip", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "publicTeamProfiles",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "publicSchemaVersion", "order": "ASCENDING" },
+        { "fieldPath": "isPublic", "order": "ASCENDING" },
+        { "fieldPath": "active", "order": "ASCENDING" },
+        { "fieldPath": "zip", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "publicTeamProfiles",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "publicSchemaVersion", "order": "ASCENDING" },
+        { "fieldPath": "isPublic", "order": "ASCENDING" },
+        { "fieldPath": "active", "order": "ASCENDING" },
+        { "fieldPath": "publicSearchState", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "publicTeamProfiles",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "publicSchemaVersion", "order": "ASCENDING" },
+        { "fieldPath": "isPublic", "order": "ASCENDING" },
+        { "fieldPath": "active", "order": "ASCENDING" },
+        { "fieldPath": "state", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "publicTeamProfiles",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "publicSchemaVersion", "order": "ASCENDING" },
+        { "fieldPath": "isPublic", "order": "ASCENDING" },
+        { "fieldPath": "active", "order": "ASCENDING" },
+        { "fieldPath": "publicSearchCity", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "publicTeamProfiles",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "publicSchemaVersion", "order": "ASCENDING" },
+        { "fieldPath": "isPublic", "order": "ASCENDING" },
+        { "fieldPath": "active", "order": "ASCENDING" },
+        { "fieldPath": "city", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "teams",
       "queryScope": "COLLECTION",
       "fields": [

--- a/firestore.rules
+++ b/firestore.rules
@@ -1602,6 +1602,33 @@ service cloud.firestore {
               isOwnerUserEmailAuthBound(request.resource.data));
     }
 
+    function isPublicTeamProfilePayloadValid(data) {
+      return data.keys().hasOnly([
+               'publicSchemaVersion',
+               'name', 'sport', 'description', 'photoUrl', 'city', 'state', 'zip',
+               'leagueUrl', 'websiteUrl', 'socialLinks',
+               'twitchChannel', 'streamUrl', 'livestreamUrl', 'streamEmbedUrl', 'youtubeEmbedUrl',
+               'standingsConfig',
+               'tournament', 'tournamentDivisions', 'tournamentPools', 'tournamentPoolOverrides',
+               'appAccess', 'webAccess', 'active', 'archived', 'status', 'isPublic',
+               'publicSearchName', 'publicSearchCity', 'publicSearchState', 'publicSearchZip',
+               'publicSearchCityState', 'sourceUpdatedAt'
+             ]) &&
+             data.get('publicSchemaVersion', 0) == 1 &&
+             data.get('isPublic', false) == true &&
+             data.get('active', false) == true &&
+             data.get('name', '') is string &&
+             data.get('name', '').size() > 0 &&
+             (!data.keys().hasAny(['socialLinks']) || data.socialLinks is map) &&
+             (!data.keys().hasAny(['standingsConfig']) || data.standingsConfig is map) &&
+             (!data.keys().hasAny(['tournament']) || data.tournament is map) &&
+             (!data.keys().hasAny(['tournamentDivisions']) || data.tournamentDivisions is list) &&
+             (!data.keys().hasAny(['tournamentPools']) || data.tournamentPools is list) &&
+             (!data.keys().hasAny(['tournamentPoolOverrides']) || data.tournamentPoolOverrides is map) &&
+             (!data.keys().hasAny(['appAccess']) || data.appAccess is bool) &&
+             (!data.keys().hasAny(['webAccess']) || data.webAccess is bool);
+    }
+
     function isOwnerUserEmailAuthBound(data) {
       return !data.keys().hasAny(['email']) ||
              (request.auth.token.email is string &&
@@ -2650,6 +2677,16 @@ service cloud.firestore {
       allow update: if (isGlobalAdmin() && isPublicUserProfilePayloadValid(userId, request.resource.data)) ||
                     isOwnerPublicUserProfilePresentationUpdateValid(userId);
       allow delete: if isGlobalAdmin() || isOwner(userId);
+    }
+
+    // Server-maintained, allow-listed presentation/search documents. The
+    // corresponding teams/{teamId} source document is never a public API.
+    match /publicTeamProfiles/{teamId} {
+      allow get: if isPublicTeamProfilePayloadValid(resource.data);
+      // Firestore cannot prove the full projection schema for a collection
+      // query. Keep list reads fail-closed; discovery uses the bounded callable.
+      allow list: if false;
+      allow create, update, delete: if false;
     }
 
     // Users collection - users should only write their own profile.

--- a/firestore.rules
+++ b/firestore.rules
@@ -1617,6 +1617,47 @@ service cloud.firestore {
               isOwnerUserEmailAuthBound(request.resource.data));
     }
 
+    function isOptionalPublicTeamProfileString(data, fieldName) {
+      return !data.keys().hasAny([fieldName]) || data.get(fieldName, null) is string;
+    }
+
+    function isOptionalPublicTeamProfileBool(data, fieldName) {
+      return !data.keys().hasAny([fieldName]) || data.get(fieldName, null) is bool;
+    }
+
+    function isOptionalPublicTeamProfileMap(data, fieldName) {
+      return !data.keys().hasAny([fieldName]) || data.get(fieldName, null) is map;
+    }
+
+    function isOptionalPublicTeamProfileList(data, fieldName) {
+      return !data.keys().hasAny([fieldName]) || data.get(fieldName, null) is list;
+    }
+
+    function isOptionalPublicTeamProfileTimestamp(data, fieldName) {
+      return !data.keys().hasAny([fieldName]) ||
+             data.get(fieldName, null) == null ||
+             data.get(fieldName, null) is timestamp;
+    }
+
+    function isPublicTeamProfileSocialLinksValid(data) {
+      let links = data.get('socialLinks', {});
+      return !data.keys().hasAny(['socialLinks']) ||
+             (links is map &&
+              links.keys().hasOnly([
+                'facebook', 'instagram', 'x', 'twitter', 'tiktok',
+                'youtube', 'linkedin', 'threads', 'bluesky'
+              ]) &&
+              isOptionalPublicTeamProfileString(links, 'facebook') &&
+              isOptionalPublicTeamProfileString(links, 'instagram') &&
+              isOptionalPublicTeamProfileString(links, 'x') &&
+              isOptionalPublicTeamProfileString(links, 'twitter') &&
+              isOptionalPublicTeamProfileString(links, 'tiktok') &&
+              isOptionalPublicTeamProfileString(links, 'youtube') &&
+              isOptionalPublicTeamProfileString(links, 'linkedin') &&
+              isOptionalPublicTeamProfileString(links, 'threads') &&
+              isOptionalPublicTeamProfileString(links, 'bluesky'));
+    }
+
     function isPublicTeamProfilePayloadValid(data) {
       return data.keys().hasOnly([
                'publicSchemaVersion',
@@ -1629,19 +1670,43 @@ service cloud.firestore {
                'publicSearchName', 'publicSearchCity', 'publicSearchState', 'publicSearchZip',
                'publicSearchCityState', 'sourceUpdatedAt'
              ]) &&
+             data.get('publicSchemaVersion', 0) is int &&
              data.get('publicSchemaVersion', 0) == 1 &&
+             data.get('isPublic', false) is bool &&
              data.get('isPublic', false) == true &&
+             data.get('active', false) is bool &&
              data.get('active', false) == true &&
              data.get('name', '') is string &&
              data.get('name', '').size() > 0 &&
-             (!data.keys().hasAny(['socialLinks']) || data.socialLinks is map) &&
-             (!data.keys().hasAny(['standingsConfig']) || data.standingsConfig is map) &&
-             (!data.keys().hasAny(['tournament']) || data.tournament is map) &&
-             (!data.keys().hasAny(['tournamentDivisions']) || data.tournamentDivisions is list) &&
-             (!data.keys().hasAny(['tournamentPools']) || data.tournamentPools is list) &&
-             (!data.keys().hasAny(['tournamentPoolOverrides']) || data.tournamentPoolOverrides is map) &&
-             (!data.keys().hasAny(['appAccess']) || data.appAccess is bool) &&
-             (!data.keys().hasAny(['webAccess']) || data.webAccess is bool);
+             isOptionalPublicTeamProfileString(data, 'sport') &&
+             isOptionalPublicTeamProfileString(data, 'description') &&
+             isOptionalPublicTeamProfileString(data, 'photoUrl') &&
+             isOptionalPublicTeamProfileString(data, 'city') &&
+             isOptionalPublicTeamProfileString(data, 'state') &&
+             isOptionalPublicTeamProfileString(data, 'zip') &&
+             isOptionalPublicTeamProfileString(data, 'leagueUrl') &&
+             isOptionalPublicTeamProfileString(data, 'websiteUrl') &&
+             isPublicTeamProfileSocialLinksValid(data) &&
+             isOptionalPublicTeamProfileString(data, 'twitchChannel') &&
+             isOptionalPublicTeamProfileString(data, 'streamUrl') &&
+             isOptionalPublicTeamProfileString(data, 'livestreamUrl') &&
+             isOptionalPublicTeamProfileString(data, 'streamEmbedUrl') &&
+             isOptionalPublicTeamProfileString(data, 'youtubeEmbedUrl') &&
+             isOptionalPublicTeamProfileMap(data, 'standingsConfig') &&
+             isOptionalPublicTeamProfileMap(data, 'tournament') &&
+             isOptionalPublicTeamProfileList(data, 'tournamentDivisions') &&
+             isOptionalPublicTeamProfileList(data, 'tournamentPools') &&
+             isOptionalPublicTeamProfileMap(data, 'tournamentPoolOverrides') &&
+             isOptionalPublicTeamProfileBool(data, 'appAccess') &&
+             isOptionalPublicTeamProfileBool(data, 'webAccess') &&
+             isOptionalPublicTeamProfileBool(data, 'archived') &&
+             isOptionalPublicTeamProfileString(data, 'status') &&
+             isOptionalPublicTeamProfileString(data, 'publicSearchName') &&
+             isOptionalPublicTeamProfileString(data, 'publicSearchCity') &&
+             isOptionalPublicTeamProfileString(data, 'publicSearchState') &&
+             isOptionalPublicTeamProfileString(data, 'publicSearchZip') &&
+             isOptionalPublicTeamProfileString(data, 'publicSearchCityState') &&
+             isOptionalPublicTeamProfileTimestamp(data, 'sourceUpdatedAt');
     }
 
     function isOwnerUserEmailAuthBound(data) {

--- a/firestore.rules
+++ b/firestore.rules
@@ -1625,18 +1625,21 @@ service cloud.firestore {
       return !data.keys().hasAny([fieldName]) || data.get(fieldName, null) is bool;
     }
 
-    function isOptionalPublicTeamProfileMap(data, fieldName) {
-      return !data.keys().hasAny([fieldName]) || data.get(fieldName, null) is map;
-    }
-
-    function isOptionalPublicTeamProfileList(data, fieldName) {
-      return !data.keys().hasAny([fieldName]) || data.get(fieldName, null) is list;
-    }
-
     function isOptionalPublicTeamProfileTimestamp(data, fieldName) {
       return !data.keys().hasAny([fieldName]) ||
              data.get(fieldName, null) == null ||
              data.get(fieldName, null) is timestamp;
+    }
+
+    function hasNoCallableOnlyPublicTeamPresentationFields(data) {
+      // Firestore rules cannot exhaustively allow-list every member of dynamic
+      // tournament arrays and override maps. Keep these sanitized structures
+      // behind getPublicTeamProfile instead of treating their container type as
+      // a sufficient public-read boundary.
+      return !data.keys().hasAny([
+        'standingsConfig',
+        'tournament', 'tournamentDivisions', 'tournamentPools', 'tournamentPoolOverrides'
+      ]);
     }
 
     function isPublicTeamProfileSocialLinksValid(data) {
@@ -1692,11 +1695,7 @@ service cloud.firestore {
              isOptionalPublicTeamProfileString(data, 'livestreamUrl') &&
              isOptionalPublicTeamProfileString(data, 'streamEmbedUrl') &&
              isOptionalPublicTeamProfileString(data, 'youtubeEmbedUrl') &&
-             isOptionalPublicTeamProfileMap(data, 'standingsConfig') &&
-             isOptionalPublicTeamProfileMap(data, 'tournament') &&
-             isOptionalPublicTeamProfileList(data, 'tournamentDivisions') &&
-             isOptionalPublicTeamProfileList(data, 'tournamentPools') &&
-             isOptionalPublicTeamProfileMap(data, 'tournamentPoolOverrides') &&
+             hasNoCallableOnlyPublicTeamPresentationFields(data) &&
              isOptionalPublicTeamProfileBool(data, 'appAccess') &&
              isOptionalPublicTeamProfileBool(data, 'webAccess') &&
              isOptionalPublicTeamProfileBool(data, 'archived') &&

--- a/firestore.rules
+++ b/firestore.rules
@@ -394,6 +394,21 @@ service cloud.firestore {
       return data.isPublic is bool && data.isPublic == true;
     }
 
+    function isPublicTeamCurrentlyDiscoverable(data) {
+      return canReadPublicTeamDocument(data) &&
+             data.get('active', true) != false &&
+             data.get('archived', false) != true &&
+             (!data.keys().hasAny(['status']) ||
+              !(data.status is string) ||
+              !(data.status.lower() in ['archived', 'inactive', 'disabled']));
+    }
+
+    function isCurrentTeamPubliclyDiscoverable(teamId) {
+      let teamPath = /databases/$(database)/documents/teams/$(teamId);
+      return exists(teamPath) &&
+             isPublicTeamCurrentlyDiscoverable(get(teamPath).data);
+    }
+
     function canReadTeamMediaManagerTeamDocument(data) {
       let permission = data.get('teamPermissions', {}).get('teamMediaManagement', {});
       return isSignedIn() &&
@@ -2682,7 +2697,8 @@ service cloud.firestore {
     // Server-maintained, allow-listed presentation/search documents. The
     // corresponding teams/{teamId} source document is never a public API.
     match /publicTeamProfiles/{teamId} {
-      allow get: if isPublicTeamProfilePayloadValid(resource.data);
+      allow get: if isPublicTeamProfilePayloadValid(resource.data) &&
+                    isCurrentTeamPubliclyDiscoverable(teamId);
       // Firestore cannot prove a whole-document key allow-list from a query.
       // Keep collection reads behind the allow-listing callable instead.
       allow list: if false;

--- a/firestore.rules
+++ b/firestore.rules
@@ -2683,8 +2683,8 @@ service cloud.firestore {
     // corresponding teams/{teamId} source document is never a public API.
     match /publicTeamProfiles/{teamId} {
       allow get: if isPublicTeamProfilePayloadValid(resource.data);
-      // Firestore cannot prove the full projection schema for a collection
-      // query. Keep list reads fail-closed; discovery uses the bounded callable.
+      // Firestore cannot prove a whole-document key allow-list from a query.
+      // Keep collection reads behind the allow-listing callable instead.
       allow list: if false;
       allow create, update, delete: if false;
     }

--- a/functions/index.js
+++ b/functions/index.js
@@ -38,6 +38,7 @@ const { createFirestoreFixedWindowRateLimiter, createInMemoryRateLimiter, getReq
 const { buildPublicGamesIcs, canExposeEmptyPublicFeed, isPublicFanGame } = require('./public-calendar-core.cjs');
 const {
   buildPublicTeamProfile,
+  collectAllPublicTeamSourceDocuments,
   isPublicTeamProfileSchemaValid,
   matchesPublicTeamProfileSearch
 } = require('./public-team-profile-core.cjs');
@@ -13153,14 +13154,18 @@ exports.discoverPublicTeamProfiles = functions.https.onCall(async (data, context
     ? cursor.offset
     : 0;
 
-  // This path is a bounded deployment-order fallback for databases that
+  // This path is a deployment-order fallback for databases that
   // predate publicTeamProfiles. Normal browse queries read the projection
   // collection directly after the backfill.
-  const teamSnap = await firestore.collection('teams')
-    .where('isPublic', '==', true)
-    .limit(1000)
-    .get();
-  const profiles = teamSnap.docs
+  const teamDocs = await collectAllPublicTeamSourceDocuments(async ({ cursor: sourceCursor, pageSize: sourcePageSize }) => {
+    let sourceQuery = firestore.collection('teams')
+      .where('isPublic', '==', true)
+      .orderBy(admin.firestore.FieldPath.documentId())
+      .limit(sourcePageSize);
+    if (sourceCursor) sourceQuery = sourceQuery.startAfter(sourceCursor);
+    return sourceQuery.get();
+  });
+  const profiles = teamDocs
     .map((docSnap) => {
       const profile = buildPublicTeamProfile(docSnap.data() || {});
       return profile && isPublicTeamProfileSchemaValid(profile)
@@ -13177,7 +13182,7 @@ exports.discoverPublicTeamProfiles = functions.https.onCall(async (data, context
     nextCursor: nextOffset < profiles.length
       ? { kind: 'public-team-callable', searchText, offset: nextOffset }
       : null,
-    boundedSourceCount: teamSnap.size
+    scannedSourceCount: teamDocs.length
   };
 });
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -12542,14 +12542,27 @@ async function collectPublicTeamBrowsePage({ useProjection, searchText, pageSize
       break;
     }
 
+    // Projection writes are asynchronous. A delayed trigger or an out-of-order
+    // delivery must never make a team discoverable after the source team has
+    // become private, inactive, or deleted. Re-read each current source row and
+    // serialize from that row; the projection remains only the bounded index
+    // used to choose candidates and advance the opaque cursor.
+    const currentTeamSnapshots = useProjection
+      ? await Promise.all(snapshot.docs.map((docSnap) => firestore.doc(`teams/${docSnap.id}`).get()))
+      : [];
+
     let consumedDocumentCount = 0;
-    for (const docSnap of snapshot.docs) {
+    for (const [index, docSnap] of snapshot.docs.entries()) {
       consumedDocumentCount += 1;
       scannedDocumentCount += 1;
       scanCursor = { lastName: docSnap.data()?.name, lastId: docSnap.id };
+      const storedProfile = docSnap.data() || null;
+      const currentTeamSnapshot = currentTeamSnapshots[index];
       const profile = useProjection
-        ? docSnap.data() || null
-        : buildPublicTeamProfile(docSnap.data() || {});
+        ? (storedProfile && isPublicTeamProfileSchemaValid(storedProfile) && currentTeamSnapshot?.exists
+            ? buildPublicTeamProfile(currentTeamSnapshot.data() || {})
+            : null)
+        : buildPublicTeamProfile(storedProfile || {});
       if (profile && isPublicTeamProfileSchemaValid(profile) && matchesPublicTeamProfileSearch(profile, searchText)) {
         teams.push({ id: docSnap.id, ...profile });
       }
@@ -13530,23 +13543,29 @@ exports.closePublicOpportunitiesForPrivateTeam = functions.firestore
 
 exports.syncPublicTeamProfileOnTeamWrite = functions.firestore
   .document('teams/{teamId}')
-  .onWrite(async (change, context) => {
+  .onWrite(async (_change, context) => {
+    const teamRef = firestore.doc(`teams/${context.params.teamId}`);
     const profileRef = firestore.doc(`publicTeamProfiles/${context.params.teamId}`);
-    const team = change.after.exists ? (change.after.data() || {}) : null;
-    const profile = team ? buildPublicTeamProfile(team) : null;
+    await firestore.runTransaction(async (transaction) => {
+      // Firestore delivers triggers at least once and does not guarantee event
+      // order. Derive the projection from the current source document, not the
+      // event image, so an older event cannot restore stale public data.
+      const teamSnapshot = await transaction.get(teamRef);
+      const profile = teamSnapshot.exists
+        ? buildPublicTeamProfile(teamSnapshot.data() || {})
+        : null;
 
-    if (!profile) {
-      await profileRef.delete().catch((error) => {
-        if (error?.code !== 5 && error?.code !== 'not-found') throw error;
-      });
-      return null;
-    }
-    if (!isPublicTeamProfileSchemaValid(profile)) {
-      throw new Error(`Refusing invalid public team profile for ${context.params.teamId}.`);
-    }
+      if (!profile) {
+        transaction.delete(profileRef);
+        return;
+      }
+      if (!isPublicTeamProfileSchemaValid(profile)) {
+        throw new Error(`Refusing invalid public team profile for ${context.params.teamId}.`);
+      }
 
-    // Overwrite instead of merge so a field removed from the allowlist or the
-    // source team cannot remain exposed on an older projection document.
-    await profileRef.set(profile);
+      // Overwrite instead of merge so a field removed from the allowlist or the
+      // source team cannot remain exposed on an older projection document.
+      transaction.set(profileRef, profile);
+    });
     return null;
   });

--- a/functions/index.js
+++ b/functions/index.js
@@ -4,7 +4,12 @@ const Stripe = require('stripe');
 const { Resend } = require('resend');
 const crypto = require('node:crypto');
 const { isPrivateIpAddress, isBlockedHostname, assertPublicHost, normalizeTargetUrl, fetchWithTimeout } = require('./utils/security-utils');
-const { createCalendarIcsCache, createCalendarIcsFetchHandler } = require('./calendar-ics-fetch-core.cjs');
+const {
+  createCalendarIcsCache,
+  createCalendarIcsFetchHandler,
+  fetchCalendarIcsWithCache
+} = require('./calendar-ics-fetch-core.cjs');
+const { sanitizePublicExternalCalendarIcs } = require('./public-external-calendar-core.cjs');
 const {
   normalizeTeamPassCheckoutInput,
   isEligibleTeamPassPurchaser,
@@ -38,6 +43,7 @@ const { createFirestoreFixedWindowRateLimiter, createInMemoryRateLimiter, getReq
 const { buildPublicGamesIcs, canExposeEmptyPublicFeed, isPublicFanGame } = require('./public-calendar-core.cjs');
 const {
   buildPublicTeamProfile,
+  isPublicTeamDiscoverable,
   isPublicTeamProfileSchemaValid,
   matchesPublicTeamProfileSearch
 } = require('./public-team-profile-core.cjs');
@@ -5127,10 +5133,74 @@ const fetchCalendarRuntime = calendarServiceAccount
 const calendarIcsCache = createCalendarIcsCache({
   ttlMs: process.env.CALENDAR_ICS_CACHE_TTL_MS
 });
+const MAX_PUBLIC_EXTERNAL_CALENDAR_SOURCES = 10;
 
 function getCalendarFeedGamesQuery(teamId) {
   return buildCalendarFeedGamesQuery(firestore.collection(`teams/${teamId}/games`));
 }
+
+async function fetchSanitizedPublicExternalCalendarIcs(rawUrl) {
+  const normalizedUrl = await normalizeTargetUrl(rawUrl);
+  const result = await fetchCalendarIcsWithCache({
+    cache: calendarIcsCache,
+    cacheKey: normalizedUrl.url,
+    fetchIcs: async () => {
+      const response = await fetchWithTimeout(
+        normalizedUrl.url,
+        normalizedUrl.hostname,
+        normalizedUrl.publicIps
+      );
+      if (!response.ok) {
+        const upstreamError = new Error(`Calendar fetch failed: ${response.status} ${response.statusText}`);
+        upstreamError.statusCode = 502;
+        throw upstreamError;
+      }
+      const rawText = await response.text();
+      const icsText = normalizeIcsText(rawText);
+      if (!icsText.includes('BEGIN:VCALENDAR')) {
+        const invalidIcsError = new Error('Response was not valid ICS');
+        invalidIcsError.statusCode = 502;
+        throw invalidIcsError;
+      }
+      return { fetchedAt: new Date().toISOString(), icsText };
+    }
+  });
+  return sanitizePublicExternalCalendarIcs(result.icsText);
+}
+
+exports.getPublicTeamExternalCalendarIcs = functions
+  .runWith(fetchCalendarRuntime)
+  .https
+  .onCall(async (data, context) => {
+    const rateLimit = checkCalendarFetchRateLimit(context.rawRequest || {});
+    if (!rateLimit.allowed) {
+      throw new functions.https.HttpsError('resource-exhausted', 'Too many calendar requests.');
+    }
+
+    const teamId = String(data?.teamId || '').trim();
+    if (!teamId || !/^[A-Za-z0-9_-]{1,128}$/.test(teamId)) {
+      throw new functions.https.HttpsError('invalid-argument', 'A valid teamId is required.');
+    }
+
+    const teamSnap = await firestore.doc(`teams/${teamId}`).get();
+    const team = teamSnap.exists ? teamSnap.data() || {} : null;
+    if (!team || !isPublicTeamDiscoverable(team)) {
+      throw new functions.https.HttpsError('not-found', 'Public team calendar not found.');
+    }
+
+    const calendarUrls = (Array.isArray(team.calendarUrls) ? team.calendarUrls : [])
+      .filter((url) => typeof url === 'string' && url.trim())
+      .slice(0, MAX_PUBLIC_EXTERNAL_CALENDAR_SOURCES);
+    const results = await Promise.allSettled(calendarUrls.map(fetchSanitizedPublicExternalCalendarIcs));
+    const calendars = results
+      .filter((result) => result.status === 'fulfilled' && result.value)
+      .map((result) => result.value);
+
+    return {
+      calendars,
+      unavailableCount: results.length - calendars.length
+    };
+  });
 
 exports.publicTeamGamesIcs = functions
   .runWith(fetchCalendarRuntime)

--- a/functions/index.js
+++ b/functions/index.js
@@ -36,6 +36,11 @@ const {
 } = require('./registration-payment-webhook-core.cjs');
 const { createFirestoreFixedWindowRateLimiter, createInMemoryRateLimiter, getRequestIp } = require('./rate-limit.cjs');
 const { buildPublicGamesIcs, canExposeEmptyPublicFeed, isPublicFanGame } = require('./public-calendar-core.cjs');
+const {
+  buildPublicTeamProfile,
+  isPublicTeamProfileSchemaValid,
+  matchesPublicTeamProfileSearch
+} = require('./public-team-profile-core.cjs');
 const { buildCalendarFeedGamesQuery } = require('./calendar-feed-window-core.cjs');
 const {
   buildPublicRsvpSummaryProjection,
@@ -13122,20 +13127,57 @@ exports.getPublicTeamProfile = functions.https.onCall(async (data, context = {})
   }
   const teamSnap = await firestore.doc(`teams/${teamId}`).get();
   const team = teamSnap.data() || {};
-  if (!teamSnap.exists || !isOpportunityTeamDiscoverable(team)) {
+  const profile = buildPublicTeamProfile(team);
+  if (!teamSnap.exists || !profile) {
     throwOpportunityError('not-found', 'Public team not found.');
   }
   return {
     item: {
       id: teamSnap.id,
-      name: cleanOpportunityText(team.name, 100),
-      sport: cleanOpportunityText(team.sport, 60) || null,
-      description: cleanOpportunityText(team.description, 1000) || null,
-      photoUrl: cleanOpportunityText(team.photoUrl, 1000) || null,
-      city: cleanOpportunityText(team.city, 80) || null,
-      state: cleanOpportunityText(team.state, 40) || null,
-      zip: cleanOpportunityText(team.zip, 10) || null
+      ...profile
     }
+  };
+});
+
+exports.discoverPublicTeamProfiles = functions.https.onCall(async (data, context = {}) => {
+  assertOpportunityRateLimit(checkPublicOpportunityBrowseRateLimit, context, 'team-discovery-fallback');
+  const searchText = cleanOpportunityText(data?.searchText, 120).toLowerCase();
+  const requestedPageSize = Number(data?.pageSize);
+  const pageSize = Number.isFinite(requestedPageSize)
+    ? Math.min(Math.max(Math.floor(requestedPageSize), 1), 100)
+    : 24;
+  const cursor = data?.cursor && typeof data.cursor === 'object' ? data.cursor : null;
+  const cursorMatches = cursor?.kind === 'public-team-callable' &&
+    cleanOpportunityText(cursor.searchText, 120).toLowerCase() === searchText;
+  const offset = cursorMatches && Number.isInteger(cursor.offset) && cursor.offset >= 0
+    ? cursor.offset
+    : 0;
+
+  // This path is a bounded deployment-order fallback for databases that
+  // predate publicTeamProfiles. Normal browse queries read the projection
+  // collection directly after the backfill.
+  const teamSnap = await firestore.collection('teams')
+    .where('isPublic', '==', true)
+    .limit(1000)
+    .get();
+  const profiles = teamSnap.docs
+    .map((docSnap) => {
+      const profile = buildPublicTeamProfile(docSnap.data() || {});
+      return profile && isPublicTeamProfileSchemaValid(profile)
+        ? { id: docSnap.id, ...profile }
+        : null;
+    })
+    .filter(Boolean)
+    .filter((profile) => matchesPublicTeamProfileSearch(profile, searchText))
+    .sort((left, right) => String(left.name || '').localeCompare(String(right.name || '')) || left.id.localeCompare(right.id));
+  const items = profiles.slice(offset, offset + pageSize);
+  const nextOffset = offset + items.length;
+  return {
+    teams: items,
+    nextCursor: nextOffset < profiles.length
+      ? { kind: 'public-team-callable', searchText, offset: nextOffset }
+      : null,
+    boundedSourceCount: teamSnap.size
   };
 });
 
@@ -13417,5 +13459,28 @@ exports.closePublicOpportunitiesForPrivateTeam = functions.firestore
       }));
       await batch.commit();
     }
+    return null;
+  });
+
+exports.syncPublicTeamProfileOnTeamWrite = functions.firestore
+  .document('teams/{teamId}')
+  .onWrite(async (change, context) => {
+    const profileRef = firestore.doc(`publicTeamProfiles/${context.params.teamId}`);
+    const team = change.after.exists ? (change.after.data() || {}) : null;
+    const profile = team ? buildPublicTeamProfile(team) : null;
+
+    if (!profile) {
+      await profileRef.delete().catch((error) => {
+        if (error?.code !== 5 && error?.code !== 'not-found') throw error;
+      });
+      return null;
+    }
+    if (!isPublicTeamProfileSchemaValid(profile)) {
+      throw new Error(`Refusing invalid public team profile for ${context.params.teamId}.`);
+    }
+
+    // Overwrite instead of merge so a field removed from the allowlist or the
+    // source team cannot remain exposed on an older projection document.
+    await profileRef.set(profile);
     return null;
   });

--- a/functions/index.js
+++ b/functions/index.js
@@ -38,7 +38,6 @@ const { createFirestoreFixedWindowRateLimiter, createInMemoryRateLimiter, getReq
 const { buildPublicGamesIcs, canExposeEmptyPublicFeed, isPublicFanGame } = require('./public-calendar-core.cjs');
 const {
   buildPublicTeamProfile,
-  collectAllPublicTeamSourceDocuments,
   isPublicTeamProfileSchemaValid,
   matchesPublicTeamProfileSearch
 } = require('./public-team-profile-core.cjs');
@@ -12492,6 +12491,89 @@ async function normalizeTeamEmailAttachmentsForDelivery(teamId, attachments) {
 // Public sports opportunity board. Public responses are serialized through an
 // explicit allow-list; Firestore rules deny direct client access to the source
 // documents because they also contain author and recipient identifiers.
+const PUBLIC_TEAM_PROFILE_MIGRATION_STATE_PATH = 'systemMigrations/publicTeamProfilesBackfill';
+const PUBLIC_TEAM_DISCOVERY_SCAN_LIMIT = 500;
+const PUBLIC_TEAM_DISCOVERY_BATCH_SIZE = 100;
+
+function readPublicTeamBrowseCursor(rawCursor, { searchText, useProjection }) {
+  const expectedSource = useProjection ? 'projection' : 'source';
+  if (!rawCursor || rawCursor.kind !== 'public-team-callable-v2' || rawCursor.source !== expectedSource) return null;
+  if (cleanOpportunityText(rawCursor.searchText, 120).toLowerCase() !== searchText) return null;
+  const lastId = String(rawCursor.lastId || '').trim();
+  const lastName = rawCursor.lastName;
+  if (!lastId || lastId.includes('/') || lastId.length > 1500) return null;
+  const lastNameType = typeof lastName;
+  if (lastName !== null && !['string', 'number', 'boolean'].includes(lastNameType)) return null;
+  if (String(lastName).length > 100) return null;
+  return { lastId, lastName };
+}
+
+async function collectPublicTeamBrowsePage({ useProjection, searchText, pageSize, cursor }) {
+  const collectionName = useProjection ? 'publicTeamProfiles' : 'teams';
+  let scanCursor = readPublicTeamBrowseCursor(cursor, { searchText, useProjection });
+  let scannedDocumentCount = 0;
+  let exhausted = false;
+  const teams = [];
+
+  while (teams.length < pageSize && scannedDocumentCount < PUBLIC_TEAM_DISCOVERY_SCAN_LIMIT && !exhausted) {
+    const remainingScanBudget = PUBLIC_TEAM_DISCOVERY_SCAN_LIMIT - scannedDocumentCount;
+    const requestedBatchSize = Math.min(PUBLIC_TEAM_DISCOVERY_BATCH_SIZE, remainingScanBudget);
+    let browseQuery = firestore.collection(collectionName);
+    if (useProjection) {
+      browseQuery = browseQuery
+        .where('publicSchemaVersion', '==', 1)
+        .where('isPublic', '==', true)
+        .where('active', '==', true)
+        .orderBy('name');
+    } else {
+      browseQuery = browseQuery
+        .where('isPublic', '==', true)
+        .orderBy('name');
+    }
+    browseQuery = browseQuery
+      .orderBy(admin.firestore.FieldPath.documentId())
+      .limit(requestedBatchSize);
+    if (scanCursor) browseQuery = browseQuery.startAfter(scanCursor.lastName, scanCursor.lastId);
+
+    const snapshot = await browseQuery.get();
+    if (snapshot.empty) {
+      exhausted = true;
+      break;
+    }
+
+    let consumedDocumentCount = 0;
+    for (const docSnap of snapshot.docs) {
+      consumedDocumentCount += 1;
+      scannedDocumentCount += 1;
+      scanCursor = { lastName: docSnap.data()?.name, lastId: docSnap.id };
+      const profile = useProjection
+        ? docSnap.data() || null
+        : buildPublicTeamProfile(docSnap.data() || {});
+      if (profile && isPublicTeamProfileSchemaValid(profile) && matchesPublicTeamProfileSearch(profile, searchText)) {
+        teams.push({ id: docSnap.id, ...profile });
+      }
+      if (teams.length >= pageSize) break;
+    }
+
+    exhausted = consumedDocumentCount === snapshot.docs.length && snapshot.docs.length < requestedBatchSize;
+  }
+
+  const hasMore = !exhausted && scanCursor && scannedDocumentCount > 0;
+  return {
+    teams,
+    nextCursor: hasMore
+      ? {
+          kind: 'public-team-callable-v2',
+          source: useProjection ? 'projection' : 'source',
+          searchText,
+          lastName: scanCursor.lastName,
+          lastId: scanCursor.lastId
+        }
+      : null,
+    scannedDocumentCount
+  };
+}
+
 function throwOpportunityError(code, message, details = {}) {
   throw new functions.https.HttpsError(code, message, details);
 }
@@ -13141,48 +13223,25 @@ exports.getPublicTeamProfile = functions.https.onCall(async (data, context = {})
 });
 
 exports.discoverPublicTeamProfiles = functions.https.onCall(async (data, context = {}) => {
-  assertOpportunityRateLimit(checkPublicOpportunityBrowseRateLimit, context, 'team-discovery-fallback');
+  assertOpportunityRateLimit(checkPublicOpportunityBrowseRateLimit, context, 'team-discovery');
   const searchText = cleanOpportunityText(data?.searchText, 120).toLowerCase();
   const requestedPageSize = Number(data?.pageSize);
   const pageSize = Number.isFinite(requestedPageSize)
     ? Math.min(Math.max(Math.floor(requestedPageSize), 1), 100)
     : 24;
   const cursor = data?.cursor && typeof data.cursor === 'object' ? data.cursor : null;
-  const cursorMatches = cursor?.kind === 'public-team-callable' &&
-    cleanOpportunityText(cursor.searchText, 120).toLowerCase() === searchText;
-  const offset = cursorMatches && Number.isInteger(cursor.offset) && cursor.offset >= 0
-    ? cursor.offset
-    : 0;
 
-  // This path is a deployment-order fallback for databases that
-  // predate publicTeamProfiles. Normal browse queries read the projection
-  // collection directly after the backfill.
-  const teamDocs = await collectAllPublicTeamSourceDocuments(async ({ cursor: sourceCursor, pageSize: sourcePageSize }) => {
-    let sourceQuery = firestore.collection('teams')
-      .where('isPublic', '==', true)
-      .orderBy(admin.firestore.FieldPath.documentId())
-      .limit(sourcePageSize);
-    if (sourceCursor) sourceQuery = sourceQuery.startAfter(sourceCursor);
-    return sourceQuery.get();
-  });
-  const profiles = teamDocs
-    .map((docSnap) => {
-      const profile = buildPublicTeamProfile(docSnap.data() || {});
-      return profile && isPublicTeamProfileSchemaValid(profile)
-        ? { id: docSnap.id, ...profile }
-        : null;
-    })
-    .filter(Boolean)
-    .filter((profile) => matchesPublicTeamProfileSearch(profile, searchText))
-    .sort((left, right) => String(left.name || '').localeCompare(String(right.name || '')) || left.id.localeCompare(right.id));
-  const items = profiles.slice(offset, offset + pageSize);
-  const nextOffset = offset + items.length;
+  // Until the full backfill records completion, use the bounded source path so
+  // a partial projection cannot hide teams. Afterwards, only the allow-listed
+  // projection and its dedicated indexes serve anonymous browse requests.
+  const migrationStateSnap = await firestore.doc(PUBLIC_TEAM_PROFILE_MIGRATION_STATE_PATH).get();
+  const useProjection = migrationStateSnap.exists && migrationStateSnap.data()?.completed === true;
+  const page = await collectPublicTeamBrowsePage({ useProjection, searchText, pageSize, cursor });
   return {
-    teams: items,
-    nextCursor: nextOffset < profiles.length
-      ? { kind: 'public-team-callable', searchText, offset: nextOffset }
-      : null,
-    scannedSourceCount: teamDocs.length
+    teams: page.teams,
+    nextCursor: page.nextCursor,
+    scannedSourceCount: useProjection ? 0 : page.scannedDocumentCount,
+    scannedProjectionCount: useProjection ? page.scannedDocumentCount : 0
   };
 });
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -12494,6 +12494,7 @@ async function normalizeTeamEmailAttachmentsForDelivery(teamId, attachments) {
 const PUBLIC_TEAM_PROFILE_MIGRATION_STATE_PATH = 'systemMigrations/publicTeamProfilesBackfill';
 const PUBLIC_TEAM_DISCOVERY_SCAN_LIMIT = 500;
 const PUBLIC_TEAM_DISCOVERY_BATCH_SIZE = 100;
+const PUBLIC_TEAM_DISCOVERY_CURSOR_VALUE_LIMIT_BYTES = 1500;
 
 function readPublicTeamBrowseCursor(rawCursor, { searchText, useProjection }) {
   const expectedSource = useProjection ? 'projection' : 'source';
@@ -12504,7 +12505,7 @@ function readPublicTeamBrowseCursor(rawCursor, { searchText, useProjection }) {
   if (!lastId || lastId.includes('/') || lastId.length > 1500) return null;
   const lastNameType = typeof lastName;
   if (lastName !== null && !['string', 'number', 'boolean'].includes(lastNameType)) return null;
-  if (String(lastName).length > 100) return null;
+  if (Buffer.byteLength(String(lastName), 'utf8') > PUBLIC_TEAM_DISCOVERY_CURSOR_VALUE_LIMIT_BYTES) return null;
   return { lastId, lastName };
 }
 
@@ -13202,6 +13203,7 @@ exports.listManagedPublicOpportunityTeams = functions.https.onCall(async (_data,
 
 exports.getPublicTeamProfile = functions.https.onCall(async (data, context = {}) => {
   assertOpportunityRateLimit(checkPublicOpportunityBrowseRateLimit, context, 'team-profile');
+  const includeInactive = data?.includeInactive === true;
   let teamId;
   try {
     teamId = normalizeFirestoreId(data?.teamId, 'teamId');
@@ -13210,7 +13212,7 @@ exports.getPublicTeamProfile = functions.https.onCall(async (data, context = {})
   }
   const teamSnap = await firestore.doc(`teams/${teamId}`).get();
   const team = teamSnap.data() || {};
-  const profile = buildPublicTeamProfile(team);
+  const profile = buildPublicTeamProfile(team, { includeInactive });
   if (!teamSnap.exists || !profile) {
     throwOpportunityError('not-found', 'Public team not found.');
   }

--- a/functions/public-external-calendar-core.cjs
+++ b/functions/public-external-calendar-core.cjs
@@ -1,0 +1,134 @@
+const MAX_PUBLIC_EXTERNAL_CALENDAR_EVENTS = 500;
+const MAX_PUBLIC_EXTERNAL_CALENDAR_ICS_LENGTH = 512_000;
+const MAX_PUBLIC_EXTERNAL_CALENDAR_PROPERTY_LENGTH = 4_096;
+
+const PUBLIC_EVENT_PROPERTIES = new Set([
+  'UID',
+  'DTSTART',
+  'DTEND',
+  'RECURRENCE-ID',
+  'SUMMARY',
+  'LOCATION',
+  'STATUS',
+  'RRULE',
+  'EXDATE'
+]);
+
+const DATE_EVENT_PROPERTIES = new Set([
+  'DTSTART',
+  'DTEND',
+  'RECURRENCE-ID',
+  'EXDATE'
+]);
+
+function unfoldIcsLines(icsText) {
+  const unfolded = [];
+  for (const rawLine of String(icsText || '').split(/\r\n|\n|\r/)) {
+    if (/^[ \t]/.test(rawLine) && unfolded.length) {
+      unfolded[unfolded.length - 1] += rawLine.slice(1);
+      continue;
+    }
+    unfolded.push(rawLine);
+  }
+  return unfolded;
+}
+
+function sanitizeDatePropertyDescriptor(descriptor, propertyName) {
+  const parameters = descriptor.split(';').slice(1);
+  const safeParameters = [];
+
+  for (const parameter of parameters) {
+    const separatorIndex = parameter.indexOf('=');
+    if (separatorIndex <= 0) continue;
+    const name = parameter.slice(0, separatorIndex).trim().toUpperCase();
+    const value = parameter.slice(separatorIndex + 1).trim();
+    if (name === 'VALUE' && /^(?:DATE|DATE-TIME)$/i.test(value)) {
+      safeParameters.push(`VALUE=${value.toUpperCase()}`);
+    }
+    if (name === 'TZID' && /^[A-Za-z0-9_+./-]{1,100}$/.test(value)) {
+      safeParameters.push(`TZID=${value}`);
+    }
+  }
+
+  return [propertyName, ...safeParameters].join(';');
+}
+
+function findIcsValueSeparator(line) {
+  let inQuotes = false;
+  for (let index = 0; index < line.length; index += 1) {
+    if (line[index] === '"' && line[index - 1] !== '\\') {
+      inQuotes = !inQuotes;
+      continue;
+    }
+    if (line[index] === ':' && !inQuotes) return index;
+  }
+  return -1;
+}
+
+function sanitizeEventPropertyLine(rawLine) {
+  const colonIndex = findIcsValueSeparator(rawLine);
+  if (colonIndex <= 0) return null;
+
+  const descriptor = rawLine.slice(0, colonIndex).trim();
+  const propertyName = descriptor.split(';')[0].trim().toUpperCase();
+  if (!PUBLIC_EVENT_PROPERTIES.has(propertyName)) return null;
+
+  const safeDescriptor = DATE_EVENT_PROPERTIES.has(propertyName)
+    ? sanitizeDatePropertyDescriptor(descriptor, propertyName)
+    : propertyName;
+  const value = rawLine
+    .slice(colonIndex + 1)
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, '')
+    .slice(0, MAX_PUBLIC_EXTERNAL_CALENDAR_PROPERTY_LENGTH);
+  return `${safeDescriptor}:${value}`;
+}
+
+function sanitizePublicExternalCalendarIcs(icsText) {
+  const sanitizedEvents = [];
+  let currentEvent = null;
+  let eventCount = 0;
+
+  for (const rawLine of unfoldIcsLines(icsText)) {
+    const normalizedLine = rawLine.trim();
+    if (normalizedLine === 'BEGIN:VEVENT') {
+      currentEvent = [];
+      continue;
+    }
+    if (normalizedLine === 'END:VEVENT') {
+      if (currentEvent && currentEvent.length && eventCount < MAX_PUBLIC_EXTERNAL_CALENDAR_EVENTS) {
+        sanitizedEvents.push(['BEGIN:VEVENT', ...currentEvent, 'END:VEVENT']);
+        eventCount += 1;
+        if (eventCount >= MAX_PUBLIC_EXTERNAL_CALENDAR_EVENTS) break;
+      }
+      currentEvent = null;
+      continue;
+    }
+    if (!currentEvent) continue;
+    const safeLine = sanitizeEventPropertyLine(normalizedLine);
+    if (safeLine) currentEvent.push(safeLine);
+  }
+
+  if (!eventCount) return '';
+  const output = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//ALL PLAYS//Public External Schedule//EN'
+  ];
+  let outputLength = output.join('\r\n').length;
+  const calendarEndLength = '\r\nEND:VCALENDAR'.length;
+  for (const eventLines of sanitizedEvents) {
+    const eventLength = `\r\n${eventLines.join('\r\n')}`.length;
+    if (outputLength + eventLength + calendarEndLength > MAX_PUBLIC_EXTERNAL_CALENDAR_ICS_LENGTH) break;
+    output.push(...eventLines);
+    outputLength += eventLength;
+  }
+  if (output.length === 3) return '';
+  output.push('END:VCALENDAR');
+  return output.join('\r\n');
+}
+
+module.exports = {
+  MAX_PUBLIC_EXTERNAL_CALENDAR_EVENTS,
+  MAX_PUBLIC_EXTERNAL_CALENDAR_ICS_LENGTH,
+  sanitizePublicExternalCalendarIcs
+};

--- a/functions/public-team-profile-core.cjs
+++ b/functions/public-team-profile-core.cjs
@@ -284,16 +284,21 @@ function matchesPublicTeamProfileSearch(profile = {}, searchText = '') {
   return search.split(/[\s,]+/).filter(Boolean).every((token) => combined.includes(token));
 }
 
-async function collectAllPublicTeamSourceDocuments(fetchPage, { pageSize = 500 } = {}) {
+async function collectAllPublicTeamSourceDocuments(fetchPage, { pageSize = 500, maxDocuments } = {}) {
   if (typeof fetchPage !== 'function') throw new Error('A public team page loader is required.');
   const normalizedPageSize = Math.min(Math.max(Number(pageSize) || 500, 1), 1000);
+  const numericMaxDocuments = Number(maxDocuments);
+  const normalizedMaxDocuments = Number.isFinite(numericMaxDocuments) && numericMaxDocuments > 0
+    ? Math.floor(numericMaxDocuments)
+    : Number.POSITIVE_INFINITY;
   const documents = [];
   let cursor = null;
-  while (true) {
-    const page = await fetchPage({ cursor, pageSize: normalizedPageSize });
+  while (documents.length < normalizedMaxDocuments) {
+    const requestedPageSize = Math.min(normalizedPageSize, normalizedMaxDocuments - documents.length);
+    const page = await fetchPage({ cursor, pageSize: requestedPageSize });
     const pageDocuments = Array.isArray(page?.docs) ? page.docs : [];
-    documents.push(...pageDocuments);
-    if (pageDocuments.length < normalizedPageSize) break;
+    documents.push(...pageDocuments.slice(0, requestedPageSize));
+    if (pageDocuments.length < requestedPageSize) break;
     cursor = pageDocuments.at(-1);
   }
   return documents;

--- a/functions/public-team-profile-core.cjs
+++ b/functions/public-team-profile-core.cjs
@@ -1,0 +1,248 @@
+const PUBLIC_TEAM_PROFILE_FIELDS = Object.freeze([
+  'publicSchemaVersion',
+  'name',
+  'sport',
+  'description',
+  'photoUrl',
+  'city',
+  'state',
+  'zip',
+  'leagueUrl',
+  'websiteUrl',
+  'socialLinks',
+  'twitchChannel',
+  'streamUrl',
+  'livestreamUrl',
+  'streamEmbedUrl',
+  'youtubeEmbedUrl',
+  'standingsConfig',
+  'tournament',
+  'tournamentDivisions',
+  'tournamentPools',
+  'tournamentPoolOverrides',
+  'appAccess',
+  'webAccess',
+  'active',
+  'archived',
+  'status',
+  'isPublic',
+  'publicSearchName',
+  'publicSearchCity',
+  'publicSearchState',
+  'publicSearchZip',
+  'publicSearchCityState',
+  'sourceUpdatedAt'
+]);
+
+const PUBLIC_TEAM_PROFILE_FIELD_SET = new Set(PUBLIC_TEAM_PROFILE_FIELDS);
+const PUBLIC_SCHEMA_VERSION = 1;
+const MAX_NESTED_DEPTH = 6;
+const MAX_OBJECT_KEYS = 100;
+const MAX_ARRAY_ITEMS = 200;
+const MAX_NESTED_STRING_LENGTH = 2000;
+const BLOCKED_NESTED_KEY_PATTERN = /(token|secret|password|credential|private|admin|owner|manager|email|phone|contact|provider|registration|auth|api.?key|access.?key|webhook|calendar.?url)/i;
+const NESTED_PRESENTATION_FIELDS = new Set([
+  'standingsConfig', 'tournament', 'tournamentDivisions',
+  'tournamentPools', 'tournamentPoolOverrides'
+]);
+const TEXT_LIMITS = Object.freeze({
+  name: 100,
+  sport: 60,
+  description: 1000,
+  photoUrl: 1000,
+  city: 80,
+  state: 40,
+  zip: 16,
+  leagueUrl: 1000,
+  websiteUrl: 1000,
+  twitchChannel: 200,
+  streamUrl: 1000,
+  livestreamUrl: 1000,
+  streamEmbedUrl: 1000,
+  youtubeEmbedUrl: 1000,
+  status: 40
+});
+
+function normalizeText(value) {
+  return String(value || '').trim();
+}
+
+function sanitizeText(value, limit) {
+  if (typeof value !== 'string' && typeof value !== 'number') return undefined;
+  const text = String(value).trim();
+  return text ? text.slice(0, limit) : undefined;
+}
+
+function sanitizeUrl(value) {
+  const text = sanitizeText(value, 1000);
+  if (!text) return undefined;
+  try {
+    const parsed = new URL(text);
+    return ['https:', 'http:'].includes(parsed.protocol) ? text : undefined;
+  } catch (_error) {
+    return undefined;
+  }
+}
+
+function isPlainObject(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function sanitizeNestedPresentationValue(value, depth = 0) {
+  if (value === null || typeof value === 'boolean') return value;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : undefined;
+  if (typeof value === 'string') return value.slice(0, MAX_NESTED_STRING_LENGTH);
+  if (depth >= MAX_NESTED_DEPTH) return undefined;
+  if (Array.isArray(value)) {
+    return value.slice(0, MAX_ARRAY_ITEMS)
+      .map((item) => sanitizeNestedPresentationValue(item, depth + 1))
+      .filter((item) => item !== undefined);
+  }
+  if (!isPlainObject(value)) return undefined;
+  const result = {};
+  Object.entries(value).slice(0, MAX_OBJECT_KEYS).forEach(([key, item]) => {
+    const normalizedKey = String(key || '').trim().slice(0, 100);
+    if (!normalizedKey || BLOCKED_NESTED_KEY_PATTERN.test(normalizedKey)) return;
+    const sanitized = sanitizeNestedPresentationValue(item, depth + 1);
+    if (sanitized !== undefined) result[normalizedKey] = sanitized;
+  });
+  return result;
+}
+
+function sanitizeSocialLinks(value) {
+  if (!isPlainObject(value)) return undefined;
+  const allowed = new Set(['facebook', 'instagram', 'x', 'twitter', 'tiktok', 'youtube', 'linkedin', 'threads', 'bluesky']);
+  const result = {};
+  Object.entries(value).forEach(([key, url]) => {
+    const normalizedKey = String(key || '').trim().toLowerCase();
+    const sanitizedUrl = allowed.has(normalizedKey) ? sanitizeUrl(url) : undefined;
+    if (sanitizedUrl) result[normalizedKey] = sanitizedUrl;
+  });
+  return result;
+}
+
+function isSafeNestedPresentationValue(value, depth = 0) {
+  if (value === null || typeof value === 'boolean') return true;
+  if (typeof value === 'number') return Number.isFinite(value);
+  if (typeof value === 'string') return value.length <= MAX_NESTED_STRING_LENGTH;
+  if (depth >= MAX_NESTED_DEPTH) return false;
+  if (Array.isArray(value)) {
+    return value.length <= MAX_ARRAY_ITEMS && value.every((item) => isSafeNestedPresentationValue(item, depth + 1));
+  }
+  if (!isPlainObject(value)) return false;
+  const entries = Object.entries(value);
+  return entries.length <= MAX_OBJECT_KEYS && entries.every(([key, item]) => (
+    key.length > 0 && key.length <= 100 &&
+    !BLOCKED_NESTED_KEY_PATTERN.test(key) &&
+    isSafeNestedPresentationValue(item, depth + 1)
+  ));
+}
+
+function isPublicTeamActive(team = {}) {
+  const status = normalizeText(team.status).toLowerCase();
+  return team.active !== false &&
+    team.archived !== true &&
+    !['archived', 'inactive', 'disabled'].includes(status);
+}
+
+function isPublicTeamDiscoverable(team = {}) {
+  return team.isPublic === true && isPublicTeamActive(team);
+}
+
+function buildPublicTeamSearchFields(team = {}) {
+  const city = normalizeText(team.city).toLowerCase();
+  const state = normalizeText(team.state).toUpperCase();
+  return {
+    publicSearchName: normalizeText(team.name).toLowerCase(),
+    publicSearchCity: city,
+    publicSearchState: state,
+    publicSearchZip: normalizeText(team.zip),
+    publicSearchCityState: city && state ? `${city}, ${state.toLowerCase()}` : ''
+  };
+}
+
+function buildPublicTeamProfile(team = {}) {
+  if (!isPublicTeamDiscoverable(team)) return null;
+
+  const profile = {};
+  PUBLIC_TEAM_PROFILE_FIELDS.forEach((field) => {
+    if (field === 'sourceUpdatedAt' || field === 'publicSchemaVersion') return;
+    const value = team[field];
+    if (TEXT_LIMITS[field]) {
+      const sanitized = field.toLowerCase().includes('url') ? sanitizeUrl(value) : sanitizeText(value, TEXT_LIMITS[field]);
+      if (sanitized !== undefined) profile[field] = sanitized;
+      return;
+    }
+    if (field === 'socialLinks') {
+      const sanitized = sanitizeSocialLinks(value);
+      if (sanitized && Object.keys(sanitized).length) profile[field] = sanitized;
+      return;
+    }
+    if (NESTED_PRESENTATION_FIELDS.has(field)) {
+      const sanitized = sanitizeNestedPresentationValue(value);
+      if (sanitized !== undefined) profile[field] = sanitized;
+      return;
+    }
+    if (['appAccess', 'webAccess'].includes(field) && typeof value === 'boolean') profile[field] = value;
+  });
+
+  return {
+    ...profile,
+    ...buildPublicTeamSearchFields(team),
+    publicSchemaVersion: PUBLIC_SCHEMA_VERSION,
+    isPublic: true,
+    active: true,
+    sourceUpdatedAt: team.updatedAt || null
+  };
+}
+
+function matchesPublicTeamProfileSearch(profile = {}, searchText = '') {
+  const search = normalizeText(searchText).toLowerCase();
+  if (!search) return true;
+  const fields = [
+    profile.name,
+    profile.sport,
+    profile.city,
+    profile.state,
+    profile.zip,
+    profile.publicSearchCityState
+  ].map((value) => normalizeText(value).toLowerCase()).filter(Boolean);
+  const combined = fields.join(' ');
+  return search.split(/[\s,]+/).filter(Boolean).every((token) => combined.includes(token));
+}
+
+function findUnexpectedPublicTeamProfileFields(profile = {}) {
+  return Object.keys(profile).filter((field) => !PUBLIC_TEAM_PROFILE_FIELD_SET.has(field));
+}
+
+function isPublicTeamProfileSchemaValid(profile = {}) {
+  return profile &&
+    typeof profile === 'object' &&
+    !Array.isArray(profile) &&
+    profile.isPublic === true &&
+    profile.active === true &&
+    profile.publicSchemaVersion === PUBLIC_SCHEMA_VERSION &&
+    normalizeText(profile.name).length > 0 &&
+    findUnexpectedPublicTeamProfileFields(profile).length === 0 &&
+    [...NESTED_PRESENTATION_FIELDS].every((field) => (
+      !Object.prototype.hasOwnProperty.call(profile, field) || isSafeNestedPresentationValue(profile[field])
+    )) &&
+    (!Object.prototype.hasOwnProperty.call(profile, 'socialLinks') || (
+      isPlainObject(profile.socialLinks) &&
+      Object.values(profile.socialLinks).every((url) => typeof url === 'string' && url.length <= 1000)
+    ));
+}
+
+module.exports = {
+  PUBLIC_TEAM_PROFILE_FIELDS,
+  PUBLIC_SCHEMA_VERSION,
+  buildPublicTeamProfile,
+  buildPublicTeamSearchFields,
+  findUnexpectedPublicTeamProfileFields,
+  isPublicTeamActive,
+  isPublicTeamDiscoverable,
+  isPublicTeamProfileSchemaValid,
+  matchesPublicTeamProfileSearch
+};

--- a/functions/public-team-profile-core.cjs
+++ b/functions/public-team-profile-core.cjs
@@ -36,14 +36,17 @@ const PUBLIC_TEAM_PROFILE_FIELDS = Object.freeze([
 
 const PUBLIC_TEAM_PROFILE_FIELD_SET = new Set(PUBLIC_TEAM_PROFILE_FIELDS);
 const PUBLIC_SCHEMA_VERSION = 1;
-const MAX_NESTED_DEPTH = 6;
-const MAX_OBJECT_KEYS = 100;
 const MAX_ARRAY_ITEMS = 200;
-const MAX_NESTED_STRING_LENGTH = 2000;
-const BLOCKED_NESTED_KEY_PATTERN = /(token|secret|password|credential|private|admin|owner|manager|email|phone|contact|provider|registration|auth|api.?key|access.?key|webhook|calendar.?url)/i;
 const NESTED_PRESENTATION_FIELDS = new Set([
   'standingsConfig', 'tournament', 'tournamentDivisions',
   'tournamentPools', 'tournamentPoolOverrides'
+]);
+const STANDINGS_TIEBREAKER_VALUES = new Set([
+  'head_to_head', 'group_head_to_head',
+  'goal_diff', 'point_diff',
+  'goals_for', 'points_for',
+  'fewest_goals_allowed', 'fewest_points_against',
+  'most_games_won', 'wins', 'name'
 ]);
 const TEXT_LIMITS = Object.freeze({
   name: 100,
@@ -90,25 +93,102 @@ function isPlainObject(value) {
   return prototype === Object.prototype || prototype === null;
 }
 
-function sanitizeNestedPresentationValue(value, depth = 0) {
-  if (value === null || typeof value === 'boolean') return value;
-  if (typeof value === 'number') return Number.isFinite(value) ? value : undefined;
-  if (typeof value === 'string') return value.slice(0, MAX_NESTED_STRING_LENGTH);
-  if (depth >= MAX_NESTED_DEPTH) return undefined;
-  if (Array.isArray(value)) {
-    return value.slice(0, MAX_ARRAY_ITEMS)
-      .map((item) => sanitizeNestedPresentationValue(item, depth + 1))
-      .filter((item) => item !== undefined);
+function sanitizeFiniteNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : undefined;
+}
+
+function sanitizeStandingsTiebreakers(value) {
+  if (!Array.isArray(value)) return undefined;
+  return value.slice(0, 20)
+    .map((item) => normalizeText(item).toLowerCase())
+    .filter((item) => STANDINGS_TIEBREAKER_VALUES.has(item));
+}
+
+function sanitizeStandingsConfig(value) {
+  if (!isPlainObject(value)) return undefined;
+  const result = {};
+  if (typeof value.enabled === 'boolean') result.enabled = value.enabled;
+  if (['points', 'win_pct'].includes(value.rankingMode)) result.rankingMode = value.rankingMode;
+  if (isPlainObject(value.points)) {
+    const points = {};
+    ['win', 'tie', 'loss'].forEach((key) => {
+      const number = sanitizeFiniteNumber(value.points[key]);
+      if (number !== undefined) points[key] = number;
+    });
+    if (Object.keys(points).length) result.points = points;
+  }
+  const maxGoalDiff = sanitizeFiniteNumber(value.maxGoalDiff);
+  if (maxGoalDiff !== undefined && maxGoalDiff > 0) result.maxGoalDiff = maxGoalDiff;
+  if (value.maxGoalDiff === null) result.maxGoalDiff = null;
+  ['tiebreakers', 'twoTeamTiebreakers', 'multiTeamTiebreakers'].forEach((key) => {
+    const tiebreakers = sanitizeStandingsTiebreakers(value[key]);
+    if (tiebreakers !== undefined) result[key] = tiebreakers;
+  });
+  return result;
+}
+
+function sanitizeTournamentGroup(value) {
+  if (typeof value === 'string' || typeof value === 'number') {
+    return sanitizeText(value, 200);
   }
   if (!isPlainObject(value)) return undefined;
   const result = {};
-  Object.entries(value).slice(0, MAX_OBJECT_KEYS).forEach(([key, item]) => {
-    const normalizedKey = String(key || '').trim().slice(0, 100);
-    if (!normalizedKey || BLOCKED_NESTED_KEY_PATTERN.test(normalizedKey)) return;
-    const sanitized = sanitizeNestedPresentationValue(item, depth + 1);
-    if (sanitized !== undefined) result[normalizedKey] = sanitized;
+  ['name', 'label', 'divisionName', 'division', 'poolName'].forEach((key) => {
+    const text = sanitizeText(value[key], 200);
+    if (text !== undefined) result[key] = text;
+  });
+  return Object.keys(result).length ? result : undefined;
+}
+
+function sanitizeTournamentGroups(value) {
+  if (!Array.isArray(value)) return undefined;
+  return value.slice(0, MAX_ARRAY_ITEMS)
+    .map(sanitizeTournamentGroup)
+    .filter((item) => item !== undefined);
+}
+
+function sanitizeTournament(value) {
+  if (!isPlainObject(value)) return undefined;
+  const result = {};
+  ['name', 'label'].forEach((key) => {
+    const text = sanitizeText(value[key], 200);
+    if (text !== undefined) result[key] = text;
+  });
+  ['divisions', 'pools'].forEach((key) => {
+    const groups = sanitizeTournamentGroups(value[key]);
+    if (groups !== undefined) result[key] = groups;
   });
   return result;
+}
+
+function sanitizeTournamentPoolOverrides(value) {
+  if (!isPlainObject(value)) return undefined;
+  const result = {};
+  Object.entries(value).slice(0, MAX_ARRAY_ITEMS).forEach(([rawKey, rawOverride]) => {
+    const key = sanitizeText(rawKey, 300);
+    if (!key || !isPlainObject(rawOverride)) return;
+    const override = {};
+    ['poolName', 'groupKey'].forEach((field) => {
+      const text = sanitizeText(rawOverride[field], 300);
+      if (text !== undefined) override[field] = text;
+    });
+    if (Array.isArray(rawOverride.teamOrder)) {
+      override.teamOrder = rawOverride.teamOrder.slice(0, MAX_ARRAY_ITEMS)
+        .map((teamName) => sanitizeText(teamName, 200))
+        .filter(Boolean);
+    }
+    if (Object.keys(override).length) result[key] = override;
+  });
+  return result;
+}
+
+function sanitizeNestedPresentationField(field, value) {
+  if (field === 'standingsConfig') return sanitizeStandingsConfig(value);
+  if (field === 'tournament') return sanitizeTournament(value);
+  if (field === 'tournamentDivisions' || field === 'tournamentPools') return sanitizeTournamentGroups(value);
+  if (field === 'tournamentPoolOverrides') return sanitizeTournamentPoolOverrides(value);
+  return undefined;
 }
 
 function sanitizeSocialLinks(value) {
@@ -123,21 +203,12 @@ function sanitizeSocialLinks(value) {
   return result;
 }
 
-function isSafeNestedPresentationValue(value, depth = 0) {
-  if (value === null || typeof value === 'boolean') return true;
-  if (typeof value === 'number') return Number.isFinite(value);
-  if (typeof value === 'string') return value.length <= MAX_NESTED_STRING_LENGTH;
-  if (depth >= MAX_NESTED_DEPTH) return false;
-  if (Array.isArray(value)) {
-    return value.length <= MAX_ARRAY_ITEMS && value.every((item) => isSafeNestedPresentationValue(item, depth + 1));
+function stableSerialize(value) {
+  if (Array.isArray(value)) return `[${value.map(stableSerialize).join(',')}]`;
+  if (isPlainObject(value)) {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableSerialize(value[key])}`).join(',')}}`;
   }
-  if (!isPlainObject(value)) return false;
-  const entries = Object.entries(value);
-  return entries.length <= MAX_OBJECT_KEYS && entries.every(([key, item]) => (
-    key.length > 0 && key.length <= 100 &&
-    !BLOCKED_NESTED_KEY_PATTERN.test(key) &&
-    isSafeNestedPresentationValue(item, depth + 1)
-  ));
+  return JSON.stringify(value);
 }
 
 function isPublicTeamActive(team = {}) {
@@ -181,7 +252,7 @@ function buildPublicTeamProfile(team = {}) {
       return;
     }
     if (NESTED_PRESENTATION_FIELDS.has(field)) {
-      const sanitized = sanitizeNestedPresentationValue(value);
+      const sanitized = sanitizeNestedPresentationField(field, value);
       if (sanitized !== undefined) profile[field] = sanitized;
       return;
     }
@@ -213,6 +284,21 @@ function matchesPublicTeamProfileSearch(profile = {}, searchText = '') {
   return search.split(/[\s,]+/).filter(Boolean).every((token) => combined.includes(token));
 }
 
+async function collectAllPublicTeamSourceDocuments(fetchPage, { pageSize = 500 } = {}) {
+  if (typeof fetchPage !== 'function') throw new Error('A public team page loader is required.');
+  const normalizedPageSize = Math.min(Math.max(Number(pageSize) || 500, 1), 1000);
+  const documents = [];
+  let cursor = null;
+  while (true) {
+    const page = await fetchPage({ cursor, pageSize: normalizedPageSize });
+    const pageDocuments = Array.isArray(page?.docs) ? page.docs : [];
+    documents.push(...pageDocuments);
+    if (pageDocuments.length < normalizedPageSize) break;
+    cursor = pageDocuments.at(-1);
+  }
+  return documents;
+}
+
 function findUnexpectedPublicTeamProfileFields(profile = {}) {
   return Object.keys(profile).filter((field) => !PUBLIC_TEAM_PROFILE_FIELD_SET.has(field));
 }
@@ -227,7 +313,8 @@ function isPublicTeamProfileSchemaValid(profile = {}) {
     normalizeText(profile.name).length > 0 &&
     findUnexpectedPublicTeamProfileFields(profile).length === 0 &&
     [...NESTED_PRESENTATION_FIELDS].every((field) => (
-      !Object.prototype.hasOwnProperty.call(profile, field) || isSafeNestedPresentationValue(profile[field])
+      !Object.prototype.hasOwnProperty.call(profile, field) ||
+      stableSerialize(profile[field]) === stableSerialize(sanitizeNestedPresentationField(field, profile[field]))
     )) &&
     (!Object.prototype.hasOwnProperty.call(profile, 'socialLinks') || (
       isPlainObject(profile.socialLinks) &&
@@ -240,6 +327,7 @@ module.exports = {
   PUBLIC_SCHEMA_VERSION,
   buildPublicTeamProfile,
   buildPublicTeamSearchFields,
+  collectAllPublicTeamSourceDocuments,
   findUnexpectedPublicTeamProfileFields,
   isPublicTeamActive,
   isPublicTeamDiscoverable,

--- a/functions/public-team-profile-core.cjs
+++ b/functions/public-team-profile-core.cjs
@@ -234,8 +234,10 @@ function buildPublicTeamSearchFields(team = {}) {
   };
 }
 
-function buildPublicTeamProfile(team = {}) {
-  if (!isPublicTeamDiscoverable(team)) return null;
+function buildPublicTeamProfile(team = {}, options = {}) {
+  const active = isPublicTeamActive(team);
+  const includeInactive = options?.includeInactive === true;
+  if (team.isPublic !== true || (!includeInactive && !active)) return null;
 
   const profile = {};
   PUBLIC_TEAM_PROFILE_FIELDS.forEach((field) => {
@@ -264,7 +266,7 @@ function buildPublicTeamProfile(team = {}) {
     ...buildPublicTeamSearchFields(team),
     publicSchemaVersion: PUBLIC_SCHEMA_VERSION,
     isPublic: true,
-    active: true,
+    active,
     sourceUpdatedAt: team.updatedAt || null
   };
 }

--- a/functions/public-team-profile-core.cjs
+++ b/functions/public-team-profile-core.cjs
@@ -274,6 +274,9 @@ function buildPublicTeamProfile(team = {}, options = {}) {
 function matchesPublicTeamProfileSearch(profile = {}, searchText = '') {
   const search = normalizeText(searchText).toLowerCase();
   if (!search) return true;
+  if (/^[a-z]{2}$/.test(search)) {
+    return normalizeText(profile.state).toLowerCase() === search;
+  }
   const fields = [
     profile.name,
     profile.sport,

--- a/functions/public-team-profile-core.cjs
+++ b/functions/public-team-profile-core.cjs
@@ -65,6 +65,17 @@ const TEXT_LIMITS = Object.freeze({
   youtubeEmbedUrl: 1000,
   status: 40
 });
+const PUBLIC_TEAM_PROFILE_STRING_FIELDS = Object.freeze([
+  ...Object.keys(TEXT_LIMITS),
+  'publicSearchName',
+  'publicSearchCity',
+  'publicSearchState',
+  'publicSearchZip',
+  'publicSearchCityState'
+]);
+const PUBLIC_TEAM_PROFILE_BOOLEAN_FIELDS = Object.freeze([
+  'appAccess', 'webAccess', 'active', 'archived', 'isPublic'
+]);
 
 function normalizeText(value) {
   return String(value || '').trim();
@@ -91,6 +102,12 @@ function isPlainObject(value) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
   const prototype = Object.getPrototypeOf(value);
   return prototype === Object.prototype || prototype === null;
+}
+
+function isTimestampLike(value) {
+  return value === null ||
+    value instanceof Date ||
+    Boolean(value && typeof value === 'object' && typeof value.toMillis === 'function');
 }
 
 function sanitizeFiniteNumber(value) {
@@ -322,6 +339,13 @@ function isPublicTeamProfileSchemaValid(profile = {}) {
     profile.publicSchemaVersion === PUBLIC_SCHEMA_VERSION &&
     normalizeText(profile.name).length > 0 &&
     findUnexpectedPublicTeamProfileFields(profile).length === 0 &&
+    PUBLIC_TEAM_PROFILE_STRING_FIELDS.every((field) => (
+      !Object.prototype.hasOwnProperty.call(profile, field) || typeof profile[field] === 'string'
+    )) &&
+    PUBLIC_TEAM_PROFILE_BOOLEAN_FIELDS.every((field) => (
+      !Object.prototype.hasOwnProperty.call(profile, field) || typeof profile[field] === 'boolean'
+    )) &&
+    (!Object.prototype.hasOwnProperty.call(profile, 'sourceUpdatedAt') || isTimestampLike(profile.sourceUpdatedAt)) &&
     [...NESTED_PRESENTATION_FIELDS].every((field) => (
       !Object.prototype.hasOwnProperty.call(profile, field) ||
       stableSerialize(profile[field]) === stableSerialize(sanitizeNestedPresentationField(field, profile[field]))

--- a/functions/test/public-external-calendar-core.test.cjs
+++ b/functions/test/public-external-calendar-core.test.cjs
@@ -1,0 +1,85 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  MAX_PUBLIC_EXTERNAL_CALENDAR_EVENTS,
+  MAX_PUBLIC_EXTERNAL_CALENDAR_ICS_LENGTH,
+  sanitizePublicExternalCalendarIcs
+} = require('../public-external-calendar-core.cjs');
+
+test('public external calendar projection keeps schedule fields and strips private metadata', () => {
+  const sanitized = sanitizePublicExternalCalendarIcs([
+    'BEGIN:VCALENDAR',
+    'BEGIN:VEVENT',
+    'UID:event-1',
+    'DTSTART;TZID=America/Chicago:20260720T180000',
+    'DTEND;TZID=America/Chicago:20260720T193000',
+    'SUMMARY:Falcons vs Tigers',
+    'LOCATION:Main Field',
+    'STATUS:CONFIRMED',
+    'RRULE:FREQ=WEEKLY;COUNT=2',
+    'EXDATE;TZID=America/Chicago:20260727T180000',
+    'DESCRIPTION:Parent phone 555-0100',
+    'ATTENDEE;CN=Private Parent:mailto:parent@example.test',
+    'ORGANIZER:mailto:coach@example.test',
+    'URL:https://calendar.example.test/private-token',
+    'BEGIN:VALARM',
+    'TRIGGER:-PT30M',
+    'END:VALARM',
+    'END:VEVENT',
+    'END:VCALENDAR'
+  ].join('\r\n'));
+
+  assert.match(sanitized, /UID:event-1/);
+  assert.match(sanitized, /DTSTART;TZID=America\/Chicago:20260720T180000/);
+  assert.match(sanitized, /SUMMARY:Falcons vs Tigers/);
+  assert.match(sanitized, /LOCATION:Main Field/);
+  assert.match(sanitized, /RRULE:FREQ=WEEKLY;COUNT=2/);
+  assert.doesNotMatch(sanitized, /DESCRIPTION|ATTENDEE|ORGANIZER|private-token|VALARM|TRIGGER/);
+  assert.ok(sanitized.endsWith('END:VCALENDAR'));
+});
+
+test('public external calendar projection unfolds public values and sanitizes property parameters', () => {
+  const sanitized = sanitizePublicExternalCalendarIcs([
+    'BEGIN:VCALENDAR',
+    'BEGIN:VEVENT',
+    'UID;ALTREP="https://private.example.test":event-2',
+    'DTSTART;TZID=America/Chicago;ALTREP="https://private.example.test":20260721T180000',
+    'SUMMARY:Falcons vs',
+    ' Tigers',
+    'LOCATION;ALTREP="https://private.example.test":Field 2',
+    'END:VEVENT',
+    'END:VCALENDAR'
+  ].join('\n'));
+
+  assert.match(sanitized, /UID:event-2/);
+  assert.match(sanitized, /DTSTART;TZID=America\/Chicago:20260721T180000/);
+  assert.match(sanitized, /SUMMARY:Falcons vsTigers/);
+  assert.match(sanitized, /LOCATION:Field 2/);
+  assert.doesNotMatch(sanitized, /ALTREP|private\.example\.test/);
+});
+
+test('public external calendar projection is event-count and payload bounded', () => {
+  const events = Array.from({ length: MAX_PUBLIC_EXTERNAL_CALENDAR_EVENTS + 25 }, (_, index) => [
+    'BEGIN:VEVENT',
+    `UID:event-${index}`,
+    `DTSTART:202607${String((index % 28) + 1).padStart(2, '0')}T180000Z`,
+    `SUMMARY:${'A'.repeat(5000)}`,
+    'END:VEVENT'
+  ].join('\r\n'));
+  const sanitized = sanitizePublicExternalCalendarIcs([
+    'BEGIN:VCALENDAR',
+    ...events,
+    'END:VCALENDAR'
+  ].join('\r\n'));
+
+  assert.ok(sanitized.length <= MAX_PUBLIC_EXTERNAL_CALENDAR_ICS_LENGTH);
+  assert.ok(sanitized.endsWith('END:VCALENDAR'));
+  assert.ok((sanitized.match(/BEGIN:VEVENT/g) || []).length <= MAX_PUBLIC_EXTERNAL_CALENDAR_EVENTS);
+  const summaries = sanitized.split('\r\n').filter((line) => line.startsWith('SUMMARY:'));
+  assert.ok(summaries.every((line) => line.length <= 'SUMMARY:'.length + 4_096));
+});
+
+test('public external calendar projection omits invalid or empty payloads', () => {
+  assert.equal(sanitizePublicExternalCalendarIcs('not a calendar'), '');
+  assert.equal(sanitizePublicExternalCalendarIcs('BEGIN:VCALENDAR\nEND:VCALENDAR'), '');
+});

--- a/functions/test/public-opportunities-callables.test.cjs
+++ b/functions/test/public-opportunities-callables.test.cjs
@@ -414,6 +414,25 @@ test('public team discovery pages the compatibility source without exposing mana
     assert.equal(Object.hasOwn(secondPage.teams[0], 'paymentConfig'), false);
 });
 
+test('public team discovery exact-matches whole state-code queries without breaking city-state searches', async () => {
+    const { callables } = loadCallables({
+        'teams/name-match': {
+            name: 'Indiana Bears', city: 'Kansas City', state: 'MO', isPublic: true, active: true
+        },
+        'teams/state-match': {
+            name: 'Wildcats', city: 'Bloomington', state: 'IN', isPublic: true, active: true
+        }
+    });
+
+    const statePage = await callables.discoverPublicTeamProfiles({ searchText: 'IN', pageSize: 10 }, {});
+    assert.deepEqual(statePage.teams.map((team) => team.id), ['state-match']);
+
+    const cityStatePage = await callables.discoverPublicTeamProfiles({
+        searchText: 'bloomington in', pageSize: 10
+    }, {});
+    assert.deepEqual(cityStatePage.teams.map((team) => team.id), ['state-match']);
+});
+
 test('public team source cursors preserve legacy names beyond presentation limits', async () => {
     const longSourceName = `Legacy ${'x'.repeat(110)}`;
     const { callables } = loadCallables({

--- a/functions/test/public-opportunities-callables.test.cjs
+++ b/functions/test/public-opportunities-callables.test.cjs
@@ -414,6 +414,49 @@ test('public team discovery pages the compatibility source without exposing mana
     assert.equal(Object.hasOwn(secondPage.teams[0], 'paymentConfig'), false);
 });
 
+test('public team source cursors preserve legacy names beyond presentation limits', async () => {
+    const longSourceName = `Legacy ${'x'.repeat(110)}`;
+    const { callables } = loadCallables({
+        'teams/long-name-team': { name: longSourceName, isPublic: true, active: true },
+        'teams/zeta-team': { name: 'Zeta', isPublic: true, active: true }
+    });
+
+    const firstPage = await callables.discoverPublicTeamProfiles({ pageSize: 1 }, {});
+    assert.deepEqual(firstPage.teams.map((team) => team.id), ['long-name-team']);
+    assert.equal(firstPage.nextCursor.lastName, longSourceName);
+
+    const secondPage = await callables.discoverPublicTeamProfiles({
+        pageSize: 1,
+        cursor: firstPage.nextCursor
+    }, {});
+    assert.deepEqual(secondPage.teams.map((team) => team.id), ['zeta-team']);
+    assert.equal(secondPage.nextCursor, null);
+});
+
+test('inactive public team details are available only through the explicit replay lookup', async () => {
+    const { callables } = loadCallables({
+        'teams/inactive-public': {
+            name: 'Inactive Public Team',
+            isPublic: true,
+            active: false,
+            ownerId: 'must-not-leak'
+        }
+    });
+
+    await assert.rejects(
+        callables.getPublicTeamProfile({ teamId: 'inactive-public' }, {}),
+        (error) => error.code === 'not-found'
+    );
+
+    const result = await callables.getPublicTeamProfile({
+        teamId: 'inactive-public',
+        includeInactive: true
+    }, {});
+    assert.equal(result.item.active, false);
+    assert.equal(result.item.isPublic, true);
+    assert.equal(Object.hasOwn(result.item, 'ownerId'), false);
+});
+
 test('completed public team backfill switches discovery to validated projection rows', async () => {
     const seed = {
         'systemMigrations/publicTeamProfilesBackfill': { completed: true },

--- a/functions/test/public-opportunities-callables.test.cjs
+++ b/functions/test/public-opportunities-callables.test.cjs
@@ -60,6 +60,7 @@ function comparable(value) {
 
 function makeFirestore(seed = {}) {
     const state = new Map(Object.entries(seed).map(([path, value]) => [path, clone(value)]));
+    const transactionTrace = [];
     let nextAutoId = 1;
 
     function makeSnapshot(path) {
@@ -84,6 +85,9 @@ function makeFirestore(seed = {}) {
             update: async (value) => {
                 if (!state.has(path)) throw new Error(`Missing document: ${path}`);
                 state.set(path, { ...state.get(path), ...clone(value) });
+            },
+            delete: async () => {
+                state.delete(path);
             },
             collection: (name) => collection(`${path}/${name}`)
         };
@@ -163,8 +167,32 @@ function makeFirestore(seed = {}) {
 
     return {
         _state: state,
+        _transactionTrace: transactionTrace,
         doc,
         collection,
+        async runTransaction(handler) {
+            const operations = [];
+            const result = await handler({
+                get: async (ref) => {
+                    transactionTrace.push(`get:${ref.path}`);
+                    return ref.get();
+                },
+                set: (ref, value, options) => {
+                    transactionTrace.push(`set:${ref.path}`);
+                    operations.push(() => ref.set(value, options));
+                },
+                update: (ref, value) => {
+                    transactionTrace.push(`update:${ref.path}`);
+                    operations.push(() => ref.update(value));
+                },
+                delete: (ref) => {
+                    transactionTrace.push(`delete:${ref.path}`);
+                    operations.push(() => ref.delete());
+                }
+            });
+            for (const operation of operations) await operation();
+            return result;
+        },
         batch() {
             const operations = [];
             return {
@@ -482,6 +510,9 @@ test('completed public team backfill switches discovery to validated projection 
         'publicTeamProfiles/safe-team': {
             publicSchemaVersion: 1, name: 'Safe', isPublic: true, active: true, publicSearchName: 'safe'
         },
+        'teams/safe-team': {
+            name: 'Safe Current', isPublic: true, active: true, ownerId: 'must-not-return'
+        },
         'publicTeamProfiles/malformed-team': {
             publicSchemaVersion: 1, name: 'Unsafe', isPublic: true, active: true, unexpectedSecret: 'must-not-return'
         },
@@ -492,9 +523,113 @@ test('completed public team backfill switches discovery to validated projection 
     const page = await callables.discoverPublicTeamProfiles({ pageSize: 10 }, {});
 
     assert.deepEqual(page.teams.map((team) => team.id), ['safe-team']);
+    assert.equal(page.teams[0].name, 'Safe Current');
+    assert.equal(Object.hasOwn(page.teams[0], 'ownerId'), false);
     assert.equal(page.nextCursor, null);
     assert.equal(page.scannedSourceCount, 0);
     assert.equal(page.scannedProjectionCount, 2);
+});
+
+test('projection discovery revalidates candidates against the current source team', async () => {
+    const seed = {
+        'systemMigrations/publicTeamProfilesBackfill': { completed: true },
+        'publicTeamProfiles/deleted-team': {
+            publicSchemaVersion: 1, name: 'Alpha Deleted', isPublic: true, active: true,
+            publicSearchName: 'alpha deleted'
+        },
+        'publicTeamProfiles/private-team': {
+            publicSchemaVersion: 1, name: 'Beta Private', isPublic: true, active: true,
+            publicSearchName: 'beta private'
+        },
+        'teams/private-team': {
+            name: 'Beta Private', isPublic: false, active: true, ownerId: 'private-owner'
+        },
+        'publicTeamProfiles/inactive-team': {
+            publicSchemaVersion: 1, name: 'Delta Inactive', isPublic: true, active: true,
+            publicSearchName: 'delta inactive'
+        },
+        'teams/inactive-team': {
+            name: 'Delta Inactive', isPublic: true, active: false, ownerId: 'private-owner'
+        },
+        'publicTeamProfiles/current-team': {
+            publicSchemaVersion: 1, name: 'Gamma Stale', isPublic: true, active: true,
+            description: 'stale projection copy', publicSearchName: 'gamma stale'
+        },
+        'teams/current-team': {
+            name: 'Gamma Current', isPublic: true, active: true,
+            description: 'current source copy', ownerId: 'must-not-return'
+        }
+    };
+    const { callables } = loadCallables(seed);
+
+    const page = await callables.discoverPublicTeamProfiles({ pageSize: 10 }, {});
+
+    assert.deepEqual(page.teams.map((team) => team.id), ['current-team']);
+    assert.equal(page.teams[0].name, 'Gamma Current');
+    assert.equal(page.teams[0].description, 'current source copy');
+    assert.equal(Object.hasOwn(page.teams[0], 'ownerId'), false);
+    assert.equal(page.scannedProjectionCount, 4);
+    assert.equal(page.nextCursor, null);
+});
+
+test('public team profile trigger ignores stale event images and projects the current source transactionally', async () => {
+    const { firestore, callables } = loadCallables({
+        'teams/private-team': {
+            name: 'Private Current', isPublic: false, active: true, ownerId: 'private-owner'
+        },
+        'publicTeamProfiles/private-team': {
+            publicSchemaVersion: 1, name: 'Stale Public', isPublic: true, active: true,
+            publicSearchName: 'stale public'
+        },
+        'publicTeamProfiles/deleted-team': {
+            publicSchemaVersion: 1, name: 'Deleted Public', isPublic: true, active: true,
+            publicSearchName: 'deleted public'
+        },
+        'teams/public-team': {
+            name: 'Public Current', isPublic: true, active: true,
+            description: 'current source copy', ownerId: 'must-not-return'
+        }
+    });
+    const stalePublicChange = {
+        after: {
+            exists: true,
+            data: () => ({ name: 'Stale Public Event', isPublic: true, active: true })
+        }
+    };
+    const stalePrivateChange = {
+        after: {
+            exists: true,
+            data: () => ({ name: 'Stale Private Event', isPublic: false, active: true })
+        }
+    };
+
+    await callables.syncPublicTeamProfileOnTeamWrite(stalePublicChange, { params: { teamId: 'private-team' } });
+    await callables.syncPublicTeamProfileOnTeamWrite(stalePublicChange, { params: { teamId: 'deleted-team' } });
+    await callables.syncPublicTeamProfileOnTeamWrite(stalePrivateChange, { params: { teamId: 'public-team' } });
+
+    assert.equal(firestore.snapshot('publicTeamProfiles/private-team'), undefined);
+    assert.equal(firestore.snapshot('publicTeamProfiles/deleted-team'), undefined);
+    assert.deepEqual(firestore.snapshot('publicTeamProfiles/public-team'), {
+        publicSchemaVersion: 1,
+        name: 'Public Current',
+        description: 'current source copy',
+        active: true,
+        isPublic: true,
+        publicSearchName: 'public current',
+        publicSearchCity: '',
+        publicSearchState: '',
+        publicSearchZip: '',
+        publicSearchCityState: '',
+        sourceUpdatedAt: null
+    });
+    assert.deepEqual(firestore._transactionTrace, [
+        'get:teams/private-team',
+        'delete:publicTeamProfiles/private-team',
+        'get:teams/deleted-team',
+        'delete:publicTeamProfiles/deleted-team',
+        'get:teams/public-team',
+        'set:publicTeamProfiles/public-team'
+    ]);
 });
 
 test('public team discovery resumes a sparse search after its bounded scan window', async () => {
@@ -502,12 +637,18 @@ test('public team discovery resumes a sparse search after its bounded scan windo
         'systemMigrations/publicTeamProfilesBackfill': { completed: true }
     };
     for (let index = 0; index < 500; index += 1) {
-        seed[`publicTeamProfiles/alpha-${String(index).padStart(3, '0')}`] = {
+        const teamId = `alpha-${String(index).padStart(3, '0')}`;
+        seed[`publicTeamProfiles/${teamId}`] = {
             publicSchemaVersion: 1,
             name: `Alpha ${String(index).padStart(3, '0')}`,
             isPublic: true,
             active: true,
             publicSearchName: `alpha ${String(index).padStart(3, '0')}`
+        };
+        seed[`teams/${teamId}`] = {
+            name: `Alpha ${String(index).padStart(3, '0')}`,
+            isPublic: true,
+            active: true
         };
     }
     seed['publicTeamProfiles/target-team'] = {
@@ -517,6 +658,7 @@ test('public team discovery resumes a sparse search after its bounded scan windo
         active: true,
         publicSearchName: 'target team'
     };
+    seed['teams/target-team'] = { name: 'Target Team', isPublic: true, active: true };
     const { callables } = loadCallables(seed);
 
     const firstScan = await callables.discoverPublicTeamProfiles({ searchText: 'target', pageSize: 10 }, {});

--- a/functions/test/public-opportunities-callables.test.cjs
+++ b/functions/test/public-opportunities-callables.test.cjs
@@ -392,6 +392,49 @@ test('public opportunity reads strip private fields and resume from returned cur
     assert.deepEqual(secondPage.items.map((item) => item.id), ['older']);
 });
 
+test('public team discovery pages the compatibility source without exposing management fields', async () => {
+    const seed = {
+        'teams/team-a': { name: 'Alpha', isPublic: true, active: true, ownerId: 'private-owner-a' },
+        'teams/team-b': { name: 'Bravo', isPublic: true, active: true, adminEmails: ['private@example.test'] },
+        'teams/team-c': { name: 'Charlie', isPublic: true, active: true, paymentConfig: { secret: true } },
+        'teams/private-team': { name: 'Private', isPublic: false, active: true, ownerId: 'private-owner' }
+    };
+    const { callables } = loadCallables(seed);
+
+    const firstPage = await callables.discoverPublicTeamProfiles({ pageSize: 2 }, {});
+    assert.deepEqual(firstPage.teams.map((team) => team.id), ['team-a', 'team-b']);
+    assert.equal(firstPage.nextCursor.kind, 'public-team-callable-v2');
+    assert.equal(firstPage.nextCursor.source, 'source');
+    assert.equal(Object.hasOwn(firstPage.teams[0], 'ownerId'), false);
+    assert.equal(Object.hasOwn(firstPage.teams[1], 'adminEmails'), false);
+
+    const secondPage = await callables.discoverPublicTeamProfiles({ pageSize: 2, cursor: firstPage.nextCursor }, {});
+    assert.deepEqual(secondPage.teams.map((team) => team.id), ['team-c']);
+    assert.equal(secondPage.nextCursor, null);
+    assert.equal(Object.hasOwn(secondPage.teams[0], 'paymentConfig'), false);
+});
+
+test('completed public team backfill switches discovery to validated projection rows', async () => {
+    const seed = {
+        'systemMigrations/publicTeamProfilesBackfill': { completed: true },
+        'publicTeamProfiles/safe-team': {
+            publicSchemaVersion: 1, name: 'Safe', isPublic: true, active: true, publicSearchName: 'safe'
+        },
+        'publicTeamProfiles/malformed-team': {
+            publicSchemaVersion: 1, name: 'Unsafe', isPublic: true, active: true, unexpectedSecret: 'must-not-return'
+        },
+        'teams/legacy-only': { name: 'Legacy Only', isPublic: true, active: true }
+    };
+    const { callables } = loadCallables(seed);
+
+    const page = await callables.discoverPublicTeamProfiles({ pageSize: 10 }, {});
+
+    assert.deepEqual(page.teams.map((team) => team.id), ['safe-team']);
+    assert.equal(page.nextCursor, null);
+    assert.equal(page.scannedSourceCount, 0);
+    assert.equal(page.scannedProjectionCount, 2);
+});
+
 test('revoked team admins lose private inquiry access with bounded, resumable stale-row scans', async () => {
     const seed = {
         'users/former-admin': { email: 'former@example.com', isAdmin: false },

--- a/functions/test/public-opportunities-callables.test.cjs
+++ b/functions/test/public-opportunities-callables.test.cjs
@@ -435,6 +435,40 @@ test('completed public team backfill switches discovery to validated projection 
     assert.equal(page.scannedProjectionCount, 2);
 });
 
+test('public team discovery resumes a sparse search after its bounded scan window', async () => {
+    const seed = {
+        'systemMigrations/publicTeamProfilesBackfill': { completed: true }
+    };
+    for (let index = 0; index < 500; index += 1) {
+        seed[`publicTeamProfiles/alpha-${String(index).padStart(3, '0')}`] = {
+            publicSchemaVersion: 1,
+            name: `Alpha ${String(index).padStart(3, '0')}`,
+            isPublic: true,
+            active: true,
+            publicSearchName: `alpha ${String(index).padStart(3, '0')}`
+        };
+    }
+    seed['publicTeamProfiles/target-team'] = {
+        publicSchemaVersion: 1,
+        name: 'Target Team',
+        isPublic: true,
+        active: true,
+        publicSearchName: 'target team'
+    };
+    const { callables } = loadCallables(seed);
+
+    const firstScan = await callables.discoverPublicTeamProfiles({ searchText: 'target', pageSize: 10 }, {});
+    assert.deepEqual(firstScan.teams, []);
+    assert.equal(firstScan.scannedProjectionCount, 500);
+    assert.equal(firstScan.nextCursor.kind, 'public-team-callable-v2');
+
+    const secondScan = await callables.discoverPublicTeamProfiles({
+        searchText: 'target', pageSize: 10, cursor: firstScan.nextCursor
+    }, {});
+    assert.deepEqual(secondScan.teams.map((team) => team.id), ['target-team']);
+    assert.equal(secondScan.nextCursor, null);
+});
+
 test('revoked team admins lose private inquiry access with bounded, resumable stale-row scans', async () => {
     const seed = {
         'users/former-admin': { email: 'former@example.com', isAdmin: false },

--- a/functions/test/public-team-profile-core.test.cjs
+++ b/functions/test/public-team-profile-core.test.cjs
@@ -122,6 +122,19 @@ test('public team fallback search matches all normalized tokens without private 
   assert.equal(matchesPublicTeamProfileSearch(profile, 'austin'), false);
 });
 
+test('public team fallback search treats a whole two-letter query as an exact state code', () => {
+  const nameMatch = buildPublicTeamProfile({
+    name: 'Indiana Bears', city: 'Kansas City', state: 'MO', isPublic: true
+  });
+  const stateMatch = buildPublicTeamProfile({
+    name: 'Wildcats', city: 'Bloomington', state: 'IN', isPublic: true
+  });
+
+  assert.equal(matchesPublicTeamProfileSearch(nameMatch, 'in'), false);
+  assert.equal(matchesPublicTeamProfileSearch(stateMatch, 'in'), true);
+  assert.equal(matchesPublicTeamProfileSearch(stateMatch, 'bloomington in'), true);
+});
+
 test('deployment fallback reads every source page instead of truncating at 1000 teams', async () => {
   const source = Array.from({ length: 1001 }, (_, index) => ({ id: `team-${index + 1}` }));
   const cursors = [];

--- a/functions/test/public-team-profile-core.test.cjs
+++ b/functions/test/public-team-profile-core.test.cjs
@@ -82,6 +82,20 @@ test('private and inactive teams have no public projection', () => {
   assert.equal(buildPublicTeamProfile({ name: 'Archived', isPublic: true, archived: true }), null);
 });
 
+test('an exact public detail lookup can safely present inactive replay history', () => {
+  const profile = buildPublicTeamProfile({
+    name: 'Inactive Public Team',
+    isPublic: true,
+    active: false,
+    ownerId: 'must-not-leak'
+  }, { includeInactive: true });
+
+  assert.equal(profile.name, 'Inactive Public Team');
+  assert.equal(profile.active, false);
+  assert.equal(profile.isPublic, true);
+  assert.equal(Object.hasOwn(profile, 'ownerId'), false);
+});
+
 test('projection validation rejects injected fields and nameless documents', () => {
   assert.equal(isPublicTeamProfileSchemaValid({ publicSchemaVersion: 1, name: 'Safe', isPublic: true, active: true, ownerEmail: 'leak@example.test' }), false);
   assert.equal(isPublicTeamProfileSchemaValid({

--- a/functions/test/public-team-profile-core.test.cjs
+++ b/functions/test/public-team-profile-core.test.cjs
@@ -111,6 +111,24 @@ test('projection validation rejects injected fields and nameless documents', () 
       'Pool A': { poolName: 'Pool A', teamOrder: ['Safe'], finalizedBy: { userId: 'private-user' } }
     }
   }), false);
+
+  for (const malformedField of [
+    { description: ['private'] },
+    { photoUrl: { private: true } },
+    { leagueUrl: ['private'] },
+    { publicSearchName: { private: true } },
+    { appAccess: 'true' },
+    { archived: 'false' },
+    { sourceUpdatedAt: { private: true } }
+  ]) {
+    assert.equal(isPublicTeamProfileSchemaValid({
+      publicSchemaVersion: 1,
+      name: 'Malformed Allowed Field',
+      isPublic: true,
+      active: true,
+      ...malformedField
+    }), false);
+  }
 });
 
 test('public team fallback search matches all normalized tokens without private fields', () => {

--- a/functions/test/public-team-profile-core.test.cjs
+++ b/functions/test/public-team-profile-core.test.cjs
@@ -3,6 +3,7 @@ const assert = require('node:assert/strict');
 const {
   PUBLIC_TEAM_PROFILE_FIELDS,
   buildPublicTeamProfile,
+  collectAllPublicTeamSourceDocuments,
   findUnexpectedPublicTeamProfileFields,
   isPublicTeamProfileSchemaValid,
   matchesPublicTeamProfileSearch
@@ -19,7 +20,17 @@ test('public team projection preserves presentation fields and strips management
     leagueUrl: 'https://league.example.test',
     socialLinks: { instagram: 'https://instagram.example.test/bluejays' },
     standingsConfig: { enabled: true, points: { win: 3 }, providerToken: 'must-not-leak' },
-    tournament: { pools: [{ name: 'Pool A', managerEmail: 'must-not-leak@example.test' }] },
+    tournament: {
+      pools: [{ name: 'Pool A', managerEmail: 'must-not-leak@example.test', notes: 'also private' }],
+      contacts: [{ name: 'Private organizer' }]
+    },
+    tournamentPoolOverrides: {
+      'Pool A': {
+        poolName: 'Pool A',
+        teamOrder: ['Blue Jays', 'Cardinals'],
+        finalizedBy: { userId: 'private-user', name: 'Private Staff', email: 'private@example.test' }
+      }
+    },
     streamUrl: 'https://youtube.example.test/live',
     isPublic: true,
     active: true,
@@ -44,6 +55,14 @@ test('public team projection preserves presentation fields and strips management
   assert.equal(profile.standingsConfig.providerToken, undefined);
   assert.equal(profile.standingsConfig.points.win, 3);
   assert.equal(profile.tournament.pools[0].managerEmail, undefined);
+  assert.equal(profile.tournament.pools[0].notes, undefined);
+  assert.equal(profile.tournament.contacts, undefined);
+  assert.deepEqual(profile.tournamentPoolOverrides['Pool A'], {
+    poolName: 'Pool A',
+    teamOrder: ['Blue Jays', 'Cardinals']
+  });
+  assert.equal(JSON.stringify(profile).includes('private-user'), false);
+  assert.equal(JSON.stringify(profile).includes('private@example.test'), false);
   assert.equal(isPublicTeamProfileSchemaValid(profile), true);
   assert.deepEqual(findUnexpectedPublicTeamProfileFields(profile), []);
 
@@ -71,6 +90,13 @@ test('projection validation rejects injected fields and nameless documents', () 
     tournament: { providerSecret: 'leak' }
   }), false);
   assert.equal(isPublicTeamProfileSchemaValid({ publicSchemaVersion: 1, name: '', isPublic: true, active: true }), false);
+  assert.equal(isPublicTeamProfileSchemaValid({
+    publicSchemaVersion: 1,
+    name: 'Unsafe Override Team', isPublic: true, active: true,
+    tournamentPoolOverrides: {
+      'Pool A': { poolName: 'Pool A', teamOrder: ['Safe'], finalizedBy: { userId: 'private-user' } }
+    }
+  }), false);
 });
 
 test('public team fallback search matches all normalized tokens without private fields', () => {
@@ -80,4 +106,17 @@ test('public team fallback search matches all normalized tokens without private 
   assert.equal(matchesPublicTeamProfileSearch(profile, 'kansas mo'), true);
   assert.equal(matchesPublicTeamProfileSearch(profile, '64110 baseball'), true);
   assert.equal(matchesPublicTeamProfileSearch(profile, 'austin'), false);
+});
+
+test('deployment fallback reads every source page instead of truncating at 1000 teams', async () => {
+  const source = Array.from({ length: 1001 }, (_, index) => ({ id: `team-${index + 1}` }));
+  const cursors = [];
+  const documents = await collectAllPublicTeamSourceDocuments(({ cursor, pageSize }) => {
+    cursors.push(cursor?.id || null);
+    const offset = cursor ? source.findIndex((item) => item.id === cursor.id) + 1 : 0;
+    return Promise.resolve({ docs: source.slice(offset, offset + pageSize) });
+  });
+
+  assert.equal(documents.length, 1001);
+  assert.deepEqual(cursors, [null, 'team-500', 'team-1000']);
 });

--- a/functions/test/public-team-profile-core.test.cjs
+++ b/functions/test/public-team-profile-core.test.cjs
@@ -1,0 +1,83 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  PUBLIC_TEAM_PROFILE_FIELDS,
+  buildPublicTeamProfile,
+  findUnexpectedPublicTeamProfileFields,
+  isPublicTeamProfileSchemaValid,
+  matchesPublicTeamProfileSearch
+} = require('../public-team-profile-core.cjs');
+
+test('public team projection preserves presentation fields and strips management data', () => {
+  const profile = buildPublicTeamProfile({
+    name: 'Blue Jays',
+    sport: 'Baseball',
+    description: 'Community baseball',
+    city: 'Austin',
+    state: 'tx',
+    zip: '78701',
+    leagueUrl: 'https://league.example.test',
+    socialLinks: { instagram: 'https://instagram.example.test/bluejays' },
+    standingsConfig: { enabled: true, points: { win: 3 }, providerToken: 'must-not-leak' },
+    tournament: { pools: [{ name: 'Pool A', managerEmail: 'must-not-leak@example.test' }] },
+    streamUrl: 'https://youtube.example.test/live',
+    isPublic: true,
+    active: true,
+    ownerId: 'owner-1',
+    ownerEmail: 'owner@example.test',
+    adminEmails: ['admin@example.test'],
+    notificationEmail: 'notify@example.test',
+    registrationProvider: { apiToken: 'provider-token' },
+    registrationSource: { secret: 'source-secret' },
+    teamPermissions: { streaming: { memberIds: ['user-1'] } },
+    calendarUrls: ['https://calendar.example.test/private-token.ics'],
+    calendarFeedToken: 'private-calendar-token',
+    privateCalendarFeedUrl: 'https://private.example.test/token'
+  });
+
+  assert.equal(profile.name, 'Blue Jays');
+  assert.equal(profile.publicSearchName, 'blue jays');
+  assert.equal(profile.publicSearchCityState, 'austin, tx');
+  assert.equal(profile.leagueUrl, 'https://league.example.test');
+  assert.equal(profile.streamUrl, 'https://youtube.example.test/live');
+  assert.equal(profile.publicSchemaVersion, 1);
+  assert.equal(profile.standingsConfig.providerToken, undefined);
+  assert.equal(profile.standingsConfig.points.win, 3);
+  assert.equal(profile.tournament.pools[0].managerEmail, undefined);
+  assert.equal(isPublicTeamProfileSchemaValid(profile), true);
+  assert.deepEqual(findUnexpectedPublicTeamProfileFields(profile), []);
+
+  for (const field of [
+    'ownerId', 'ownerEmail', 'adminEmails', 'notificationEmail',
+    'registrationProvider', 'registrationSource', 'teamPermissions',
+    'calendarUrls', 'calendarFeedToken', 'privateCalendarFeedUrl'
+  ]) {
+    assert.equal(Object.prototype.hasOwnProperty.call(profile, field), false, `${field} must not enter the projection`);
+    assert.equal(PUBLIC_TEAM_PROFILE_FIELDS.includes(field), false, `${field} must not be allow-listed`);
+  }
+});
+
+test('private and inactive teams have no public projection', () => {
+  assert.equal(buildPublicTeamProfile({ name: 'Private', isPublic: false, active: true }), null);
+  assert.equal(buildPublicTeamProfile({ name: 'Inactive', isPublic: true, active: false }), null);
+  assert.equal(buildPublicTeamProfile({ name: 'Archived', isPublic: true, archived: true }), null);
+});
+
+test('projection validation rejects injected fields and nameless documents', () => {
+  assert.equal(isPublicTeamProfileSchemaValid({ publicSchemaVersion: 1, name: 'Safe', isPublic: true, active: true, ownerEmail: 'leak@example.test' }), false);
+  assert.equal(isPublicTeamProfileSchemaValid({
+    publicSchemaVersion: 1,
+    name: 'Unsafe Nested Team', isPublic: true, active: true,
+    tournament: { providerSecret: 'leak' }
+  }), false);
+  assert.equal(isPublicTeamProfileSchemaValid({ publicSchemaVersion: 1, name: '', isPublic: true, active: true }), false);
+});
+
+test('public team fallback search matches all normalized tokens without private fields', () => {
+  const profile = buildPublicTeamProfile({
+    name: 'Blue Jays', sport: 'Baseball', city: 'Kansas City', state: 'MO', zip: '64110', isPublic: true
+  });
+  assert.equal(matchesPublicTeamProfileSearch(profile, 'kansas mo'), true);
+  assert.equal(matchesPublicTeamProfileSearch(profile, '64110 baseball'), true);
+  assert.equal(matchesPublicTeamProfileSearch(profile, 'austin'), false);
+});

--- a/js/db.js
+++ b/js/db.js
@@ -638,15 +638,6 @@ function normalizePublicTeamSearchValue(value, { uppercase = false } = {}) {
     return uppercase ? normalized.toUpperCase() : normalized.toLowerCase();
 }
 
-function toTitleCase(value) {
-    return String(value || '')
-        .trim()
-        .split(/\s+/)
-        .filter(Boolean)
-        .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase())
-        .join(' ');
-}
-
 function buildPublicTeamSearchFields(teamData = {}) {
     const searchFields = {};
 
@@ -683,119 +674,6 @@ function normalizePublicTeamSearchInput(value) {
     return String(value || '').trim();
 }
 
-function buildPublicTeamSearchDescriptor(searchText = '') {
-    const trimmed = normalizePublicTeamSearchInput(searchText);
-    if (!trimmed) return null;
-
-    if (/^\d{1,5}$/.test(trimmed)) {
-        return {
-            type: 'zip',
-            normalized: trimmed
-        };
-    }
-
-    if (/^[A-Za-z]{2}$/.test(trimmed) && !trimmed.includes(',')) {
-        return {
-            type: 'state',
-            normalized: trimmed.toLowerCase(),
-            state: trimmed.toUpperCase()
-        };
-    }
-
-    return {
-        type: 'location',
-        normalized: trimmed.toLowerCase()
-    };
-}
-
-function buildPublicTeamSearchStrategies(searchText = '') {
-    const descriptor = buildPublicTeamSearchDescriptor(searchText);
-    const rawTrimmed = normalizePublicTeamSearchInput(searchText);
-    const trimmed = descriptor?.normalized || rawTrimmed;
-    if (!descriptor) return [];
-
-    const strategies = [];
-    const normalizedName = normalizePublicTeamSearchValue(rawTrimmed);
-    const legacyNameSearch = toTitleCase(rawTrimmed);
-    if (normalizedName) {
-        strategies.push(
-            { field: 'publicSearchName', start: normalizedName, end: `${normalizedName}\uf8ff` },
-            { field: 'name', start: legacyNameSearch, end: `${legacyNameSearch}\uf8ff` }
-        );
-    }
-
-    if (descriptor.type === 'zip') {
-        strategies.push(
-            { field: 'publicSearchZip', start: trimmed, end: `${trimmed}\uf8ff` },
-            { field: 'zip', start: trimmed, end: `${trimmed}\uf8ff` }
-        );
-        return strategies;
-    }
-
-    const [rawCityPart, rawStatePart = ''] = trimmed.split(',').map((part) => part.trim()).filter((part, index, parts) => index === 0 || part || parts.length > 1);
-
-    if (descriptor.type === 'state') {
-        const normalizedState = descriptor.state;
-        strategies.push(
-            { field: 'publicSearchState', start: normalizedState, end: `${normalizedState}\uf8ff` },
-            { field: 'state', start: normalizedState, end: `${normalizedState}\uf8ff` }
-        );
-        return strategies;
-    }
-
-    const citySearch = normalizePublicTeamSearchValue(rawCityPart || trimmed);
-    const legacyCitySearch = toTitleCase(rawCityPart || trimmed);
-    const normalizedState = rawStatePart ? rawStatePart.toUpperCase() : '';
-    const filterByState = normalizedState
-        ? (team) => String(team.publicSearchState || team.state || '').trim().toUpperCase().startsWith(normalizedState)
-        : null;
-
-    strategies.push(
-        { field: 'publicSearchCity', start: citySearch, end: `${citySearch}\uf8ff`, filter: filterByState },
-        { field: 'city', start: legacyCitySearch, end: `${legacyCitySearch}\uf8ff`, filter: filterByState }
-    );
-
-    return strategies;
-}
-
-function sortTeamsByName(teams = []) {
-    return [...teams].sort((a, b) => String(a.name || '').localeCompare(String(b.name || '')));
-}
-
-function buildPublicTeamSearchPageCursor(searchText, strategyCursors = [], bufferedTeams = []) {
-    if (!bufferedTeams.length && !strategyCursors.some(Boolean)) {
-        return null;
-    }
-
-    return {
-        kind: 'public-team-search',
-        searchText,
-        strategyCursors,
-        bufferedTeams
-    };
-}
-
-function readPublicTeamSearchPageCursor(cursor, searchText, strategyCount) {
-    if (!cursor || typeof cursor !== 'object' || cursor.kind !== 'public-team-search') {
-        return {
-            strategyCursors: Array.from({ length: strategyCount }, () => null),
-            bufferedTeams: []
-        };
-    }
-
-    if (normalizePublicTeamSearchInput(cursor.searchText || '') !== searchText) {
-        return {
-            strategyCursors: Array.from({ length: strategyCount }, () => null),
-            bufferedTeams: []
-        };
-    }
-
-    return {
-        strategyCursors: Array.from({ length: strategyCount }, (_, index) => cursor.strategyCursors?.[index] || null),
-        bufferedTeams: Array.isArray(cursor.bufferedTeams) ? cursor.bufferedTeams : []
-    };
-}
-
 async function discoverPublicTeamsFromCallable({ searchText = '', cursor = null, pageSize = DEFAULT_PUBLIC_TEAM_DISCOVERY_PAGE_SIZE } = {}) {
     const discoverProfiles = httpsCallable(functions, 'discoverPublicTeamProfiles');
     const result = await discoverProfiles({ searchText, cursor, pageSize });
@@ -823,112 +701,11 @@ export async function discoverPublicTeams(options = {}) {
         ? Math.min(Math.max(Math.floor(rawPageSize), 1), 100)
         : DEFAULT_PUBLIC_TEAM_DISCOVERY_PAGE_SIZE;
     const searchText = normalizePublicTeamSearchInput(options.searchText || options.locationFilter || '');
-    const cursor = options.cursor || null;
-    const teamsRef = collection(db, 'publicTeamProfiles');
-
-    if (cursor?.kind === 'public-team-callable') {
-        return discoverPublicTeamsFromCallable({ searchText, cursor, pageSize });
-    }
-
-    if (!searchText) {
-        const constraints = [
-            where('publicSchemaVersion', '==', 1),
-            where('isPublic', '==', true),
-            where('active', '==', true),
-            orderBy('name')
-        ];
-        if (cursor) {
-            constraints.push(startAfterQuery(cursor));
-        }
-        constraints.push(limitQuery(pageSize));
-        let snapshot;
-        try {
-            snapshot = await getDocs(query(teamsRef, ...constraints));
-        } catch (error) {
-            if (!isPublicProjectionFallbackError(error)) throw error;
-            return discoverPublicTeamsFromCallable({ searchText, cursor: null, pageSize });
-        }
-        if (!cursor && snapshot.docs.length === 0) {
-            return discoverPublicTeamsFromCallable({ searchText, pageSize });
-        }
-        const teams = filterTeamsByActive(snapshot.docs.map((teamDoc) => ({ id: teamDoc.id, ...teamDoc.data() })), false);
-        return {
-            teams,
-            nextCursor: snapshot.docs.length === pageSize ? snapshot.docs[snapshot.docs.length - 1] : null
-        };
-    }
-
-    let strategies = buildPublicTeamSearchStrategies(searchText);
-    if (!strategies.length) {
-        return { teams: [], nextCursor: null };
-    }
-
-    const previousPageCursor = readPublicTeamSearchPageCursor(cursor, searchText, strategies.length);
-    if (previousPageCursor.bufferedTeams.length >= pageSize) {
-        const teams = previousPageCursor.bufferedTeams.slice(0, pageSize);
-        const bufferedTeams = previousPageCursor.bufferedTeams.slice(pageSize);
-        return {
-            teams,
-            nextCursor: buildPublicTeamSearchPageCursor(searchText, previousPageCursor.strategyCursors, bufferedTeams)
-        };
-    }
-
-    strategies = strategies.map((strategy, index) => ({
-        ...strategy,
-        startAfterConstraint: previousPageCursor.strategyCursors[index]
-            ? [startAfterQuery(previousPageCursor.strategyCursors[index])]
-            : []
-    }));
-    let snapshots;
-    try {
-        snapshots = await Promise.all(strategies.map((strategy) => getDocs(query(
-            teamsRef,
-            where('publicSchemaVersion', '==', 1),
-            where('isPublic', '==', true),
-            where('active', '==', true),
-            where(strategy.field, '>=', strategy.start),
-            where(strategy.field, '<=', strategy.end),
-            orderBy(strategy.field),
-            ...strategy.startAfterConstraint,
-            limitQuery(pageSize)
-        ))));
-    } catch (error) {
-        if (!isPublicProjectionFallbackError(error)) throw error;
-        return discoverPublicTeamsFromCallable({ searchText, cursor: null, pageSize });
-    }
-
-    if (!cursor && snapshots.every((snapshot) => snapshot.docs.length === 0)) {
-        return discoverPublicTeamsFromCallable({ searchText, pageSize });
-    }
-
-    const teamsById = new Map(previousPageCursor.bufferedTeams
-        .filter((team) => team?.id)
-        .map((team) => [team.id, team]));
-    snapshots.forEach((snapshot, index) => {
-        const strategy = strategies[index];
-        snapshot.docs.forEach((teamDoc) => {
-            const team = { id: teamDoc.id, ...teamDoc.data() };
-            if (typeof strategy.filter === 'function' && !strategy.filter(team)) {
-                return;
-            }
-            teamsById.set(team.id, team);
-        });
+    return discoverPublicTeamsFromCallable({
+        searchText,
+        cursor: options.cursor || null,
+        pageSize
     });
-
-    const sortedTeams = filterTeamsByActive(sortTeamsByName(Array.from(teamsById.values())), false);
-    const teams = sortedTeams.slice(0, pageSize);
-    const bufferedTeams = sortedTeams.slice(pageSize);
-    const strategyCursors = snapshots.map((snapshot, index) => snapshot.docs.length
-        ? snapshot.docs[snapshot.docs.length - 1]
-        : previousPageCursor.strategyCursors[index] || null);
-    const hasMorePages = bufferedTeams.length > 0 || snapshots.some((snapshot) => snapshot.docs.length === pageSize);
-
-    return {
-        teams,
-        nextCursor: hasMorePages
-            ? buildPublicTeamSearchPageCursor(searchText, strategyCursors, bufferedTeams)
-            : null
-    };
 }
 
 export async function getPublicTeamRosterCount(teamId) {
@@ -978,24 +755,7 @@ async function getAllOrderedCollectionDocuments(collectionRef, fieldName) {
     return documents;
 }
 
-async function getAllPublicTeamProfilesWithFallback(publicTeamsRef) {
-    let snapshot;
-    try {
-        snapshot = await getDocs(query(
-            publicTeamsRef,
-            where('publicSchemaVersion', '==', 1),
-            where('isPublic', '==', true),
-            where('active', '==', true),
-            orderBy('name')
-        ));
-    } catch (error) {
-        if (!isPublicProjectionFallbackError(error)) throw error;
-        snapshot = { docs: [] };
-    }
-    if (snapshot.docs.length > 0) {
-        return snapshot.docs.map((teamDoc) => ({ id: teamDoc.id, ...teamDoc.data() }));
-    }
-
+async function getAllPublicTeamProfiles() {
     const teams = [];
     let cursor = null;
     do {
@@ -1013,19 +773,18 @@ export async function getTeams(options = {}) {
     const locationFilter = String(options.locationFilter || '').trim().toLowerCase();
 
     const teamsRef = collection(db, "teams");
-    const publicTeamsRef = collection(db, 'publicTeamProfiles');
     let teams = [];
     if (includePrivate) {
         teams = (await getAllOrderedCollectionDocuments(teamsRef, "name"))
             .map(doc => ({ id: doc.id, ...doc.data() }));
     } else if (publicOnly) {
-        teams = (await getAllPublicTeamProfilesWithFallback(publicTeamsRef))
+        teams = (await getAllPublicTeamProfiles())
             .sort((a, b) => String(a.name || '').localeCompare(String(b.name || '')));
     } else {
         const currentUser = auth.currentUser;
         const currentUserEmail = String(currentUser?.email || '').trim().toLowerCase();
         const teamSnapshots = await Promise.all([
-            getAllPublicTeamProfilesWithFallback(publicTeamsRef),
+            getAllPublicTeamProfiles(),
             currentUser?.uid
                 ? getDocs(query(teamsRef, where("ownerId", "==", currentUser.uid)))
                 : Promise.resolve({ docs: [] }),

--- a/js/db.js
+++ b/js/db.js
@@ -796,6 +796,23 @@ function readPublicTeamSearchPageCursor(cursor, searchText, strategyCount) {
     };
 }
 
+async function discoverPublicTeamsFromCallable({ searchText = '', cursor = null, pageSize = DEFAULT_PUBLIC_TEAM_DISCOVERY_PAGE_SIZE } = {}) {
+    const discoverProfiles = httpsCallable(functions, 'discoverPublicTeamProfiles');
+    const result = await discoverProfiles({ searchText, cursor, pageSize });
+    const teams = Array.isArray(result.data?.teams)
+        ? result.data.teams.filter((team) => team?.isPublic === true && isTeamActive(team))
+        : [];
+    return {
+        teams,
+        nextCursor: result.data?.nextCursor || null
+    };
+}
+
+function isPublicProjectionFallbackError(error) {
+    const code = String(error?.code || '').replace(/^firestore\//, '');
+    return code === 'permission-denied' || code === 'not-found';
+}
+
 export async function discoverPublicTeams(options = {}) {
     const rawPageSize = Number(options.pageSize);
     const pageSize = Number.isFinite(rawPageSize)
@@ -803,15 +820,33 @@ export async function discoverPublicTeams(options = {}) {
         : DEFAULT_PUBLIC_TEAM_DISCOVERY_PAGE_SIZE;
     const searchText = normalizePublicTeamSearchInput(options.searchText || options.locationFilter || '');
     const cursor = options.cursor || null;
-    const teamsRef = collection(db, 'teams');
+    const teamsRef = collection(db, 'publicTeamProfiles');
+
+    if (cursor?.kind === 'public-team-callable') {
+        return discoverPublicTeamsFromCallable({ searchText, cursor, pageSize });
+    }
 
     if (!searchText) {
-        const constraints = [where('isPublic', '==', true), orderBy('name')];
+        const constraints = [
+            where('publicSchemaVersion', '==', 1),
+            where('isPublic', '==', true),
+            where('active', '==', true),
+            orderBy('name')
+        ];
         if (cursor) {
             constraints.push(startAfterQuery(cursor));
         }
         constraints.push(limitQuery(pageSize));
-        const snapshot = await getDocs(query(teamsRef, ...constraints));
+        let snapshot;
+        try {
+            snapshot = await getDocs(query(teamsRef, ...constraints));
+        } catch (error) {
+            if (!isPublicProjectionFallbackError(error)) throw error;
+            return discoverPublicTeamsFromCallable({ searchText, cursor: null, pageSize });
+        }
+        if (!cursor && snapshot.docs.length === 0) {
+            return discoverPublicTeamsFromCallable({ searchText, pageSize });
+        }
         const teams = filterTeamsByActive(snapshot.docs.map((teamDoc) => ({ id: teamDoc.id, ...teamDoc.data() })), false);
         return {
             teams,
@@ -840,15 +875,27 @@ export async function discoverPublicTeams(options = {}) {
             ? [startAfterQuery(previousPageCursor.strategyCursors[index])]
             : []
     }));
-    const snapshots = await Promise.all(strategies.map((strategy) => getDocs(query(
-        teamsRef,
-        where('isPublic', '==', true),
-        where(strategy.field, '>=', strategy.start),
-        where(strategy.field, '<=', strategy.end),
-        orderBy(strategy.field),
-        ...strategy.startAfterConstraint,
-        limitQuery(pageSize)
-    ))));
+    let snapshots;
+    try {
+        snapshots = await Promise.all(strategies.map((strategy) => getDocs(query(
+            teamsRef,
+            where('publicSchemaVersion', '==', 1),
+            where('isPublic', '==', true),
+            where('active', '==', true),
+            where(strategy.field, '>=', strategy.start),
+            where(strategy.field, '<=', strategy.end),
+            orderBy(strategy.field),
+            ...strategy.startAfterConstraint,
+            limitQuery(pageSize)
+        ))));
+    } catch (error) {
+        if (!isPublicProjectionFallbackError(error)) throw error;
+        return discoverPublicTeamsFromCallable({ searchText, cursor: null, pageSize });
+    }
+
+    if (!cursor && snapshots.every((snapshot) => snapshot.docs.length === 0)) {
+        return discoverPublicTeamsFromCallable({ searchText, pageSize });
+    }
 
     const teamsById = new Map(previousPageCursor.bufferedTeams
         .filter((team) => team?.id)
@@ -927,6 +974,34 @@ async function getAllOrderedCollectionDocuments(collectionRef, fieldName) {
     return documents;
 }
 
+async function getAllPublicTeamProfilesWithFallback(publicTeamsRef) {
+    let snapshot;
+    try {
+        snapshot = await getDocs(query(
+            publicTeamsRef,
+            where('publicSchemaVersion', '==', 1),
+            where('isPublic', '==', true),
+            where('active', '==', true),
+            orderBy('name')
+        ));
+    } catch (error) {
+        if (!isPublicProjectionFallbackError(error)) throw error;
+        snapshot = { docs: [] };
+    }
+    if (snapshot.docs.length > 0) {
+        return snapshot.docs.map((teamDoc) => ({ id: teamDoc.id, ...teamDoc.data() }));
+    }
+
+    const teams = [];
+    let cursor = null;
+    do {
+        const page = await discoverPublicTeamsFromCallable({ cursor, pageSize: 100 });
+        teams.push(...page.teams);
+        cursor = page.nextCursor;
+    } while (cursor && teams.length < 1000);
+    return teams;
+}
+
 export async function getTeams(options = {}) {
     const includeInactive = !!options.includeInactive;
     const publicOnly = options.publicOnly === true;
@@ -934,19 +1009,19 @@ export async function getTeams(options = {}) {
     const locationFilter = String(options.locationFilter || '').trim().toLowerCase();
 
     const teamsRef = collection(db, "teams");
+    const publicTeamsRef = collection(db, 'publicTeamProfiles');
     let teams = [];
     if (includePrivate) {
         teams = (await getAllOrderedCollectionDocuments(teamsRef, "name"))
             .map(doc => ({ id: doc.id, ...doc.data() }));
     } else if (publicOnly) {
-        teams = (await getDocs(query(teamsRef, where("isPublic", "==", true)))).docs
-            .map(doc => ({ id: doc.id, ...doc.data() }))
+        teams = (await getAllPublicTeamProfilesWithFallback(publicTeamsRef))
             .sort((a, b) => String(a.name || '').localeCompare(String(b.name || '')));
     } else {
         const currentUser = auth.currentUser;
         const currentUserEmail = String(currentUser?.email || '').trim().toLowerCase();
         const teamSnapshots = await Promise.all([
-            getDocs(query(teamsRef, where("isPublic", "==", true))),
+            getAllPublicTeamProfilesWithFallback(publicTeamsRef),
             currentUser?.uid
                 ? getDocs(query(teamsRef, where("ownerId", "==", currentUser.uid)))
                 : Promise.resolve({ docs: [] }),
@@ -955,7 +1030,11 @@ export async function getTeams(options = {}) {
                 : Promise.resolve({ docs: [] })
         ]);
         const teamsById = new Map();
-        teamSnapshots.forEach((snapshot) => {
+        teamSnapshots.forEach((snapshot, index) => {
+            if (index === 0) {
+                snapshot.forEach((team) => teamsById.set(team.id, team));
+                return;
+            }
             snapshot.docs.forEach(doc => teamsById.set(doc.id, { id: doc.id, ...doc.data() }));
         });
         teams = Array.from(teamsById.values()).sort((a, b) => String(a.name || '').localeCompare(String(b.name || '')));
@@ -995,15 +1074,41 @@ export async function getTeams(options = {}) {
 
 export async function getTeam(teamId, options = {}) {
     const includeInactive = !!options.includeInactive;
-    const docRef = doc(db, "teams", teamId);
-    const docSnap = await getDoc(docRef);
-    if (docSnap.exists()) {
-        const team = { id: docSnap.id, ...docSnap.data() };
-        if (!includeInactive && !isTeamActive(team)) return null;
-        return team;
-    } else {
-        return null;
+    const normalizedTeamId = String(teamId || '').trim();
+    if (!normalizedTeamId) return null;
+
+    if (auth.currentUser) {
+        try {
+            const sourceSnap = await getDoc(doc(db, 'teams', normalizedTeamId));
+            if (!sourceSnap.exists()) return null;
+            const sourceTeam = { id: sourceSnap.id, ...sourceSnap.data() };
+            if (!includeInactive && !isTeamActive(sourceTeam)) return null;
+            return sourceTeam;
+        } catch (error) {
+            if (!isPublicProjectionFallbackError(error)) throw error;
+        }
     }
+
+    try {
+        const publicSnap = await getDoc(doc(db, 'publicTeamProfiles', normalizedTeamId));
+        if (publicSnap.exists()) {
+            const publicTeam = { id: publicSnap.id, ...publicSnap.data(), isPublic: true };
+            if (!includeInactive && !isTeamActive(publicTeam)) return null;
+            return publicTeam;
+        }
+    } catch (error) {
+        if (!isPublicProjectionFallbackError(error)) throw error;
+    }
+
+    // Deployment-order fallback: the callable already returns an allow-listed
+    // projection and remains safe while publicTeamProfiles is being backfilled.
+    const getPublicTeamProfile = httpsCallable(functions, 'getPublicTeamProfile');
+    const result = await getPublicTeamProfile({ teamId: normalizedTeamId });
+    const item = result.data?.item || null;
+    if (!item) return null;
+    const publicTeam = { ...item, id: item.id || normalizedTeamId, isPublic: true, active: true };
+    if (!includeInactive && !isTeamActive(publicTeam)) return null;
+    return publicTeam;
 }
 
 function getTeamMediaFoldersRef(teamId) {
@@ -7508,12 +7613,8 @@ async function projectSharedHomepageGame(sharedGame, shouldIncludeTeam) {
     const teamIds = getSharedHomepageTeamIds(sharedGame);
 
     for (const teamId of teamIds) {
-        const teamSnap = await getDoc(doc(db, 'teams', teamId));
-        if (!teamSnap.exists()) {
-            continue;
-        }
-
-        const team = { id: teamSnap.id, ...teamSnap.data() };
+        const team = await getTeam(teamId);
+        if (!team) continue;
         if (!shouldIncludeTeam(team)) {
             continue;
         }

--- a/js/db.js
+++ b/js/db.js
@@ -916,6 +916,17 @@ export async function getTeam(teamId, options = {}) {
     return publicTeam;
 }
 
+export async function getPublicTeamExternalCalendarIcs(teamId) {
+    const normalizedTeamId = String(teamId || '').trim();
+    if (!normalizedTeamId) return [];
+    const callable = httpsCallable(functions, 'getPublicTeamExternalCalendarIcs');
+    const result = await callable({ teamId: normalizedTeamId });
+    const calendars = Array.isArray(result.data?.calendars) ? result.data.calendars : [];
+    return calendars
+        .filter((icsText) => typeof icsText === 'string' && icsText.includes('BEGIN:VCALENDAR'))
+        .slice(0, 10);
+}
+
 function getTeamMediaFoldersRef(teamId) {
     return collection(db, `teams/${teamId}/mediaFolders`);
 }

--- a/js/db.js
+++ b/js/db.js
@@ -809,8 +809,12 @@ async function discoverPublicTeamsFromCallable({ searchText = '', cursor = null,
 }
 
 function isPublicProjectionFallbackError(error) {
-    const code = String(error?.code || '').replace(/^firestore\//, '');
+    const code = String(error?.code || '').replace(/^(?:firestore|functions)\//, '');
     return code === 'permission-denied' || code === 'not-found';
+}
+
+function isPublicProjectionNotFoundError(error) {
+    return String(error?.code || '').replace(/^(?:firestore|functions)\//, '') === 'not-found';
 }
 
 export async function discoverPublicTeams(options = {}) {
@@ -1103,7 +1107,13 @@ export async function getTeam(teamId, options = {}) {
     // Deployment-order fallback: the callable already returns an allow-listed
     // projection and remains safe while publicTeamProfiles is being backfilled.
     const getPublicTeamProfile = httpsCallable(functions, 'getPublicTeamProfile');
-    const result = await getPublicTeamProfile({ teamId: normalizedTeamId });
+    let result;
+    try {
+        result = await getPublicTeamProfile({ teamId: normalizedTeamId });
+    } catch (error) {
+        if (isPublicProjectionNotFoundError(error)) return null;
+        throw error;
+    }
     const item = result.data?.item || null;
     if (!item) return null;
     const publicTeam = { ...item, id: item.id || normalizedTeamId, isPublic: true, active: true };

--- a/js/db.js
+++ b/js/db.js
@@ -128,13 +128,16 @@ export async function normalizeParentScopeLinks(parentLinks = []) {
 
         let team = teamCache.get(teamId);
         if (team === undefined) {
-            team = await getTeam(teamId, { includeInactive: true });
+            team = await getTeam(teamId, { includeInactive: true, preservePermissionDenied: true });
             teamCache.set(teamId, team || null);
         }
         if (!team || !isTeamActive(team)) {
             staleLinkCount += 1;
             continue;
         }
+
+        const teamReadBlocked = team.blockedByPermissions === true;
+        if (teamReadBlocked) blockedLinkCount += 1;
 
         let playerSnap = playerCache.get(playerKey);
         if (playerSnap === undefined) {
@@ -143,7 +146,7 @@ export async function normalizeParentScopeLinks(parentLinks = []) {
             } catch (error) {
                 if (error?.code === 'permission-denied') {
                     console.warn('[parent-scope] Preserving legacy player link while roster permissions are being repaired:', error);
-                    blockedLinkCount += 1;
+                    if (!teamReadBlocked) blockedLinkCount += 1;
                     playerSnap = { blockedByPermissions: true };
                 } else {
                     throw error;
@@ -676,14 +679,26 @@ function normalizePublicTeamSearchInput(value) {
 
 async function discoverPublicTeamsFromCallable({ searchText = '', cursor = null, pageSize = DEFAULT_PUBLIC_TEAM_DISCOVERY_PAGE_SIZE } = {}) {
     const discoverProfiles = httpsCallable(functions, 'discoverPublicTeamProfiles');
-    const result = await discoverProfiles({ searchText, cursor, pageSize });
-    const teams = Array.isArray(result.data?.teams)
-        ? result.data.teams.filter((team) => team?.isPublic === true && isTeamActive(team))
-        : [];
-    return {
-        teams,
-        nextCursor: result.data?.nextCursor || null
-    };
+    const seenEmptyPageCursors = new Set();
+    let currentCursor = cursor;
+
+    while (true) {
+        const result = await discoverProfiles({ searchText, cursor: currentCursor, pageSize });
+        const teams = Array.isArray(result.data?.teams)
+            ? result.data.teams.filter((team) => team?.isPublic === true && isTeamActive(team))
+            : [];
+        const nextCursor = result.data?.nextCursor || null;
+        if (teams.length > 0 || !nextCursor) {
+            return { teams, nextCursor };
+        }
+
+        const cursorKey = JSON.stringify(nextCursor);
+        if (seenEmptyPageCursors.has(cursorKey)) {
+            throw new Error('Public team discovery returned a repeated empty-page cursor.');
+        }
+        seenEmptyPageCursors.add(cursorKey);
+        currentCursor = nextCursor;
+    }
 }
 
 function isPublicProjectionFallbackError(error) {
@@ -762,7 +777,7 @@ async function getAllPublicTeamProfiles() {
         const page = await discoverPublicTeamsFromCallable({ cursor, pageSize: 100 });
         teams.push(...page.teams);
         cursor = page.nextCursor;
-    } while (cursor && teams.length < 1000);
+    } while (cursor);
     return teams;
 }
 
@@ -837,8 +852,14 @@ export async function getTeams(options = {}) {
 
 export async function getTeam(teamId, options = {}) {
     const includeInactive = !!options.includeInactive;
+    const preservePermissionDenied = options.preservePermissionDenied === true;
     const normalizedTeamId = String(teamId || '').trim();
     if (!normalizedTeamId) return null;
+    let sourceReadDenied = false;
+
+    const permissionDeniedPlaceholder = () => sourceReadDenied && preservePermissionDenied
+        ? { id: normalizedTeamId, active: true, blockedByPermissions: true }
+        : null;
 
     if (auth.currentUser) {
         try {
@@ -849,6 +870,7 @@ export async function getTeam(teamId, options = {}) {
             return sourceTeam;
         } catch (error) {
             if (!isPublicProjectionFallbackError(error)) throw error;
+            sourceReadDenied = String(error?.code || '').replace(/^(?:firestore|functions)\//, '') === 'permission-denied';
         }
     }
 
@@ -870,11 +892,11 @@ export async function getTeam(teamId, options = {}) {
     try {
         result = await getPublicTeamProfile({ teamId: normalizedTeamId });
     } catch (error) {
-        if (isPublicProjectionNotFoundError(error)) return null;
+        if (isPublicProjectionNotFoundError(error)) return permissionDeniedPlaceholder();
         throw error;
     }
     const item = result.data?.item || null;
-    if (!item) return null;
+    if (!item) return permissionDeniedPlaceholder();
     const publicTeam = { ...item, id: item.id || normalizedTeamId, isPublic: true, active: true };
     if (!includeInactive && !isTeamActive(publicTeam)) return null;
     return publicTeam;

--- a/js/db.js
+++ b/js/db.js
@@ -247,6 +247,7 @@ export { collection, getDocs, deleteDoc, query };
 const limitQuery = limit;
 const startAfterQuery = startAfter;
 const DEFAULT_PUBLIC_TEAM_DISCOVERY_PAGE_SIZE = 24;
+const MAX_PUBLIC_TEAM_EMPTY_PAGE_CONTINUATIONS = 1;
 const MAX_PUBLIC_TEAM_ROSTER_COUNT = 200;
 export const DEFAULT_CHAT_CONVERSATION_PAGE_SIZE = 25;
 const CHAT_REACTIONS = [
@@ -681,6 +682,7 @@ async function discoverPublicTeamsFromCallable({ searchText = '', cursor = null,
     const discoverProfiles = httpsCallable(functions, 'discoverPublicTeamProfiles');
     const seenEmptyPageCursors = new Set();
     let currentCursor = cursor;
+    let emptyPageContinuations = 0;
 
     while (true) {
         const result = await discoverProfiles({ searchText, cursor: currentCursor, pageSize });
@@ -697,6 +699,10 @@ async function discoverPublicTeamsFromCallable({ searchText = '', cursor = null,
             throw new Error('Public team discovery returned a repeated empty-page cursor.');
         }
         seenEmptyPageCursors.add(cursorKey);
+        if (emptyPageContinuations >= MAX_PUBLIC_TEAM_EMPTY_PAGE_CONTINUATIONS) {
+            return { teams, nextCursor };
+        }
+        emptyPageContinuations += 1;
         currentCursor = nextCursor;
     }
 }

--- a/js/db.js
+++ b/js/db.js
@@ -890,14 +890,22 @@ export async function getTeam(teamId, options = {}) {
     const getPublicTeamProfile = httpsCallable(functions, 'getPublicTeamProfile');
     let result;
     try {
-        result = await getPublicTeamProfile({ teamId: normalizedTeamId });
+        result = await getPublicTeamProfile({
+            teamId: normalizedTeamId,
+            ...(includeInactive ? { includeInactive: true } : {})
+        });
     } catch (error) {
         if (isPublicProjectionNotFoundError(error)) return permissionDeniedPlaceholder();
         throw error;
     }
     const item = result.data?.item || null;
     if (!item) return permissionDeniedPlaceholder();
-    const publicTeam = { ...item, id: item.id || normalizedTeamId, isPublic: true, active: true };
+    const publicTeam = {
+        ...item,
+        id: item.id || normalizedTeamId,
+        isPublic: true,
+        active: item.active !== false
+    };
     if (!includeInactive && !isTeamActive(publicTeam)) return null;
     return publicTeam;
 }
@@ -7404,7 +7412,9 @@ async function projectSharedHomepageGame(sharedGame, shouldIncludeTeam) {
     const teamIds = getSharedHomepageTeamIds(sharedGame);
 
     for (const teamId of teamIds) {
-        const team = await getTeam(teamId);
+        // The caller-specific visibility predicate owns active-team policy.
+        // Replay history intentionally permits inactive public teams.
+        const team = await getTeam(teamId, { includeInactive: true });
         if (!team) continue;
         if (!shouldIncludeTeam(team)) {
             continue;

--- a/js/global-search.js
+++ b/js/global-search.js
@@ -25,6 +25,7 @@ let cachedAccessibleTeamsUserKey = '';
 const playerSearchQueryLimit = playerSearchResultLimit;
 const playerSearchTeamLimit = 8;
 const teamSearchQueryLimit = 20;
+const publicTeamSearchPageRequestLimit = 2;
 
 let currentUser = null;
 let keyHandlerInstalled = false;
@@ -438,6 +439,8 @@ function openModal({ initialQuery = '' } = {}) {
         flatResults: [],
         teams: [],
         publicTeams: [],
+        publicTeamsNextCursor: null,
+        publicTeamsSearchText: '',
         loadingTeams: true,
         teamsError: '',
         loadingPublicTeams: false,
@@ -496,6 +499,13 @@ function openModal({ initialQuery = '' } = {}) {
     root.addEventListener('keydown', onKeyDown);
 
     const onClickResult = (e) => {
+        const continueTeamsButton = e.target?.closest?.('[data-global-search-more-teams="1"]');
+        if (continueTeamsButton) {
+            const cursor = modalState?.publicTeamsNextCursor;
+            const searchText = modalState?.publicTeamsSearchText || modalState?.input?.value || '';
+            if (cursor) void runTeamSearch(searchText, { cursor, append: true });
+            return;
+        }
         const btn = e.target?.closest?.('[data-global-search-result="1"]');
         if (!btn) return;
         const href = btn.getAttribute('data-href');
@@ -579,6 +589,7 @@ function openModal({ initialQuery = '' } = {}) {
         const actionsHtml = renderSection('Actions', matchedActions, 0);
         const teamsOffset = matchedActions.length;
         const teamsRows = matchedTeams.map((item, idx) => renderResultRow(item, (teamsOffset + idx) === modalState.activeIndex)).join('');
+        const canContinueTeamSearch = q.trim().length >= 2 && Boolean(modalState.publicTeamsNextCursor);
         const teamsStatus = modalState.loadingTeams
             ? `<div class="text-sm text-gray-500 px-1 py-2">Loading teams...</div>`
             : modalState.teamsError
@@ -590,8 +601,13 @@ function openModal({ initialQuery = '' } = {}) {
                         : (matchedTeams.length === 0
                             ? (q.trim().length < 2
                                 ? `<div class="text-sm text-gray-500 px-1 py-2">Type at least 2 characters to search public teams</div>`
-                                : `<div class="text-sm text-gray-500 px-1 py-2">No matching teams</div>`)
+                                : canContinueTeamSearch
+                                    ? `<div class="text-sm text-gray-500 px-1 py-2">No matching teams in this scan yet</div>`
+                                    : `<div class="text-sm text-gray-500 px-1 py-2">No matching teams</div>`)
                             : '');
+        const teamContinuationHtml = canContinueTeamSearch && !modalState.loadingPublicTeams
+            ? `<button type="button" data-global-search-more-teams="1" class="mt-2 text-xs font-bold text-primary-700 hover:text-primary-800">Continue team search</button>`
+            : '';
 
         const teamsHtml = `
             <div>
@@ -600,6 +616,7 @@ function openModal({ initialQuery = '' } = {}) {
                     ${teamsRows}
                 </div>
                 ${teamsStatus}
+                ${teamContinuationHtml}
             </div>
         `;
 
@@ -621,7 +638,7 @@ function openModal({ initialQuery = '' } = {}) {
             </div>
         `;
 
-        const emptyHtml = modalState.flatResults.length === 0 && !modalState.loadingTeams
+        const emptyHtml = modalState.flatResults.length === 0 && !modalState.loadingTeams && !canContinueTeamSearch
             ? `<div class="text-sm text-gray-500 px-1 py-6 text-center">No results</div>`
             : '';
 
@@ -635,12 +652,14 @@ function openModal({ initialQuery = '' } = {}) {
         `;
     };
 
-    const runTeamSearch = async (rawQuery) => {
+    const runTeamSearch = async (rawQuery, { cursor: initialCursor = null, append = false } = {}) => {
         const q = (rawQuery || '').trim();
         if (!modalState) return;
 
         if (q.length < 2) {
             modalState.publicTeams = [];
+            modalState.publicTeamsNextCursor = null;
+            modalState.publicTeamsSearchText = '';
             modalState.loadingPublicTeams = false;
             modalState.publicTeamsError = '';
             renderResults();
@@ -648,22 +667,50 @@ function openModal({ initialQuery = '' } = {}) {
         }
 
         const reqId = ++modalState.publicTeamsReqId;
+        if (!append) modalState.publicTeamsNextCursor = null;
         modalState.loadingPublicTeams = true;
         modalState.publicTeamsError = '';
         renderResults();
 
         try {
-            const result = await discoverPublicTeams({ searchText: q, pageSize: teamSearchQueryLimit });
-            if (!modalState || reqId !== modalState.publicTeamsReqId) return;
-            const publicTeams = (result?.teams || []).filter((team) => isTeamActive(team) && !modalState.teamsById.has(team.id));
-            modalState.publicTeams = publicTeams;
+            const publicTeamsById = new Map(append
+                ? (modalState.publicTeams || []).map((team) => [team.id, team])
+                : []);
+            const seenCursors = new Set();
+            let cursor = initialCursor;
+            if (cursor) seenCursors.add(JSON.stringify(cursor));
+
+            for (let requestCount = 0;
+                requestCount < publicTeamSearchPageRequestLimit && publicTeamsById.size < teamSearchQueryLimit;
+                requestCount += 1) {
+                const remainingTeamSlots = teamSearchQueryLimit - publicTeamsById.size;
+                const result = await discoverPublicTeams(cursor
+                    ? { searchText: q, cursor, pageSize: remainingTeamSlots }
+                    : { searchText: q, pageSize: remainingTeamSlots });
+                if (!modalState || reqId !== modalState.publicTeamsReqId) return;
+                (result?.teams || [])
+                    .filter((team) => isTeamActive(team) && !modalState.teamsById.has(team.id))
+                    .forEach((team) => publicTeamsById.set(team.id, team));
+
+                cursor = result?.nextCursor || null;
+                if (!cursor || publicTeamsById.size >= teamSearchQueryLimit) break;
+                const cursorKey = JSON.stringify(cursor);
+                if (seenCursors.has(cursorKey)) {
+                    throw new Error('Public team search returned a repeated cursor.');
+                }
+                seenCursors.add(cursorKey);
+            }
+
+            modalState.publicTeams = Array.from(publicTeamsById.values());
+            modalState.publicTeamsNextCursor = publicTeamsById.size < teamSearchQueryLimit ? cursor : null;
+            modalState.publicTeamsSearchText = q;
             modalState.loadingPublicTeams = false;
             modalState.publicTeamsError = '';
             renderResults();
         } catch (e) {
             console.error('[GlobalSearch] Team search failed:', e);
             if (!modalState || reqId !== modalState.publicTeamsReqId) return;
-            modalState.publicTeams = [];
+            if (!append) modalState.publicTeams = [];
             modalState.loadingPublicTeams = false;
             modalState.publicTeamsError = 'Public team search unavailable.';
             renderResults();
@@ -770,6 +817,9 @@ function openModal({ initialQuery = '' } = {}) {
 
     input.addEventListener('input', () => {
         modalState.activeIndex = 0;
+        if ((modalState.input.value || '').trim() !== modalState.publicTeamsSearchText) {
+            modalState.publicTeamsNextCursor = null;
+        }
         scheduleSearches();
         renderResults();
     });
@@ -785,6 +835,7 @@ function openModal({ initialQuery = '' } = {}) {
             if (!modalState) return;
             modalState.teams = teams;
             modalState.publicTeams = [];
+            modalState.publicTeamsNextCursor = null;
             modalState.loadingTeams = false;
             modalState.teamsError = '';
             modalState.teamsById = new Map((teams || []).map(t => [t.id, t]));

--- a/js/global-search.js
+++ b/js/global-search.js
@@ -673,8 +673,10 @@ function openModal({ initialQuery = '' } = {}) {
         renderResults();
 
         try {
-            const publicTeamsById = new Map(append
-                ? (modalState.publicTeams || []).map((team) => [team.id, team])
+            const existingPublicTeams = append ? (modalState.publicTeams || []) : [];
+            const shouldAppendExistingTeams = append && existingPublicTeams.length < teamSearchQueryLimit;
+            const publicTeamsById = new Map(shouldAppendExistingTeams
+                ? existingPublicTeams.map((team) => [team.id, team])
                 : []);
             const seenCursors = new Set();
             let cursor = initialCursor;
@@ -693,16 +695,17 @@ function openModal({ initialQuery = '' } = {}) {
                     .forEach((team) => publicTeamsById.set(team.id, team));
 
                 cursor = result?.nextCursor || null;
-                if (!cursor || publicTeamsById.size >= teamSearchQueryLimit) break;
+                if (!cursor) break;
                 const cursorKey = JSON.stringify(cursor);
                 if (seenCursors.has(cursorKey)) {
                     throw new Error('Public team search returned a repeated cursor.');
                 }
                 seenCursors.add(cursorKey);
+                if (publicTeamsById.size >= teamSearchQueryLimit) break;
             }
 
             modalState.publicTeams = Array.from(publicTeamsById.values());
-            modalState.publicTeamsNextCursor = publicTeamsById.size < teamSearchQueryLimit ? cursor : null;
+            modalState.publicTeamsNextCursor = cursor;
             modalState.publicTeamsSearchText = q;
             modalState.loadingPublicTeams = false;
             modalState.publicTeamsError = '';

--- a/js/utils.js
+++ b/js/utils.js
@@ -198,7 +198,7 @@ export function renderHeader(container, user) {
   // Global search: injected into the shared header in one place.
   // Lazy-import to avoid adding weight to initial render and to avoid circular deps.
   try {
-    import('./global-search.js?v=11')
+    import('./global-search.js?v=12')
       .then(({ setupHeaderSearch }) => {
         if (typeof setupHeaderSearch === 'function') {
           setupHeaderSearch({ user, headerContainer: container });

--- a/js/utils.js
+++ b/js/utils.js
@@ -198,7 +198,7 @@ export function renderHeader(container, user) {
   // Global search: injected into the shared header in one place.
   // Lazy-import to avoid adding weight to initial render and to avoid circular deps.
   try {
-    import('./global-search.js?v=10')
+    import('./global-search.js?v=11')
       .then(({ setupHeaderSearch }) => {
         if (typeof setupHeaderSearch === 'function') {
           setupHeaderSearch({ user, headerContainer: container });

--- a/js/utils.js
+++ b/js/utils.js
@@ -198,7 +198,7 @@ export function renderHeader(container, user) {
   // Global search: injected into the shared header in one place.
   // Lazy-import to avoid adding weight to initial render and to avoid circular deps.
   try {
-    import('./global-search.js?v=9')
+    import('./global-search.js?v=10')
       .then(({ setupHeaderSearch }) => {
         if (typeof setupHeaderSearch === 'function') {
           setupHeaderSearch({ user, headerContainer: container });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "vitest run tests/unit",
     "test:unit": "vitest run tests/unit",
     "test:unit:ci": "vitest run tests/unit --reporter=dot && npm run test:storage-rules:ci",
-    "test:storage-rules:ci": "firebase emulators:exec --only firestore,storage --project demo-allplays \"vitest run tests/unit/storage-rules-team-boundary.test.js tests/unit/player-rules-privacy.test.js tests/unit/private-ai-rules.test.js tests/unit/team-entitlement-rules.test.js tests/unit/team-email-send-rules.test.js tests/unit/app-social-rules.test.js tests/unit/rsvp-note-privacy-rules.test.js --reporter=dot --no-file-parallelism\"",
+    "test:storage-rules:ci": "firebase emulators:exec --only firestore,storage --project demo-allplays \"vitest run tests/unit/storage-rules-team-boundary.test.js tests/unit/player-rules-privacy.test.js tests/unit/public-team-projection-compatibility.test.js tests/unit/private-ai-rules.test.js tests/unit/team-entitlement-rules.test.js tests/unit/team-email-send-rules.test.js tests/unit/app-social-rules.test.js tests/unit/rsvp-note-privacy-rules.test.js --reporter=dot --no-file-parallelism\"",
     "test:coverage-map": "node scripts/report-test-coverage-map.mjs --check",
     "test:functions:notifications": "npm run test:notifications --prefix functions",
     "test:functions:auth-email": "node --test functions/test/auth-email-*.test.cjs",

--- a/team.html
+++ b/team.html
@@ -324,9 +324,9 @@
     </div>
 
     <script type="module">
-        import { getTeam, getPlayers, getGames, getConfigs, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile, getAllUsers, saveTeamAvailabilityPreferences, grantScorekeeperAccess, revokeScorekeeperAccess, grantStreamScoreAccess, revokeStreamScoreAccess, getRsvps, getRsvpSummaries, submitRsvp, getMyRsvp, getLocalAttractionSponsors, getAdSpaceSponsors, postChatMessage, getPublicTrackingItems, getPlayerTrackingStatuses } from './js/db.js?v=107';
+        import { getTeam, getPublicTeamExternalCalendarIcs, getPlayers, getGames, getConfigs, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile, getAllUsers, saveTeamAvailabilityPreferences, grantScorekeeperAccess, revokeScorekeeperAccess, grantStreamScoreAccess, revokeStreamScoreAccess, getRsvps, getRsvpSummaries, submitRsvp, getMyRsvp, getLocalAttractionSponsors, getAdSpaceSponsors, postChatMessage, getPublicTrackingItems, getPlayerTrackingStatuses } from './js/db.js?v=107';
         import { normalizeExternalWebsiteUrl, selectRotatingSponsor } from './js/local-attractions.js?v=2';
-        import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, isTrackedCalendarEvent, expandRecurrence, escapeHtml, shareOrCopy } from './js/utils.js?v=15';
+        import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, fetchAndParseCalendar, parseICS, extractOpponent, isPracticeEvent, isTrackedCalendarEvent, expandRecurrence, escapeHtml, shareOrCopy } from './js/utils.js?v=15';
         import { fetchLeagueStandings } from './js/league-standings.js?v=1';
         import { computeNativeStandings } from './js/native-standings.js?v=1';
         import { computeTournamentPoolStandings } from './js/tournament-standings.js?v=4';
@@ -2290,43 +2290,53 @@
 
             const trackedUids = await getTrackedCalendarEventUids(currentTeamId);
 
-            if (team.calendarUrls && team.calendarUrls.length > 0) {
-                for (const calendarUrl of team.calendarUrls) {
+            const appendExternalCalendarEvents = (calendarEvents) => {
+                calendarEvents.forEach(event => {
+                    if (isTrackedCalendarEvent(event, trackedUids)) return;
+
+                    // Check if event is cancelled (standard iCal STATUS or TeamSnap [CANCELED] prefix)
+                    const isCancelled = event.status?.toUpperCase() === 'CANCELLED' ||
+                        event.summary?.includes('[CANCELED]');
+
+                    const hasConflict = scheduleEntries.some((entry) => {
+                        const eventDate = event.dtstart;
+                        return Math.abs(entry.date - eventDate) < 60000;
+                    });
+
+                    if (hasConflict) return;
+
+                    const isPractice = isPracticeEvent(event.summary);
+                    // Clean [CANCELED] prefix from summary before extracting opponent
+                    const cleanSummary = event.summary?.replace(/\[CANCELED\]\s*/gi, '') || '';
+                    const opponent = extractOpponent(cleanSummary, team.name);
+
+                    allEvents.push({
+                        type: 'calendar',
+                        date: event.dtstart,
+                        opponent: opponent,
+                        location: event.location || 'TBD',
+                        isPractice: isPractice,
+                        isCancelled: isCancelled,
+                        calendarEvent: event
+                    });
+                });
+            };
+
+            const calendarUrls = Array.isArray(team.calendarUrls) ? team.calendarUrls : [];
+            if (calendarUrls.length > 0) {
+                for (const calendarUrl of calendarUrls) {
                     try {
-                        const calendarEvents = await fetchAndParseCalendar(calendarUrl);
-
-                        calendarEvents.forEach(event => {
-                            if (isTrackedCalendarEvent(event, trackedUids)) return;
-
-                            // Check if event is cancelled (standard iCal STATUS or TeamSnap [CANCELED] prefix)
-                            const isCancelled = event.status?.toUpperCase() === 'CANCELLED' ||
-                                event.summary?.includes('[CANCELED]');
-
-                            const hasConflict = scheduleEntries.some((entry) => {
-                                const eventDate = event.dtstart;
-                                return Math.abs(entry.date - eventDate) < 60000;
-                            });
-
-                            if (hasConflict) return;
-
-                            const isPractice = isPracticeEvent(event.summary);
-                            // Clean [CANCELED] prefix from summary before extracting opponent
-                            const cleanSummary = event.summary?.replace(/\[CANCELED\]\s*/gi, '') || '';
-                            const opponent = extractOpponent(cleanSummary, team.name);
-
-                            allEvents.push({
-                                type: 'calendar',
-                                date: event.dtstart,
-                                opponent: opponent,
-                                location: event.location || 'TBD',
-                                isPractice: isPractice,
-                                isCancelled: isCancelled,
-                                calendarEvent: event
-                            });
-                        });
+                        appendExternalCalendarEvents(await fetchAndParseCalendar(calendarUrl));
                     } catch (error) {
                         console.error('Error fetching calendar:', calendarUrl, error);
                     }
+                }
+            } else if (team.isPublic === true) {
+                try {
+                    const sanitizedCalendars = await getPublicTeamExternalCalendarIcs(currentTeamId);
+                    sanitizedCalendars.forEach((icsText) => appendExternalCalendarEvents(parseICS(icsText)));
+                } catch (error) {
+                    console.error('Error fetching public team external calendars:', error);
                 }
             }
 

--- a/teams.html
+++ b/teams.html
@@ -178,7 +178,9 @@
           await loadTeams(activeLocationFilter, { cursor: nextCursor, append: true });
         };
 
-        if (teams.length === 0 && !append) {
+        renderedTeams = append ? [...renderedTeams, ...teams] : teams;
+
+        if (renderedTeams.length === 0) {
           const emptyMessage = browseCursor
             ? locationFilter
               ? `No matches in this scan yet for "${escapeHtml(locationFilter)}". Continue searching to scan more public teams.`
@@ -205,8 +207,6 @@
           });
           return;
         }
-
-        renderedTeams = append ? [...renderedTeams, ...teams] : teams;
 
         // Resolve locations for teams with zip
         const uniqueZips = [...new Set(renderedTeams

--- a/teams.html
+++ b/teams.html
@@ -172,11 +172,20 @@
         // Defense in depth: the query only requests public teams, and this keeps
         // private teams hidden if a stale helper or local test double returns one.
         const teams = allTeams.filter(t => t.isPublic === true);
+        const loadNextDiscoveryPage = async () => {
+          const nextCursor = browseCursor;
+          if (!nextCursor) return;
+          await loadTeams(activeLocationFilter, { cursor: nextCursor, append: true });
+        };
 
         if (teams.length === 0 && !append) {
-          const emptyMessage = locationFilter
-            ? `No public teams found for "${escapeHtml(locationFilter)}".`
-            : 'No teams found yet.';
+          const emptyMessage = browseCursor
+            ? locationFilter
+              ? `No matches in this scan yet for "${escapeHtml(locationFilter)}". Continue searching to scan more public teams.`
+              : 'No teams in this scan yet. Continue searching to scan more public teams.'
+            : locationFilter
+              ? `No public teams found for "${escapeHtml(locationFilter)}".`
+              : 'No teams found yet.';
           container.innerHTML = `
             <div class="col-span-full text-center py-16 bg-white rounded-2xl shadow-md border border-gray-200">
               <div class="max-w-md mx-auto">
@@ -184,12 +193,16 @@
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path>
                 </svg>
                 <p class="text-gray-600 text-lg mb-4">${emptyMessage}</p>
-                ${locationFilter ? '' : `<a href="login.html#signup" class="inline-block px-6 py-3 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition font-medium">
+                ${locationFilter || browseCursor ? '' : `<a href="login.html#signup" class="inline-block px-6 py-3 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition font-medium">
                   Create the First Team
                 </a>`}
               </div>
             </div>
           `;
+          renderLoadMoreButton(container, {
+            canLoadMore: Boolean(browseCursor),
+            onClick: loadNextDiscoveryPage
+          });
           return;
         }
 
@@ -289,11 +302,7 @@
 
         renderLoadMoreButton(container, {
           canLoadMore: Boolean(browseCursor),
-          onClick: async () => {
-            const nextCursor = browseCursor;
-            if (!nextCursor) return;
-            await loadTeams(activeLocationFilter, { cursor: nextCursor, append: true });
-          }
+          onClick: loadNextDiscoveryPage
         });
 
         // Attach card navigation

--- a/tests/coverage/feature-coverage-map.json
+++ b/tests/coverage/feature-coverage-map.json
@@ -228,6 +228,7 @@
                 "queueInviteEmail",
                 "queueParentInviteEmail",
                 "syncApprovedParentMembershipRequestUserLink",
+                "syncPublicTeamProfileOnTeamWrite",
                 "syncPublicUserProfileProjection"
             ],
             "unitTests": [
@@ -751,6 +752,7 @@
                 "closePublicOpportunity",
                 "createOpportunityInquiry",
                 "createPublicOpportunity",
+                "discoverPublicTeamProfiles",
                 "getOpportunityInquiry",
                 "getPublicOpportunity",
                 "getPublicTeamProfile",

--- a/tests/coverage/feature-coverage-map.json
+++ b/tests/coverage/feature-coverage-map.json
@@ -296,6 +296,7 @@
                 "createScopedRsvpToken",
                 "dispatchDuePreEventReminders",
                 "fetchCalendarIcs",
+                "getPublicTeamExternalCalendarIcs",
                 "getPublicRsvp",
                 "notifyGameCreated",
                 "notifyGameUpdated",
@@ -311,6 +312,7 @@
             ],
             "unitTests": [
                 "functions/test/calendar-ics-fetch-core.test.cjs",
+                "functions/test/public-external-calendar-core.test.cjs",
                 "tests/unit/app-schedule-availability-panels.test.tsx",
                 "tests/unit/app-schedule-event-detail-cancel.test.js",
                 "tests/unit/app-schedule-service-contracts.test.js",

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -173,16 +173,23 @@ async function mockSearchModules(page) {
                     }).slice(0, 20);
                 }
 
-                export async function searchAppTeams(queryText, appAccessTeams = []) {
+                export async function searchAppTeamsPage(queryText, appAccessTeams = []) {
                     window.__teamSearchQueries.push(String(queryText || ''));
                     const q = String(queryText || '').trim().toLowerCase();
                     const publicTeams = q.includes('bea') ? [
                         { id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210', isPublic: true }
                     ] : [];
-                    return [...appAccessTeams, ...publicTeams].filter((team) => {
-                        const haystack = [team.name, team.sport, team.zip].filter(Boolean).join(' ').toLowerCase();
-                        return haystack.includes(q);
-                    }).slice(0, 20);
+                    return {
+                        teams: [...appAccessTeams, ...publicTeams].filter((team) => {
+                            const haystack = [team.name, team.sport, team.zip].filter(Boolean).join(' ').toLowerCase();
+                            return haystack.includes(q);
+                        }).slice(0, 20),
+                        nextCursor: null
+                    };
+                }
+
+                export async function searchAppTeams(queryText, appAccessTeams = []) {
+                    return (await searchAppTeamsPage(queryText, appAccessTeams)).teams;
                 }
 
                 export async function searchAppPlayers(queryText) {

--- a/tests/smoke/team-schedule-calendar.spec.js
+++ b/tests/smoke/team-schedule-calendar.spec.js
@@ -52,6 +52,11 @@ export async function getTeam(teamId) {
     return { ...clone(team), id: teamId };
 }
 
+export async function getPublicTeamExternalCalendarIcs(teamId) {
+    window.__publicTeamCalendarCalls = (window.__publicTeamCalendarCalls || []).concat(teamId);
+    return ['BEGIN:VCALENDAR\\r\\nEND:VCALENDAR'];
+}
+
 export async function getPlayers() {
     return [];
 }
@@ -173,6 +178,13 @@ export function formatTime(value) {
 }
 
 export async function fetchAndParseCalendar() {
+    return calendarEvents.map((event) => ({
+        ...event,
+        dtstart: new Date(event.dtstart)
+    }));
+}
+
+export function parseICS() {
     return calendarEvents.map((event) => ({
         ...event,
         dtstart: new Date(event.dtstart)
@@ -500,6 +512,38 @@ async function gotoCalendarMonth(page, fromDate, targetDate) {
 
     throw new Error(`Unable to navigate calendar to ${targetDate.toISOString()}`);
 }
+
+test('public projection team keeps external calendar events through the sanitized server feed', async ({ page, baseURL }) => {
+    const now = new Date();
+    const externalGameDate = addDays(now, 8, 18);
+    const scenario = {
+        team: {
+            name: 'Projected Team',
+            sport: 'Soccer',
+            isPublic: true,
+            active: true
+        },
+        games: [],
+        trackedUids: [],
+        calendarEvents: [
+            {
+                uid: 'projected-calendar-game',
+                dtstart: makeIso(externalGameDate),
+                summary: 'Projected Team vs Comets',
+                location: 'Public Field',
+                status: 'CONFIRMED'
+            }
+        ]
+    };
+
+    await mockTeamPageModules(page, scenario);
+    await page.goto(buildUrl(baseURL, '/team.html#teamId=team-a'), { waitUntil: 'domcontentloaded' });
+
+    await page.locator('#schedule-filter-all-upcoming').click();
+    await expect(page.locator('#schedule-list')).toContainText('Comets');
+    await expect(page.locator('#schedule-list')).toContainText('Public Field');
+    await expect.poll(() => page.evaluate(() => window.__publicTeamCalendarCalls || [])).toEqual(['team-a']);
+});
 
 test('team schedule calendar shows only practices in the dedicated practice filter and modal', async ({ page, baseURL }) => {
     const now = new Date();

--- a/tests/smoke/teams-location-search.spec.js
+++ b/tests/smoke/teams-location-search.spec.js
@@ -40,6 +40,15 @@ export async function discoverPublicTeams(options = {}) {
     }
     return { teams: pages.kansas, nextCursor: 'search-page-2' };
   }
+  if (filter.includes('sparse')) {
+    if (options.cursor === 'sparse-page-3') {
+      return { teams: [], nextCursor: null };
+    }
+    if (options.cursor === 'sparse-page-2') {
+      return { teams: [], nextCursor: 'sparse-page-3' };
+    }
+    return { teams: [], nextCursor: 'sparse-page-2' };
+  }
   return { teams: [], nextCursor: null };
 }
 
@@ -116,4 +125,33 @@ test('browse teams location search paginates filtered results and clear restores
     await expect(page.getByText('Alpha Soccer')).toBeVisible();
     await expect(page.getByText('Kansas City Current')).toHaveCount(0);
     await expect.poll(() => page.evaluate(() => window.__teamSearchCalls.at(-1))).toEqual({ cursor: null, pageSize: 24 });
+});
+
+test('browse teams preserves sparse-search guidance through empty continuation pages', async ({ page, baseURL }) => {
+    await page.route('**/js/auth.js?v=*', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: AUTH_STUB }));
+    await page.route('**/js/db.js?v=*', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: DB_STUB }));
+    await page.route('**/js/telemetry.js?v=*', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: '' }));
+    await page.route('**/js/utils.js?v=*', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: UTILS_STUB }));
+
+    await page.goto(`${baseURL}/teams.html`, { waitUntil: 'domcontentloaded' });
+    await page.locator('#location-search-input').fill('Sparse');
+    await page.locator('#search-button').click();
+
+    const scanMessage = 'No matches in this scan yet for "Sparse". Continue searching to scan more public teams.';
+    await expect(page.getByText(scanMessage)).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Load more teams' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Load more teams' }).click();
+    await expect(page.getByText(scanMessage)).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Load more teams' })).toBeVisible();
+    await expect.poll(() => page.evaluate(() => window.__teamSearchCalls.at(-1))).toEqual({
+      searchText: 'Sparse', cursor: 'sparse-page-2', pageSize: 24
+    });
+
+    await page.getByRole('button', { name: 'Load more teams' }).click();
+    await expect(page.getByText('No public teams found for "Sparse".')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Load more teams' })).toHaveCount(0);
+    await expect.poll(() => page.evaluate(() => window.__teamSearchCalls.at(-1))).toEqual({
+      searchText: 'Sparse', cursor: 'sparse-page-3', pageSize: 24
+    });
 });

--- a/tests/unit/app-search-service.test.js
+++ b/tests/unit/app-search-service.test.js
@@ -43,6 +43,7 @@ import {
     resetAppSearchCache,
     scoreSearchText,
     searchAppTeams,
+    searchAppTeamsPage,
     searchAppPlayers,
     splitSearchTokens
 } from '../../apps/app/src/lib/searchService.ts';
@@ -824,6 +825,48 @@ describe('React app search service', () => {
         expect(teams.find((team) => team.id === 'team-home')).toMatchObject({
             name: 'Bearcats Public',
             isPublic: true
+        });
+    });
+
+    it('continues a bounded empty public-team page before caching app search results', async () => {
+        const firstCursor = { kind: 'public-team-callable-v2', lastId: 'middle' };
+        dbMocks.discoverPublicTeams
+            .mockResolvedValueOnce({ teams: [], nextCursor: firstCursor })
+            .mockResolvedValueOnce({
+                teams: [{ id: 'team-target', name: 'Target Team', isPublic: true }],
+                nextCursor: null
+            });
+
+        const teams = await searchAppTeams('target', [], auth.user);
+
+        expect(teams.map((team) => team.id)).toEqual(['team-target']);
+        expect(dbMocks.discoverPublicTeams).toHaveBeenNthCalledWith(1, {
+            searchText: 'target', cursor: null, pageSize: 20
+        });
+        expect(dbMocks.discoverPublicTeams).toHaveBeenNthCalledWith(2, {
+            searchText: 'target', cursor: firstCursor, pageSize: 20
+        });
+    });
+
+    it('preserves a residual app-search cursor at the cap and resumes from it', async () => {
+        const firstCursor = { lastId: 'first' };
+        const residualCursor = { lastId: 'second' };
+        dbMocks.discoverPublicTeams
+            .mockResolvedValueOnce({ teams: [], nextCursor: firstCursor })
+            .mockResolvedValueOnce({ teams: [], nextCursor: residualCursor })
+            .mockResolvedValueOnce({
+                teams: [{ id: 'team-target', name: 'Target Team', isPublic: true }],
+                nextCursor: null
+            });
+
+        const firstPage = await searchAppTeamsPage('target', [], auth.user);
+        expect(firstPage).toEqual({ teams: [], nextCursor: residualCursor });
+
+        const secondPage = await searchAppTeamsPage('target', [], auth.user, firstPage.nextCursor);
+        expect(secondPage.teams.map((team) => team.id)).toEqual(['team-target']);
+        expect(secondPage.nextCursor).toBeNull();
+        expect(dbMocks.discoverPublicTeams).toHaveBeenNthCalledWith(3, {
+            searchText: 'target', cursor: residualCursor, pageSize: 20
         });
     });
 

--- a/tests/unit/app-search-service.test.js
+++ b/tests/unit/app-search-service.test.js
@@ -817,9 +817,9 @@ describe('React app search service', () => {
             nextCursor: null
         });
 
-        const teams = await searchAppTeams('be', [{ id: 'team-home', name: 'Bearcats', sport: 'Soccer', fromAppAccess: true }], auth.user);
+        const teams = await searchAppTeams('bea', [{ id: 'team-home', name: 'Bearcats', sport: 'Soccer', fromAppAccess: true }], auth.user);
 
-        expect(dbMocks.discoverPublicTeams).toHaveBeenCalledWith({ searchText: 'be', cursor: null, pageSize: 20 });
+        expect(dbMocks.discoverPublicTeams).toHaveBeenCalledWith({ searchText: 'bea', cursor: null, pageSize: 20 });
         expect(teams.map((team) => team.id)).toEqual(['team-home', 'team-public']);
         expect(teams.find((team) => team.id === 'team-home')).toMatchObject({
             name: 'Bearcats Public',
@@ -844,8 +844,8 @@ describe('React app search service', () => {
             nextCursor: null
         });
 
-        const first = await searchAppTeams('be', [{ id: 'team-home', name: 'Bearcats', sport: 'Soccer', fromAppAccess: true }], auth.user);
-        const second = await searchAppTeams(' BE ', [{ id: 'team-home', name: 'Bearcats', sport: 'Soccer', fromAppAccess: true }], auth.user);
+        const first = await searchAppTeams('bea', [{ id: 'team-home', name: 'Bearcats', sport: 'Soccer', fromAppAccess: true }], auth.user);
+        const second = await searchAppTeams(' BEA ', [{ id: 'team-home', name: 'Bearcats', sport: 'Soccer', fromAppAccess: true }], auth.user);
 
         expect(dbMocks.discoverPublicTeams).toHaveBeenCalledTimes(1);
         expect(first.map((team) => team.id)).toEqual(['team-home', 'team-public']);

--- a/tests/unit/db-homepage-shared-games.test.js
+++ b/tests/unit/db-homepage-shared-games.test.js
@@ -22,6 +22,7 @@ describe('homepage shared game discovery queries', () => {
 
         expect(source).toContain("collectionGroup(db, 'sharedGames')");
         expect(source).toContain('projectSharedGameForTeam(sharedGame, teamId)');
+        expect(source).toContain('const team = await getTeam(teamId, { includeInactive: true });');
 
         const upcomingSource = getFunctionSource(source, 'getUpcomingLiveGames');
         expect(upcomingSource).toContain('getSharedHomepageGames');

--- a/tests/unit/db-parent-scope-normalization.test.js
+++ b/tests/unit/db-parent-scope-normalization.test.js
@@ -167,6 +167,49 @@ describe('parent scope normalization', () => {
         });
     });
 
+    it('preserves a private-team parent link when the team source read is permission denied', async () => {
+        const getTeam = vi.fn().mockResolvedValue({
+            id: 'private-team', active: true, blockedByPermissions: true
+        });
+        const getDoc = vi.fn().mockResolvedValue(makeSnap('private-player', {
+            name: 'Private Player', number: '7', active: true
+        }));
+        const doc = vi.fn((_db, collectionPath, playerId) => ({ path: `${collectionPath}/${playerId}` }));
+        const normalizeParentScopeLinks = buildNormalizeParentScopeLinks({
+            getTeam,
+            getDoc,
+            doc,
+            db: {},
+            isTeamActive: (team) => team?.active !== false
+        });
+
+        const result = await normalizeParentScopeLinks([{
+            teamId: 'private-team',
+            playerId: 'private-player',
+            teamName: 'Private Team',
+            playerName: 'Old Player Name'
+        }]);
+
+        expect(getTeam).toHaveBeenCalledWith('private-team', {
+            includeInactive: true,
+            preservePermissionDenied: true
+        });
+        expect(result).toEqual({
+            activeLinks: [{
+                teamId: 'private-team',
+                playerId: 'private-player',
+                teamName: 'Private Team',
+                playerName: 'Private Player',
+                playerNumber: '7',
+                playerPhotoUrl: null
+            }],
+            parentTeamIds: ['private-team'],
+            parentPlayerKeys: ['private-team::private-player'],
+            blockedLinkCount: 1,
+            staleLinkCount: 0
+        });
+    });
+
     it('backfills cleaned parent access scope fields instead of raw parentOf links', async () => {
         const getUserProfile = vi.fn().mockResolvedValue({
             parentOf: [

--- a/tests/unit/db-public-team-discovery-source.test.js
+++ b/tests/unit/db-public-team-discovery-source.test.js
@@ -3,11 +3,14 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 describe('public team discovery source', () => {
-    it('maintains bounded team-name search strategies alongside location search', () => {
+    it('materializes public search fields and keeps callable discovery bounded and cursor-resumable', () => {
         const source = readFileSync(resolve(process.cwd(), 'js/db.js'), 'utf8');
+        const functionsSource = readFileSync(resolve(process.cwd(), 'functions/index.js'), 'utf8');
 
         expect(source).toContain("searchFields.publicSearchName = normalizePublicTeamSearchValue(teamData.name);");
-        expect(source).toContain("{ field: 'publicSearchName', start: normalizedName, end: `${normalizedName}\\uf8ff` }");
-        expect(source).toContain("{ field: 'name', start: legacyNameSearch, end: `${legacyNameSearch}\\uf8ff` }");
+        expect(source).toContain("httpsCallable(functions, 'discoverPublicTeamProfiles')");
+        expect(functionsSource).toContain('PUBLIC_TEAM_DISCOVERY_SCAN_LIMIT = 500');
+        expect(functionsSource).toContain('.orderBy(admin.firestore.FieldPath.documentId())');
+        expect(functionsSource).toContain('browseQuery.startAfter(scanCursor.lastName, scanCursor.lastId)');
     });
 });

--- a/tests/unit/discover-public-teams-search-pagination.test.js
+++ b/tests/unit/discover-public-teams-search-pagination.test.js
@@ -166,6 +166,40 @@ describe('discoverPublicTeams search pagination', () => {
         });
         expect(callable).toHaveBeenNthCalledWith(2, { searchText: 'target', cursor: scanCursor, pageSize: 24 });
     });
+
+    it('returns a resumable cursor after the bounded empty-page continuation limit', async () => {
+        const firstCursor = {
+            kind: 'public-team-callable-v2', source: 'projection', searchText: 'target', lastName: 'Alpha', lastId: 'alpha'
+        };
+        const resumeCursor = {
+            kind: 'public-team-callable-v2', source: 'projection', searchText: 'target', lastName: 'Middle', lastId: 'middle'
+        };
+        const callable = vi.fn()
+            .mockResolvedValueOnce({ data: { teams: [], nextCursor: firstCursor } })
+            .mockResolvedValueOnce({ data: { teams: [], nextCursor: resumeCursor } })
+            .mockResolvedValueOnce({
+                data: {
+                    teams: [{ id: 'target', name: 'Target Team', isPublic: true, active: true }],
+                    nextCursor: null
+                }
+            });
+        firebaseMocks.httpsCallable.mockReturnValue(callable);
+        const { discoverPublicTeams } = await import('../../js/db.js?v=91');
+
+        await expect(discoverPublicTeams({ searchText: 'target' })).resolves.toEqual({
+            teams: [],
+            nextCursor: resumeCursor
+        });
+        expect(callable).toHaveBeenCalledTimes(2);
+
+        await expect(discoverPublicTeams({ searchText: 'target', cursor: resumeCursor })).resolves.toEqual({
+            teams: [{ id: 'target', name: 'Target Team', isPublic: true, active: true }],
+            nextCursor: null
+        });
+        expect(callable).toHaveBeenNthCalledWith(3, {
+            searchText: 'target', cursor: resumeCursor, pageSize: 24
+        });
+    });
 });
 
 describe('public team roster count', () => {

--- a/tests/unit/discover-public-teams-search-pagination.test.js
+++ b/tests/unit/discover-public-teams-search-pagination.test.js
@@ -1,24 +1,28 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const firebaseMocks = vi.hoisted(() => ({
+    auth: { currentUser: null },
     collection: vi.fn((database, name) => ({ database, name })),
+    doc: vi.fn((database, ...segments) => ({ database, path: segments.join('/') })),
     query: vi.fn((...parts) => parts),
     where: vi.fn((field, op, value) => ({ type: 'where', field, op, value })),
     orderBy: vi.fn((field) => ({ type: 'orderBy', field })),
     limit: vi.fn((value) => ({ type: 'limit', value })),
     startAfter: vi.fn((value) => ({ type: 'startAfter', value })),
     getDocs: vi.fn(),
+    getDoc: vi.fn(),
     getCountFromServer: vi.fn(),
+    httpsCallable: vi.fn(),
 }));
 
 vi.mock('../../js/firebase.js?v=22', () => ({
     db: {},
-    auth: { currentUser: null },
+    auth: firebaseMocks.auth,
     storage: {},
     collection: firebaseMocks.collection,
     getDocs: firebaseMocks.getDocs,
-    getDoc: vi.fn(),
-    doc: vi.fn(),
+    getDoc: firebaseMocks.getDoc,
+    doc: firebaseMocks.doc,
     addDoc: vi.fn(),
     updateDoc: vi.fn(),
     deleteDoc: vi.fn(),
@@ -40,7 +44,7 @@ vi.mock('../../js/firebase.js?v=22', () => ({
     writeBatch: vi.fn(),
     runTransaction: vi.fn(),
     functions: {},
-    httpsCallable: vi.fn(),
+    httpsCallable: firebaseMocks.httpsCallable,
     ref: vi.fn(),
     uploadBytes: vi.fn(),
     getDownloadURL: vi.fn(),
@@ -70,6 +74,7 @@ function createTeamDoc(id, data) {
 describe('discoverPublicTeams search pagination', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        firebaseMocks.auth.currentUser = null;
     });
 
     it('returns opaque cursors for searched results and uses them on the next page', async () => {
@@ -111,6 +116,10 @@ describe('discoverPublicTeams search pagination', () => {
         const firstPage = await discoverPublicTeams({ searchText: 'atlanta', pageSize: 2 });
 
         expect(firstPage.teams.map((team) => team.id)).toEqual(['team-atl-1', 'team-atl-2']);
+        expect(firebaseMocks.collection).toHaveBeenCalledWith(expect.anything(), 'publicTeamProfiles');
+        expect(firebaseMocks.where).toHaveBeenCalledWith('publicSchemaVersion', '==', 1);
+        expect(firebaseMocks.where).toHaveBeenCalledWith('isPublic', '==', true);
+        expect(firebaseMocks.where).toHaveBeenCalledWith('active', '==', true);
         expect(firstPage.nextCursor).toMatchObject({
             kind: 'public-team-search',
             searchText: 'atlanta',
@@ -172,6 +181,42 @@ describe('discoverPublicTeams search pagination', () => {
         expect(firebaseMocks.getDocs).not.toHaveBeenCalled();
         expect(firebaseMocks.startAfter).not.toHaveBeenCalled();
     });
+
+    it('preserves browse during an upgrade with preexisting public teams and zero projection docs', async () => {
+        firebaseMocks.getDocs.mockResolvedValue({ docs: [] });
+        const callable = vi.fn().mockResolvedValue({
+            data: {
+                teams: [{ id: 'legacy-public', name: 'Legacy Public', isPublic: true, active: true }],
+                nextCursor: { kind: 'public-team-callable', searchText: '', offset: 1 }
+            }
+        });
+        firebaseMocks.httpsCallable.mockReturnValue(callable);
+        const { discoverPublicTeams } = await import('../../js/db.js?v=91');
+
+        await expect(discoverPublicTeams({ pageSize: 24 })).resolves.toEqual({
+            teams: [{ id: 'legacy-public', name: 'Legacy Public', isPublic: true, active: true }],
+            nextCursor: { kind: 'public-team-callable', searchText: '', offset: 1 }
+        });
+        expect(firebaseMocks.collection).toHaveBeenCalledWith(expect.anything(), 'publicTeamProfiles');
+        expect(firebaseMocks.httpsCallable).toHaveBeenCalledWith(expect.anything(), 'discoverPublicTeamProfiles');
+        expect(callable).toHaveBeenCalledWith({ searchText: '', cursor: null, pageSize: 24 });
+    });
+
+    it('uses the callable when projection rules are not deployed yet without masking network failures', async () => {
+        const denied = Object.assign(new Error('projection rules not deployed'), { code: 'permission-denied' });
+        firebaseMocks.getDocs.mockRejectedValueOnce(denied);
+        const callable = vi.fn().mockResolvedValue({
+            data: { teams: [{ id: 'safe-team', name: 'Safe Team', isPublic: true, active: true }], nextCursor: null }
+        });
+        firebaseMocks.httpsCallable.mockReturnValue(callable);
+        const { discoverPublicTeams } = await import('../../js/db.js?v=91');
+
+        await expect(discoverPublicTeams()).resolves.toMatchObject({ teams: [expect.objectContaining({ id: 'safe-team' })] });
+
+        const unavailable = Object.assign(new Error('offline'), { code: 'unavailable' });
+        firebaseMocks.getDocs.mockRejectedValueOnce(unavailable);
+        await expect(discoverPublicTeams()).rejects.toBe(unavailable);
+    });
 });
 
 describe('public team roster count', () => {
@@ -205,6 +250,81 @@ describe('public team roster count', () => {
             count: 200,
             isCapped: true
         });
+    });
+});
+
+describe('public team source/projection fallback', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        firebaseMocks.auth.currentUser = null;
+    });
+
+    it('reads the strict projection directly for anonymous public detail', async () => {
+        firebaseMocks.getDoc.mockResolvedValue({
+            id: 'team-public',
+            exists: () => true,
+            data: () => ({ name: 'Public Team', isPublic: true, active: true })
+        });
+        const { getTeam } = await import('../../js/db.js?v=91');
+
+        await expect(getTeam('team-public')).resolves.toMatchObject({ id: 'team-public', name: 'Public Team' });
+        expect(firebaseMocks.doc).toHaveBeenCalledWith(expect.anything(), 'publicTeamProfiles', 'team-public');
+        expect(firebaseMocks.httpsCallable).not.toHaveBeenCalled();
+    });
+
+    it('falls back to an allow-listed callable while a projection is missing', async () => {
+        firebaseMocks.getDoc.mockResolvedValue({ exists: () => false });
+        const callable = vi.fn().mockResolvedValue({ data: { item: { id: 'team-public', name: 'Public Team', sport: 'Soccer' } } });
+        firebaseMocks.httpsCallable.mockReturnValue(callable);
+        const { getTeam } = await import('../../js/db.js?v=91');
+
+        await expect(getTeam('team-public')).resolves.toMatchObject({ id: 'team-public', name: 'Public Team', isPublic: true });
+        expect(firebaseMocks.httpsCallable).toHaveBeenCalledWith(expect.anything(), 'getPublicTeamProfile');
+        expect(callable).toHaveBeenCalledWith({ teamId: 'team-public' });
+    });
+
+    it('falls back when projection rules lag but does not mask projection network errors', async () => {
+        firebaseMocks.getDoc.mockRejectedValueOnce(Object.assign(new Error('denied'), { code: 'permission-denied' }));
+        const callable = vi.fn().mockResolvedValue({ data: { item: { id: 'team-public', name: 'Public Team' } } });
+        firebaseMocks.httpsCallable.mockReturnValue(callable);
+        const { getTeam } = await import('../../js/db.js?v=91');
+
+        await expect(getTeam('team-public')).resolves.toMatchObject({ id: 'team-public', name: 'Public Team' });
+
+        const unavailable = Object.assign(new Error('offline'), { code: 'unavailable' });
+        firebaseMocks.getDoc.mockRejectedValueOnce(unavailable);
+        await expect(getTeam('team-public')).rejects.toBe(unavailable);
+    });
+
+    it('uses the source for an authorized manager and never masks network errors', async () => {
+        firebaseMocks.auth.currentUser = { uid: 'owner-1' };
+        firebaseMocks.getDoc.mockResolvedValueOnce({
+            id: 'private-team',
+            exists: () => true,
+            data: () => ({ name: 'Private Team', isPublic: false, active: true, ownerId: 'owner-1' })
+        });
+        const { getTeam } = await import('../../js/db.js?v=91');
+        await expect(getTeam('private-team')).resolves.toMatchObject({ name: 'Private Team', ownerId: 'owner-1' });
+
+        const networkError = Object.assign(new Error('offline'), { code: 'unavailable' });
+        firebaseMocks.getDoc.mockRejectedValueOnce(networkError);
+        await expect(getTeam('public-team')).rejects.toBe(networkError);
+        expect(firebaseMocks.httpsCallable).not.toHaveBeenCalled();
+    });
+
+    it('falls back for a logged-in public nonmember only on permission denial', async () => {
+        firebaseMocks.auth.currentUser = { uid: 'other-1' };
+        firebaseMocks.getDoc
+            .mockRejectedValueOnce(Object.assign(new Error('denied'), { code: 'permission-denied' }))
+            .mockResolvedValueOnce({
+                id: 'public-team',
+                exists: () => true,
+                data: () => ({ name: 'Public Team', isPublic: true, active: true })
+            });
+        const { getTeam } = await import('../../js/db.js?v=91');
+
+        await expect(getTeam('public-team')).resolves.toMatchObject({ name: 'Public Team' });
+        expect(firebaseMocks.getDoc).toHaveBeenCalledTimes(2);
     });
 });
 

--- a/tests/unit/discover-public-teams-search-pagination.test.js
+++ b/tests/unit/discover-public-teams-search-pagination.test.js
@@ -144,6 +144,28 @@ describe('discoverPublicTeams search pagination', () => {
         await expect(discoverPublicTeams()).rejects.toBe(unavailable);
         expect(firebaseMocks.getDocs).not.toHaveBeenCalled();
     });
+
+    it('continues bounded empty scan pages so sparse search matches are not reported missing', async () => {
+        const scanCursor = {
+            kind: 'public-team-callable-v2', source: 'projection', searchText: 'target', lastName: 'Middle', lastId: 'middle'
+        };
+        const callable = vi.fn()
+            .mockResolvedValueOnce({ data: { teams: [], nextCursor: scanCursor } })
+            .mockResolvedValueOnce({
+                data: {
+                    teams: [{ id: 'target', name: 'Target Team', isPublic: true, active: true }],
+                    nextCursor: null
+                }
+            });
+        firebaseMocks.httpsCallable.mockReturnValue(callable);
+        const { discoverPublicTeams } = await import('../../js/db.js?v=91');
+
+        await expect(discoverPublicTeams({ searchText: 'target' })).resolves.toEqual({
+            teams: [{ id: 'target', name: 'Target Team', isPublic: true, active: true }],
+            nextCursor: null
+        });
+        expect(callable).toHaveBeenNthCalledWith(2, { searchText: 'target', cursor: scanCursor, pageSize: 24 });
+    });
 });
 
 describe('public team roster count', () => {
@@ -263,6 +285,25 @@ describe('public team source/projection fallback', () => {
         await expect(getTeam('public-team')).resolves.toMatchObject({ name: 'Public Team' });
         expect(firebaseMocks.getDoc).toHaveBeenCalledTimes(2);
     });
+
+    it('returns an explicit placeholder only when parent-link normalization must preserve denied private scope', async () => {
+        firebaseMocks.auth.currentUser = { uid: 'parent-1' };
+        firebaseMocks.getDoc
+            .mockRejectedValueOnce(Object.assign(new Error('private team source denied'), { code: 'permission-denied' }))
+            .mockResolvedValueOnce({ exists: () => false });
+        const callable = vi.fn().mockRejectedValue(Object.assign(new Error('not public'), { code: 'functions/not-found' }));
+        firebaseMocks.httpsCallable.mockReturnValue(callable);
+        const { getTeam } = await import('../../js/db.js?v=91');
+
+        await expect(getTeam('private-team', {
+            includeInactive: true,
+            preservePermissionDenied: true
+        })).resolves.toEqual({
+            id: 'private-team',
+            active: true,
+            blockedByPermissions: true
+        });
+    });
 });
 
 describe('bounded stat tracker config reads', () => {
@@ -324,5 +365,38 @@ describe('complete legacy collection helpers', () => {
         expect(firebaseMocks.limit).toHaveBeenNthCalledWith(1, 100);
         expect(firebaseMocks.limit).toHaveBeenNthCalledWith(2, 100);
         expect(firebaseMocks.startAfter).toHaveBeenCalledWith(firstPage.at(-1));
+    });
+
+    it('continues callable public-team pages past 1000 results', async () => {
+        const callable = vi.fn();
+        for (let pageIndex = 0; pageIndex < 11; pageIndex += 1) {
+            const resultCount = pageIndex < 10 ? 100 : 1;
+            const start = pageIndex * 100;
+            callable.mockResolvedValueOnce({
+                data: {
+                    teams: Array.from({ length: resultCount }, (_, index) => ({
+                        id: `public-${start + index + 1}`,
+                        name: `Public ${String(start + index + 1).padStart(4, '0')}`,
+                        isPublic: true,
+                        active: true
+                    })),
+                    nextCursor: pageIndex < 10
+                        ? {
+                            kind: 'public-team-callable-v2',
+                            source: 'projection',
+                            lastId: `public-${start + resultCount}`
+                        }
+                        : null
+                }
+            });
+        }
+        firebaseMocks.httpsCallable.mockReturnValue(callable);
+
+        const { getTeams } = await import('../../js/db.js?v=85');
+        const teams = await getTeams({ publicOnly: true });
+
+        expect(teams).toHaveLength(1001);
+        expect(callable).toHaveBeenCalledTimes(11);
+        expect(callable.mock.calls.at(-1)?.[0]?.cursor).toMatchObject({ lastId: 'public-1000' });
     });
 });

--- a/tests/unit/discover-public-teams-search-pagination.test.js
+++ b/tests/unit/discover-public-teams-search-pagination.test.js
@@ -232,6 +232,23 @@ describe('public team source/projection fallback', () => {
         expect(callable).toHaveBeenCalledWith({ teamId: 'team-public' });
     });
 
+    it('preserves inactive public presentation for replay-only lookups', async () => {
+        firebaseMocks.getDoc.mockResolvedValue({ exists: () => false });
+        const callable = vi.fn().mockResolvedValue({
+            data: { item: { id: 'inactive-public', name: 'Replay Team', isPublic: true, active: false } }
+        });
+        firebaseMocks.httpsCallable.mockReturnValue(callable);
+        const { getTeam } = await import('../../js/db.js?v=91');
+
+        await expect(getTeam('inactive-public', { includeInactive: true })).resolves.toMatchObject({
+            id: 'inactive-public',
+            name: 'Replay Team',
+            isPublic: true,
+            active: false
+        });
+        expect(callable).toHaveBeenCalledWith({ teamId: 'inactive-public', includeInactive: true });
+    });
+
     it('preserves the missing-team null contract when the callable reports not found', async () => {
         firebaseMocks.getDoc.mockResolvedValue({ exists: () => false });
         const callable = vi.fn().mockRejectedValue(Object.assign(new Error('missing'), { code: 'functions/not-found' }));

--- a/tests/unit/discover-public-teams-search-pagination.test.js
+++ b/tests/unit/discover-public-teams-search-pagination.test.js
@@ -242,6 +242,21 @@ describe('public team source/projection fallback', () => {
         firebaseMocks.auth.currentUser = null;
     });
 
+    it('loads only bounded sanitized ICS payloads from the public calendar callable', async () => {
+        const validCalendars = Array.from({ length: 12 }, (_, index) => `BEGIN:VCALENDAR\nX-ID:${index}\nEND:VCALENDAR`);
+        const callable = vi.fn().mockResolvedValue({
+            data: { calendars: [...validCalendars, null, { private: true }, 'not a calendar'] }
+        });
+        firebaseMocks.httpsCallable.mockReturnValue(callable);
+        const { getPublicTeamExternalCalendarIcs } = await import('../../js/db.js?v=91');
+
+        await expect(getPublicTeamExternalCalendarIcs(' team-public ')).resolves.toEqual(validCalendars.slice(0, 10));
+        expect(firebaseMocks.httpsCallable).toHaveBeenCalledWith(expect.anything(), 'getPublicTeamExternalCalendarIcs');
+        expect(callable).toHaveBeenCalledWith({ teamId: 'team-public' });
+        await expect(getPublicTeamExternalCalendarIcs('  ')).resolves.toEqual([]);
+        expect(callable).toHaveBeenCalledTimes(1);
+    });
+
     it('reads the strict projection directly for anonymous public detail', async () => {
         firebaseMocks.getDoc.mockResolvedValue({
             id: 'team-public',

--- a/tests/unit/discover-public-teams-search-pagination.test.js
+++ b/tests/unit/discover-public-teams-search-pagination.test.js
@@ -308,13 +308,27 @@ describe('public team source/projection fallback', () => {
         expect(callable).toHaveBeenCalledWith({ teamId: 'deleted-team' });
     });
 
-    it('falls back when projection rules lag but does not mask projection network errors', async () => {
+    it('falls back to callable-only nested presentation without masking projection network errors', async () => {
         firebaseMocks.getDoc.mockRejectedValueOnce(Object.assign(new Error('denied'), { code: 'permission-denied' }));
-        const callable = vi.fn().mockResolvedValue({ data: { item: { id: 'team-public', name: 'Public Team' } } });
+        const callable = vi.fn().mockResolvedValue({
+            data: {
+                item: {
+                    id: 'team-public',
+                    name: 'Public Team',
+                    standingsConfig: { enabled: true },
+                    tournament: { pools: [{ name: 'Pool A' }] }
+                }
+            }
+        });
         firebaseMocks.httpsCallable.mockReturnValue(callable);
         const { getTeam } = await import('../../js/db.js?v=91');
 
-        await expect(getTeam('team-public')).resolves.toMatchObject({ id: 'team-public', name: 'Public Team' });
+        await expect(getTeam('team-public')).resolves.toMatchObject({
+            id: 'team-public',
+            name: 'Public Team',
+            standingsConfig: { enabled: true },
+            tournament: { pools: [{ name: 'Pool A' }] }
+        });
 
         const unavailable = Object.assign(new Error('offline'), { code: 'unavailable' });
         firebaseMocks.getDoc.mockRejectedValueOnce(unavailable);

--- a/tests/unit/discover-public-teams-search-pagination.test.js
+++ b/tests/unit/discover-public-teams-search-pagination.test.js
@@ -283,6 +283,16 @@ describe('public team source/projection fallback', () => {
         expect(callable).toHaveBeenCalledWith({ teamId: 'team-public' });
     });
 
+    it('preserves the missing-team null contract when the callable reports not found', async () => {
+        firebaseMocks.getDoc.mockResolvedValue({ exists: () => false });
+        const callable = vi.fn().mockRejectedValue(Object.assign(new Error('missing'), { code: 'functions/not-found' }));
+        firebaseMocks.httpsCallable.mockReturnValue(callable);
+        const { getTeam } = await import('../../js/db.js?v=91');
+
+        await expect(getTeam('deleted-team')).resolves.toBeNull();
+        expect(callable).toHaveBeenCalledWith({ teamId: 'deleted-team' });
+    });
+
     it('falls back when projection rules lag but does not mask projection network errors', async () => {
         firebaseMocks.getDoc.mockRejectedValueOnce(Object.assign(new Error('denied'), { code: 'permission-denied' }));
         const callable = vi.fn().mockResolvedValue({ data: { item: { id: 'team-public', name: 'Public Team' } } });

--- a/tests/unit/discover-public-teams-search-pagination.test.js
+++ b/tests/unit/discover-public-teams-search-pagination.test.js
@@ -58,8 +58,8 @@ vi.mock('../../js/firebase-images.js?v=10', () => ({
 }));
 
 vi.mock('../../js/team-visibility.js?v=2', () => ({
-    isTeamActive: vi.fn(() => true),
-    filterTeamsByActive: vi.fn((teams) => teams),
+    isTeamActive: vi.fn((team) => team?.active !== false && team?.archived !== true),
+    filterTeamsByActive: vi.fn((teams) => teams.filter((team) => team?.active !== false && team?.archived !== true)),
     shouldIncludeTeamInLiveOrUpcoming: vi.fn(() => true),
     shouldIncludeTeamInReplay: vi.fn(() => true)
 }));
@@ -77,145 +77,72 @@ describe('discoverPublicTeams search pagination', () => {
         firebaseMocks.auth.currentUser = null;
     });
 
-    it('returns opaque cursors for searched results and uses them on the next page', async () => {
-        const firstAtlantaDoc = createTeamDoc('team-atl-1', {
-            name: 'Atlanta Fire',
-            isPublic: true,
-            publicSearchName: 'atlanta fire',
-            publicSearchCity: 'atlanta'
-        });
-        const secondAtlantaDoc = createTeamDoc('team-atl-2', {
-            name: 'Atlanta United 2',
-            isPublic: true,
-            publicSearchName: 'atlanta united 2',
-            publicSearchCity: 'atlanta'
-        });
-        const kansasDoc = createTeamDoc('team-kc-1', {
-            name: 'Kansas City Current',
-            isPublic: true,
-            publicSearchCity: 'atlanta'
-        });
-        const zebrasDoc = createTeamDoc('team-zebras-1', {
-            name: 'Zebras FC',
-            isPublic: true,
-            publicSearchName: 'zebras fc'
-        });
-
-        firebaseMocks.getDocs
-            .mockResolvedValueOnce({ docs: [firstAtlantaDoc, secondAtlantaDoc] })
-            .mockResolvedValueOnce({ docs: [] })
-            .mockResolvedValueOnce({ docs: [firstAtlantaDoc, kansasDoc] })
-            .mockResolvedValueOnce({ docs: [] })
-            .mockResolvedValueOnce({ docs: [zebrasDoc] })
-            .mockResolvedValueOnce({ docs: [] })
-            .mockResolvedValueOnce({ docs: [] })
-            .mockResolvedValueOnce({ docs: [] });
-
+    it('uses the allow-listing callable as the primary browse boundary and forwards opaque cursors', async () => {
+        const firstCursor = {
+            kind: 'public-team-callable-v2',
+            source: 'projection',
+            searchText: 'atlanta',
+            lastName: 'Atlanta United',
+            lastId: 'team-atl-2'
+        };
+        const callable = vi.fn()
+            .mockResolvedValueOnce({
+                data: {
+                    teams: [
+                        { id: 'team-atl-1', name: 'Atlanta Fire', isPublic: true, active: true },
+                        { id: 'team-atl-2', name: 'Atlanta United', isPublic: true, active: true }
+                    ],
+                    nextCursor: firstCursor
+                }
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    teams: [{ id: 'team-atl-3', name: 'Atlanta Wave', isPublic: true, active: true }],
+                    nextCursor: null
+                }
+            });
+        firebaseMocks.httpsCallable.mockReturnValue(callable);
         const { discoverPublicTeams } = await import('../../js/db.js?v=107');
 
-        const firstPage = await discoverPublicTeams({ searchText: 'atlanta', pageSize: 2 });
-
+        const firstPage = await discoverPublicTeams({ searchText: ' Atlanta ', pageSize: 2 });
         expect(firstPage.teams.map((team) => team.id)).toEqual(['team-atl-1', 'team-atl-2']);
-        expect(firebaseMocks.collection).toHaveBeenCalledWith(expect.anything(), 'publicTeamProfiles');
-        expect(firebaseMocks.where).toHaveBeenCalledWith('publicSchemaVersion', '==', 1);
-        expect(firebaseMocks.where).toHaveBeenCalledWith('isPublic', '==', true);
-        expect(firebaseMocks.where).toHaveBeenCalledWith('active', '==', true);
-        expect(firstPage.nextCursor).toMatchObject({
-            kind: 'public-team-search',
-            searchText: 'atlanta',
-            bufferedTeams: [expect.objectContaining({ id: 'team-kc-1' })]
-        });
+        expect(firstPage.nextCursor).toEqual(firstCursor);
 
-        const secondPage = await discoverPublicTeams({
-            searchText: 'atlanta',
-            pageSize: 2,
-            cursor: firstPage.nextCursor
-        });
-
-        expect(secondPage.teams.map((team) => team.id)).toEqual(['team-kc-1', 'team-zebras-1']);
-        expect(secondPage.nextCursor).toBeNull();
-        expect(firebaseMocks.startAfter).toHaveBeenCalledTimes(2);
-        expect(firebaseMocks.startAfter).toHaveBeenNthCalledWith(1, secondAtlantaDoc);
-        expect(firebaseMocks.startAfter).toHaveBeenNthCalledWith(2, kansasDoc);
-    });
-
-    it('serves the next page from buffered search teams before querying Firestore again', async () => {
-        const bufferedAtlantaTeam = {
-            id: 'team-atl-3',
-            name: 'Atlanta United 3',
-            isPublic: true,
-            publicSearchName: 'atlanta united 3'
-        };
-        const bufferedKansasTeam = {
-            id: 'team-kc-2',
-            name: 'Kansas City Wave',
-            isPublic: true,
-            publicSearchCity: 'atlanta'
-        };
-        const persistedCursorDoc = createTeamDoc('team-atl-2', {
-            name: 'Atlanta United 2',
-            isPublic: true,
-            publicSearchName: 'atlanta united 2'
-        });
-
-        const { discoverPublicTeams } = await import('../../js/db.js?v=107');
-
-        const page = await discoverPublicTeams({
-            searchText: 'atlanta',
-            pageSize: 2,
-            cursor: {
-                kind: 'public-team-search',
-                searchText: 'atlanta',
-                strategyCursors: [persistedCursorDoc, null, null, null],
-                bufferedTeams: [bufferedAtlantaTeam, bufferedKansasTeam]
-            }
-        });
-
-        expect(page.teams.map((team) => team.id)).toEqual(['team-atl-3', 'team-kc-2']);
-        expect(page.nextCursor).toMatchObject({
-            kind: 'public-team-search',
-            searchText: 'atlanta',
-            strategyCursors: [persistedCursorDoc, null, null, null],
-            bufferedTeams: []
-        });
+        const secondPage = await discoverPublicTeams({ searchText: 'atlanta', pageSize: 2, cursor: firstCursor });
+        expect(secondPage.teams.map((team) => team.id)).toEqual(['team-atl-3']);
+        expect(callable).toHaveBeenNthCalledWith(1, { searchText: 'Atlanta', cursor: null, pageSize: 2 });
+        expect(callable).toHaveBeenNthCalledWith(2, { searchText: 'atlanta', cursor: firstCursor, pageSize: 2 });
         expect(firebaseMocks.getDocs).not.toHaveBeenCalled();
-        expect(firebaseMocks.startAfter).not.toHaveBeenCalled();
     });
 
-    it('preserves browse during an upgrade with preexisting public teams and zero projection docs', async () => {
-        firebaseMocks.getDocs.mockResolvedValue({ docs: [] });
+    it('clamps page size and rejects non-public or inactive callable output defensively', async () => {
         const callable = vi.fn().mockResolvedValue({
             data: {
-                teams: [{ id: 'legacy-public', name: 'Legacy Public', isPublic: true, active: true }],
-                nextCursor: { kind: 'public-team-callable', searchText: '', offset: 1 }
+                teams: [
+                    { id: 'safe-team', name: 'Safe Team', isPublic: true, active: true },
+                    { id: 'private-team', name: 'Private Team', isPublic: false, active: true },
+                    { id: 'inactive-team', name: 'Inactive Team', isPublic: true, active: false }
+                ],
+                nextCursor: null
             }
         });
         firebaseMocks.httpsCallable.mockReturnValue(callable);
         const { discoverPublicTeams } = await import('../../js/db.js?v=91');
 
-        await expect(discoverPublicTeams({ pageSize: 24 })).resolves.toEqual({
-            teams: [{ id: 'legacy-public', name: 'Legacy Public', isPublic: true, active: true }],
-            nextCursor: { kind: 'public-team-callable', searchText: '', offset: 1 }
+        await expect(discoverPublicTeams({ pageSize: 1000 })).resolves.toEqual({
+            teams: [{ id: 'safe-team', name: 'Safe Team', isPublic: true, active: true }],
+            nextCursor: null
         });
-        expect(firebaseMocks.collection).toHaveBeenCalledWith(expect.anything(), 'publicTeamProfiles');
-        expect(firebaseMocks.httpsCallable).toHaveBeenCalledWith(expect.anything(), 'discoverPublicTeamProfiles');
-        expect(callable).toHaveBeenCalledWith({ searchText: '', cursor: null, pageSize: 24 });
+        expect(callable).toHaveBeenCalledWith({ searchText: '', cursor: null, pageSize: 100 });
     });
 
-    it('uses the callable when projection rules are not deployed yet without masking network failures', async () => {
-        const denied = Object.assign(new Error('projection rules not deployed'), { code: 'permission-denied' });
-        firebaseMocks.getDocs.mockRejectedValueOnce(denied);
-        const callable = vi.fn().mockResolvedValue({
-            data: { teams: [{ id: 'safe-team', name: 'Safe Team', isPublic: true, active: true }], nextCursor: null }
-        });
-        firebaseMocks.httpsCallable.mockReturnValue(callable);
+    it('propagates callable failures instead of returning incomplete discovery data', async () => {
+        const unavailable = Object.assign(new Error('offline'), { code: 'functions/unavailable' });
+        firebaseMocks.httpsCallable.mockReturnValue(vi.fn().mockRejectedValue(unavailable));
         const { discoverPublicTeams } = await import('../../js/db.js?v=91');
 
-        await expect(discoverPublicTeams()).resolves.toMatchObject({ teams: [expect.objectContaining({ id: 'safe-team' })] });
-
-        const unavailable = Object.assign(new Error('offline'), { code: 'unavailable' });
-        firebaseMocks.getDocs.mockRejectedValueOnce(unavailable);
         await expect(discoverPublicTeams()).rejects.toBe(unavailable);
+        expect(firebaseMocks.getDocs).not.toHaveBeenCalled();
     });
 });
 

--- a/tests/unit/firestore-rules-architecture-fixes.test.js
+++ b/tests/unit/firestore-rules-architecture-fixes.test.js
@@ -47,16 +47,22 @@ describe('firestore.rules architecture fixes', () => {
         expect(getUserByEmailBody).toContain('where("email", "==", email), limitQuery(1)');
     });
 
-    it('preserves unbounded public team list queries while keeping broad admin lists bounded', () => {
+    it('adds the strict projection while preserving unbounded legacy public team queries during rollout', () => {
         const teamsStart = rules.indexOf('match /teams/{teamId}');
         const teamsEnd = rules.indexOf('\n    }', teamsStart) + '\n    }'.length;
         const teamRules = rules.slice(teamsStart, teamsEnd);
+        const projectionStart = rules.indexOf('match /publicTeamProfiles/{teamId}');
+        const projectionEnd = rules.indexOf('\n    }', projectionStart) + '\n    }'.length;
+        const projectionRules = rules.slice(projectionStart, projectionEnd);
 
         expect(rules).toContain('function canReadPublicTeamDocument(data)');
         expect(rules).toContain('function canListManagedTeamDocument(data)');
         expect(teamRules).toContain('allow list: if isBoundedGlobalAdminListQuery() ||');
-        expect(teamRules).toContain('canReadPublicTeamDocument(resource.data) ||');
         expect(teamRules).toContain('canListManagedTeamDocument(resource.data);');
+        expect(teamRules).toContain('canReadPublicTeamDocument(resource.data) ||');
+        expect(projectionRules).toContain('allow list: if false;');
+        expect(projectionRules).toContain('allow get: if isPublicTeamProfilePayloadValid(resource.data);');
+        expect(projectionRules).toContain('allow create, update, delete: if false;');
         expect(teamRules).not.toContain('(!isGlobalAdmin() && canReadTeamDocument(resource.data));');
     });
 

--- a/tests/unit/firestore-rules-architecture-fixes.test.js
+++ b/tests/unit/firestore-rules-architecture-fixes.test.js
@@ -61,7 +61,8 @@ describe('firestore.rules architecture fixes', () => {
         expect(teamRules).toContain('canListManagedTeamDocument(resource.data);');
         expect(teamRules).toContain('canReadPublicTeamDocument(resource.data) ||');
         expect(projectionRules).toContain('allow list: if false;');
-        expect(projectionRules).toContain('allow get: if isPublicTeamProfilePayloadValid(resource.data);');
+        expect(projectionRules).toContain('allow get: if isPublicTeamProfilePayloadValid(resource.data) &&');
+        expect(projectionRules).toContain('isCurrentTeamPubliclyDiscoverable(teamId);');
         expect(projectionRules).toContain('allow create, update, delete: if false;');
         expect(teamRules).not.toContain('(!isGlobalAdmin() && canReadTeamDocument(resource.data));');
     });

--- a/tests/unit/global-search-modal-integration.test.js
+++ b/tests/unit/global-search-modal-integration.test.js
@@ -73,7 +73,7 @@ describe('legacy global search modal', () => {
     });
 
     it('opens without bootstrapping all public teams and waits for a 2-character query before public discovery', async () => {
-        const { setupHeaderSearch } = await import('../../js/global-search.js?v=11');
+        const { setupHeaderSearch } = await import('../../js/global-search.js?v=12');
 
         setupHeaderSearch({
             user: {
@@ -118,7 +118,7 @@ describe('legacy global search modal', () => {
                 teams: [{ id: 'team-target', name: 'Target United', isPublic: true, active: true }],
                 nextCursor: null
             });
-        const { setupHeaderSearch } = await import('../../js/global-search.js?v=11');
+        const { setupHeaderSearch } = await import('../../js/global-search.js?v=12');
 
         setupHeaderSearch({ user: { uid: 'user-1', email: 'user@example.com' }, headerContainer: null });
         window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }));
@@ -141,7 +141,7 @@ describe('legacy global search modal', () => {
         dbMocks.discoverPublicTeams
             .mockResolvedValueOnce({ teams: [], nextCursor: { lastId: 'first' } })
             .mockResolvedValueOnce({ teams: [], nextCursor: { lastId: 'second' } });
-        const { setupHeaderSearch } = await import('../../js/global-search.js?v=11');
+        const { setupHeaderSearch } = await import('../../js/global-search.js?v=12');
 
         setupHeaderSearch({ user: { uid: 'user-1', email: 'user@example.com' }, headerContainer: null });
         window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }));
@@ -158,10 +158,54 @@ describe('legacy global search modal', () => {
         expect(document.body.textContent).not.toContain('No results');
     });
 
+    it('continues from a full public-team page without growing the bounded result set', async () => {
+        const nextCursor = { kind: 'public-team-callable-v2', lastId: 'team-20' };
+        dbMocks.discoverPublicTeams
+            .mockResolvedValueOnce({
+                teams: Array.from({ length: 20 }, (_, index) => ({
+                    id: `team-${index + 1}`,
+                    name: `Target Team ${index + 1}`,
+                    isPublic: true,
+                    active: true
+                })),
+                nextCursor
+            })
+            .mockResolvedValueOnce({
+                teams: [{ id: 'team-21', name: 'Target Team 21', isPublic: true, active: true }],
+                nextCursor: null
+            });
+        const { setupHeaderSearch } = await import('../../js/global-search.js?v=12');
+
+        setupHeaderSearch({ user: { uid: 'user-1', email: 'user@example.com' }, headerContainer: null });
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }));
+        await flushAsyncWork();
+        const input = document.querySelector('[data-global-search-input="1"]');
+        input.value = 'target';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        await vi.advanceTimersByTimeAsync(200);
+        await flushAsyncWork();
+
+        expect(dbMocks.discoverPublicTeams).toHaveBeenCalledTimes(1);
+        expect(document.body.textContent).toContain('Target Team 1');
+        const continueButton = document.querySelector('[data-global-search-more-teams="1"]');
+        expect(continueButton).not.toBeNull();
+
+        continueButton.click();
+        await flushAsyncWork();
+
+        expect(dbMocks.discoverPublicTeams).toHaveBeenNthCalledWith(2, {
+            searchText: 'target', cursor: nextCursor, pageSize: 20
+        });
+        expect(document.body.textContent).toContain('Target Team 21');
+        expect(document.body.textContent).not.toContain('Target Team 1');
+        expect(document.querySelectorAll('[data-global-search-result="1"]')).toHaveLength(1);
+        expect(document.querySelector('[data-global-search-more-teams="1"]')).toBeNull();
+    });
+
     it('fails a repeated global-search cursor without issuing an unbounded loop', async () => {
         const repeatedCursor = { lastId: 'same' };
         dbMocks.discoverPublicTeams.mockResolvedValue({ teams: [], nextCursor: repeatedCursor });
-        const { setupHeaderSearch } = await import('../../js/global-search.js?v=11');
+        const { setupHeaderSearch } = await import('../../js/global-search.js?v=12');
 
         setupHeaderSearch({ user: { uid: 'user-1', email: 'user@example.com' }, headerContainer: null });
         window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }));
@@ -181,7 +225,7 @@ describe('legacy global search modal', () => {
         dbMocks.discoverPublicTeams
             .mockImplementationOnce(() => new Promise((resolve) => { resolveFirstSearch = resolve; }))
             .mockResolvedValueOnce({ teams: [], nextCursor: null });
-        const { setupHeaderSearch } = await import('../../js/global-search.js?v=11');
+        const { setupHeaderSearch } = await import('../../js/global-search.js?v=12');
 
         setupHeaderSearch({ user: { uid: 'user-1', email: 'user@example.com' }, headerContainer: null });
         window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }));
@@ -207,7 +251,7 @@ describe('legacy global search modal', () => {
     });
 
     it('uses parent team link visibility summaries without per-team fallback reads', async () => {
-        const { setupHeaderSearch } = await import('../../js/global-search.js?v=11');
+        const { setupHeaderSearch } = await import('../../js/global-search.js?v=12');
 
         setupHeaderSearch({
             user: {
@@ -253,7 +297,7 @@ describe('legacy global search modal', () => {
     });
 
     it('falls back to Firestore when parent links only mark app access without visibility', async () => {
-        const { setupHeaderSearch } = await import('../../js/global-search.js?v=11');
+        const { setupHeaderSearch } = await import('../../js/global-search.js?v=12');
 
         firebaseMocks.getDoc.mockResolvedValueOnce(firestoreDoc('team-app-access-only', {
             name: 'Stored Access Rockets',
@@ -288,7 +332,7 @@ describe('legacy global search modal', () => {
     });
 
     it('searches a query-matching private team beyond the first eight private teams', async () => {
-        const { setupHeaderSearch } = await import('../../js/global-search.js?v=11');
+        const { setupHeaderSearch } = await import('../../js/global-search.js?v=12');
         const privateTeams = [
             ...Array.from({ length: 8 }, (_, index) => ({
                 teamId: `team-private-${index}`,

--- a/tests/unit/global-search-modal-integration.test.js
+++ b/tests/unit/global-search-modal-integration.test.js
@@ -73,7 +73,7 @@ describe('legacy global search modal', () => {
     });
 
     it('opens without bootstrapping all public teams and waits for a 2-character query before public discovery', async () => {
-        const { setupHeaderSearch } = await import('../../js/global-search.js?v=9');
+        const { setupHeaderSearch } = await import('../../js/global-search.js?v=11');
 
         setupHeaderSearch({
             user: {
@@ -118,7 +118,7 @@ describe('legacy global search modal', () => {
                 teams: [{ id: 'team-target', name: 'Target United', isPublic: true, active: true }],
                 nextCursor: null
             });
-        const { setupHeaderSearch } = await import('../../js/global-search.js?v=10');
+        const { setupHeaderSearch } = await import('../../js/global-search.js?v=11');
 
         setupHeaderSearch({ user: { uid: 'user-1', email: 'user@example.com' }, headerContainer: null });
         window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }));
@@ -141,7 +141,7 @@ describe('legacy global search modal', () => {
         dbMocks.discoverPublicTeams
             .mockResolvedValueOnce({ teams: [], nextCursor: { lastId: 'first' } })
             .mockResolvedValueOnce({ teams: [], nextCursor: { lastId: 'second' } });
-        const { setupHeaderSearch } = await import('../../js/global-search.js?v=10');
+        const { setupHeaderSearch } = await import('../../js/global-search.js?v=11');
 
         setupHeaderSearch({ user: { uid: 'user-1', email: 'user@example.com' }, headerContainer: null });
         window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }));
@@ -161,7 +161,7 @@ describe('legacy global search modal', () => {
     it('fails a repeated global-search cursor without issuing an unbounded loop', async () => {
         const repeatedCursor = { lastId: 'same' };
         dbMocks.discoverPublicTeams.mockResolvedValue({ teams: [], nextCursor: repeatedCursor });
-        const { setupHeaderSearch } = await import('../../js/global-search.js?v=10');
+        const { setupHeaderSearch } = await import('../../js/global-search.js?v=11');
 
         setupHeaderSearch({ user: { uid: 'user-1', email: 'user@example.com' }, headerContainer: null });
         window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }));
@@ -181,7 +181,7 @@ describe('legacy global search modal', () => {
         dbMocks.discoverPublicTeams
             .mockImplementationOnce(() => new Promise((resolve) => { resolveFirstSearch = resolve; }))
             .mockResolvedValueOnce({ teams: [], nextCursor: null });
-        const { setupHeaderSearch } = await import('../../js/global-search.js?v=10');
+        const { setupHeaderSearch } = await import('../../js/global-search.js?v=11');
 
         setupHeaderSearch({ user: { uid: 'user-1', email: 'user@example.com' }, headerContainer: null });
         window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }));
@@ -207,7 +207,7 @@ describe('legacy global search modal', () => {
     });
 
     it('uses parent team link visibility summaries without per-team fallback reads', async () => {
-        const { setupHeaderSearch } = await import('../../js/global-search.js?v=9');
+        const { setupHeaderSearch } = await import('../../js/global-search.js?v=11');
 
         setupHeaderSearch({
             user: {
@@ -253,7 +253,7 @@ describe('legacy global search modal', () => {
     });
 
     it('falls back to Firestore when parent links only mark app access without visibility', async () => {
-        const { setupHeaderSearch } = await import('../../js/global-search.js?v=9');
+        const { setupHeaderSearch } = await import('../../js/global-search.js?v=11');
 
         firebaseMocks.getDoc.mockResolvedValueOnce(firestoreDoc('team-app-access-only', {
             name: 'Stored Access Rockets',
@@ -288,7 +288,7 @@ describe('legacy global search modal', () => {
     });
 
     it('searches a query-matching private team beyond the first eight private teams', async () => {
-        const { setupHeaderSearch } = await import('../../js/global-search.js?v=9');
+        const { setupHeaderSearch } = await import('../../js/global-search.js?v=11');
         const privateTeams = [
             ...Array.from({ length: 8 }, (_, index) => ({
                 teamId: `team-private-${index}`,

--- a/tests/unit/global-search-modal-integration.test.js
+++ b/tests/unit/global-search-modal-integration.test.js
@@ -110,6 +110,102 @@ describe('legacy global search modal', () => {
         expect(firebaseMocks.doc).toHaveBeenCalledWith(firebaseMocks.db, 'teams', 'team-access');
     });
 
+    it('continues a bounded empty public-team page before reporting no global-search result', async () => {
+        const firstCursor = { kind: 'public-team-callable-v2', lastId: 'middle' };
+        dbMocks.discoverPublicTeams
+            .mockResolvedValueOnce({ teams: [], nextCursor: firstCursor })
+            .mockResolvedValueOnce({
+                teams: [{ id: 'team-target', name: 'Target United', isPublic: true, active: true }],
+                nextCursor: null
+            });
+        const { setupHeaderSearch } = await import('../../js/global-search.js?v=10');
+
+        setupHeaderSearch({ user: { uid: 'user-1', email: 'user@example.com' }, headerContainer: null });
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }));
+        await flushAsyncWork();
+        const input = document.querySelector('[data-global-search-input="1"]');
+        input.value = 'target';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        await vi.advanceTimersByTimeAsync(200);
+        await flushAsyncWork();
+
+        expect(dbMocks.discoverPublicTeams).toHaveBeenNthCalledWith(1, { searchText: 'target', pageSize: 20 });
+        expect(dbMocks.discoverPublicTeams).toHaveBeenNthCalledWith(2, {
+            searchText: 'target', cursor: firstCursor, pageSize: 20
+        });
+        expect(document.body.textContent).toContain('Target United');
+        expect(document.body.textContent).not.toContain('No results');
+    });
+
+    it('caps sparse global team search continuation at two page requests', async () => {
+        dbMocks.discoverPublicTeams
+            .mockResolvedValueOnce({ teams: [], nextCursor: { lastId: 'first' } })
+            .mockResolvedValueOnce({ teams: [], nextCursor: { lastId: 'second' } });
+        const { setupHeaderSearch } = await import('../../js/global-search.js?v=10');
+
+        setupHeaderSearch({ user: { uid: 'user-1', email: 'user@example.com' }, headerContainer: null });
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }));
+        await flushAsyncWork();
+        const input = document.querySelector('[data-global-search-input="1"]');
+        input.value = 'target';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        await vi.advanceTimersByTimeAsync(200);
+        await flushAsyncWork();
+
+        expect(dbMocks.discoverPublicTeams).toHaveBeenCalledTimes(2);
+        expect(document.body.textContent).toContain('No matching teams in this scan yet');
+        expect(document.body.textContent).toContain('Continue team search');
+        expect(document.body.textContent).not.toContain('No results');
+    });
+
+    it('fails a repeated global-search cursor without issuing an unbounded loop', async () => {
+        const repeatedCursor = { lastId: 'same' };
+        dbMocks.discoverPublicTeams.mockResolvedValue({ teams: [], nextCursor: repeatedCursor });
+        const { setupHeaderSearch } = await import('../../js/global-search.js?v=10');
+
+        setupHeaderSearch({ user: { uid: 'user-1', email: 'user@example.com' }, headerContainer: null });
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }));
+        await flushAsyncWork();
+        const input = document.querySelector('[data-global-search-input="1"]');
+        input.value = 'target';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        await vi.advanceTimersByTimeAsync(200);
+        await flushAsyncWork();
+
+        expect(dbMocks.discoverPublicTeams).toHaveBeenCalledTimes(2);
+        expect(document.body.textContent).toContain('Public team search unavailable');
+    });
+
+    it('does not continue a stale sparse search after the query changes', async () => {
+        let resolveFirstSearch;
+        dbMocks.discoverPublicTeams
+            .mockImplementationOnce(() => new Promise((resolve) => { resolveFirstSearch = resolve; }))
+            .mockResolvedValueOnce({ teams: [], nextCursor: null });
+        const { setupHeaderSearch } = await import('../../js/global-search.js?v=10');
+
+        setupHeaderSearch({ user: { uid: 'user-1', email: 'user@example.com' }, headerContainer: null });
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }));
+        await flushAsyncWork();
+        const input = document.querySelector('[data-global-search-input="1"]');
+        input.value = 'target';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        await vi.advanceTimersByTimeAsync(200);
+
+        input.value = 'new query';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        await vi.advanceTimersByTimeAsync(200);
+        resolveFirstSearch({ teams: [], nextCursor: { lastId: 'stale-cursor' } });
+        await flushAsyncWork();
+
+        expect(dbMocks.discoverPublicTeams).toHaveBeenCalledTimes(2);
+        expect(dbMocks.discoverPublicTeams).toHaveBeenNthCalledWith(2, {
+            searchText: 'new query', pageSize: 20
+        });
+        expect(dbMocks.discoverPublicTeams.mock.calls).not.toContainEqual([{
+            searchText: 'target', cursor: { lastId: 'stale-cursor' }, pageSize: 20
+        }]);
+    });
+
     it('uses parent team link visibility summaries without per-team fallback reads', async () => {
         const { setupHeaderSearch } = await import('../../js/global-search.js?v=9');
 

--- a/tests/unit/global-search-player-fallback.test.js
+++ b/tests/unit/global-search-player-fallback.test.js
@@ -7,6 +7,7 @@ const source = readFileSync(resolve(process.cwd(), 'js/global-search.js'), 'utf8
 describe('legacy global player search scoping', () => {
     it('uses bounded public team discovery instead of bootstrapping the full catalog', () => {
         expect(source).toContain("import { discoverPublicTeams } from './db.js?v=107';");
+        expect(source).not.toContain("import { discoverPublicTeams } from './db.js?v=91';");
         expect(source).not.toContain('import { getTeams }');
         expect(source).toContain('const teamSearchQueryLimit = 20;');
         expect(source).toContain('const publicTeamSearchPageRequestLimit = 2;');

--- a/tests/unit/global-search-player-fallback.test.js
+++ b/tests/unit/global-search-player-fallback.test.js
@@ -9,8 +9,11 @@ describe('legacy global player search scoping', () => {
         expect(source).toContain("import { discoverPublicTeams } from './db.js?v=107';");
         expect(source).not.toContain('import { getTeams }');
         expect(source).toContain('const teamSearchQueryLimit = 20;');
+        expect(source).toContain('const publicTeamSearchPageRequestLimit = 2;');
         expect(source).toContain('if (q.length < 2) {');
-        expect(source).toContain("const result = await discoverPublicTeams({ searchText: q, pageSize: teamSearchQueryLimit });");
+        expect(source).toContain('requestCount < publicTeamSearchPageRequestLimit');
+        expect(source).toContain('? { searchText: q, cursor, pageSize: remainingTeamSlots }');
+        expect(source).toContain("throw new Error('Public team search returned a repeated cursor.')");
         expect(source).not.toContain('const teams = await getTeams();');
     });
 

--- a/tests/unit/public-opportunities-functions-source.test.js
+++ b/tests/unit/public-opportunities-functions-source.test.js
@@ -89,8 +89,13 @@ describe('public opportunity callable wiring', () => {
     expect(source).toContain("require('./public-team-profile-core.cjs')");
     expect(source).toMatch(/getPublicTeamProfile[\s\S]*const profile = buildPublicTeamProfile\(team\)/);
     expect(source).toContain('profile && isPublicTeamProfileSchemaValid(profile)');
-    expect(source).toContain('collectAllPublicTeamSourceDocuments');
     expect(source).toContain('.orderBy(admin.firestore.FieldPath.documentId())');
+    expect(source).toContain("PUBLIC_TEAM_PROFILE_MIGRATION_STATE_PATH = 'systemMigrations/publicTeamProfilesBackfill'");
+    expect(source).toContain("const collectionName = useProjection ? 'publicTeamProfiles' : 'teams';");
+    expect(source).toContain(".where('publicSchemaVersion', '==', 1)");
+    expect(source).toContain('PUBLIC_TEAM_DISCOVERY_SCAN_LIMIT = 500');
+    expect(source).toContain('PUBLIC_TEAM_DISCOVERY_BATCH_SIZE = 100');
+    expect(source).toContain('while (teams.length < pageSize && scannedDocumentCount < PUBLIC_TEAM_DISCOVERY_SCAN_LIMIT && !exhausted)');
     expect(source).not.toContain(".where('isPublic', '==', true)\n    .limit(1000)");
   });
 

--- a/tests/unit/public-opportunities-functions-source.test.js
+++ b/tests/unit/public-opportunities-functions-source.test.js
@@ -87,7 +87,8 @@ describe('public opportunity callable wiring', () => {
     expect(source).toMatch(/createOpportunityInquiry[\s\S]*requireOpportunityAuth\(context, \{ verified: true \}\)/);
     expect(source).toContain('exports.getPublicTeamProfile');
     expect(source).toContain("require('./public-team-profile-core.cjs')");
-    expect(source).toMatch(/getPublicTeamProfile[\s\S]*const profile = buildPublicTeamProfile\(team\)/);
+    expect(source).toMatch(/getPublicTeamProfile[\s\S]*const includeInactive = data\?\.includeInactive === true/);
+    expect(source).toMatch(/getPublicTeamProfile[\s\S]*const profile = buildPublicTeamProfile\(team, \{ includeInactive \}\)/);
     expect(source).toContain('profile && isPublicTeamProfileSchemaValid(profile)');
     expect(source).toContain('.orderBy(admin.firestore.FieldPath.documentId())');
     expect(source).toContain("PUBLIC_TEAM_PROFILE_MIGRATION_STATE_PATH = 'systemMigrations/publicTeamProfilesBackfill'");

--- a/tests/unit/public-opportunities-functions-source.test.js
+++ b/tests/unit/public-opportunities-functions-source.test.js
@@ -86,7 +86,9 @@ describe('public opportunity callable wiring', () => {
   it('requires verified inquiry senders and allow-lists public team profiles', () => {
     expect(source).toMatch(/createOpportunityInquiry[\s\S]*requireOpportunityAuth\(context, \{ verified: true \}\)/);
     expect(source).toContain('exports.getPublicTeamProfile');
-    expect(source).toContain("description: cleanOpportunityText(team.description, 1000) || null");
+    expect(source).toContain("require('./public-team-profile-core.cjs')");
+    expect(source).toMatch(/getPublicTeamProfile[\s\S]*const profile = buildPublicTeamProfile\(team\)/);
+    expect(source).toContain('profile && isPublicTeamProfileSchemaValid(profile)');
   });
 
   it('routes team inquiries only to current team administrators', () => {

--- a/tests/unit/public-opportunities-functions-source.test.js
+++ b/tests/unit/public-opportunities-functions-source.test.js
@@ -89,6 +89,9 @@ describe('public opportunity callable wiring', () => {
     expect(source).toContain("require('./public-team-profile-core.cjs')");
     expect(source).toMatch(/getPublicTeamProfile[\s\S]*const profile = buildPublicTeamProfile\(team\)/);
     expect(source).toContain('profile && isPublicTeamProfileSchemaValid(profile)');
+    expect(source).toContain('collectAllPublicTeamSourceDocuments');
+    expect(source).toContain('.orderBy(admin.firestore.FieldPath.documentId())');
+    expect(source).not.toContain(".where('isPublic', '==', true)\n    .limit(1000)");
   });
 
   it('routes team inquiries only to current team administrators', () => {

--- a/tests/unit/public-team-profile-core.test.js
+++ b/tests/unit/public-team-profile-core.test.js
@@ -1,0 +1,75 @@
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const {
+  buildPublicTeamProfile,
+  collectAllPublicTeamSourceDocuments,
+  isPublicTeamProfileSchemaValid,
+  matchesPublicTeamProfileSearch
+} = require('../../functions/public-team-profile-core.cjs');
+
+describe('public team profile callable boundary', () => {
+  it('builds an exact public allow-list and strips management data', () => {
+    const profile = buildPublicTeamProfile({
+      name: 'Safe Team',
+      isPublic: true,
+      active: true,
+      city: 'Atlanta',
+      state: 'GA',
+      ownerId: 'private-owner',
+      adminEmails: ['private@example.com'],
+      paymentConfig: { secret: true }
+    });
+
+    expect(profile).toMatchObject({
+      publicSchemaVersion: 1,
+      name: 'Safe Team',
+      city: 'Atlanta',
+      state: 'GA',
+      isPublic: true,
+      active: true
+    });
+    expect(profile).not.toHaveProperty('ownerId');
+    expect(profile).not.toHaveProperty('adminEmails');
+    expect(profile).not.toHaveProperty('paymentConfig');
+    expect(isPublicTeamProfileSchemaValid(profile)).toBe(true);
+    expect(isPublicTeamProfileSchemaValid({ ...profile, unexpectedSecret: 'nope' })).toBe(false);
+  });
+
+  it('matches normalized public presentation fields without consulting private data', () => {
+    const profile = buildPublicTeamProfile({
+      name: 'Atlanta Fire', isPublic: true, active: true, city: 'Atlanta', state: 'GA', zip: '30303'
+    });
+
+    expect(matchesPublicTeamProfileSearch(profile, 'atlanta ga')).toBe(true);
+    expect(matchesPublicTeamProfileSearch(profile, '30303')).toBe(true);
+    expect(matchesPublicTeamProfileSearch(profile, 'private-owner')).toBe(false);
+  });
+
+  it('caps paged compatibility scans and never requests more than the remaining budget', async () => {
+    const documents = Array.from({ length: 7 }, (_, index) => ({ id: `team-${index}` }));
+    const fetchPage = vi.fn(async ({ cursor, pageSize }) => {
+      const start = cursor ? documents.indexOf(cursor) + 1 : 0;
+      return { docs: documents.slice(start, start + pageSize) };
+    });
+
+    const result = await collectAllPublicTeamSourceDocuments(fetchPage, { pageSize: 3, maxDocuments: 5 });
+
+    expect(result.map((document) => document.id)).toEqual(['team-0', 'team-1', 'team-2', 'team-3', 'team-4']);
+    expect(fetchPage).toHaveBeenNthCalledWith(1, { cursor: null, pageSize: 3 });
+    expect(fetchPage).toHaveBeenNthCalledWith(2, { cursor: documents[2], pageSize: 2 });
+    expect(fetchPage).toHaveBeenCalledTimes(2);
+  });
+
+  it('records completion only after a full applied backfill', () => {
+    const migrationSource = readFileSync(new URL('../../_migration/backfill-public-team-profiles.js', import.meta.url), 'utf8');
+    const completionWrite = migrationSource.indexOf("db.doc(PUBLIC_TEAM_PROFILE_MIGRATION_STATE_PATH).set({ completed: true }");
+    const projectionLoop = migrationSource.indexOf('for (const teamSnap of teamDocs)');
+
+    expect(migrationSource).toContain("PUBLIC_TEAM_PROFILE_MIGRATION_STATE_PATH = 'systemMigrations/publicTeamProfilesBackfill'");
+    expect(migrationSource).toContain('if (options.apply && !options.teamId)');
+    expect(completionWrite).toBeGreaterThan(projectionLoop);
+  });
+});

--- a/tests/unit/public-team-profile-core.test.js
+++ b/tests/unit/public-team-profile-core.test.js
@@ -48,6 +48,19 @@ describe('public team profile callable boundary', () => {
     expect(matchesPublicTeamProfileSearch(profile, 'private-owner')).toBe(false);
   });
 
+  it('matches a whole two-letter query only against state while preserving city-state token searches', () => {
+    const nameMatch = buildPublicTeamProfile({
+      name: 'Indiana Bears', isPublic: true, active: true, city: 'Kansas City', state: 'MO'
+    });
+    const stateMatch = buildPublicTeamProfile({
+      name: 'Wildcats', isPublic: true, active: true, city: 'Bloomington', state: 'IN'
+    });
+
+    expect(matchesPublicTeamProfileSearch(nameMatch, 'in')).toBe(false);
+    expect(matchesPublicTeamProfileSearch(stateMatch, 'IN')).toBe(true);
+    expect(matchesPublicTeamProfileSearch(stateMatch, 'bloomington in')).toBe(true);
+  });
+
   it('caps paged compatibility scans and never requests more than the remaining budget', async () => {
     const documents = Array.from({ length: 7 }, (_, index) => ({ id: `team-${index}` }));
     const fetchPage = vi.fn(async ({ cursor, pageSize }) => {

--- a/tests/unit/public-team-profile-core.test.js
+++ b/tests/unit/public-team-profile-core.test.js
@@ -1,6 +1,7 @@
 import { createRequire } from 'node:module';
 import { readFileSync } from 'node:fs';
 import { describe, expect, it, vi } from 'vitest';
+import { runPublicTeamProfileBackfill } from '../../_migration/backfill-public-team-profiles.js';
 
 const require = createRequire(import.meta.url);
 const {
@@ -9,6 +10,50 @@ const {
   isPublicTeamProfileSchemaValid,
   matchesPublicTeamProfileSearch
 } = require('../../functions/public-team-profile-core.cjs');
+
+function createBackfillSnapshot(id, data) {
+  return {
+    id,
+    exists: data !== null,
+    data: () => data
+  };
+}
+
+function createBackfillDb({ listedTeam, currentTeam, existingProfile = null }) {
+  const state = {
+    profile: existingProfile,
+    completion: null,
+    transactionReads: []
+  };
+  const db = {
+    collection: vi.fn(() => ({
+      get: vi.fn(async () => ({ docs: [createBackfillSnapshot('team-race', listedTeam)] }))
+    })),
+    doc: vi.fn((path) => ({
+      path,
+      get: vi.fn(async () => createBackfillSnapshot('team-race', state.profile)),
+      set: vi.fn(async (value) => {
+        if (path === 'systemMigrations/publicTeamProfilesBackfill') state.completion = value;
+      })
+    })),
+    runTransaction: vi.fn(async (handler) => handler({
+      get: vi.fn(async (ref) => {
+        state.transactionReads.push(ref.path);
+        if (ref.path === 'teams/team-race') {
+          return createBackfillSnapshot('team-race', currentTeam);
+        }
+        return createBackfillSnapshot('team-race', state.profile);
+      }),
+      set: vi.fn((ref, value) => {
+        if (ref.path === 'publicTeamProfiles/team-race') state.profile = value;
+      }),
+      delete: vi.fn((ref) => {
+        if (ref.path === 'publicTeamProfiles/team-race') state.profile = null;
+      })
+    }))
+  };
+  return { db, state };
+}
 
 describe('public team profile callable boundary', () => {
   it('builds an exact public allow-list and strips management data', () => {
@@ -84,5 +129,71 @@ describe('public team profile callable boundary', () => {
     expect(migrationSource).toContain("PUBLIC_TEAM_PROFILE_MIGRATION_STATE_PATH = 'systemMigrations/publicTeamProfilesBackfill'");
     expect(migrationSource).toContain('if (options.apply && !options.teamId)');
     expect(completionWrite).toBeGreaterThan(projectionLoop);
+  });
+
+  it('transactionally re-reads current visibility before completing an applied backfill', async () => {
+    const stalePublic = { name: 'Race Team', isPublic: true, active: true };
+    const privateRace = createBackfillDb({
+      listedTeam: stalePublic,
+      currentTeam: { ...stalePublic, isPublic: false },
+      existingProfile: buildPublicTeamProfile(stalePublic)
+    });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const privateSummary = await runPublicTeamProfileBackfill({
+      apply: true, teamId: '', projectId: 'demo-allplays', serviceAccountPath: ''
+    }, { db: privateRace.db });
+
+    expect(privateSummary).toMatchObject({
+      projectionsUpserted: 0,
+      projectionsDeleted: 1,
+      migrationCompletionRecorded: true
+    });
+    expect(privateRace.state.profile).toBeNull();
+    expect(privateRace.state.transactionReads).toEqual([
+      'teams/team-race',
+      'publicTeamProfiles/team-race'
+    ]);
+    expect(privateRace.state.completion).toEqual({ completed: true });
+
+    const publicNow = { name: 'Newly Public Race Team', isPublic: true, active: true, state: 'MO' };
+    const publicRace = createBackfillDb({
+      listedTeam: { ...publicNow, isPublic: false },
+      currentTeam: publicNow
+    });
+    const publicSummary = await runPublicTeamProfileBackfill({
+      apply: true, teamId: '', projectId: 'demo-allplays', serviceAccountPath: ''
+    }, { db: publicRace.db });
+
+    expect(publicSummary).toMatchObject({
+      projectionsUpserted: 1,
+      projectionsDeleted: 0,
+      migrationCompletionRecorded: true
+    });
+    expect(publicRace.state.profile).toMatchObject({
+      name: 'Newly Public Race Team', isPublic: true, active: true, state: 'MO'
+    });
+    expect(publicRace.state.transactionReads).toEqual(['teams/team-race']);
+
+    const deletedRace = createBackfillDb({
+      listedTeam: stalePublic,
+      currentTeam: null,
+      existingProfile: buildPublicTeamProfile(stalePublic)
+    });
+    const deletedSummary = await runPublicTeamProfileBackfill({
+      apply: true, teamId: '', projectId: 'demo-allplays', serviceAccountPath: ''
+    }, { db: deletedRace.db });
+
+    expect(deletedSummary).toMatchObject({
+      projectionsUpserted: 0,
+      projectionsDeleted: 1,
+      migrationCompletionRecorded: true
+    });
+    expect(deletedRace.state.profile).toBeNull();
+    expect(deletedRace.state.transactionReads).toEqual([
+      'teams/team-race',
+      'publicTeamProfiles/team-race'
+    ]);
+    logSpy.mockRestore();
   });
 });

--- a/tests/unit/public-team-profile-core.test.js
+++ b/tests/unit/public-team-profile-core.test.js
@@ -23,17 +23,29 @@ function createBackfillDb({ listedTeam, currentTeam, existingProfile = null }) {
   const state = {
     profile: existingProfile,
     completion: null,
+    completionWrites: [],
+    teamCollectionReads: 0,
     transactionReads: []
   };
   const db = {
-    collection: vi.fn(() => ({
-      get: vi.fn(async () => ({ docs: [createBackfillSnapshot('team-race', listedTeam)] }))
+    collection: vi.fn((path) => ({
+      get: vi.fn(async () => {
+        if (path === 'publicTeamProfiles') {
+          return { docs: state.profile ? [createBackfillSnapshot('team-race', state.profile)] : [] };
+        }
+        state.teamCollectionReads += 1;
+        const team = state.teamCollectionReads === 1 ? listedTeam : currentTeam;
+        return { docs: team ? [createBackfillSnapshot('team-race', team)] : [] };
+      })
     })),
     doc: vi.fn((path) => ({
       path,
       get: vi.fn(async () => createBackfillSnapshot('team-race', state.profile)),
       set: vi.fn(async (value) => {
-        if (path === 'systemMigrations/publicTeamProfilesBackfill') state.completion = value;
+        if (path === 'systemMigrations/publicTeamProfilesBackfill') {
+          state.completion = value;
+          state.completionWrites.push(value);
+        }
       })
     })),
     runTransaction: vi.fn(async (handler) => handler({
@@ -52,6 +64,71 @@ function createBackfillDb({ listedTeam, currentTeam, existingProfile = null }) {
       })
     }))
   };
+  return { db, state };
+}
+
+function createConcurrentBackfillDb({ keepChanging = false } = {}) {
+  const teams = new Map([
+    ['team-existing', { name: 'Existing Public Team', isPublic: true, active: true, revision: 0 }]
+  ]);
+  const profiles = new Map();
+  const state = {
+    completionWrites: [],
+    events: [],
+    teamCollectionReads: 0,
+    teams,
+    profiles
+  };
+
+  const snapshotForPath = (path) => {
+    const [collectionName, id] = path.split('/');
+    const source = collectionName === 'teams' ? teams : profiles;
+    const value = source.get(id) || null;
+    return createBackfillSnapshot(id, value);
+  };
+
+  const db = {
+    collection: vi.fn((path) => ({
+      get: vi.fn(async () => {
+        if (path === 'teams') {
+          state.teamCollectionReads += 1;
+          if (state.teamCollectionReads === 2) {
+            teams.set('team-concurrent', {
+              name: 'Concurrent Public Team', isPublic: true, active: true, revision: 0
+            });
+          }
+          if (keepChanging && state.teamCollectionReads > 1) {
+            const existing = teams.get('team-existing');
+            teams.set('team-existing', { ...existing, revision: existing.revision + 1 });
+          }
+          return { docs: Array.from(teams, ([id, value]) => createBackfillSnapshot(id, value)) };
+        }
+        return { docs: Array.from(profiles, ([id, value]) => createBackfillSnapshot(id, value)) };
+      })
+    })),
+    doc: vi.fn((path) => ({
+      path,
+      get: vi.fn(async () => snapshotForPath(path)),
+      set: vi.fn(async (value) => {
+        if (path === 'systemMigrations/publicTeamProfilesBackfill') {
+          state.completionWrites.push(value);
+          state.events.push(`migration:${value.completed}`);
+        }
+      })
+    })),
+    runTransaction: vi.fn(async (handler) => handler({
+      get: vi.fn(async (ref) => snapshotForPath(ref.path)),
+      set: vi.fn((ref, value) => {
+        const id = ref.path.split('/').pop();
+        profiles.set(id, value);
+        state.events.push(`profile:${id}`);
+      }),
+      delete: vi.fn((ref) => {
+        profiles.delete(ref.path.split('/').pop());
+      })
+    }))
+  };
+
   return { db, state };
 }
 
@@ -81,6 +158,23 @@ describe('public team profile callable boundary', () => {
     expect(profile).not.toHaveProperty('paymentConfig');
     expect(isPublicTeamProfileSchemaValid(profile)).toBe(true);
     expect(isPublicTeamProfileSchemaValid({ ...profile, unexpectedSecret: 'nope' })).toBe(false);
+  });
+
+  it('rejects malformed values even when every top-level field is allow-listed', () => {
+    const base = { publicSchemaVersion: 1, name: 'Safe Team', isPublic: true, active: true };
+    const malformedFields = [
+      { description: ['private'] },
+      { photoUrl: { private: true } },
+      { leagueUrl: ['private'] },
+      { publicSearchName: { private: true } },
+      { appAccess: 'true' },
+      { archived: 'false' },
+      { sourceUpdatedAt: { private: true } }
+    ];
+
+    malformedFields.forEach((malformedField) => {
+      expect(isPublicTeamProfileSchemaValid({ ...base, ...malformedField })).toBe(false);
+    });
   });
 
   it('matches normalized public presentation fields without consulting private data', () => {
@@ -123,11 +217,13 @@ describe('public team profile callable boundary', () => {
 
   it('records completion only after a full applied backfill', () => {
     const migrationSource = readFileSync(new URL('../../_migration/backfill-public-team-profiles.js', import.meta.url), 'utf8');
-    const completionWrite = migrationSource.indexOf("db.doc(PUBLIC_TEAM_PROFILE_MIGRATION_STATE_PATH).set({ completed: true }");
+    const completionWrite = migrationSource.indexOf("migrationStateRef.set({ completed: true }");
     const projectionLoop = migrationSource.indexOf('for (const teamSnap of teamDocs)');
 
     expect(migrationSource).toContain("PUBLIC_TEAM_PROFILE_MIGRATION_STATE_PATH = 'systemMigrations/publicTeamProfilesBackfill'");
     expect(migrationSource).toContain('if (options.apply && !options.teamId)');
+    expect(migrationSource).toContain('migrationStateRef.set({ completed: false }');
+    expect(migrationSource).toContain('reconcilePublicTeamProfilesToFixedPoint(db)');
     expect(completionWrite).toBeGreaterThan(projectionLoop);
   });
 
@@ -157,6 +253,7 @@ describe('public team profile callable boundary', () => {
       'publicTeamProfiles/team-race'
     ]);
     expect(privateRace.state.completion).toEqual({ completed: true });
+    expect(privateRace.state.completionWrites).toEqual([{ completed: false }, { completed: true }]);
 
     const publicNow = { name: 'Newly Public Race Team', isPublic: true, active: true, state: 'MO' };
     const publicRace = createBackfillDb({
@@ -168,17 +265,14 @@ describe('public team profile callable boundary', () => {
     }, { db: publicRace.db });
 
     expect(publicSummary).toMatchObject({
-      projectionsUpserted: 2,
+      projectionsUpserted: 1,
       projectionsDeleted: 0,
       migrationCompletionRecorded: true
     });
     expect(publicRace.state.profile).toMatchObject({
       name: 'Newly Public Race Team', isPublic: true, active: true, state: 'MO'
     });
-    expect(publicRace.state.transactionReads).toEqual([
-      'teams/team-race',
-      'teams/team-race'
-    ]);
+    expect(publicRace.state.transactionReads).toEqual(['teams/team-race', 'teams/team-race']);
 
     const deletedRace = createBackfillDb({
       listedTeam: stalePublic,
@@ -197,74 +291,44 @@ describe('public team profile callable boundary', () => {
     expect(deletedRace.state.profile).toBeNull();
     expect(deletedRace.state.transactionReads).toEqual([
       'teams/team-race',
-      'publicTeamProfiles/team-race',
-      'teams/team-race',
       'publicTeamProfiles/team-race'
     ]);
     logSpy.mockRestore();
   });
 
-  it('reconciles teams created after the initial snapshot before recording completion', async () => {
-    const teams = new Map([
-      ['existing-team', { name: 'Existing Team', isPublic: true, active: true }],
-      ['late-team', { name: 'Late Team', isPublic: true, active: true }]
-    ]);
-    const profiles = new Map();
-    const events = [];
-    let collectionReads = 0;
-    const db = {
-      collection: vi.fn(() => ({
-        get: vi.fn(async () => {
-          collectionReads += 1;
-          const visibleIds = collectionReads === 1
-            ? ['existing-team']
-            : ['existing-team', 'late-team'];
-          return {
-            docs: visibleIds.map((id) => createBackfillSnapshot(id, teams.get(id)))
-          };
-        })
-      })),
-      doc: vi.fn((path) => ({
-        path,
-        set: vi.fn(async (value) => {
-          if (path === 'systemMigrations/publicTeamProfilesBackfill') {
-            events.push(`completed:${value.completed}`);
-          }
-        })
-      })),
-      runTransaction: vi.fn(async (handler) => handler({
-        get: vi.fn(async (ref) => {
-          if (ref.path.startsWith('teams/')) {
-            const id = ref.path.slice('teams/'.length);
-            return createBackfillSnapshot(id, teams.get(id) || null);
-          }
-          const id = ref.path.slice('publicTeamProfiles/'.length);
-          return createBackfillSnapshot(id, profiles.get(id) || null);
-        }),
-        set: vi.fn((ref, value) => {
-          const id = ref.path.slice('publicTeamProfiles/'.length);
-          profiles.set(id, value);
-          events.push(`profile:${id}`);
-        }),
-        delete: vi.fn()
-      }))
-    };
+  it('reconciles a public team created after the initial snapshot before recording completion', async () => {
+    const concurrent = createConcurrentBackfillDb();
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     const summary = await runPublicTeamProfileBackfill({
       apply: true, teamId: '', projectId: 'demo-allplays', serviceAccountPath: ''
-    }, { db });
+    }, { db: concurrent.db });
 
-    expect(collectionReads).toBe(2);
-    expect(profiles.get('late-team')).toMatchObject({
-      name: 'Late Team', isPublic: true, active: true
-    });
-    expect(events.indexOf('profile:late-team')).toBeLessThan(events.indexOf('completed:true'));
     expect(summary).toMatchObject({
-      teamsScanned: 3,
-      projectionsUpserted: 3,
+      teamsScanned: 1,
+      reconciliationPasses: 1,
+      teamsReconciled: 2,
       migrationCompletionRecorded: true
     });
+    expect(concurrent.state.profiles.get('team-concurrent')).toMatchObject({
+      name: 'Concurrent Public Team', isPublic: true, active: true
+    });
+    expect(concurrent.state.events.indexOf('profile:team-concurrent')).toBeLessThan(
+      concurrent.state.events.lastIndexOf('migration:true')
+    );
+    expect(concurrent.state.completionWrites).toEqual([{ completed: false }, { completed: true }]);
+    logSpy.mockRestore();
+  });
+
+  it('leaves projection mode disabled when reconciliation cannot reach a fixed point', async () => {
+    const changing = createConcurrentBackfillDb({ keepChanging: true });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await expect(runPublicTeamProfileBackfill({
+      apply: true, teamId: '', projectId: 'demo-allplays', serviceAccountPath: ''
+    }, { db: changing.db })).rejects.toThrow('migration completion was not recorded');
+
+    expect(changing.state.completionWrites).toEqual([{ completed: false }]);
     logSpy.mockRestore();
   });
 });

--- a/tests/unit/public-team-profile-core.test.js
+++ b/tests/unit/public-team-profile-core.test.js
@@ -152,6 +152,8 @@ describe('public team profile callable boundary', () => {
     expect(privateRace.state.profile).toBeNull();
     expect(privateRace.state.transactionReads).toEqual([
       'teams/team-race',
+      'publicTeamProfiles/team-race',
+      'teams/team-race',
       'publicTeamProfiles/team-race'
     ]);
     expect(privateRace.state.completion).toEqual({ completed: true });
@@ -166,14 +168,17 @@ describe('public team profile callable boundary', () => {
     }, { db: publicRace.db });
 
     expect(publicSummary).toMatchObject({
-      projectionsUpserted: 1,
+      projectionsUpserted: 2,
       projectionsDeleted: 0,
       migrationCompletionRecorded: true
     });
     expect(publicRace.state.profile).toMatchObject({
       name: 'Newly Public Race Team', isPublic: true, active: true, state: 'MO'
     });
-    expect(publicRace.state.transactionReads).toEqual(['teams/team-race']);
+    expect(publicRace.state.transactionReads).toEqual([
+      'teams/team-race',
+      'teams/team-race'
+    ]);
 
     const deletedRace = createBackfillDb({
       listedTeam: stalePublic,
@@ -192,8 +197,74 @@ describe('public team profile callable boundary', () => {
     expect(deletedRace.state.profile).toBeNull();
     expect(deletedRace.state.transactionReads).toEqual([
       'teams/team-race',
+      'publicTeamProfiles/team-race',
+      'teams/team-race',
       'publicTeamProfiles/team-race'
     ]);
+    logSpy.mockRestore();
+  });
+
+  it('reconciles teams created after the initial snapshot before recording completion', async () => {
+    const teams = new Map([
+      ['existing-team', { name: 'Existing Team', isPublic: true, active: true }],
+      ['late-team', { name: 'Late Team', isPublic: true, active: true }]
+    ]);
+    const profiles = new Map();
+    const events = [];
+    let collectionReads = 0;
+    const db = {
+      collection: vi.fn(() => ({
+        get: vi.fn(async () => {
+          collectionReads += 1;
+          const visibleIds = collectionReads === 1
+            ? ['existing-team']
+            : ['existing-team', 'late-team'];
+          return {
+            docs: visibleIds.map((id) => createBackfillSnapshot(id, teams.get(id)))
+          };
+        })
+      })),
+      doc: vi.fn((path) => ({
+        path,
+        set: vi.fn(async (value) => {
+          if (path === 'systemMigrations/publicTeamProfilesBackfill') {
+            events.push(`completed:${value.completed}`);
+          }
+        })
+      })),
+      runTransaction: vi.fn(async (handler) => handler({
+        get: vi.fn(async (ref) => {
+          if (ref.path.startsWith('teams/')) {
+            const id = ref.path.slice('teams/'.length);
+            return createBackfillSnapshot(id, teams.get(id) || null);
+          }
+          const id = ref.path.slice('publicTeamProfiles/'.length);
+          return createBackfillSnapshot(id, profiles.get(id) || null);
+        }),
+        set: vi.fn((ref, value) => {
+          const id = ref.path.slice('publicTeamProfiles/'.length);
+          profiles.set(id, value);
+          events.push(`profile:${id}`);
+        }),
+        delete: vi.fn()
+      }))
+    };
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const summary = await runPublicTeamProfileBackfill({
+      apply: true, teamId: '', projectId: 'demo-allplays', serviceAccountPath: ''
+    }, { db });
+
+    expect(collectionReads).toBe(2);
+    expect(profiles.get('late-team')).toMatchObject({
+      name: 'Late Team', isPublic: true, active: true
+    });
+    expect(events.indexOf('profile:late-team')).toBeLessThan(events.indexOf('completed:true'));
+    expect(summary).toMatchObject({
+      teamsScanned: 3,
+      projectionsUpserted: 3,
+      migrationCompletionRecorded: true
+    });
     logSpy.mockRestore();
   });
 });

--- a/tests/unit/public-team-projection-compatibility.test.js
+++ b/tests/unit/public-team-projection-compatibility.test.js
@@ -16,6 +16,9 @@ describe('public team projection compatibility contract', () => {
         expect(dbSource).toContain("httpsCallable(functions, 'getPublicTeamProfile')");
         expect(dbSource).toContain('if (!isPublicProjectionFallbackError(error)) throw error;');
         expect(dbSource).toMatch(/discoverPublicTeams[\s\S]*discoverPublicTeamsFromCallable/);
+        expect(rules).toContain('function hasNoCallableOnlyPublicTeamPresentationFields(data)');
+        expect(rules).toContain("'tournament', 'tournamentDivisions', 'tournamentPools', 'tournamentPoolOverrides'");
+        expect(rules).toContain('hasNoCallableOnlyPublicTeamPresentationFields(data)');
     });
 
     it('preserves public external schedules without putting calendar credentials in the profile projection', () => {
@@ -98,6 +101,30 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('public team projection co
             where('active', '==', true),
             limit(100)
         )));
+    });
+
+    it('keeps nested presentation structures behind the sanitizing callable', async () => {
+        const callableOnlyFields = [
+            { standingsConfig: { enabled: true, providerToken: 'must-not-return' } },
+            { tournament: { pools: [{ name: 'Pool A', managerEmail: 'private@example.test' }] } },
+            { tournamentDivisions: [{ name: 'Division A', managerEmail: 'private@example.test' }] },
+            { tournamentPools: [{ name: 'Pool A', managerEmail: 'private@example.test' }] },
+            { tournamentPoolOverrides: { 'Pool A': { groupKey: 'a', managerEmail: 'private@example.test' } } }
+        ];
+        const publicDb = testEnv.unauthenticatedContext().firestore();
+
+        for (const callableOnlyField of callableOnlyFields) {
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                await setDoc(doc(context.firestore(), 'publicTeamProfiles/public-team'), {
+                    publicSchemaVersion: 1,
+                    name: 'Public Team',
+                    isPublic: true,
+                    active: true,
+                    ...callableOnlyField
+                });
+            });
+            await assertFails(getDoc(doc(publicDb, 'publicTeamProfiles/public-team')));
+        }
     });
 
     it('fails closed when any allow-listed projection field has a malformed type', async () => {

--- a/tests/unit/public-team-projection-compatibility.test.js
+++ b/tests/unit/public-team-projection-compatibility.test.js
@@ -1,0 +1,71 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { assertFails, assertSucceeds, initializeTestEnvironment } from '@firebase/rules-unit-testing';
+import { collection, doc, getDoc, getDocs, query, setDoc, where } from 'firebase/firestore';
+
+const rules = readFileSync(resolve(process.cwd(), 'firestore.rules'), 'utf8');
+const dbSource = readFileSync(resolve(process.cwd(), 'js/db.js'), 'utf8');
+
+describe('public team projection compatibility contract', () => {
+    it('adds projection-first readers and preserves the callable deployment fallback', () => {
+        expect(dbSource).toContain("collection(db, 'publicTeamProfiles')");
+        expect(dbSource).toContain("httpsCallable(functions, 'discoverPublicTeamProfiles')");
+        expect(dbSource).toContain("httpsCallable(functions, 'getPublicTeamProfile')");
+        expect(dbSource).toContain('if (!isPublicProjectionFallbackError(error)) throw error;');
+    });
+});
+
+describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('public team projection compatibility rules', () => {
+    let testEnv;
+
+    beforeAll(async () => {
+        testEnv = await initializeTestEnvironment({
+            projectId: `allplays-public-team-compat-${Date.now()}`,
+            firestore: { rules }
+        });
+    }, 30000);
+
+    beforeEach(async () => {
+        await testEnv.clearFirestore();
+        await testEnv.withSecurityRulesDisabled(async (context) => {
+            const db = context.firestore();
+            await setDoc(doc(db, 'teams/public-team'), {
+                name: 'Public Team', isPublic: true, active: true, ownerId: 'owner-1'
+            });
+            await setDoc(doc(db, 'publicTeamProfiles/public-team'), {
+                publicSchemaVersion: 1,
+                name: 'Public Team', isPublic: true, active: true, publicSearchName: 'public team'
+            });
+            await setDoc(doc(db, 'publicTeamProfiles/malformed-team'), {
+                publicSchemaVersion: 1,
+                name: 'Malformed Team', isPublic: true, active: true,
+                unexpectedSecret: 'must-not-list'
+            });
+        });
+    });
+
+    afterAll(async () => testEnv?.cleanup());
+
+    it('lets old and new clients read the same public team during rollout', async () => {
+        const db = testEnv.unauthenticatedContext().firestore();
+        await assertSucceeds(getDoc(doc(db, 'teams/public-team')));
+        await assertSucceeds(getDocs(query(collection(db, 'teams'), where('isPublic', '==', true))));
+        const projection = await assertSucceeds(getDoc(doc(db, 'publicTeamProfiles/public-team')));
+        expect(projection.data()).toMatchObject({ name: 'Public Team', isPublic: true });
+        await assertFails(getDoc(doc(db, 'publicTeamProfiles/malformed-team')));
+        await assertFails(getDocs(query(
+            collection(db, 'publicTeamProfiles'),
+            where('publicSchemaVersion', '==', 1),
+            where('isPublic', '==', true),
+            where('active', '==', true)
+        )));
+    });
+
+    it('keeps projection writes server-only', async () => {
+        const ownerDb = testEnv.authenticatedContext('owner-1').firestore();
+        await assertFails(setDoc(doc(ownerDb, 'publicTeamProfiles/injected'), {
+            name: 'Injected', isPublic: true, active: true
+        }));
+    });
+});

--- a/tests/unit/public-team-projection-compatibility.test.js
+++ b/tests/unit/public-team-projection-compatibility.test.js
@@ -61,7 +61,11 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('public team projection co
 
     it('fails closed if a privileged writer ever creates a malformed projection', async () => {
         await testEnv.withSecurityRulesDisabled(async (context) => {
-            await setDoc(doc(context.firestore(), 'publicTeamProfiles/malformed-team'), {
+            const db = context.firestore();
+            await setDoc(doc(db, 'teams/malformed-team'), {
+                name: 'Malformed Team', isPublic: true, active: true
+            });
+            await setDoc(doc(db, 'publicTeamProfiles/malformed-team'), {
                 publicSchemaVersion: 1,
                 name: 'Malformed Team', isPublic: true, active: true,
                 unexpectedSecret: 'must-not-list'
@@ -76,6 +80,55 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('public team projection co
             where('active', '==', true),
             limit(100)
         )));
+    });
+
+    it('fails closed when any allow-listed projection field has a malformed type', async () => {
+        const malformedFields = [
+            { name: { private: 'value' } },
+            { sport: { private: 'value' } },
+            { description: ['private'] },
+            { photoUrl: { private: 'value' } },
+            { city: ['private'] },
+            { state: { private: 'value' } },
+            { zip: ['private'] },
+            { leagueUrl: { private: 'value' } },
+            { websiteUrl: ['private'] },
+            { socialLinks: { privateEmail: 'private@example.test' } },
+            { twitchChannel: { private: 'value' } },
+            { streamUrl: ['private'] },
+            { livestreamUrl: { private: 'value' } },
+            { streamEmbedUrl: ['private'] },
+            { youtubeEmbedUrl: { private: 'value' } },
+            { standingsConfig: ['private'] },
+            { tournament: ['private'] },
+            { tournamentDivisions: { private: 'value' } },
+            { tournamentPools: { private: 'value' } },
+            { tournamentPoolOverrides: ['private'] },
+            { appAccess: 'true' },
+            { webAccess: 1 },
+            { archived: 'false' },
+            { status: { private: 'value' } },
+            { publicSearchName: ['private'] },
+            { publicSearchCity: { private: 'value' } },
+            { publicSearchState: ['private'] },
+            { publicSearchZip: { private: 'value' } },
+            { publicSearchCityState: ['private'] },
+            { sourceUpdatedAt: { private: 'value' } }
+        ];
+        const publicDb = testEnv.unauthenticatedContext().firestore();
+
+        for (const malformedField of malformedFields) {
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                await setDoc(doc(context.firestore(), 'publicTeamProfiles/public-team'), {
+                    publicSchemaVersion: 1,
+                    name: 'Public Team',
+                    isPublic: true,
+                    active: true,
+                    ...malformedField
+                });
+            });
+            await assertFails(getDoc(doc(publicDb, 'publicTeamProfiles/public-team')));
+        }
     });
 
     it('fails closed when a projection outlives a private, inactive, or deleted source team', async () => {

--- a/tests/unit/public-team-projection-compatibility.test.js
+++ b/tests/unit/public-team-projection-compatibility.test.js
@@ -2,17 +2,18 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { assertFails, assertSucceeds, initializeTestEnvironment } from '@firebase/rules-unit-testing';
-import { collection, doc, getDoc, getDocs, query, setDoc, where } from 'firebase/firestore';
+import { collection, doc, getDoc, getDocs, limit, query, setDoc, where } from 'firebase/firestore';
 
 const rules = readFileSync(resolve(process.cwd(), 'firestore.rules'), 'utf8');
 const dbSource = readFileSync(resolve(process.cwd(), 'js/db.js'), 'utf8');
 
 describe('public team projection compatibility contract', () => {
-    it('adds projection-first readers and preserves the callable deployment fallback', () => {
-        expect(dbSource).toContain("collection(db, 'publicTeamProfiles')");
+    it('keeps strict projection detail reads and callable-only collection discovery', () => {
+        expect(dbSource).toContain("doc(db, 'publicTeamProfiles', normalizedTeamId)");
         expect(dbSource).toContain("httpsCallable(functions, 'discoverPublicTeamProfiles')");
         expect(dbSource).toContain("httpsCallable(functions, 'getPublicTeamProfile')");
         expect(dbSource).toContain('if (!isPublicProjectionFallbackError(error)) throw error;');
+        expect(dbSource).toMatch(/discoverPublicTeams[\s\S]*discoverPublicTeamsFromCallable/);
     });
 });
 
@@ -37,11 +38,6 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('public team projection co
                 publicSchemaVersion: 1,
                 name: 'Public Team', isPublic: true, active: true, publicSearchName: 'public team'
             });
-            await setDoc(doc(db, 'publicTeamProfiles/malformed-team'), {
-                publicSchemaVersion: 1,
-                name: 'Malformed Team', isPublic: true, active: true,
-                unexpectedSecret: 'must-not-list'
-            });
         });
     });
 
@@ -53,12 +49,32 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('public team projection co
         await assertSucceeds(getDocs(query(collection(db, 'teams'), where('isPublic', '==', true))));
         const projection = await assertSucceeds(getDoc(doc(db, 'publicTeamProfiles/public-team')));
         expect(projection.data()).toMatchObject({ name: 'Public Team', isPublic: true });
+        await assertFails(getDocs(query(
+            collection(db, 'publicTeamProfiles'),
+            where('publicSchemaVersion', '==', 1),
+            where('isPublic', '==', true),
+            where('active', '==', true),
+            limit(100)
+        )));
+        await assertFails(getDocs(query(collection(db, 'publicTeamProfiles'), limit(101))));
+    });
+
+    it('fails closed if a privileged writer ever creates a malformed projection', async () => {
+        await testEnv.withSecurityRulesDisabled(async (context) => {
+            await setDoc(doc(context.firestore(), 'publicTeamProfiles/malformed-team'), {
+                publicSchemaVersion: 1,
+                name: 'Malformed Team', isPublic: true, active: true,
+                unexpectedSecret: 'must-not-list'
+            });
+        });
+        const db = testEnv.unauthenticatedContext().firestore();
         await assertFails(getDoc(doc(db, 'publicTeamProfiles/malformed-team')));
         await assertFails(getDocs(query(
             collection(db, 'publicTeamProfiles'),
             where('publicSchemaVersion', '==', 1),
             where('isPublic', '==', true),
-            where('active', '==', true)
+            where('active', '==', true),
+            limit(100)
         )));
     });
 

--- a/tests/unit/public-team-projection-compatibility.test.js
+++ b/tests/unit/public-team-projection-compatibility.test.js
@@ -6,6 +6,8 @@ import { collection, deleteDoc, doc, getDoc, getDocs, limit, query, setDoc, wher
 
 const rules = readFileSync(resolve(process.cwd(), 'firestore.rules'), 'utf8');
 const dbSource = readFileSync(resolve(process.cwd(), 'js/db.js'), 'utf8');
+const functionsSource = readFileSync(resolve(process.cwd(), 'functions/index.js'), 'utf8');
+const teamPageSource = readFileSync(resolve(process.cwd(), 'team.html'), 'utf8');
 
 describe('public team projection compatibility contract', () => {
     it('keeps strict projection detail reads and callable-only collection discovery', () => {
@@ -14,6 +16,22 @@ describe('public team projection compatibility contract', () => {
         expect(dbSource).toContain("httpsCallable(functions, 'getPublicTeamProfile')");
         expect(dbSource).toContain('if (!isPublicProjectionFallbackError(error)) throw error;');
         expect(dbSource).toMatch(/discoverPublicTeams[\s\S]*discoverPublicTeamsFromCallable/);
+    });
+
+    it('preserves public external schedules without putting calendar credentials in the profile projection', () => {
+        expect(dbSource).toContain("httpsCallable(functions, 'getPublicTeamExternalCalendarIcs')");
+        expect(teamPageSource).toContain('getPublicTeamExternalCalendarIcs(currentTeamId)');
+        expect(teamPageSource).toContain('appendExternalCalendarEvents(parseICS(icsText))');
+        expect(teamPageSource).toContain("from './js/db.js?v=103'");
+
+        const callableStart = functionsSource.indexOf('exports.getPublicTeamExternalCalendarIcs');
+        const callableEnd = functionsSource.indexOf('\nexports.publicTeamGamesIcs', callableStart);
+        const callableSource = functionsSource.slice(callableStart, callableEnd);
+        expect(callableSource).toContain('isPublicTeamDiscoverable(team)');
+        expect(functionsSource).toContain('sanitizePublicExternalCalendarIcs(result.icsText)');
+        expect(callableSource).toContain('calendarUrls.map(fetchSanitizedPublicExternalCalendarIcs)');
+        expect(callableSource).toContain('return {\n      calendars,');
+        expect(callableSource).not.toContain('return { calendarUrls');
     });
 });
 

--- a/tests/unit/public-team-projection-compatibility.test.js
+++ b/tests/unit/public-team-projection-compatibility.test.js
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { assertFails, assertSucceeds, initializeTestEnvironment } from '@firebase/rules-unit-testing';
-import { collection, doc, getDoc, getDocs, limit, query, setDoc, where } from 'firebase/firestore';
+import { collection, deleteDoc, doc, getDoc, getDocs, limit, query, setDoc, where } from 'firebase/firestore';
 
 const rules = readFileSync(resolve(process.cwd(), 'firestore.rules'), 'utf8');
 const dbSource = readFileSync(resolve(process.cwd(), 'js/db.js'), 'utf8');
@@ -76,6 +76,36 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('public team projection co
             where('active', '==', true),
             limit(100)
         )));
+    });
+
+    it('fails closed when a projection outlives a private, inactive, or deleted source team', async () => {
+        const db = testEnv.unauthenticatedContext().firestore();
+
+        await testEnv.withSecurityRulesDisabled(async (context) => {
+            await setDoc(doc(context.firestore(), 'teams/public-team'), {
+                name: 'Private Current', isPublic: false, active: true
+            });
+        });
+        await assertFails(getDoc(doc(db, 'publicTeamProfiles/public-team')));
+
+        await testEnv.withSecurityRulesDisabled(async (context) => {
+            await setDoc(doc(context.firestore(), 'teams/public-team'), {
+                name: 'Inactive Current', isPublic: true, active: false
+            });
+        });
+        await assertFails(getDoc(doc(db, 'publicTeamProfiles/public-team')));
+
+        await testEnv.withSecurityRulesDisabled(async (context) => {
+            await setDoc(doc(context.firestore(), 'teams/public-team'), {
+                name: 'Archived Current', isPublic: true, active: true, status: 'ARCHIVED'
+            });
+        });
+        await assertFails(getDoc(doc(db, 'publicTeamProfiles/public-team')));
+
+        await testEnv.withSecurityRulesDisabled(async (context) => {
+            await deleteDoc(doc(context.firestore(), 'teams/public-team'));
+        });
+        await assertFails(getDoc(doc(db, 'publicTeamProfiles/public-team')));
     });
 
     it('keeps projection writes server-only', async () => {

--- a/tests/unit/rsvp-precedence-cache-bust.test.js
+++ b/tests/unit/rsvp-precedence-cache-bust.test.js
@@ -69,7 +69,8 @@ describe('RSVP precedence cache delivery', () => {
             expect(readRepoFile(path)).toContain(expectedVersion);
         }
 
-        expect(readRepoFile('js/utils.js')).toContain("import('./global-search.js?v=10')");
+        expect(readRepoFile('js/utils.js')).toContain("import('./global-search.js?v=11')");
+        expect(readRepoFile('js/utils.js')).not.toContain("import('./global-search.js?v=10')");
         expect(readRepoFile('js/db.js')).toContain("from './utils.js?v=15';");
         expect(readRepoFile('parent-dashboard.html')).toContain('js/utils.js?v=15');
         expect(readRepoFile('js/live-game.js')).toContain("from './live-game-state.js?v=7';");

--- a/tests/unit/rsvp-precedence-cache-bust.test.js
+++ b/tests/unit/rsvp-precedence-cache-bust.test.js
@@ -69,7 +69,7 @@ describe('RSVP precedence cache delivery', () => {
             expect(readRepoFile(path)).toContain(expectedVersion);
         }
 
-        expect(readRepoFile('js/utils.js')).toContain("import('./global-search.js?v=9')");
+        expect(readRepoFile('js/utils.js')).toContain("import('./global-search.js?v=10')");
         expect(readRepoFile('js/db.js')).toContain("from './utils.js?v=15';");
         expect(readRepoFile('parent-dashboard.html')).toContain('js/utils.js?v=15');
         expect(readRepoFile('js/live-game.js')).toContain("from './live-game-state.js?v=7';");

--- a/tests/unit/rsvp-precedence-cache-bust.test.js
+++ b/tests/unit/rsvp-precedence-cache-bust.test.js
@@ -69,8 +69,8 @@ describe('RSVP precedence cache delivery', () => {
             expect(readRepoFile(path)).toContain(expectedVersion);
         }
 
-        expect(readRepoFile('js/utils.js')).toContain("import('./global-search.js?v=11')");
-        expect(readRepoFile('js/utils.js')).not.toContain("import('./global-search.js?v=10')");
+        expect(readRepoFile('js/utils.js')).toContain("import('./global-search.js?v=12')");
+        expect(readRepoFile('js/utils.js')).not.toContain("import('./global-search.js?v=11')");
         expect(readRepoFile('js/db.js')).toContain("from './utils.js?v=15';");
         expect(readRepoFile('parent-dashboard.html')).toContain('js/utils.js?v=15');
         expect(readRepoFile('js/live-game.js')).toContain("from './live-game-state.js?v=7';");

--- a/tests/unit/teams-html-escaping.test.js
+++ b/tests/unit/teams-html-escaping.test.js
@@ -46,6 +46,8 @@ describe('teams page HTML escaping', () => {
         expect(source).toContain("let activeLocationFilter = '';");
         expect(source).toContain('browseCursor = discovery.nextCursor || null;');
         expect(source).toContain('canLoadMore: Boolean(browseCursor),');
+        expect(source).toContain('No matches in this scan yet');
+        expect(source).toContain('onClick: loadNextDiscoveryPage');
         expect(source).toContain("await loadTeams(activeLocationFilter, { cursor: nextCursor, append: true });");
         expect(source).toContain("activeLocationFilter = getLocationSearchValue();");
         expect(source).toContain("activeLocationFilter = '';");

--- a/tests/unit/teams-public-visibility.test.js
+++ b/tests/unit/teams-public-visibility.test.js
@@ -12,10 +12,14 @@ describe('public teams visibility', () => {
         expect(source).toContain('const publicOnly = options.publicOnly === true;');
         expect(source).toContain('const includePrivate = options.includePrivate === true || includeInactive;');
         expect(source).toContain('} else if (publicOnly) {');
-        expect(source).toContain('getDocs(query(teamsRef, where("isPublic", "==", true)))');
+        expect(source).toContain("const publicTeamsRef = collection(db, 'publicTeamProfiles');");
+        expect(source).toContain("where('publicSchemaVersion', '==', 1)");
+        expect(source).toContain("where('isPublic', '==', true)");
+        expect(source).toContain("where('active', '==', true)");
         expect(source).toContain('.sort((a, b) => String(a.name || \'\').localeCompare(String(b.name || \'\')))');
         expect(source).toContain('export async function discoverPublicTeams(options = {})');
-        expect(source).toContain("where('isPublic', '==', true), orderBy('name')");
+        expect(source).toContain("const teamsRef = collection(db, 'publicTeamProfiles');");
+        expect(source).toContain("const constraints = [\n            where('publicSchemaVersion', '==', 1)");
         expect(source).toContain('getDocs(query(teamsRef, where("ownerId", "==", currentUser.uid)))');
         expect(source).toContain('getDocs(query(teamsRef, where("adminEmails", "array-contains", currentUserEmail)))');
         expect(source).not.toContain('const q = includePrivate');
@@ -23,25 +27,12 @@ describe('public teams visibility', () => {
 
     it('keeps discovery on indexed queries and removes the runtime zip-resolution fallback', () => {
         const source = readRepoFile('js/db.js');
-        const indexes = JSON.parse(readRepoFile('firestore.indexes.json'));
-        const teamIndexes = indexes.indexes
-            .filter((index) => index.collectionGroup === 'teams' && index.queryScope === 'COLLECTION')
-            .map((index) => index.fields.map((field) => field.fieldPath).join(','));
-
         expect(source).not.toContain('appendResolvedZipPublicTeamMatches');
         expect(source).not.toContain("const publicTeamsSnapshot = await getDocs(query(teamsRef, where('isPublic', '==', true)));");
         expect(source).not.toContain('await appendResolvedZipPublicTeamMatches(teamsRef, searchDescriptor, teamsById);');
-        expect(source).toContain('const snapshots = await Promise.all(strategies.map((strategy) => getDocs(query(');
-        expect(teamIndexes).toEqual(expect.arrayContaining([
-            'isPublic,publicSearchName',
-            'isPublic,name',
-            'isPublic,publicSearchCity',
-            'isPublic,city',
-            'isPublic,publicSearchState',
-            'isPublic,state',
-            'isPublic,publicSearchZip',
-            'isPublic,zip'
-        ]));
+        expect(source).toContain('snapshots = await Promise.all(strategies.map((strategy) => getDocs(query(');
+        expect(source).toContain('if (!isPublicProjectionFallbackError(error)) throw error;');
+        expect(source).not.toContain("teamsRef,\n        where('isPublic', '==', true),");
     });
 
     it('keeps zip-backed state filters on indexed fields and avoids blocking saves on ZIP resolution', () => {
@@ -74,7 +65,7 @@ describe('public teams visibility', () => {
         expect(source).not.toContain('getTeams(locationFilter ? { locationFilter } : {})');
     });
 
-    it('does not allow anonymous reads of private team documents in Firestore rules', () => {
+    it('keeps legacy public source reads during the projection compatibility phase', () => {
         const rules = readRepoFile('firestore.rules');
 
         expect(rules).toContain('function canReadTeamDocument(data)');
@@ -84,6 +75,7 @@ describe('public teams visibility', () => {
         expect(rules).toContain('allow list: if isBoundedGlobalAdminListQuery() ||');
         expect(rules).toContain('canReadPublicTeamDocument(resource.data) ||');
         expect(rules).toContain('canListManagedTeamDocument(resource.data);');
+        expect(rules).toContain('match /publicTeamProfiles/{teamId}');
         expect(rules).not.toContain('allow read: if true;  // Public teams for browsing');
     });
 });

--- a/tests/unit/teams-public-visibility.test.js
+++ b/tests/unit/teams-public-visibility.test.js
@@ -12,33 +12,34 @@ describe('public teams visibility', () => {
         expect(source).toContain('const publicOnly = options.publicOnly === true;');
         expect(source).toContain('const includePrivate = options.includePrivate === true || includeInactive;');
         expect(source).toContain('} else if (publicOnly) {');
-        expect(source).toContain("const publicTeamsRef = collection(db, 'publicTeamProfiles');");
-        expect(source).toContain("where('publicSchemaVersion', '==', 1)");
-        expect(source).toContain("where('isPublic', '==', true)");
-        expect(source).toContain("where('active', '==', true)");
+        expect(source).toContain("httpsCallable(functions, 'discoverPublicTeamProfiles')");
+        expect(source).toContain('async function getAllPublicTeamProfiles()');
         expect(source).toContain('.sort((a, b) => String(a.name || \'\').localeCompare(String(b.name || \'\')))');
         expect(source).toContain('export async function discoverPublicTeams(options = {})');
-        expect(source).toContain("const teamsRef = collection(db, 'publicTeamProfiles');");
-        expect(source).toContain("const constraints = [\n            where('publicSchemaVersion', '==', 1)");
+        expect(source).toMatch(/export async function discoverPublicTeams[\s\S]*discoverPublicTeamsFromCallable/);
         expect(source).toContain('getDocs(query(teamsRef, where("ownerId", "==", currentUser.uid)))');
         expect(source).toContain('getDocs(query(teamsRef, where("adminEmails", "array-contains", currentUserEmail)))');
         expect(source).not.toContain('const q = includePrivate');
     });
 
-    it('keeps discovery on indexed queries and removes the runtime zip-resolution fallback', () => {
+    it('keeps discovery behind the server projection boundary and removes runtime source scans', () => {
         const source = readRepoFile('js/db.js');
+        const functionsSource = readRepoFile('functions/index.js');
         expect(source).not.toContain('appendResolvedZipPublicTeamMatches');
         expect(source).not.toContain("const publicTeamsSnapshot = await getDocs(query(teamsRef, where('isPublic', '==', true)));");
         expect(source).not.toContain('await appendResolvedZipPublicTeamMatches(teamsRef, searchDescriptor, teamsById);');
-        expect(source).toContain('snapshots = await Promise.all(strategies.map((strategy) => getDocs(query(');
-        expect(source).toContain('if (!isPublicProjectionFallbackError(error)) throw error;');
+        expect(functionsSource).toContain("const collectionName = useProjection ? 'publicTeamProfiles' : 'teams';");
+        expect(functionsSource).toContain(".where('publicSchemaVersion', '==', 1)");
+        expect(functionsSource).toContain(".orderBy('name')");
+        expect(functionsSource).toContain('PUBLIC_TEAM_DISCOVERY_SCAN_LIMIT = 500');
+        expect(functionsSource).toContain("kind: 'public-team-callable-v2'");
         expect(source).not.toContain("teamsRef,\n        where('isPublic', '==', true),");
     });
 
     it('keeps zip-backed state filters on indexed fields and avoids blocking saves on ZIP resolution', () => {
         const source = readRepoFile('js/db.js');
 
-        expect(source).toContain("String(team.publicSearchState || team.state || '').trim().toUpperCase().startsWith(normalizedState)");
+        expect(source).toContain('searchFields.publicSearchState = normalizePublicTeamSearchValue(teamData.state, { uppercase: true });');
         expect(source).toContain('Object.assign(teamData, buildPublicTeamSearchFields(teamData));');
         expect(source).not.toContain('buildMaterializedPublicTeamSearchFields');
     });


### PR DESCRIPTION
## Summary
- add an additive `publicTeams` projection with marker-safe public player records and server-maintained synchronization
- route discovery and public RSVP reads to the projection, with a sanitizing callable fallback during rollout
- add migration tooling, indexes, rules, documentation, and regression coverage

## Rollout safety
This PR is intentionally phase 1 only. It does not close anonymous reads from the legacy `teams` source yet, so existing clients remain functional while projections are populated.

Safe production sequence after merge:
1. deploy the functions, rules, indexes, and compatible clients
2. run the backfill in dry-run mode
3. apply the backfill and verify projection counts/content
4. monitor production compatibility
5. ship the separate phase 2 enforcement PR only after verification

## Validation
- focused unit suites: 27 passed, 4 skipped
- Functions tests: 183 passed
- Firebase rules CI: passed
- migration diff guard: passed

## Risk
The public data boundary remains permissive in this additive phase by design. Enforcement is separated so rollout can be stopped without breaking existing web or native clients.