### PR TITLE
Add verified Firestore recovery controls

### DIFF
--- a/.github/workflows/firestore-recovery-health.yml
+++ b/.github/workflows/firestore-recovery-health.yml
@@ -1,0 +1,39 @@
+name: firestore-recovery-health
+
+on:
+  schedule:
+    - cron: '17 15 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-recovery:
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Configure Firebase service account
+        run: |
+          credentials_file="$RUNNER_TEMP/firebase-service-account.json"
+          printf '%s' '${{ secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311 }}' > "$credentials_file"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$credentials_file" >> "$GITHUB_ENV"
+
+      - name: Setup Google Cloud CLI
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Verify PITR, delete protection, and managed backups
+        run: npm run ops:verify-firestore-recovery

--- a/.github/workflows/firestore-recovery-health.yml
+++ b/.github/workflows/firestore-recovery-health.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
         with:
-          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311 }}
+          credentials_json: ${{ secrets.FIRESTORE_RECOVERY_READ_ONLY_SERVICE_ACCOUNT_GAME_FLOW_C6311 }}
           create_credentials_file: true
           cleanup_credentials: true
 

--- a/.github/workflows/firestore-recovery-health.yml
+++ b/.github/workflows/firestore-recovery-health.yml
@@ -26,14 +26,17 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Configure Firebase service account
-        run: |
-          credentials_file="$RUNNER_TEMP/firebase-service-account.json"
-          printf '%s' '${{ secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311 }}' > "$credentials_file"
-          echo "GOOGLE_APPLICATION_CREDENTIALS=$credentials_file" >> "$GITHUB_ENV"
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311 }}
+          create_credentials_file: true
+          cleanup_credentials: true
 
       - name: Setup Google Cloud CLI
         uses: google-github-actions/setup-gcloud@v3
 
       - name: Verify PITR, delete protection, and managed backups
+        env:
+          FIREBASE_PROJECT_ID: game-flow-c6311
         run: npm run ops:verify-firestore-recovery

--- a/.github/workflows/firestore-recovery-health.yml
+++ b/.github/workflows/firestore-recovery-health.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
         with:
-          credentials_json: ${{ secrets.FIRESTORE_RECOVERY_READ_ONLY_SERVICE_ACCOUNT_GAME_FLOW_C6311 }}
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311 }}
           create_credentials_file: true
           cleanup_credentials: true
 

--- a/docs/firestore-recovery-runbook.md
+++ b/docs/firestore-recovery-runbook.md
@@ -1,0 +1,111 @@
+# Firestore recovery runbook
+
+The production `game-flow-c6311/(default)` database has three independent
+recovery controls:
+
+- seven-day point-in-time recovery (PITR);
+- database delete protection;
+- a daily managed backup retained for 14 days.
+
+The scheduled `firestore-recovery-health` workflow checks those settings every
+day and fails if the newest ready backup is more than 36 hours old. A newly
+created schedule gets one 36-hour grace window to produce its first backup.
+
+## Verify the recovery posture
+
+Authenticate `gcloud` as a principal with Firestore backup-viewer access, then
+run:
+
+```bash
+npm run ops:verify-firestore-recovery
+```
+
+The command prints only recovery metadata. It does not read application
+documents or mutate the database.
+
+## Point-in-time recovery drill
+
+Never restore over `(default)`. A drill creates a separate, temporary database
+from a whole-minute PITR timestamp:
+
+```bash
+gcloud firestore databases clone \
+  --project=game-flow-c6311 \
+  --source-database='projects/game-flow-c6311/databases/(default)' \
+  --snapshot-time='YYYY-MM-DDTHH:MM:00Z' \
+  --destination-database='restore-drill-YYYYMMDD'
+```
+
+Wait until `sourceInfo.progress` is `COMPLETED`, then compare collection and
+document counts for representative top-level and nested collections. Validate
+at minimum `users`, `teams`, `accessCodes`, and a team subcollection. Record the
+snapshot time, operation name, counts, and result before deleting the isolated
+drill database.
+
+Delete only the exact drill database after validation:
+
+```bash
+gcloud firestore databases delete \
+  --project=game-flow-c6311 \
+  --database='restore-drill-YYYYMMDD' \
+  --quiet
+```
+
+## Managed-backup restore drill
+
+After the first scheduled backup reaches `READY`, exercise the independent
+managed-backup path at least quarterly:
+
+```bash
+gcloud firestore backups list --project=game-flow-c6311
+gcloud firestore databases restore \
+  --project=game-flow-c6311 \
+  --source-backup='projects/game-flow-c6311/locations/nam5/backups/BACKUP_ID' \
+  --destination-database='backup-drill-YYYYMMDD'
+```
+
+Validate the same representative counts, record the evidence, and delete only
+the temporary restored database. A managed backup restore always creates a new
+database; production traffic remains on `(default)` throughout the drill.
+
+## Recovery drill evidence
+
+### 2026-07-18 PITR clone drill
+
+- Source: `projects/game-flow-c6311/databases/(default)`
+- Snapshot: `2026-07-18T02:40:00Z`
+- Temporary destination: `restore-drill-20260718a`
+- Clone operation:
+  `projects/game-flow-c6311/databases/restore-drill-20260718a/operations/-HVvaGoOJpVFQ07xUd7VExAqNW1hbgQiDBAaGg`
+- Clone completed: `2026-07-18T03:17:05.747809Z`
+- Validation result: all sampled source and clone counts matched.
+
+| Collection path | Source | Clone |
+| --- | ---: | ---: |
+| `users` | 40 | 40 |
+| `teams` | 50 | 50 |
+| `accessCodes` | 88 | 88 |
+| `teams/0JSOplS6f99GIYNS8Sk7/games` | 1 | 1 |
+| `teams/0JSOplS6f99GIYNS8Sk7/statTrackerConfigs` | 2 | 2 |
+
+The isolated clone was deleted at `2026-07-18T03:22:45.217550Z` by operation
+`projects/game-flow-c6311/databases/restore-drill-20260718a/operations/Z96ZsBAG0uvlsQgLGgcQAoe96qAQBtLr0IkIDAodGg`.
+After cleanup, the temporary database returned `NOT_FOUND`; the source still
+reported PITR and delete protection enabled. No production traffic was moved
+and the source database was not changed by the drill.
+
+The managed-backup schedule was still within its documented initial 36-hour
+window when this PITR drill ran. Run the independent managed-backup restore
+drill after the first scheduled backup reaches `READY`.
+
+## Incident recovery
+
+1. Stop the writer that caused corruption before restoring anything.
+2. Record the incident window and choose a PITR minute immediately before it.
+3. Clone or restore into a new database and validate data there.
+4. Do not redirect production clients until owners approve the validated data
+   and a rollback plan exists.
+5. Preserve the affected source database until the incident is closed.
+
+PITR and backups incur Google Cloud storage/restore charges. Do not disable them
+to address a transient billing alert; investigate usage and retention first.

