### PR TITLE
Improve production error observability

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -716,7 +716,7 @@
 
     <div id="footer-container"></div>
 
-    <script type="module" src="js/admin.js?v=10"></script>
+    <script type="module" src="js/admin.js?v=11"></script>
 </body>
 
 </html>

--- a/admin.html
+++ b/admin.html
@@ -539,6 +539,8 @@
                             <option value="auth_context">Auth context</option>
                             <option value="js_error">JS errors</option>
                             <option value="js_unhandled_rejection">Unhandled rejections</option>
+                            <option value="app_load_error">App errors</option>
+                            <option value="public_rsvp_error">Public RSVP errors</option>
                             <option value="interaction_rage_click">Rage clicks</option>
                             <option value="app_initial_load">App initial load</option>
                             <option value="app_ux_timing">App UX timers</option>

--- a/functions/index.js
+++ b/functions/index.js
@@ -64,6 +64,7 @@ const {
   buildRsvpTokenAuditPayload
 } = require('./rsvp-token-core.cjs');
 const { isAllowedPublicRsvpOrigin } = require('./public-rsvp-cors-core.cjs');
+const { isAllowedTelemetryOrigin } = require('./telemetry-cors-core.cjs');
 const {
   normalizeText,
   resolveTeamEmailRecipients,
@@ -4794,10 +4795,6 @@ function isAllowedOrigin(origin) {
   return allowedOriginSet.has(origin);
 }
 
-function isAllowedTelemetryOrigin(origin) {
-  return !!origin && allowedOriginSet.has(origin);
-}
-
 function writeCorsHeaders(req, res, methods = 'GET,OPTIONS') {
   const origin = req.headers.origin;
   if (origin && allowedOriginSet.has(origin)) {
@@ -4806,6 +4803,17 @@ function writeCorsHeaders(req, res, methods = 'GET,OPTIONS') {
   }
   res.set('Access-Control-Allow-Methods', methods);
   res.set('Access-Control-Allow-Headers', 'Authorization, Content-Type, X-Firebase-AppCheck');
+  res.set('Cache-Control', 'no-store');
+}
+
+function writeTelemetryCorsHeaders(req, res) {
+  const origin = req.headers.origin;
+  if (isAllowedTelemetryOrigin(origin, allowedOriginSet)) {
+    res.set('Access-Control-Allow-Origin', origin);
+    res.set('Vary', 'Origin');
+  }
+  res.set('Access-Control-Allow-Methods', 'POST,OPTIONS');
+  res.set('Access-Control-Allow-Headers', 'Authorization, Content-Type');
   res.set('Cache-Control', 'no-store');
 }
 
@@ -12385,9 +12393,9 @@ exports.collectTelemetry = functions
   .runWith({ timeoutSeconds: 15, memory: '256MB' })
   .https
   .onRequest(async (req, res) => {
-    writeCorsHeaders(req, res, 'POST,OPTIONS');
+    writeTelemetryCorsHeaders(req, res);
 
-    if (!isAllowedTelemetryOrigin(req.headers.origin)) {
+    if (!isAllowedTelemetryOrigin(req.headers.origin, allowedOriginSet)) {
       res.status(403).json({ ok: false, error: 'Origin not allowed' });
       return;
     }

--- a/functions/index.js
+++ b/functions/index.js
@@ -5018,7 +5018,7 @@ function applyTelemetryAggregateWrites(batch, event, dateKey, options = {}) {
   const serverTimestamp = admin.firestore.FieldValue.serverTimestamp;
   const isPageView = event.name === 'page_view';
   const isInteraction = event.name.startsWith('interaction_');
-  const isError = event.name.startsWith('js_');
+  const isError = event.name.startsWith('js_') || event.name === 'public_rsvp_error';
 
   batch.set(db.collection('telemetryDaily').doc(dateKey), {
     date: dateKey,

--- a/functions/index.js
+++ b/functions/index.js
@@ -5018,7 +5018,9 @@ function applyTelemetryAggregateWrites(batch, event, dateKey, options = {}) {
   const serverTimestamp = admin.firestore.FieldValue.serverTimestamp;
   const isPageView = event.name === 'page_view';
   const isInteraction = event.name.startsWith('interaction_');
-  const isError = event.name.startsWith('js_') || event.name === 'public_rsvp_error';
+  const isError = event.name.startsWith('js_')
+    || event.name === 'app_load_error'
+    || event.name === 'public_rsvp_error';
 
   batch.set(db.collection('telemetryDaily').doc(dateKey), {
     date: dateKey,

--- a/functions/telemetry-cors-core.cjs
+++ b/functions/telemetry-cors-core.cjs
@@ -1,0 +1,11 @@
+'use strict';
+
+const { isAllowedPublicRsvpOrigin } = require('./public-rsvp-cors-core.cjs');
+
+function isAllowedTelemetryOrigin(origin, configuredOriginSet = new Set()) {
+  if (typeof origin !== 'string' || !origin) return false;
+  return isAllowedPublicRsvpOrigin(origin)
+    || configuredOriginSet?.has?.(origin) === true;
+}
+
+module.exports = { isAllowedTelemetryOrigin };

--- a/functions/test/telemetry-cors-core.test.cjs
+++ b/functions/test/telemetry-cors-core.test.cjs
@@ -1,0 +1,26 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { isAllowedTelemetryOrigin } = require('../telemetry-cors-core.cjs');
+
+test('telemetry CORS allows production and Firebase Hosting RSVP origins', () => {
+  assert.equal(isAllowedTelemetryOrigin('https://allplays.ai'), true);
+  assert.equal(isAllowedTelemetryOrigin('https://www.allplays.ai'), true);
+  assert.equal(isAllowedTelemetryOrigin('https://game-flow-c6311.web.app'), true);
+  assert.equal(isAllowedTelemetryOrigin('https://game-flow-c6311.firebaseapp.com'), true);
+  assert.equal(isAllowedTelemetryOrigin('https://game-flow-c6311--pr-4029-5585dlsc.web.app'), true);
+});
+
+test('telemetry CORS preserves explicitly configured origins', () => {
+  const configuredOrigins = new Set(['https://telemetry-client.example.test']);
+  assert.equal(isAllowedTelemetryOrigin('https://telemetry-client.example.test', configuredOrigins), true);
+});
+
+test('telemetry CORS rejects missing and lookalike origins', () => {
+  assert.equal(isAllowedTelemetryOrigin(''), false);
+  assert.equal(isAllowedTelemetryOrigin(undefined), false);
+  assert.equal(isAllowedTelemetryOrigin('https://evil.example'), false);
+  assert.equal(isAllowedTelemetryOrigin('https://game-flow-c6311--x.web.app.evil.com'), false);
+  assert.equal(isAllowedTelemetryOrigin('http://allplays.ai'), false);
+});

--- a/js/admin.js
+++ b/js/admin.js
@@ -281,6 +281,7 @@ let telemetryState = {
 const telemetryIssueEvents = [
     { name: 'js_error', label: 'JS errors' },
     { name: 'js_unhandled_rejection', label: 'Unhandled rejections' },
+    { name: 'app_load_error', label: 'App errors' },
     { name: 'interaction_rage_click', label: 'Rage clicks' }
 ];
 
@@ -871,8 +872,8 @@ function renderTelemetryNeedsAttention() {
 
     if (!totalIssues) {
         element.innerHTML = `
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-3">${countCards}</div>
-            <p class="text-sm text-gray-500">No errors or rage clicks recorded for this range.</p>
+            <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-3">${countCards}</div>
+            <p class="text-sm text-gray-500">No tracked errors or rage clicks recorded for this range.</p>
         `;
         return;
     }
@@ -895,7 +896,7 @@ function renderTelemetryNeedsAttention() {
         .join('') || '<p class="text-sm text-gray-500">No recent raw examples loaded for this range.</p>';
 
     element.innerHTML = `
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-3">${countCards}</div>
+        <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-3">${countCards}</div>
         <div>
             <p class="text-xs font-semibold text-gray-500 uppercase mb-2">Recent examples</p>
             <div class="space-y-2">${recentRows}</div>

--- a/js/admin.js
+++ b/js/admin.js
@@ -282,6 +282,7 @@ const telemetryIssueEvents = [
     { name: 'js_error', label: 'JS errors' },
     { name: 'js_unhandled_rejection', label: 'Unhandled rejections' },
     { name: 'app_load_error', label: 'App errors' },
+    { name: 'public_rsvp_error', label: 'Public RSVP errors' },
     { name: 'interaction_rage_click', label: 'Rage clicks' }
 ];
 
@@ -872,7 +873,7 @@ function renderTelemetryNeedsAttention() {
 
     if (!totalIssues) {
         element.innerHTML = `
-            <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-3">${countCards}</div>
+            <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-5 gap-3">${countCards}</div>
             <p class="text-sm text-gray-500">No tracked errors or rage clicks recorded for this range.</p>
         `;
         return;
@@ -896,7 +897,7 @@ function renderTelemetryNeedsAttention() {
         .join('') || '<p class="text-sm text-gray-500">No recent raw examples loaded for this range.</p>';
 
     element.innerHTML = `
-        <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-3">${countCards}</div>
+        <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-5 gap-3">${countCards}</div>
         <div>
             <p class="text-xs font-semibold text-gray-500 uppercase mb-2">Recent examples</p>
             <div class="space-y-2">${recentRows}</div>

--- a/js/public-rsvp-telemetry.js
+++ b/js/public-rsvp-telemetry.js
@@ -1,4 +1,6 @@
 const DEFAULT_TELEMETRY_ENDPOINT = 'https://us-central1-game-flow-c6311.cloudfunctions.net/collectTelemetry';
+const TELEMETRY_OPT_OUT_KEY = 'allplays.telemetry.optOut';
+const LOCAL_DEVELOPMENT_HOSTNAMES = new Set(['localhost', '127.0.0.1', '0.0.0.0', '']);
 const ALLOWED_FAILURE_KINDS = new Set([
     'missing_token',
     'configuration_error',
@@ -24,6 +26,35 @@ function resolveTelemetryEndpoint() {
         : DEFAULT_TELEMETRY_ENDPOINT;
 }
 
+function readTelemetryOptOut() {
+    try {
+        return window.localStorage?.getItem(TELEMETRY_OPT_OUT_KEY) === '1';
+    } catch {
+        return false;
+    }
+}
+
+export function isPublicRsvpTelemetryEnabled({
+    config = window.__ALLPLAYS_CONFIG__ || {},
+    globalEnabled = window.ALLPLAYS_TELEMETRY_ENABLED,
+    hostname = window.location?.hostname || '',
+    search = window.location?.search || '',
+    optedOut = readTelemetryOptOut()
+} = {}) {
+    const telemetryOverride = new URLSearchParams(search).get('telemetry');
+    if (telemetryOverride === '0') return false;
+    if (telemetryOverride === '1') return true;
+    if (optedOut) return false;
+    if (config.enabled === false || config.telemetryEnabled === false || globalEnabled === false) {
+        return false;
+    }
+
+    return !LOCAL_DEVELOPMENT_HOSTNAMES.has(hostname)
+        || config.enabled === true
+        || config.telemetryEnabled === true
+        || globalEnabled === true;
+}
+
 export function normalizePublicRsvpFailure(properties = {}) {
     const providedFailureKind = String(properties.failureKind || '');
     const providedHttpStatus = Number(properties.httpStatus || 0);
@@ -43,6 +74,8 @@ export function normalizePublicRsvpFailure(properties = {}) {
 
 export async function capturePublicRsvpFailure(properties = {}) {
     try {
+        if (!isPublicRsvpTelemetryEnabled()) return false;
+
         const anonymousContextId = randomId('public_rsvp');
         const event = {
             id: randomId('event'),

--- a/js/public-rsvp-telemetry.js
+++ b/js/public-rsvp-telemetry.js
@@ -1,0 +1,72 @@
+const DEFAULT_TELEMETRY_ENDPOINT = 'https://us-central1-game-flow-c6311.cloudfunctions.net/collectTelemetry';
+const ALLOWED_FAILURE_KINDS = new Set([
+    'missing_token',
+    'configuration_error',
+    'request_rejected',
+    'rate_limited',
+    'server_error',
+    'network_error',
+    'unexpected_error'
+]);
+
+function randomId(prefix) {
+    if (window.crypto?.randomUUID) {
+        return `${prefix}_${window.crypto.randomUUID()}`;
+    }
+    return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function resolveTelemetryEndpoint() {
+    const configuredEndpoint = window.__ALLPLAYS_CONFIG__?.telemetryEndpoint
+        || window.ALLPLAYS_TELEMETRY_ENDPOINT;
+    return typeof configuredEndpoint === 'string' && configuredEndpoint.trim()
+        ? configuredEndpoint.trim()
+        : DEFAULT_TELEMETRY_ENDPOINT;
+}
+
+export function normalizePublicRsvpFailure(properties = {}) {
+    const providedFailureKind = String(properties.failureKind || '');
+    const providedHttpStatus = Number(properties.httpStatus || 0);
+
+    return {
+        label: properties.stage === 'submit' ? 'Public RSVP submit' : 'Public RSVP init',
+        stage: properties.stage === 'submit' ? 'submit' : 'init',
+        failureKind: ALLOWED_FAILURE_KINDS.has(providedFailureKind)
+            ? providedFailureKind
+            : 'unexpected_error',
+        httpStatus: Number.isInteger(providedHttpStatus) && providedHttpStatus >= 400 && providedHttpStatus <= 599
+            ? providedHttpStatus
+            : 0,
+        online: properties.online !== false
+    };
+}
+
+export async function capturePublicRsvpFailure(properties = {}) {
+    try {
+        const anonymousContextId = randomId('public_rsvp');
+        const event = {
+            id: randomId('event'),
+            name: 'public_rsvp_error',
+            version: '1.0.0',
+            sessionId: anonymousContextId,
+            visitorId: anonymousContextId,
+            signedIn: false,
+            clientTimestamp: new Date().toISOString(),
+            pagePath: '/public-rsvp.html',
+            appRoute: '/public-rsvp.html',
+            properties: normalizePublicRsvpFailure(properties)
+        };
+        const response = await fetch(resolveTelemetryEndpoint(), {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                sentAt: new Date().toISOString(),
+                events: [event]
+            }),
+            keepalive: true
+        });
+        return response.ok;
+    } catch {
+        return false;
+    }
+}

--- a/js/public-rsvp-telemetry.js
+++ b/js/public-rsvp-telemetry.js
@@ -1,3 +1,5 @@
+import { getPrimaryAppCheckHeaders } from './firebase-app-check-rest.js?v=1';
+
 const DEFAULT_TELEMETRY_ENDPOINT = 'https://us-central1-game-flow-c6311.cloudfunctions.net/collectTelemetry';
 const TELEMETRY_OPT_OUT_KEY = 'allplays.telemetry.optOut';
 const LOCAL_DEVELOPMENT_HOSTNAMES = new Set(['localhost', '127.0.0.1', '0.0.0.0', '']);
@@ -89,9 +91,11 @@ export async function capturePublicRsvpFailure(properties = {}) {
             appRoute: '/public-rsvp.html',
             properties: normalizePublicRsvpFailure(properties)
         };
-        const response = await fetch(resolveTelemetryEndpoint(), {
+        const endpoint = resolveTelemetryEndpoint();
+        const headers = await getPrimaryAppCheckHeaders({ 'Content-Type': 'application/json' }, endpoint);
+        const response = await fetch(endpoint, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers,
             body: JSON.stringify({
                 sentAt: new Date().toISOString(),
                 events: [event]

--- a/public-rsvp.html
+++ b/public-rsvp.html
@@ -92,7 +92,7 @@
 
         function loadPublicRsvpTelemetry() {
             if (!publicRsvpTelemetryModulePromise) {
-                publicRsvpTelemetryModulePromise = import('./js/public-rsvp-telemetry.js?v=1');
+                publicRsvpTelemetryModulePromise = import('./js/public-rsvp-telemetry.js?v=2');
             }
             return publicRsvpTelemetryModulePromise;
         }

--- a/public-rsvp.html
+++ b/public-rsvp.html
@@ -28,7 +28,7 @@
                 <p class="text-xs text-gray-500 mt-4">For privacy, this page only shows event details after a valid RSVP link is confirmed.</p>
             </div>
 
-            <form id="rsvp-form" class="hidden px-6 py-6 space-y-5">
+            <form id="rsvp-form" data-telemetry-ignore class="hidden px-6 py-6 space-y-5">
                 <div>
                     <p id="team-name" class="text-sm text-gray-500"></p>
                     <h2 id="event-title" class="text-xl font-bold text-gray-900 mt-1"></h2>

--- a/public-rsvp.html
+++ b/public-rsvp.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>RSVP | ALL PLAYS</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module" src="/js/telemetry.js?v=2"></script>
 </head>
 <body class="min-h-screen bg-gray-50 text-gray-900">
     <main class="max-w-xl mx-auto px-4 py-8">
@@ -89,11 +90,55 @@
             states[name].classList.remove('hidden');
         }
 
+        function reportPublicRsvpFailure(stage, error = {}) {
+            try {
+                const allowedFailureKinds = new Set([
+                    'missing_token',
+                    'configuration_error',
+                    'request_rejected',
+                    'rate_limited',
+                    'server_error',
+                    'network_error',
+                    'unexpected_error'
+                ]);
+                const providedFailureKind = String(error.publicRsvpFailureKind || '');
+                const failureKind = allowedFailureKinds.has(providedFailureKind)
+                    ? providedFailureKind
+                    : error instanceof TypeError
+                        ? 'network_error'
+                        : 'unexpected_error';
+                const providedHttpStatus = Number(error.publicRsvpHttpStatus || 0);
+                const httpStatus = Number.isInteger(providedHttpStatus) && providedHttpStatus >= 400 && providedHttpStatus <= 599
+                    ? providedHttpStatus
+                    : 0;
+                const normalizedStage = stage === 'submit' ? 'submit' : 'init';
+
+                window.AllPlaysTelemetry?.capture('public_rsvp_error', {
+                    label: normalizedStage === 'submit' ? 'Public RSVP submit' : 'Public RSVP init',
+                    stage: normalizedStage,
+                    failureKind,
+                    httpStatus,
+                    online: navigator.onLine !== false
+                }, { flush: true });
+            } catch {
+                // Telemetry is best-effort and must never interrupt the RSVP flow.
+            }
+        }
+
+        function buildPublicRsvpRequestError(message, failureKind, httpStatus = 0) {
+            const error = new Error(message);
+            error.publicRsvpFailureKind = failureKind;
+            error.publicRsvpHttpStatus = httpStatus;
+            return error;
+        }
+
         function getFunctionsBaseUrl() {
             const configured = window.__ALLPLAYS_CONFIG__?.functionsBaseUrl || window.__ALLPLAYS_CONFIG__?.functions?.baseUrl;
             if (configured) return String(configured).replace(/\/$/, '');
             const projectId = auth.app?.options?.projectId;
-            if (!projectId) throw new Error('Firebase project ID is not configured.');
+            if (!projectId) {
+                throw buildPublicRsvpRequestError('Firebase project ID is not configured.', 'configuration_error');
+            }
             return `https://us-central1-${projectId}.cloudfunctions.net`;
         }
 
@@ -101,7 +146,12 @@
             const response = await fetch(`${getFunctionsBaseUrl()}/${path}`, options);
             const payload = await response.json().catch(() => ({}));
             if (!response.ok || payload.ok === false) {
-                throw new Error(payload.error || 'RSVP link unavailable.');
+                const failureKind = response.status === 429
+                    ? 'rate_limited'
+                    : response.status >= 500
+                        ? 'server_error'
+                        : 'request_rejected';
+                throw buildPublicRsvpRequestError(payload.error || 'RSVP link unavailable.', failureKind, response.status);
             }
             return payload;
         }
@@ -116,6 +166,7 @@
 
         async function init() {
             if (!token) {
+                reportPublicRsvpFailure('init', { publicRsvpFailureKind: 'missing_token' });
                 document.getElementById('error-message').textContent = 'Missing RSVP link token.';
                 showState('error');
                 return;
@@ -130,6 +181,7 @@
                 }
                 showState('form');
             } catch (error) {
+                reportPublicRsvpFailure('init', error);
                 document.getElementById('error-message').textContent = error.message || 'The link is invalid, expired, or no longer available.';
                 showState('error');
             }
@@ -150,6 +202,7 @@
                 document.getElementById('success-message').textContent = 'Thanks. Your RSVP was recorded and team summaries were updated.';
                 showState('success');
             } catch (error) {
+                reportPublicRsvpFailure('submit', error);
                 document.getElementById('error-message').textContent = error.message || 'Unable to submit RSVP.';
                 showState('error');
             } finally {

--- a/public-rsvp.html
+++ b/public-rsvp.html
@@ -76,7 +76,7 @@
         const token = params.get('token') || '';
         const requestedResponse = params.get('response') || '';
         const validResponses = new Set(['going', 'maybe', 'not_going']);
-        const publicRsvpTelemetryReady = import('./js/telemetry.js?v=2').catch(() => null);
+        let publicRsvpTelemetryModulePromise = null;
 
         const states = {
             loading: document.getElementById('loading-state'),
@@ -88,6 +88,13 @@
         function showState(name) {
             Object.values(states).forEach((el) => el.classList.add('hidden'));
             states[name].classList.remove('hidden');
+        }
+
+        function loadPublicRsvpTelemetry() {
+            if (!publicRsvpTelemetryModulePromise) {
+                publicRsvpTelemetryModulePromise = import('./js/public-rsvp-telemetry.js?v=1');
+            }
+            return publicRsvpTelemetryModulePromise;
         }
 
         function reportPublicRsvpFailure(stage, error = {}) {
@@ -120,15 +127,9 @@
                     httpStatus,
                     online: navigator.onLine !== false
                 };
-                const captureFailure = () => {
-                    window.AllPlaysTelemetry?.capture('public_rsvp_error', properties, { flush: true });
-                };
-
-                if (window.AllPlaysTelemetry?.capture) {
-                    captureFailure();
-                } else {
-                    void publicRsvpTelemetryReady.then(captureFailure).catch(() => {});
-                }
+                void loadPublicRsvpTelemetry()
+                    .then(({ capturePublicRsvpFailure }) => capturePublicRsvpFailure(properties))
+                    .catch(() => {});
             } catch {
                 // Telemetry is best-effort and must never interrupt the RSVP flow.
             }

--- a/public-rsvp.html
+++ b/public-rsvp.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>RSVP | ALL PLAYS</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <script type="module" src="/js/telemetry.js?v=2"></script>
 </head>
 <body class="min-h-screen bg-gray-50 text-gray-900">
     <main class="max-w-xl mx-auto px-4 py-8">
@@ -77,6 +76,7 @@
         const token = params.get('token') || '';
         const requestedResponse = params.get('response') || '';
         const validResponses = new Set(['going', 'maybe', 'not_going']);
+        const publicRsvpTelemetryReady = import('./js/telemetry.js?v=2').catch(() => null);
 
         const states = {
             loading: document.getElementById('loading-state'),
@@ -113,13 +113,22 @@
                     : 0;
                 const normalizedStage = stage === 'submit' ? 'submit' : 'init';
 
-                window.AllPlaysTelemetry?.capture('public_rsvp_error', {
+                const properties = {
                     label: normalizedStage === 'submit' ? 'Public RSVP submit' : 'Public RSVP init',
                     stage: normalizedStage,
                     failureKind,
                     httpStatus,
                     online: navigator.onLine !== false
-                }, { flush: true });
+                };
+                const captureFailure = () => {
+                    window.AllPlaysTelemetry?.capture('public_rsvp_error', properties, { flush: true });
+                };
+
+                if (window.AllPlaysTelemetry?.capture) {
+                    captureFailure();
+                } else {
+                    void publicRsvpTelemetryReady.then(captureFailure).catch(() => {});
+                }
             } catch {
                 // Telemetry is best-effort and must never interrupt the RSVP flow.
             }

--- a/tests/unit/admin-telemetry-event-store.test.js
+++ b/tests/unit/admin-telemetry-event-store.test.js
@@ -28,6 +28,8 @@ describe('admin telemetry event store dashboard', () => {
             'auth_context',
             'js_error',
             'js_unhandled_rejection',
+            'app_load_error',
+            'public_rsvp_error',
             'interaction_rage_click',
             'app_initial_load',
             'app_ux_timing',

--- a/tests/unit/admin-telemetry-issues.test.js
+++ b/tests/unit/admin-telemetry-issues.test.js
@@ -16,7 +16,9 @@ describe('admin telemetry issue-first view', () => {
         expect(filterValues).toContain('js_error');
         expect(filterValues).toContain('js_unhandled_rejection');
         expect(filterValues).toContain('app_load_error');
+        expect(filterValues).toContain('public_rsvp_error');
         expect(filterValues).toContain('interaction_rage_click');
+        expect(adminHtml).toContain('src="js/admin.js?v=11"');
     });
 
     it('renders issue counts from aggregate telemetry and recent examples from raw events', () => {
@@ -25,6 +27,7 @@ describe('admin telemetry issue-first view', () => {
         expect(adminJs).toContain("{ name: 'js_error', label: 'JS errors' }");
         expect(adminJs).toContain("{ name: 'js_unhandled_rejection', label: 'Unhandled rejections' }");
         expect(adminJs).toContain("{ name: 'app_load_error', label: 'App errors' }");
+        expect(adminJs).toContain("{ name: 'public_rsvp_error', label: 'Public RSVP errors' }");
         expect(adminJs).toContain("{ name: 'interaction_rage_click', label: 'Rage clicks' }");
         expect(adminJs).toContain('function renderTelemetryNeedsAttention()');
         expect(adminJs).toContain('function getTelemetryIssueCounts()');
@@ -32,7 +35,7 @@ describe('admin telemetry issue-first view', () => {
         expect(adminJs).toContain('const totalIssues = Array.from(issueCounts.values()).reduce((sum, count) => sum + count, 0);');
         expect(adminJs).toContain('const issueEvents = telemetryState.events.filter((event) => issueCounts.has(event.name));');
         expect(adminJs).toContain('No tracked errors or rage clicks recorded for this range.');
-        expect(adminJs).toContain('grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-3');
+        expect(adminJs).toContain('grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-5 gap-3');
         expect(adminJs).toContain('renderTelemetryNeedsAttention();');
     });
 });

--- a/tests/unit/admin-telemetry-issues.test.js
+++ b/tests/unit/admin-telemetry-issues.test.js
@@ -15,6 +15,7 @@ describe('admin telemetry issue-first view', () => {
             .map((option) => option.value);
         expect(filterValues).toContain('js_error');
         expect(filterValues).toContain('js_unhandled_rejection');
+        expect(filterValues).toContain('app_load_error');
         expect(filterValues).toContain('interaction_rage_click');
     });
 
@@ -23,13 +24,15 @@ describe('admin telemetry issue-first view', () => {
 
         expect(adminJs).toContain("{ name: 'js_error', label: 'JS errors' }");
         expect(adminJs).toContain("{ name: 'js_unhandled_rejection', label: 'Unhandled rejections' }");
+        expect(adminJs).toContain("{ name: 'app_load_error', label: 'App errors' }");
         expect(adminJs).toContain("{ name: 'interaction_rage_click', label: 'Rage clicks' }");
         expect(adminJs).toContain('function renderTelemetryNeedsAttention()');
         expect(adminJs).toContain('function getTelemetryIssueCounts()');
         expect(adminJs).toContain('telemetryState.eventDaily.forEach((row) => {');
         expect(adminJs).toContain('const totalIssues = Array.from(issueCounts.values()).reduce((sum, count) => sum + count, 0);');
         expect(adminJs).toContain('const issueEvents = telemetryState.events.filter((event) => issueCounts.has(event.name));');
-        expect(adminJs).toContain('No errors or rage clicks recorded for this range.');
+        expect(adminJs).toContain('No tracked errors or rage clicks recorded for this range.');
+        expect(adminJs).toContain('grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-3');
         expect(adminJs).toContain('renderTelemetryNeedsAttention();');
     });
 });

--- a/tests/unit/firebase-rest-app-check-coverage.test.js
+++ b/tests/unit/firebase-rest-app-check-coverage.test.js
@@ -9,6 +9,7 @@ const primaryRestCallers = [
     '../../apps/app/src/lib/profileService.ts',
     '../../apps/app/src/lib/scheduleService.ts',
     '../../apps/app/src/lib/teamDetailService.ts',
+    '../../js/public-rsvp-telemetry.js',
     '../../js/schedule-notifications.js',
     '../../js/team-pass.js',
     '../../js/telemetry.js'
@@ -50,6 +51,7 @@ describe('raw Firebase REST App Check coverage', () => {
             'apps/app/src/lib/profileService.ts',
             'apps/app/src/lib/scheduleService.ts',
             'apps/app/src/lib/teamDetailService.ts',
+            'js/public-rsvp-telemetry.js',
             'js/schedule-notifications.js',
             'js/team-pass.js',
             'js/telemetry.js'

--- a/tests/unit/public-rsvp-page.test.js
+++ b/tests/unit/public-rsvp-page.test.js
@@ -26,4 +26,36 @@ describe('public RSVP page', () => {
         expect(source).toContain('For privacy, this page only shows event details after a valid RSVP link is confirmed.');
         expect(source).toContain('The link is invalid, expired, or no longer available.');
     });
+
+    it('reports init and submit failures through fail-open telemetry without RSVP secrets or PII', () => {
+        const source = readPublicRsvpPage();
+        const reporterStart = source.indexOf('function reportPublicRsvpFailure(stage, error = {})');
+        const reporterEnd = source.indexOf('function buildPublicRsvpRequestError', reporterStart);
+        const reporterSource = source.slice(reporterStart, reporterEnd);
+
+        expect(source).toContain('<script type="module" src="/js/telemetry.js?v=2"></script>');
+        expect(source).not.toContain("import { captureTelemetryEvent }");
+        expect(reporterStart).toBeGreaterThanOrEqual(0);
+        expect(reporterEnd).toBeGreaterThan(reporterStart);
+        expect(reporterSource).toContain("window.AllPlaysTelemetry?.capture('public_rsvp_error'");
+        expect(reporterSource).toContain("const normalizedStage = stage === 'submit' ? 'submit' : 'init'");
+        expect(reporterSource).toContain("label: normalizedStage === 'submit' ? 'Public RSVP submit' : 'Public RSVP init'");
+        expect(reporterSource).toContain('stage: normalizedStage,');
+        expect(reporterSource).toContain('failureKind,');
+        expect(reporterSource).toContain('httpStatus,');
+        expect(reporterSource).toContain('online: navigator.onLine !== false');
+        expect(reporterSource).toContain('} catch {');
+        expect(reporterSource).not.toContain('window.location');
+        expect(reporterSource).not.toContain('URLSearchParams');
+        expect(reporterSource).not.toContain('requestedResponse');
+        expect(reporterSource).not.toContain('error.message');
+        expect(reporterSource).not.toContain('payload');
+        expect(reporterSource).not.toContain('selected');
+        expect(reporterSource).not.toContain('teamName');
+        expect(reporterSource).not.toContain('childName');
+
+        expect(source).toContain("reportPublicRsvpFailure('init', { publicRsvpFailureKind: 'missing_token' });");
+        expect(source).toContain("reportPublicRsvpFailure('init', error);");
+        expect(source).toContain("reportPublicRsvpFailure('submit', error);");
+    });
 });

--- a/tests/unit/public-rsvp-page.test.js
+++ b/tests/unit/public-rsvp-page.test.js
@@ -34,6 +34,7 @@ describe('public RSVP page', () => {
         const reporterSource = source.slice(reporterStart, reporterEnd);
 
         expect(source).toContain('<script type="module" src="/js/telemetry.js?v=2"></script>');
+        expect(source).toContain('<form id="rsvp-form" data-telemetry-ignore');
         expect(source).not.toContain("import { captureTelemetryEvent }");
         expect(reporterStart).toBeGreaterThanOrEqual(0);
         expect(reporterEnd).toBeGreaterThan(reporterStart);

--- a/tests/unit/public-rsvp-page.test.js
+++ b/tests/unit/public-rsvp-page.test.js
@@ -34,13 +34,14 @@ describe('public RSVP page', () => {
         const reporterSource = source.slice(reporterStart, reporterEnd);
 
         expect(source).not.toContain('<script type="module" src="/js/telemetry.js?v=2"></script>');
-        expect(source).toContain("const publicRsvpTelemetryReady = import('./js/telemetry.js?v=2').catch(() => null);");
+        expect(source).not.toContain("import('./js/telemetry.js");
+        expect(source).toContain("publicRsvpTelemetryModulePromise = import('./js/public-rsvp-telemetry.js?v=1');");
         expect(source).toContain('<form id="rsvp-form" data-telemetry-ignore');
         expect(source).not.toContain("import { captureTelemetryEvent }");
         expect(reporterStart).toBeGreaterThanOrEqual(0);
         expect(reporterEnd).toBeGreaterThan(reporterStart);
-        expect(reporterSource).toContain("window.AllPlaysTelemetry?.capture('public_rsvp_error', properties, { flush: true });");
-        expect(reporterSource).toContain('void publicRsvpTelemetryReady.then(captureFailure).catch(() => {});');
+        expect(reporterSource).toContain('.then(({ capturePublicRsvpFailure }) => capturePublicRsvpFailure(properties))');
+        expect(reporterSource).not.toContain('window.AllPlaysTelemetry');
         expect(reporterSource).toContain("const normalizedStage = stage === 'submit' ? 'submit' : 'init'");
         expect(reporterSource).toContain("label: normalizedStage === 'submit' ? 'Public RSVP submit' : 'Public RSVP init'");
         expect(reporterSource).toContain('stage: normalizedStage,');

--- a/tests/unit/public-rsvp-page.test.js
+++ b/tests/unit/public-rsvp-page.test.js
@@ -35,7 +35,7 @@ describe('public RSVP page', () => {
 
         expect(source).not.toContain('<script type="module" src="/js/telemetry.js?v=2"></script>');
         expect(source).not.toContain("import('./js/telemetry.js");
-        expect(source).toContain("publicRsvpTelemetryModulePromise = import('./js/public-rsvp-telemetry.js?v=1');");
+        expect(source).toContain("publicRsvpTelemetryModulePromise = import('./js/public-rsvp-telemetry.js?v=2');");
         expect(source).toContain('<form id="rsvp-form" data-telemetry-ignore');
         expect(source).not.toContain("import { captureTelemetryEvent }");
         expect(reporterStart).toBeGreaterThanOrEqual(0);

--- a/tests/unit/public-rsvp-page.test.js
+++ b/tests/unit/public-rsvp-page.test.js
@@ -33,12 +33,14 @@ describe('public RSVP page', () => {
         const reporterEnd = source.indexOf('function buildPublicRsvpRequestError', reporterStart);
         const reporterSource = source.slice(reporterStart, reporterEnd);
 
-        expect(source).toContain('<script type="module" src="/js/telemetry.js?v=2"></script>');
+        expect(source).not.toContain('<script type="module" src="/js/telemetry.js?v=2"></script>');
+        expect(source).toContain("const publicRsvpTelemetryReady = import('./js/telemetry.js?v=2').catch(() => null);");
         expect(source).toContain('<form id="rsvp-form" data-telemetry-ignore');
         expect(source).not.toContain("import { captureTelemetryEvent }");
         expect(reporterStart).toBeGreaterThanOrEqual(0);
         expect(reporterEnd).toBeGreaterThan(reporterStart);
-        expect(reporterSource).toContain("window.AllPlaysTelemetry?.capture('public_rsvp_error'");
+        expect(reporterSource).toContain("window.AllPlaysTelemetry?.capture('public_rsvp_error', properties, { flush: true });");
+        expect(reporterSource).toContain('void publicRsvpTelemetryReady.then(captureFailure).catch(() => {});');
         expect(reporterSource).toContain("const normalizedStage = stage === 'submit' ? 'submit' : 'init'");
         expect(reporterSource).toContain("label: normalizedStage === 'submit' ? 'Public RSVP submit' : 'Public RSVP init'");
         expect(reporterSource).toContain('stage: normalizedStage,');

--- a/tests/unit/public-rsvp-telemetry.test.js
+++ b/tests/unit/public-rsvp-telemetry.test.js
@@ -3,6 +3,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 
+const appCheckMocks = vi.hoisted(() => ({
+    getPrimaryAppCheckHeaders: vi.fn(async (headers) => ({
+        ...headers,
+        'X-Firebase-AppCheck': 'test-app-check-token'
+    }))
+}));
+
+vi.mock('../../js/firebase-app-check-rest.js?v=1', () => ({
+    getPrimaryAppCheckHeaders: appCheckMocks.getPrimaryAppCheckHeaders
+}));
+
 import {
     capturePublicRsvpFailure,
     isPublicRsvpTelemetryEnabled,
@@ -16,6 +27,7 @@ describe('public RSVP failure telemetry', () => {
     beforeEach(() => {
         mockFetch.mockReset();
         mockFetch.mockResolvedValue({ ok: true });
+        appCheckMocks.getPrimaryAppCheckHeaders.mockClear();
         window.fetch = mockFetch;
         window.__ALLPLAYS_CONFIG__ = {
             telemetryEndpoint: 'https://telemetry.example.test/collect'
@@ -89,9 +101,16 @@ describe('public RSVP failure telemetry', () => {
         expect(url).toBe('https://telemetry.example.test/collect');
         expect(options).toMatchObject({
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Firebase-AppCheck': 'test-app-check-token'
+            },
             keepalive: true
         });
+        expect(appCheckMocks.getPrimaryAppCheckHeaders).toHaveBeenCalledWith(
+            { 'Content-Type': 'application/json' },
+            'https://telemetry.example.test/collect'
+        );
         expect(options.headers.Authorization).toBeUndefined();
         expect(payload.authToken).toBeUndefined();
         expect(event).toMatchObject({

--- a/tests/unit/public-rsvp-telemetry.test.js
+++ b/tests/unit/public-rsvp-telemetry.test.js
@@ -5,6 +5,7 @@ import { readFileSync } from 'node:fs';
 
 import {
     capturePublicRsvpFailure,
+    isPublicRsvpTelemetryEnabled,
     normalizePublicRsvpFailure
 } from '../../js/public-rsvp-telemetry.js';
 
@@ -19,6 +20,7 @@ describe('public RSVP failure telemetry', () => {
         window.__ALLPLAYS_CONFIG__ = {
             telemetryEndpoint: 'https://telemetry.example.test/collect'
         };
+        delete window.ALLPLAYS_TELEMETRY_ENABLED;
     });
 
     it('normalizes to the fixed failure property allowlist', () => {
@@ -40,15 +42,31 @@ describe('public RSVP failure telemetry', () => {
 
     it('has no automatic page collection, persistent identity, or auth path', () => {
         expect(reporterSource).not.toContain('addEventListener');
-        expect(reporterSource).not.toContain('localStorage');
         expect(reporterSource).not.toContain('sessionStorage');
+        expect(reporterSource).not.toContain('allplays.telemetry.session');
+        expect(reporterSource).not.toContain('allplays.telemetry.visitor');
         expect(reporterSource).not.toContain('Authorization');
-        expect(reporterSource).not.toContain('window.location');
         expect(reporterSource).not.toContain('document.');
         expect(reporterSource).not.toContain('navigator.');
         expect(reporterSource).not.toContain('userAgent');
         expect(reporterSource).not.toContain('referrer');
         expect(reporterSource).not.toContain('queryKeys');
+    });
+
+    it('honors the production telemetry gate without loading the full collector', async () => {
+        expect(isPublicRsvpTelemetryEnabled({ hostname: 'allplays.ai' })).toBe(true);
+        expect(isPublicRsvpTelemetryEnabled({ hostname: 'localhost' })).toBe(false);
+        expect(isPublicRsvpTelemetryEnabled({ hostname: '127.0.0.1' })).toBe(false);
+        expect(isPublicRsvpTelemetryEnabled({ hostname: 'localhost', config: { telemetryEnabled: true } })).toBe(true);
+        expect(isPublicRsvpTelemetryEnabled({ hostname: 'allplays.ai', config: { telemetryEnabled: false } })).toBe(false);
+        expect(isPublicRsvpTelemetryEnabled({ hostname: 'allplays.ai', globalEnabled: false })).toBe(false);
+        expect(isPublicRsvpTelemetryEnabled({ hostname: 'allplays.ai', optedOut: true })).toBe(false);
+        expect(isPublicRsvpTelemetryEnabled({ hostname: 'allplays.ai', search: '?telemetry=0' })).toBe(false);
+        expect(isPublicRsvpTelemetryEnabled({ hostname: 'localhost', search: '?telemetry=1' })).toBe(true);
+
+        window.__ALLPLAYS_CONFIG__.telemetryEnabled = false;
+        await expect(capturePublicRsvpFailure({ failureKind: 'missing_token' })).resolves.toBe(false);
+        expect(mockFetch).not.toHaveBeenCalled();
     });
 
     it('sends one anonymous failure event without URL secrets, answers, storage IDs, or auth', async () => {

--- a/tests/unit/public-rsvp-telemetry.test.js
+++ b/tests/unit/public-rsvp-telemetry.test.js
@@ -1,0 +1,124 @@
+/** @vitest-environment jsdom */
+/** @vitest-environment-options {"url":"https://allplays.ai/public-rsvp.html?token=private-token&response=not_going"} */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+import {
+    capturePublicRsvpFailure,
+    normalizePublicRsvpFailure
+} from '../../js/public-rsvp-telemetry.js';
+
+const mockFetch = vi.fn();
+const reporterSource = readFileSync('js/public-rsvp-telemetry.js', 'utf8');
+
+describe('public RSVP failure telemetry', () => {
+    beforeEach(() => {
+        mockFetch.mockReset();
+        mockFetch.mockResolvedValue({ ok: true });
+        window.fetch = mockFetch;
+        window.__ALLPLAYS_CONFIG__ = {
+            telemetryEndpoint: 'https://telemetry.example.test/collect'
+        };
+    });
+
+    it('normalizes to the fixed failure property allowlist', () => {
+        expect(normalizePublicRsvpFailure({
+            stage: 'other',
+            failureKind: 'private-token',
+            httpStatus: 200,
+            online: false,
+            childName: 'Private Child',
+            response: 'not_going'
+        })).toEqual({
+            label: 'Public RSVP init',
+            stage: 'init',
+            failureKind: 'unexpected_error',
+            httpStatus: 0,
+            online: false
+        });
+    });
+
+    it('has no automatic page collection, persistent identity, or auth path', () => {
+        expect(reporterSource).not.toContain('addEventListener');
+        expect(reporterSource).not.toContain('localStorage');
+        expect(reporterSource).not.toContain('sessionStorage');
+        expect(reporterSource).not.toContain('Authorization');
+        expect(reporterSource).not.toContain('window.location');
+        expect(reporterSource).not.toContain('document.');
+        expect(reporterSource).not.toContain('navigator.');
+        expect(reporterSource).not.toContain('userAgent');
+        expect(reporterSource).not.toContain('referrer');
+        expect(reporterSource).not.toContain('queryKeys');
+    });
+
+    it('sends one anonymous failure event without URL secrets, answers, storage IDs, or auth', async () => {
+        await capturePublicRsvpFailure({
+            stage: 'submit',
+            failureKind: 'request_rejected',
+            httpStatus: 403,
+            online: true,
+            token: 'private-token',
+            childName: 'Private Child',
+            response: 'not_going',
+            error: 'private server response'
+        });
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        const [url, options] = mockFetch.mock.calls[0];
+        const payload = JSON.parse(options.body);
+        const event = payload.events[0];
+
+        expect(url).toBe('https://telemetry.example.test/collect');
+        expect(options).toMatchObject({
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            keepalive: true
+        });
+        expect(options.headers.Authorization).toBeUndefined();
+        expect(payload.authToken).toBeUndefined();
+        expect(event).toMatchObject({
+            name: 'public_rsvp_error',
+            signedIn: false,
+            pagePath: '/public-rsvp.html',
+            appRoute: '/public-rsvp.html',
+            properties: {
+                label: 'Public RSVP submit',
+                stage: 'submit',
+                failureKind: 'request_rejected',
+                httpStatus: 403,
+                online: true
+            }
+        });
+        expect(Object.keys(event).sort()).toEqual([
+            'appRoute',
+            'clientTimestamp',
+            'id',
+            'name',
+            'pagePath',
+            'properties',
+            'sessionId',
+            'signedIn',
+            'version',
+            'visitorId'
+        ]);
+        expect(event.sessionId).toBe(event.visitorId);
+        expect(JSON.stringify(payload)).not.toContain('private-token');
+        expect(JSON.stringify(payload)).not.toContain('Private Child');
+        expect(JSON.stringify(payload)).not.toContain('not_going');
+        expect(JSON.stringify(payload)).not.toContain('private server response');
+        expect(JSON.stringify(payload)).not.toContain('userAgent');
+        expect(JSON.stringify(payload)).not.toContain('referrer');
+        expect(JSON.stringify(payload)).not.toContain('queryKeys');
+    });
+
+    it('fails open when telemetry delivery is unavailable', async () => {
+        mockFetch.mockRejectedValue(new Error('offline'));
+
+        await expect(capturePublicRsvpFailure({
+            stage: 'init',
+            failureKind: 'network_error',
+            httpStatus: 0,
+            online: false
+        })).resolves.toBe(false);
+    });
+});

--- a/tests/unit/rsvp-precedence-cache-bust.test.js
+++ b/tests/unit/rsvp-precedence-cache-bust.test.js
@@ -53,7 +53,7 @@ describe('RSVP precedence cache delivery', () => {
 
     it('propagates fresh keys through cached wrapper and shared utility entry modules', () => {
         const consumerVersions = {
-            'admin.html': 'js/admin.js?v=10',
+            'admin.html': 'js/admin.js?v=11',
             'certificates.html': 'js/certificates/studio.js?v=15',
             'live-game.html': 'js/live-game.js?v=19',
             'live-tracker.html': 'js/live-tracker.js?v=2',

--- a/tests/unit/telemetry-cors-origins.test.js
+++ b/tests/unit/telemetry-cors-origins.test.js
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+
+const require = createRequire(import.meta.url);
+const functionsSource = readFileSync(resolve(process.cwd(), 'functions/index.js'), 'utf8');
+const { isAllowedTelemetryOrigin } = require(resolve(process.cwd(), 'functions/telemetry-cors-core.cjs'));
+
+function extractTelemetryCorsWrapper(functionsFileSource) {
+    const start = functionsFileSource.indexOf('function writeTelemetryCorsHeaders(req, res)');
+    expect(start, 'Expected writeTelemetryCorsHeaders to exist in functions/index.js').toBeGreaterThanOrEqual(0);
+
+    const end = functionsFileSource.indexOf('\nfunction normalizeTelemetryString', start);
+    expect(end, 'Expected telemetry CORS wrapper to end before telemetry normalization').toBeGreaterThan(start);
+    return functionsFileSource.slice(start, end);
+}
+
+describe('telemetry CORS origins', () => {
+    it('uses the dedicated telemetry origin gate for headers and rejection', () => {
+        const wrapper = extractTelemetryCorsWrapper(functionsSource);
+
+        expect(functionsSource).toContain("require('./telemetry-cors-core.cjs')");
+        expect(wrapper).toContain('isAllowedTelemetryOrigin(origin, allowedOriginSet)');
+        expect(wrapper).not.toContain("Access-Control-Allow-Origin', '*'");
+        expect(functionsSource).toContain('if (!isAllowedTelemetryOrigin(req.headers.origin, allowedOriginSet))');
+    });
+
+    it('allows production, Firebase Hosting, preview, and configured origins', () => {
+        expect(isAllowedTelemetryOrigin('https://allplays.ai')).toBe(true);
+        expect(isAllowedTelemetryOrigin('https://game-flow-c6311.web.app')).toBe(true);
+        expect(isAllowedTelemetryOrigin('https://game-flow-c6311.firebaseapp.com')).toBe(true);
+        expect(isAllowedTelemetryOrigin('https://game-flow-c6311--pr-4029-5585dlsc.web.app')).toBe(true);
+        expect(isAllowedTelemetryOrigin(
+            'https://telemetry-client.example.test',
+            new Set(['https://telemetry-client.example.test'])
+        )).toBe(true);
+    });
+
+    it('rejects missing, insecure, and lookalike origins', () => {
+        expect(isAllowedTelemetryOrigin('')).toBe(false);
+        expect(isAllowedTelemetryOrigin('http://allplays.ai')).toBe(false);
+        expect(isAllowedTelemetryOrigin('https://evil.example')).toBe(false);
+        expect(isAllowedTelemetryOrigin('https://game-flow-c6311--x.web.app.evil.com')).toBe(false);
+    });
+});

--- a/tests/unit/telemetry-workflow-db-storage.test.js
+++ b/tests/unit/telemetry-workflow-db-storage.test.js
@@ -217,4 +217,37 @@ describe('telemetry workflow DB storage', () => {
             })
         ]));
     });
+
+    it('counts public RSVP failures in daily, page, route, and session error aggregates', async () => {
+        const harness = createFirestoreHarness();
+        const { normalizeTelemetryEvent, commitTelemetryEvents } = loadTelemetryCollectorHelpers()(harness.admin);
+        const receivedAt = new Date('2030-06-01T12:00:00.000Z');
+        const event = normalizeTelemetryEvent({
+            id: 'public-rsvp-error-1',
+            name: 'public_rsvp_error',
+            version: '1.0.0',
+            sessionId: 'session-public-rsvp-error',
+            visitorId: 'visitor-public-rsvp-error',
+            signedIn: false,
+            clientTimestamp: '2030-06-01T11:59:59.000Z',
+            pagePath: '/public-rsvp.html',
+            appRoute: '/public-rsvp.html',
+            properties: { failureKind: 'request_rejected' }
+        }, receivedAt);
+
+        await expect(commitTelemetryEvents(harness.db, [event], '2030-06-01')).resolves.toEqual({
+            stored: 1,
+            duplicates: 0
+        });
+
+        const errorAggregateCollections = new Set([
+            'telemetryDaily',
+            'telemetryPagesDaily',
+            'telemetryRoutesDaily',
+            'telemetrySessions'
+        ]);
+        const errorAggregateWrites = harness.sets.filter((write) => errorAggregateCollections.has(write.ref.collectionName));
+        expect(errorAggregateWrites).toHaveLength(4);
+        expect(errorAggregateWrites.every((write) => write.data.errors?.increment === 1)).toBe(true);
+    });
 });

--- a/tests/unit/telemetry-workflow-db-storage.test.js
+++ b/tests/unit/telemetry-workflow-db-storage.test.js
@@ -218,25 +218,25 @@ describe('telemetry workflow DB storage', () => {
         ]));
     });
 
-    it('counts public RSVP failures in daily, page, route, and session error aggregates', async () => {
+    it('counts app-load and public RSVP failures in daily, page, route, and session error aggregates', async () => {
         const harness = createFirestoreHarness();
         const { normalizeTelemetryEvent, commitTelemetryEvents } = loadTelemetryCollectorHelpers()(harness.admin);
         const receivedAt = new Date('2030-06-01T12:00:00.000Z');
-        const event = normalizeTelemetryEvent({
-            id: 'public-rsvp-error-1',
-            name: 'public_rsvp_error',
+        const events = ['app_load_error', 'public_rsvp_error'].map((name, index) => normalizeTelemetryEvent({
+            id: `${name}-${index}`,
+            name,
             version: '1.0.0',
-            sessionId: 'session-public-rsvp-error',
-            visitorId: 'visitor-public-rsvp-error',
+            sessionId: `session-error-${index}`,
+            visitorId: `visitor-error-${index}`,
             signedIn: false,
             clientTimestamp: '2030-06-01T11:59:59.000Z',
-            pagePath: '/public-rsvp.html',
-            appRoute: '/public-rsvp.html',
+            pagePath: name === 'public_rsvp_error' ? '/public-rsvp.html' : '/',
+            appRoute: name === 'public_rsvp_error' ? '/public-rsvp.html' : '/home',
             properties: { failureKind: 'request_rejected' }
-        }, receivedAt);
+        }, receivedAt));
 
-        await expect(commitTelemetryEvents(harness.db, [event], '2030-06-01')).resolves.toEqual({
-            stored: 1,
+        await expect(commitTelemetryEvents(harness.db, events, '2030-06-01')).resolves.toEqual({
+            stored: 2,
             duplicates: 0
         });
 
@@ -247,7 +247,7 @@ describe('telemetry workflow DB storage', () => {
             'telemetrySessions'
         ]);
         const errorAggregateWrites = harness.sets.filter((write) => errorAggregateCollections.has(write.ref.collectionName));
-        expect(errorAggregateWrites).toHaveLength(4);
+        expect(errorAggregateWrites).toHaveLength(8);
         expect(errorAggregateWrites.every((write) => write.data.errors?.increment === 1)).toBe(true);
     });
 });

--- a/tests/unit/telemetry.test.js
+++ b/tests/unit/telemetry.test.js
@@ -250,4 +250,54 @@ describe('telemetry.js payload handling', () => {
             properties: { property: 'value' }
         });
     });
+
+    it('excludes RSVP answers from generic interactions while preserving explicit failure telemetry', async () => {
+        document.body.innerHTML = `
+            <form id="rsvp-form" data-telemetry-ignore>
+                <label>
+                    <input type="radio" name="response" value="not_going">
+                    <span>Can't Go</span>
+                </label>
+                <button type="submit">Submit RSVP</button>
+            </form>
+        `;
+        const form = document.getElementById('rsvp-form');
+        const radio = form.querySelector('input[name="response"]');
+        radio.checked = true;
+
+        radio.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        radio.dispatchEvent(new Event('change', { bubbles: true }));
+        form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+        window.AllPlaysTelemetry.capture('public_rsvp_error', {
+            label: 'Public RSVP submit',
+            stage: 'submit',
+            failureKind: 'request_rejected',
+            httpStatus: 400,
+            online: true
+        });
+
+        await telemetryModule.flush();
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        const [, options] = mockFetch.mock.calls[0];
+        const payload = JSON.parse(options.body);
+        expect(payload.events).toHaveLength(1);
+        expect(payload.events[0]).toMatchObject({
+            name: 'public_rsvp_error',
+            properties: {
+                label: 'Public RSVP submit',
+                stage: 'submit',
+                failureKind: 'request_rejected',
+                httpStatus: 400,
+                online: true
+            }
+        });
+        expect(payload.events.map((event) => event.name)).not.toEqual(expect.arrayContaining([
+            'interaction_click',
+            'interaction_change',
+            'interaction_submit'
+        ]));
+        expect(JSON.stringify(payload)).not.toContain("Can't Go");
+        expect(JSON.stringify(payload)).not.toContain('not_going');
+    });
 });


### PR DESCRIPTION
## Summary

- report public RSVP initialization and submission failures through the existing production custom telemetry pipeline
- expose `app_load_error` in the admin issue-first telemetry view and event filter
- add a direct `public_rsvp_error` filter while keeping expected invalid/expired-link traffic out of issue-first counts
- add regression coverage for the telemetry contract and admin visibility

## Privacy and behavior contract

Public RSVP telemetry is best-effort and fail-open: telemetry loading or capture failures cannot interrupt the RSVP flow. The event payload is strictly allowlisted to:

- static label
- normalized stage (`init` or `submit`)
- categorized failure kind
- bounded HTTP status (400–599, otherwise 0)
- browser online status

It does **not** include the RSVP token or query value, selected RSVP response, raw error message, response payload, URL, team or child information, or other PII. Existing user-facing messages and RSVP behavior are unchanged. This uses the existing production custom telemetry endpoint and adds no Sentry or DSN dependency.

## Validation

- Focused regression suite: 5 files passed, 25 tests passed
- Full unit suite: 627 files passed, 3 skipped; 4,296 tests passed, 58 skipped
- `git diff --check` passed