--- a/docs/firestore-recovery-runbook.md
+++ b/docs/firestore-recovery-runbook.md
@@ -51,8 +51,19 @@ gcloud firestore databases clone \
   --destination-database='restore-drill-YYYYMMDD'
 ```
 
-Wait until `sourceInfo.progress` is `COMPLETED`, then compare collection and
-document counts for representative top-level and nested collections. Validate
+Use the operation name returned by the clone command to monitor the clone:
+
+```bash
+gcloud firestore operations describe 'OPERATION_NAME' \
+  --project="$ALLPLAYS_FIRESTORE_PROJECT_ID" \
+  --format='yaml(done,error,metadata.operationState,metadata.progressPercentage)'
+```
+
+Wait until `done` is true and `metadata.operationState` is `SUCCESSFUL`, then
+compare collection and document counts for representative top-level and nested
+collections. Use `metadata.progressPercentage` only to monitor an operation
+still in progress. If the operation reports an error or a failed or cancelled
+state, stop the drill and investigate instead of validating the clone. Validate
 at minimum `users`, `teams`, `accessCodes`, and a team subcollection. Record the
 snapshot time, operation name, counts, and result before deleting the isolated
 drill database.

--- a/docs/firestore-recovery-runbook.md
+++ b/docs/firestore-recovery-runbook.md
@@ -17,7 +17,8 @@ Authenticate `gcloud` as a principal with Firestore backup-viewer access, then
 run:
 
 ```bash
-npm run ops:verify-firestore-recovery
+export ALLPLAYS_FIRESTORE_PROJECT_ID='YOUR_PROJECT_ID'
+npm run ops:verify-firestore-recovery -- --project="$ALLPLAYS_FIRESTORE_PROJECT_ID"
 ```
 
 The command prints only recovery metadata. It does not read application
@@ -29,9 +30,10 @@ Never restore over `(default)`. A drill creates a separate, temporary database
 from a whole-minute PITR timestamp:
 
 ```bash
+export ALLPLAYS_FIRESTORE_PROJECT_ID='YOUR_PROJECT_ID'
 gcloud firestore databases clone \
-  --project=game-flow-c6311 \
-  --source-database='projects/game-flow-c6311/databases/(default)' \
+  --project="$ALLPLAYS_FIRESTORE_PROJECT_ID" \
+  --source-database="projects/$ALLPLAYS_FIRESTORE_PROJECT_ID/databases/(default)" \
   --snapshot-time='YYYY-MM-DDTHH:MM:00Z' \
   --destination-database='restore-drill-YYYYMMDD'
 ```
@@ -46,7 +48,7 @@ Delete only the exact drill database after validation:
 
 ```bash
 gcloud firestore databases delete \
-  --project=game-flow-c6311 \
+  --project="$ALLPLAYS_FIRESTORE_PROJECT_ID" \
   --database='restore-drill-YYYYMMDD' \
   --quiet
 ```
@@ -57,10 +59,10 @@ After the first scheduled backup reaches `READY`, exercise the independent
 managed-backup path at least quarterly:
 
 ```bash
-gcloud firestore backups list --project=game-flow-c6311
+gcloud firestore backups list --project="$ALLPLAYS_FIRESTORE_PROJECT_ID"
 gcloud firestore databases restore \
-  --project=game-flow-c6311 \
-  --source-backup='projects/game-flow-c6311/locations/nam5/backups/BACKUP_ID' \
+  --project="$ALLPLAYS_FIRESTORE_PROJECT_ID" \
+  --source-backup="projects/$ALLPLAYS_FIRESTORE_PROJECT_ID/locations/nam5/backups/BACKUP_ID" \
   --destination-database='backup-drill-YYYYMMDD'
 ```
 

--- a/docs/firestore-recovery-runbook.md
+++ b/docs/firestore-recovery-runbook.md
@@ -13,8 +13,21 @@ created schedule gets one 36-hour grace window to produce its first backup.
 
 ## Verify the recovery posture
 
-Authenticate `gcloud` as a principal with Firestore backup-viewer access, then
-run:
+Authenticate `gcloud` as a principal with a project-level custom role containing
+exactly these read-only Firestore permissions:
+
+- `datastore.databases.getMetadata` for the database posture;
+- `datastore.backupSchedules.list` for the managed-backup schedule; and
+- `datastore.backups.list` for backup lineage and freshness.
+
+No single read-only Firestore predefined role contains all three permissions.
+If a custom role is unavailable, grant the principal all of
+`roles/datastore.viewer`, `roles/datastore.backupSchedulesViewer`, and
+`roles/datastore.backupsViewer`. That predefined-role combination is broader
+than the custom role because `roles/datastore.viewer` can also read application
+documents.
+
+Then run:
 
 ```bash
 export ALLPLAYS_FIRESTORE_PROJECT_ID='YOUR_PROJECT_ID'

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:smoke:visual:update": "playwright test --config=playwright.smoke.config.js --grep @visual --update-snapshots",
     "test:smoke:team-fallback": "playwright test tests/smoke/team-fallback-regressions.spec.js --config=playwright.smoke.config.js --reporter=line",
     "ci:firebase-rules": "node scripts/validate-firebase-rules-ci.mjs",
+    "ops:verify-firestore-recovery": "node scripts/verify-firestore-recovery.mjs",
     "stage:pages": "node scripts/stage-pages-bundle.mjs",
     "app:build-help-index": "node scripts/build-app-help-knowledge-index.mjs",
     "app:check-bundle-size": "node scripts/check-app-bundle-size.mjs",

--- a/scripts/verify-firestore-recovery.mjs
+++ b/scripts/verify-firestore-recovery.mjs
@@ -72,7 +72,11 @@ export function evaluateFirestoreRecoveryPosture({
 
 function readFlag(argv, name, fallback) {
     const index = argv.indexOf(name);
-    return index >= 0 ? String(argv[index + 1] || '').trim() : fallback;
+    if (index >= 0) return String(argv[index + 1] || '').trim();
+
+    const prefix = `${name}=`;
+    const assignment = argv.find((argument) => String(argument).startsWith(prefix));
+    return assignment == null ? fallback : String(assignment).slice(prefix.length).trim();
 }
 
 function runGcloudJson(args) {

--- a/scripts/verify-firestore-recovery.mjs
+++ b/scripts/verify-firestore-recovery.mjs
@@ -50,7 +50,7 @@ export function evaluateFirestoreRecoveryPosture({
         .filter((backup) => (
             currentDatabaseUid
             && String(backup?.databaseUid || '').trim() === currentDatabaseUid
-            && (!backup?.state || backup.state === 'READY')
+            && backup?.state === 'READY'
         ))
         .sort((left, right) => timestampMillis(right.snapshotTime || right.createTime) - timestampMillis(left.snapshotTime || left.createTime));
     const newestBackup = readyBackups[0] || null;

--- a/scripts/verify-firestore-recovery.mjs
+++ b/scripts/verify-firestore-recovery.mjs
@@ -34,6 +34,11 @@ export function evaluateFirestoreRecoveryPosture({
         failures.push('Database delete protection is not enabled.');
     }
 
+    const currentDatabaseUid = String(database?.uid || '').trim();
+    if (!currentDatabaseUid) {
+        failures.push('The current database UID is unavailable, so backup lineage cannot be verified.');
+    }
+
     const dailySchedule = schedules.find((schedule) => schedule?.dailyRecurrence != null);
     if (!dailySchedule) {
         failures.push('No daily managed-backup schedule exists.');
@@ -42,7 +47,11 @@ export function evaluateFirestoreRecoveryPosture({
     }
 
     const readyBackups = backups
-        .filter((backup) => !backup?.state || backup.state === 'READY')
+        .filter((backup) => (
+            currentDatabaseUid
+            && String(backup?.databaseUid || '').trim() === currentDatabaseUid
+            && (!backup?.state || backup.state === 'READY')
+        ))
         .sort((left, right) => timestampMillis(right.snapshotTime || right.createTime) - timestampMillis(left.snapshotTime || left.createTime));
     const newestBackup = readyBackups[0] || null;
 

--- a/scripts/verify-firestore-recovery.mjs
+++ b/scripts/verify-firestore-recovery.mjs
@@ -3,7 +3,6 @@
 import { execFileSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 
-const DEFAULT_PROJECT_ID = 'game-flow-c6311';
 const DEFAULT_DATABASE_ID = '(default)';
 const DEFAULT_MAX_BACKUP_AGE_HOURS = 36;
 const MINIMUM_DAILY_RETENTION_SECONDS = 14 * 24 * 60 * 60;
@@ -77,21 +76,39 @@ function readFlag(argv, name, fallback) {
 }
 
 function runGcloudJson(args) {
-    const output = execFileSync('gcloud', args, {
-        encoding: 'utf8',
-        stdio: ['ignore', 'pipe', 'inherit']
-    });
-    return JSON.parse(output || 'null');
+    try {
+        const output = execFileSync('gcloud', args, {
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'inherit']
+        });
+        return JSON.parse(output || 'null');
+    } catch (error) {
+        const command = args.filter((arg) => !String(arg).startsWith('--format=')).slice(0, 4).join(' ');
+        throw new Error(
+            `gcloud ${command} failed. Verify Cloud SDK installation, authentication, project access, and Firestore permissions.`,
+            { cause: error }
+        );
+    }
+}
+
+export function parseFirestoreRecoveryArgs(argv = process.argv.slice(2), environment = process.env) {
+    const projectId = readFlag(argv, '--project', environment.FIREBASE_PROJECT_ID || '');
+    if (!projectId) {
+        throw new Error('Set FIREBASE_PROJECT_ID or pass --project before checking Firestore recovery.');
+    }
+    return {
+        projectId,
+        databaseId: readFlag(argv, '--database', environment.FIRESTORE_DATABASE_ID || DEFAULT_DATABASE_ID),
+        maxBackupAgeHours: Number(readFlag(
+            argv,
+            '--max-backup-age-hours',
+            environment.FIRESTORE_MAX_BACKUP_AGE_HOURS || String(DEFAULT_MAX_BACKUP_AGE_HOURS)
+        ))
+    };
 }
 
 export function verifyFirestoreRecovery(argv = process.argv.slice(2)) {
-    const projectId = readFlag(argv, '--project', process.env.FIREBASE_PROJECT_ID || DEFAULT_PROJECT_ID);
-    const databaseId = readFlag(argv, '--database', process.env.FIRESTORE_DATABASE_ID || DEFAULT_DATABASE_ID);
-    const maxBackupAgeHours = Number(readFlag(
-        argv,
-        '--max-backup-age-hours',
-        process.env.FIRESTORE_MAX_BACKUP_AGE_HOURS || String(DEFAULT_MAX_BACKUP_AGE_HOURS)
-    ));
+    const { projectId, databaseId, maxBackupAgeHours } = parseFirestoreRecoveryArgs(argv);
 
     const database = runGcloudJson([
         'firestore', 'databases', 'describe',
@@ -133,5 +150,10 @@ export function verifyFirestoreRecovery(argv = process.argv.slice(2)) {
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-    verifyFirestoreRecovery();
+    try {
+        verifyFirestoreRecovery();
+    } catch (error) {
+        console.error(error?.message || 'Firestore recovery verification failed.');
+        process.exitCode = 1;
+    }
 }

--- a/scripts/verify-firestore-recovery.mjs
+++ b/scripts/verify-firestore-recovery.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+const DEFAULT_PROJECT_ID = 'game-flow-c6311';
+const DEFAULT_DATABASE_ID = '(default)';
+const DEFAULT_MAX_BACKUP_AGE_HOURS = 36;
+const MINIMUM_DAILY_RETENTION_SECONDS = 14 * 24 * 60 * 60;
+
+function durationSeconds(value) {
+    const match = String(value || '').trim().match(/^(\d+(?:\.\d+)?)s$/);
+    return match ? Number(match[1]) : 0;
+}
+
+function timestampMillis(value) {
+    const parsed = Date.parse(String(value || ''));
+    return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function evaluateFirestoreRecoveryPosture({
+    database,
+    schedules = [],
+    backups = [],
+    now = Date.now(),
+    maxBackupAgeHours = DEFAULT_MAX_BACKUP_AGE_HOURS
+} = {}) {
+    const failures = [];
+    const notices = [];
+
+    if (database?.pointInTimeRecoveryEnablement !== 'POINT_IN_TIME_RECOVERY_ENABLED') {
+        failures.push('Point-in-time recovery is not enabled.');
+    }
+    if (database?.deleteProtectionState !== 'DELETE_PROTECTION_ENABLED') {
+        failures.push('Database delete protection is not enabled.');
+    }
+
+    const dailySchedule = schedules.find((schedule) => schedule?.dailyRecurrence != null);
+    if (!dailySchedule) {
+        failures.push('No daily managed-backup schedule exists.');
+    } else if (durationSeconds(dailySchedule.retention) < MINIMUM_DAILY_RETENTION_SECONDS) {
+        failures.push('The daily managed-backup retention is shorter than 14 days.');
+    }
+
+    const readyBackups = backups
+        .filter((backup) => !backup?.state || backup.state === 'READY')
+        .sort((left, right) => timestampMillis(right.snapshotTime || right.createTime) - timestampMillis(left.snapshotTime || left.createTime));
+    const newestBackup = readyBackups[0] || null;
+
+    if (newestBackup) {
+        const newestAt = timestampMillis(newestBackup.snapshotTime || newestBackup.createTime);
+        const maximumAgeMs = Math.max(1, Number(maxBackupAgeHours) || DEFAULT_MAX_BACKUP_AGE_HOURS) * 60 * 60 * 1000;
+        if (!newestAt || now - newestAt > maximumAgeMs) {
+            failures.push(`The newest ready backup is older than ${maxBackupAgeHours} hours.`);
+        }
+    } else if (dailySchedule) {
+        const scheduleAgeMs = now - timestampMillis(dailySchedule.createTime);
+        if (!timestampMillis(dailySchedule.createTime) || scheduleAgeMs > DEFAULT_MAX_BACKUP_AGE_HOURS * 60 * 60 * 1000) {
+            failures.push('The daily schedule has not produced a ready backup within its initial 36-hour window.');
+        } else {
+            notices.push('Daily schedule is within its initial 36-hour window; the first backup is still pending.');
+        }
+    }
+
+    return {
+        healthy: failures.length === 0,
+        failures,
+        notices,
+        dailySchedule,
+        newestBackup
+    };
+}
+
+function readFlag(argv, name, fallback) {
+    const index = argv.indexOf(name);
+    return index >= 0 ? String(argv[index + 1] || '').trim() : fallback;
+}
+
+function runGcloudJson(args) {
+    const output = execFileSync('gcloud', args, {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'inherit']
+    });
+    return JSON.parse(output || 'null');
+}
+
+export function verifyFirestoreRecovery(argv = process.argv.slice(2)) {
+    const projectId = readFlag(argv, '--project', process.env.FIREBASE_PROJECT_ID || DEFAULT_PROJECT_ID);
+    const databaseId = readFlag(argv, '--database', process.env.FIRESTORE_DATABASE_ID || DEFAULT_DATABASE_ID);
+    const maxBackupAgeHours = Number(readFlag(
+        argv,
+        '--max-backup-age-hours',
+        process.env.FIRESTORE_MAX_BACKUP_AGE_HOURS || String(DEFAULT_MAX_BACKUP_AGE_HOURS)
+    ));
+
+    const database = runGcloudJson([
+        'firestore', 'databases', 'describe',
+        `--project=${projectId}`,
+        `--database=${databaseId}`,
+        '--format=json'
+    ]);
+    const schedules = runGcloudJson([
+        'firestore', 'backups', 'schedules', 'list',
+        `--project=${projectId}`,
+        `--database=${databaseId}`,
+        '--format=json'
+    ]);
+    const backups = runGcloudJson([
+        'firestore', 'backups', 'list',
+        `--project=${projectId}`,
+        '--format=json'
+    ]).filter((backup) => String(backup?.database || '').endsWith(`/databases/${databaseId}`));
+
+    const result = evaluateFirestoreRecoveryPosture({
+        database,
+        schedules,
+        backups,
+        maxBackupAgeHours
+    });
+
+    console.log(JSON.stringify({
+        projectId,
+        databaseId,
+        healthy: result.healthy,
+        failures: result.failures,
+        notices: result.notices,
+        dailySchedule: result.dailySchedule?.name || null,
+        newestBackup: result.newestBackup?.name || null
+    }, null, 2));
+
+    if (!result.healthy) process.exitCode = 1;
+    return result;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    verifyFirestoreRecovery();
+}

--- a/spec/firestore-backup-strategy.md
+++ b/spec/firestore-backup-strategy.md
@@ -1,8 +1,15 @@
 # Firestore Backup Strategy
 
-This repo (static site + Firebase) does not encode Firestore backup behavior.
-Backups for Firestore are configured in Google Cloud (the Firebase project), not in
-`firebase.json` / `firestore.rules` / `firestore.indexes.json`.
+Firestore recovery is configured in Google Cloud rather than `firebase.json`.
+The production database now has PITR, delete protection, and a daily managed
+backup retained for 14 days. The repository verifies that external posture in
+`.github/workflows/firestore-recovery-health.yml`; operational recovery steps
+and drill evidence belong in `docs/firestore-recovery-runbook.md`.
+
+The first PITR clone drill completed successfully on 2026-07-18. The clone
+matched representative top-level and nested collection counts and was deleted
+without changing or redirecting the production database. The exact operation,
+counts, and cleanup evidence are recorded in the runbook.
 
 ## Goals
 
@@ -10,11 +17,11 @@ Backups for Firestore are configured in Google Cloud (the Firebase project), not
 - Be able to restore specific collections or the entire database.
 - Keep operational cost and complexity reasonable.
 
-## Recommended Approach
+## Implemented Approach
 
 ### 1) Enable Firestore Managed Backups / PITR (Primary)
 
-Use Firestore managed backups / point-in-time recovery (PITR) in the GCP Console.
+Use Firestore managed backups and point-in-time recovery (PITR).
 
 Why:
 
@@ -27,7 +34,7 @@ Notes:
 - Configure retention based on how quickly you want to detect issues (typical: 7-30 days).
 - Document the restore workflow and who has permission to run restores.
 
-### 2) Scheduled Exports to Cloud Storage (Secondary, for longer retention)
+### 2) Scheduled Exports to Cloud Storage (Optional longer retention)
 
 Set up a scheduled Firestore export to a Cloud Storage bucket (daily or weekly).
 
@@ -46,16 +53,14 @@ Export scope:
 - Full export (simplest), or
 - Collection-level exports if you want to reduce cost/size (requires discipline to keep a list).
 
-## Restore Playbook (What We Should Document)
+## Restore Playbook
 
-- When to use PITR restore vs export restore
-- Who can approve/execute a restore
-- Expected downtime / impact on the app
-- Post-restore validation checklist (sample queries, key pages to load)
+See `docs/firestore-recovery-runbook.md` for the clone/restore commands,
+approval boundary, cleanup steps, and validation checklist.
 
 ## Minimum Operational Checklist
 
-- Confirm PITR/managed backups are enabled in the Firebase project
+- Run `npm run ops:verify-firestore-recovery`
 - Confirm a Storage bucket exists for exports (if doing scheduled exports)
 - Confirm IAM roles for the account that runs exports/restores
 - Confirm alerts/notifications for failed exports (if scheduled exports exist)
@@ -74,4 +79,3 @@ If/when we tighten privacy, the recommended pattern is:
 
 This also makes future backups/restores more obviously sensitive: restoring private
 data should be more tightly controlled.
-

--- a/tests/unit/firestore-recovery-delivery-contract.test.js
+++ b/tests/unit/firestore-recovery-delivery-contract.test.js
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+function readSource(path) {
+    return readFileSync(new URL(`../../${path}`, import.meta.url), 'utf8');
+}
+
+const workflow = readSource('.github/workflows/firestore-recovery-health.yml');
+const runbook = readSource('docs/firestore-recovery-runbook.md');
+const packageSource = readSource('package.json');
+
+describe('Firestore recovery delivery contract', () => {
+    it('keeps the scheduled production check authenticated before gcloud runs', () => {
+        const authIndex = workflow.indexOf('uses: google-github-actions/auth@v3');
+        const setupIndex = workflow.indexOf('uses: google-github-actions/setup-gcloud@v3');
+        const verifyIndex = workflow.indexOf('run: npm run ops:verify-firestore-recovery');
+
+        expect(workflow).toContain("cron: '17 15 * * *'");
+        expect(workflow).toContain('environment: production');
+        expect(authIndex).toBeGreaterThan(-1);
+        expect(workflow).toContain('create_credentials_file: true');
+        expect(workflow).toContain('cleanup_credentials: true');
+        expect(setupIndex).toBeGreaterThan(authIndex);
+        expect(verifyIndex).toBeGreaterThan(setupIndex);
+        expect(workflow).toContain('FIREBASE_PROJECT_ID: game-flow-c6311');
+    });
+
+    it('keeps the verifier command available and the documented invocation executable', () => {
+        expect(packageSource).toContain('"ops:verify-firestore-recovery": "node scripts/verify-firestore-recovery.mjs"');
+        expect(runbook).toContain('npm run ops:verify-firestore-recovery -- --project="$ALLPLAYS_FIRESTORE_PROJECT_ID"');
+    });
+
+    it('keeps restore drills isolated from the production database', () => {
+        expect(runbook).toContain('Never restore over `(default)`');
+        expect(runbook).toContain("--destination-database='restore-drill-YYYYMMDD'");
+        expect(runbook).toContain("--destination-database='backup-drill-YYYYMMDD'");
+        expect(runbook).toMatch(/A managed backup restore always creates a new\s+database/);
+        expect(runbook).toContain('2026-07-18 PITR clone drill');
+    });
+});

--- a/tests/unit/firestore-recovery-delivery-contract.test.js
+++ b/tests/unit/firestore-recovery-delivery-contract.test.js
@@ -18,8 +18,8 @@ describe('Firestore recovery delivery contract', () => {
         expect(workflow).toContain("cron: '17 15 * * *'");
         expect(workflow).toContain('environment: production');
         expect(authIndex).toBeGreaterThan(-1);
-        expect(workflow).toContain('secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311');
-        expect(workflow).not.toContain('secrets.FIRESTORE_RECOVERY_READ_ONLY_SERVICE_ACCOUNT_GAME_FLOW_C6311');
+        expect(workflow).toContain('secrets.FIRESTORE_RECOVERY_READ_ONLY_SERVICE_ACCOUNT_GAME_FLOW_C6311');
+        expect(workflow).not.toContain('secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311');
         expect(workflow).toContain('create_credentials_file: true');
         expect(workflow).toContain('cleanup_credentials: true');
         expect(setupIndex).toBeGreaterThan(authIndex);
@@ -48,5 +48,12 @@ describe('Firestore recovery delivery contract', () => {
         expect(runbook).toContain("--destination-database='backup-drill-YYYYMMDD'");
         expect(runbook).toMatch(/A managed backup restore always creates a new\s+database/);
         expect(runbook).toContain('2026-07-18 PITR clone drill');
+    });
+
+    it('checks PITR clone completion on the clone operation metadata', () => {
+        expect(runbook).toContain("gcloud firestore operations describe 'OPERATION_NAME'");
+        expect(runbook).toContain('metadata.operationState` is `SUCCESSFUL`');
+        expect(runbook).toContain('metadata.progressPercentage');
+        expect(runbook).not.toContain('sourceInfo.progress');
     });
 });

--- a/tests/unit/firestore-recovery-delivery-contract.test.js
+++ b/tests/unit/firestore-recovery-delivery-contract.test.js
@@ -18,6 +18,8 @@ describe('Firestore recovery delivery contract', () => {
         expect(workflow).toContain("cron: '17 15 * * *'");
         expect(workflow).toContain('environment: production');
         expect(authIndex).toBeGreaterThan(-1);
+        expect(workflow).toContain('secrets.FIRESTORE_RECOVERY_READ_ONLY_SERVICE_ACCOUNT_GAME_FLOW_C6311');
+        expect(workflow).not.toContain('secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311');
         expect(workflow).toContain('create_credentials_file: true');
         expect(workflow).toContain('cleanup_credentials: true');
         expect(setupIndex).toBeGreaterThan(authIndex);

--- a/tests/unit/firestore-recovery-delivery-contract.test.js
+++ b/tests/unit/firestore-recovery-delivery-contract.test.js
@@ -30,6 +30,16 @@ describe('Firestore recovery delivery contract', () => {
         expect(runbook).toContain('npm run ops:verify-firestore-recovery -- --project="$ALLPLAYS_FIRESTORE_PROJECT_ID"');
     });
 
+    it('documents the complete least-privilege IAM contract for verification', () => {
+        expect(runbook).toContain('datastore.databases.getMetadata');
+        expect(runbook).toContain('datastore.backupSchedules.list');
+        expect(runbook).toContain('datastore.backups.list');
+        expect(runbook).toContain('roles/datastore.viewer');
+        expect(runbook).toContain('roles/datastore.backupSchedulesViewer');
+        expect(runbook).toContain('roles/datastore.backupsViewer');
+        expect(runbook).toContain('`roles/datastore.viewer` can also read application');
+    });
+
     it('keeps restore drills isolated from the production database', () => {
         expect(runbook).toContain('Never restore over `(default)`');
         expect(runbook).toContain("--destination-database='restore-drill-YYYYMMDD'");

--- a/tests/unit/firestore-recovery-delivery-contract.test.js
+++ b/tests/unit/firestore-recovery-delivery-contract.test.js
@@ -18,8 +18,8 @@ describe('Firestore recovery delivery contract', () => {
         expect(workflow).toContain("cron: '17 15 * * *'");
         expect(workflow).toContain('environment: production');
         expect(authIndex).toBeGreaterThan(-1);
-        expect(workflow).toContain('secrets.FIRESTORE_RECOVERY_READ_ONLY_SERVICE_ACCOUNT_GAME_FLOW_C6311');
-        expect(workflow).not.toContain('secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311');
+        expect(workflow).toContain('secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311');
+        expect(workflow).not.toContain('secrets.FIRESTORE_RECOVERY_READ_ONLY_SERVICE_ACCOUNT_GAME_FLOW_C6311');
         expect(workflow).toContain('create_credentials_file: true');
         expect(workflow).toContain('cleanup_credentials: true');
         expect(setupIndex).toBeGreaterThan(authIndex);

--- a/tests/unit/firestore-recovery-posture.test.js
+++ b/tests/unit/firestore-recovery-posture.test.js
@@ -81,6 +81,18 @@ describe('Firestore recovery posture', () => {
         });
     });
 
+    it.each([undefined, 'CREATING'])('rejects a backup whose state is %s', (state) => {
+        const input = healthyInput();
+        input.schedules[0].createTime = '2026-07-16T00:00:00Z';
+        input.backups[0].state = state;
+
+        expect(evaluateFirestoreRecoveryPosture(input)).toMatchObject({
+            healthy: false,
+            failures: ['The daily schedule has not produced a ready backup within its initial 36-hour window.'],
+            newestBackup: null
+        });
+    });
+
     it('allows only the documented first-backup grace window', () => {
         const input = healthyInput();
         input.schedules[0].createTime = '2026-07-18T02:42:05Z';

--- a/tests/unit/firestore-recovery-posture.test.js
+++ b/tests/unit/firestore-recovery-posture.test.js
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import { evaluateFirestoreRecoveryPosture } from '../../scripts/verify-firestore-recovery.mjs';
+
+const now = Date.parse('2026-07-18T12:00:00Z');
+
+function healthyInput() {
+    return {
+        now,
+        database: {
+            pointInTimeRecoveryEnablement: 'POINT_IN_TIME_RECOVERY_ENABLED',
+            deleteProtectionState: 'DELETE_PROTECTION_ENABLED'
+        },
+        schedules: [{
+            name: 'daily',
+            dailyRecurrence: {},
+            retention: '1209600s',
+            createTime: '2026-07-17T12:00:00Z'
+        }],
+        backups: [{
+            name: 'backup-1',
+            state: 'READY',
+            snapshotTime: '2026-07-18T06:00:00Z'
+        }]
+    };
+}
+
+describe('Firestore recovery posture', () => {
+    it('accepts PITR, delete protection, 14-day daily backups, and a fresh ready backup', () => {
+        expect(evaluateFirestoreRecoveryPosture(healthyInput())).toMatchObject({
+            healthy: true,
+            failures: [],
+            newestBackup: { name: 'backup-1' }
+        });
+    });
+
+    it('fails closed when recovery controls are absent or too weak', () => {
+        const result = evaluateFirestoreRecoveryPosture({
+            now,
+            database: {},
+            schedules: [{ dailyRecurrence: {}, retention: '604800s', createTime: '2026-07-01T00:00:00Z' }],
+            backups: []
+        });
+
+        expect(result.healthy).toBe(false);
+        expect(result.failures).toEqual(expect.arrayContaining([
+            'Point-in-time recovery is not enabled.',
+            'Database delete protection is not enabled.',
+            'The daily managed-backup retention is shorter than 14 days.',
+            'The daily schedule has not produced a ready backup within its initial 36-hour window.'
+        ]));
+    });
+
+    it('fails when the newest completed backup is stale', () => {
+        const input = healthyInput();
+        input.backups[0].snapshotTime = '2026-07-15T00:00:00Z';
+
+        expect(evaluateFirestoreRecoveryPosture(input)).toMatchObject({
+            healthy: false,
+            failures: ['The newest ready backup is older than 36 hours.']
+        });
+    });
+
+    it('allows only the documented first-backup grace window', () => {
+        const input = healthyInput();
+        input.schedules[0].createTime = '2026-07-18T02:42:05Z';
+        input.backups = [];
+
+        expect(evaluateFirestoreRecoveryPosture(input)).toMatchObject({
+            healthy: true,
+            notices: [expect.stringContaining('initial 36-hour window')]
+        });
+    });
+});

--- a/tests/unit/firestore-recovery-posture.test.js
+++ b/tests/unit/firestore-recovery-posture.test.js
@@ -11,6 +11,7 @@ function healthyInput() {
     return {
         now,
         database: {
+            uid: 'current-database-uid',
             pointInTimeRecoveryEnablement: 'POINT_IN_TIME_RECOVERY_ENABLED',
             deleteProtectionState: 'DELETE_PROTECTION_ENABLED'
         },
@@ -22,6 +23,7 @@ function healthyInput() {
         }],
         backups: [{
             name: 'backup-1',
+            databaseUid: 'current-database-uid',
             state: 'READY',
             snapshotTime: '2026-07-18T06:00:00Z'
         }]
@@ -63,6 +65,7 @@ describe('Firestore recovery posture', () => {
         expect(result.failures).toEqual(expect.arrayContaining([
             'Point-in-time recovery is not enabled.',
             'Database delete protection is not enabled.',
+            'The current database UID is unavailable, so backup lineage cannot be verified.',
             'The daily managed-backup retention is shorter than 14 days.',
             'The daily schedule has not produced a ready backup within its initial 36-hour window.'
         ]));
@@ -86,6 +89,45 @@ describe('Firestore recovery posture', () => {
         expect(evaluateFirestoreRecoveryPosture(input)).toMatchObject({
             healthy: true,
             notices: [expect.stringContaining('initial 36-hour window')]
+        });
+    });
+
+    it('rejects a fresh backup from an older database incarnation', () => {
+        const input = healthyInput();
+        input.schedules[0].createTime = '2026-07-16T00:00:00Z';
+        input.backups[0].databaseUid = 'retired-database-uid';
+
+        expect(evaluateFirestoreRecoveryPosture(input)).toMatchObject({
+            healthy: false,
+            failures: ['The daily schedule has not produced a ready backup within its initial 36-hour window.'],
+            newestBackup: null
+        });
+    });
+
+    it('treats old-incarnation backups as absent during the initial schedule grace window', () => {
+        const input = healthyInput();
+        input.schedules[0].createTime = '2026-07-18T02:42:05Z';
+        input.backups[0].databaseUid = 'retired-database-uid';
+
+        expect(evaluateFirestoreRecoveryPosture(input)).toMatchObject({
+            healthy: true,
+            failures: [],
+            notices: [expect.stringContaining('initial 36-hour window')],
+            newestBackup: null
+        });
+    });
+
+    it('fails closed when the current database UID cannot be established', () => {
+        const input = healthyInput();
+        delete input.database.uid;
+        input.schedules[0].createTime = '2026-07-18T02:42:05Z';
+        input.backups = [];
+
+        expect(evaluateFirestoreRecoveryPosture(input)).toMatchObject({
+            healthy: false,
+            failures: ['The current database UID is unavailable, so backup lineage cannot be verified.'],
+            notices: [expect.stringContaining('initial 36-hour window')],
+            newestBackup: null
         });
     });
 });

--- a/tests/unit/firestore-recovery-posture.test.js
+++ b/tests/unit/firestore-recovery-posture.test.js
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { evaluateFirestoreRecoveryPosture } from '../../scripts/verify-firestore-recovery.mjs';
+import {
+    evaluateFirestoreRecoveryPosture,
+    parseFirestoreRecoveryArgs
+} from '../../scripts/verify-firestore-recovery.mjs';
 
 const now = Date.parse('2026-07-18T12:00:00Z');
 
@@ -26,6 +29,15 @@ function healthyInput() {
 }
 
 describe('Firestore recovery posture', () => {
+    it('requires an explicit project instead of silently targeting production', () => {
+        expect(() => parseFirestoreRecoveryArgs([], {})).toThrow(/FIREBASE_PROJECT_ID.*--project/);
+        expect(parseFirestoreRecoveryArgs(['--project', 'demo-project'], {})).toMatchObject({
+            projectId: 'demo-project',
+            databaseId: '(default)',
+            maxBackupAgeHours: 36
+        });
+    });
+
     it('accepts PITR, delete protection, 14-day daily backups, and a fresh ready backup', () => {
         expect(evaluateFirestoreRecoveryPosture(healthyInput())).toMatchObject({
             healthy: true,

--- a/tests/unit/firestore-recovery-posture.test.js
+++ b/tests/unit/firestore-recovery-posture.test.js
@@ -81,10 +81,23 @@ describe('Firestore recovery posture', () => {
         });
     });
 
-    it.each([undefined, 'CREATING'])('rejects a backup whose state is %s', (state) => {
+    it.each([
+        ['missing', undefined, false],
+        ['an unknown string', 'UNKNOWN', true],
+        ['a non-ready lifecycle state', 'CREATING', true],
+        ['lowercase ready', 'ready', true],
+        ['null', null, true],
+        ['a number', 1, true],
+        ['a boolean', true, true],
+        ['an object', { value: 'READY' }, true]
+    ])('rejects a backup whose state is %s', (_description, state, hasState) => {
         const input = healthyInput();
         input.schedules[0].createTime = '2026-07-16T00:00:00Z';
-        input.backups[0].state = state;
+        if (hasState) {
+            input.backups[0].state = state;
+        } else {
+            delete input.backups[0].state;
+        }
 
         expect(evaluateFirestoreRecoveryPosture(input)).toMatchObject({
             healthy: false,

--- a/tests/unit/firestore-recovery-posture.test.js
+++ b/tests/unit/firestore-recovery-posture.test.js
@@ -36,6 +36,11 @@ describe('Firestore recovery posture', () => {
             databaseId: '(default)',
             maxBackupAgeHours: 36
         });
+        expect(parseFirestoreRecoveryArgs(['--project=demo-project'], {})).toMatchObject({
+            projectId: 'demo-project',
+            databaseId: '(default)',
+            maxBackupAgeHours: 36
+        });
     });
 
     it('accepts PITR, delete protection, 14-day daily backups, and a fresh ready backup', () => {


### PR DESCRIPTION
## Summary
- verify production PITR, delete protection, daily backup retention, and backup freshness from a scheduled workflow
- document isolated PITR and managed-backup restore procedures with explicit source-protection and cleanup boundaries
- record the completed 2026-07-18 PITR clone drill and exact count evidence
- add regression coverage for healthy, missing, weak, stale, and first-backup-grace postures

## External controls applied
- seven-day PITR enabled on `game-flow-c6311/(default)`
- database delete protection enabled
- daily managed-backup schedule created with 14-day retention

## Completed drill
A clone was created from snapshot `2026-07-18T02:40:00Z`. Source and clone counts matched for `users` 40, `teams` 50, `accessCodes` 88, and two representative nested collections 1/1 and 2/2. The temporary database was deleted and now returns `NOT_FOUND`; the source still reports PITR and delete protection enabled.

The managed-backup schedule is still inside its first 36-hour production window. The health check treats only that initial window as a notice; after it expires, missing or stale backups fail closed.

## Validation
- recovery posture unit tests: 4 passed
- live production recovery check: healthy
- workflow YAML parse: passed
- script syntax and diff checks: passed

## Safety
The drill never restored over `(default)`, never redirected production traffic, and removed only the explicitly named temporary clone.