### PR TITLE
Rebuild Firestore recovery controls

### DIFF
--- a/.github/workflows/firestore-recovery-health.yml
+++ b/.github/workflows/firestore-recovery-health.yml
@@ -1,0 +1,77 @@
+name: firestore-recovery-health
+
+on:
+  schedule:
+    - cron: '17 */6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: firestore-recovery-health
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  verify-recovery:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      FIREBASE_PROJECT_ID: game-flow-c6311
+      FIRESTORE_RECOVERY_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.FIRESTORE_RECOVERY_WORKLOAD_IDENTITY_PROVIDER }}
+      FIRESTORE_RECOVERY_SERVICE_ACCOUNT: ${{ vars.FIRESTORE_RECOVERY_SERVICE_ACCOUNT }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 22
+
+      - name: Fail closed unless the recovery OIDC identity is exact
+        run: node scripts/verify-firestore-recovery-identity.mjs
+
+      - name: Authenticate to Google Cloud with GitHub OIDC
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ vars.FIRESTORE_RECOVERY_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.FIRESTORE_RECOVERY_SERVICE_ACCOUNT }}
+          create_credentials_file: true
+          cleanup_credentials: true
+
+      - name: Setup Google Cloud CLI
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+        with:
+          version: '557.0.0'
+
+      - name: Verify PITR, delete protection, and managed backups
+        run: npm run ops:verify-firestore-recovery
+
+  reconcile-recovery-status:
+    needs: verify-recovery
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 22
+
+      - name: Reconcile durable recovery incident
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERIFY_RESULT: ${{ needs.verify-recovery.result }}
+        run: node scripts/reconcile-firestore-recovery-issue.mjs

--- a/docs/firestore-recovery-runbook.md
+++ b/docs/firestore-recovery-runbook.md
@@ -1,0 +1,472 @@
+# Firestore recovery runbook
+
+The production `game-flow-c6311/(default)` database has three independent
+recovery controls:
+
+- seven-day point-in-time recovery (PITR);
+- database delete protection; and
+- a daily managed backup retained for at least 14 days.
+
+The scheduled `firestore-recovery-health` workflow checks those controls every
+six hours. It accepts only an exact `READY` backup from the current database UID and
+fails if the newest usable backup is more than 36 hours old. A genuinely new
+daily schedule receives one 36-hour first-backup grace window. Production is
+pinned to backup schedule
+`projects/game-flow-c6311/databases/(default)/backupSchedules/8a7f67fe-c6eb-4a4e-8a48-20e96e9fdf57`;
+its original creation time is pinned to `2026-07-18T02:42:05.213778Z`.
+Recreating or replacing that schedule fails verification instead of resetting
+the grace window. A backup must have its own valid `snapshotTime`; a backup's
+`createTime` is never accepted as a freshness substitute. Missing,
+malformed, stale, wrong-lineage, or materially future metadata fails closed.
+Every usable backup must have the exact database resource, a canonical backup
+resource name, the current UUIDv4 database UID, and a valid `expireTime` beyond
+the next six-hour health-check window; an already-expired or imminently expiring
+backup is not counted as restorable evidence.
+Google timestamps must be valid UTC RFC 3339 values; only ten minutes of normal
+clock skew is tolerated before a future schedule or backup fails the check.
+
+## Keyless health-check identity
+
+The workflow must use GitHub OIDC through Google Workload Identity Federation.
+Do not create or store a service-account JSON key for this job. The workflow
+preflight refuses missing configuration, a non-canonical provider name, a
+service account from another project, a repository other than
+`pauljsnider/allplays`, a ref other than `refs/heads/master`, or a different
+workflow path before it asks Google for credentials. The Google trust boundary
+uses GitHub's immutable numeric repository and owner IDs, not reusable
+repository or account names.
+
+The metadata reader needs a project-level custom role containing exactly:
+
+- `datastore.databases.getMetadata`;
+- `datastore.backupSchedules.list`; and
+- `datastore.backups.list`.
+
+The GitHub identity needs `roles/iam.workloadIdentityUser` on only the dedicated
+service account. It does not need Service Account Token Creator, application
+document reads, restore permissions, deploy permissions, or any database write.
+
+### External provisioning inputs
+
+Provisioning lives outside this repository. The following resources were
+reconciled and verified in production on 2026-07-18; future operators must
+compare this exact desired state rather than blindly creating duplicates:
+
+| Input | Exact desired value |
+| --- | --- |
+| Google Cloud project ID | `game-flow-c6311` |
+| Google Cloud project number | `982493478258` |
+| Custom role ID | `allplaysFirestoreRecoveryMetadataViewer` |
+| Service account ID | `allplays-firestore-recovery` |
+| Service account email | `allplays-firestore-recovery@game-flow-c6311.iam.gserviceaccount.com` |
+| Workload Identity pool ID | `github-actions` |
+| Workload Identity provider ID | `allplays-recovery` |
+| GitHub repository | `pauljsnider/allplays` |
+| Immutable GitHub repository ID | `1106220007` |
+| Immutable GitHub repository-owner ID | `211066188` |
+| Allowed Git ref | `refs/heads/master` |
+| Allowed workflow ref | `pauljsnider/allplays/.github/workflows/firestore-recovery-health.yml@refs/heads/master` |
+
+The provider must map `google.subject=assertion.sub`,
+`attribute.repository_id=assertion.repository_id`,
+`attribute.repository_owner_id=assertion.repository_owner_id`,
+`attribute.ref=assertion.ref`, and
+`attribute.workflow_ref=assertion.workflow_ref`. Its attribute condition must
+require both immutable IDs plus the exact ref and workflow above. Bind
+`roles/iam.workloadIdentityUser` to this member and no broader pool member:
+
+```text
+assertion.repository_id == '1106220007' && assertion.repository_owner_id == '211066188' && assertion.ref == 'refs/heads/master' && assertion.workflow_ref == 'pauljsnider/allplays/.github/workflows/firestore-recovery-health.yml@refs/heads/master'
+```
+
+```text
+principalSet://iam.googleapis.com/projects/982493478258/locations/global/workloadIdentityPools/github-actions/attribute.repository_id/1106220007
+```
+
+Set these non-secret variables on the GitHub `production` environment:
+
+```text
+FIRESTORE_RECOVERY_WORKLOAD_IDENTITY_PROVIDER=projects/982493478258/locations/global/workloadIdentityPools/github-actions/providers/allplays-recovery
+FIRESTORE_RECOVERY_SERVICE_ACCOUNT=allplays-firestore-recovery@game-flow-c6311.iam.gserviceaccount.com
+```
+
+The immutable repository-ID principal set and provider condition are the
+security boundary; the exact ref and workflow are additional constraints. Verify the
+condition and role permissions in Google Cloud, verify that no user-managed key
+exists on the dedicated service account, then run a manual workflow dispatch
+from `master` after this workflow is merged. The 2026-07-18 provisioning audit
+found the pool/provider `ACTIVE`, exactly three custom-role permissions, only
+the repository-ID `workloadIdentityUser` principal, zero user-managed keys, and
+both exact GitHub production-environment variables. The first workflow dispatch
+and scheduled heartbeat still must succeed before monitoring is called active.
+
+## Verify the recovery posture manually
+
+Authenticate `gcloud` as the dedicated metadata reader through an approved
+keyless method, then run:
+
+```bash
+export ALLPLAYS_FIRESTORE_PROJECT_ID='YOUR_PROJECT_ID'
+npm run ops:verify-firestore-recovery -- --project="$ALLPLAYS_FIRESTORE_PROJECT_ID"
+```
+
+The command prints only recovery metadata. It does not read application
+documents or mutate a database. `--max-backup-age-hours` is limited to a finite
+value from 1 through 168 hours so a typo such as `Infinity`, `NaN`, `0`, or an
+unreasonably large threshold cannot silently disable freshness monitoring.
+
+## Health-check failure
+
+The verification job has a ten-minute timeout; each `gcloud` read has a
+two-minute timeout. A separate downstream job runs after ordinary verification
+failure or job timeout, emits an error annotation, writes immediate response
+steps to the run summary, and fails the workflow. It never changes cloud state.
+
+Treat any failure as "recovery posture unverified" until proved otherwise:
+
+1. Inspect the failed command and determine whether the cause is OIDC/IAM,
+   malformed API output, or an actual posture failure.
+2. Re-run the read-only verifier using an approved metadata-reader identity.
+3. If PITR, delete protection, the daily schedule, retention, backup lineage, or
+   freshness is wrong, open a production incident and page the production
+   owner. Do not wait for the next scheduled run.
+4. Do not disable or recreate a recovery control to clear the alert. Preserve
+   metadata and determine why it changed.
+5. If the failure is authentication-only, repair the exact OIDC trust and rerun
+   the workflow; do not substitute deploy credentials or a JSON key.
+
+The failure summary is not an out-of-band pager. The repository owner must route
+failures from the `firestore-recovery-health` workflow to the production on-call
+destination and exercise that notification before calling monitoring complete.
+
+The separate status job has only `contents: read` and `issues: write`. On a
+failed, cancelled, skipped, or timed-out verification it creates or reopens one
+marker-protected issue titled `[Recovery] Firestore recovery posture is
+unverified`, assigns it to `pauljsnider`, applies the `recovery-monitor` label,
+and updates it with the exact run URL. It closes that managed issue only after a
+later successful verification. Before any update, reopen, or close, the
+reconciler requires exact REST author ID `41898282`, login
+`github-actions[bot]`, type `Bot`, the bot-only label, and the management marker.
+The server-side search is restricted to the unforgeable `app/github-actions`
+author, so public-user title/marker copies are ignored and cannot suppress the
+managed incident. Duplicate bot-authored exact-title issues, incomplete search
+results, result-count mismatches, or identity mismatches fail closed without
+editing an untrusted issue.
+
+That issue handles explicit workflow failures but is not a dead-man. An external
+read-only watcher must query the exact workflow's latest `event=schedule` run
+and alert if there is no successful completion within the exercised heartbeat
+window, the workflow returns 404, or the API repeatedly fails. The watcher must
+live outside this repository's GitHub Actions so deleting/disablement cannot
+silence both monitors. Do not call recovery monitoring complete until that
+external route has been exercised.
+
+## Point-in-time recovery drill
+
+Never restore over `(default)`. A drill creates a separate, temporary database
+from a whole-minute PITR timestamp:
+
+```bash
+export ALLPLAYS_FIRESTORE_PROJECT_ID='YOUR_PROJECT_ID'
+export ALLPLAYS_PITR_DRILL_DATABASE='restore-drill-YYYYMMDD-abcdef'
+printf '%s' "$ALLPLAYS_PITR_DRILL_DATABASE" | grep -Eq '^restore-drill-[0-9]{8}-[a-z0-9]{6}$'
+# Require an exact describe of this destination to return NOT_FOUND first.
+gcloud firestore databases clone \
+  --project="$ALLPLAYS_FIRESTORE_PROJECT_ID" \
+  --source-database="projects/$ALLPLAYS_FIRESTORE_PROJECT_ID/databases/(default)" \
+  --snapshot-time='YYYY-MM-DDTHH:MM:00Z' \
+  --destination-database="$ALLPLAYS_PITR_DRILL_DATABASE"
+```
+
+Use the returned operation name to monitor the clone:
+
+```bash
+gcloud firestore operations describe 'OPERATION_NAME' \
+  --project="$ALLPLAYS_FIRESTORE_PROJECT_ID" \
+  --format='yaml(done,error,metadata.operationState,metadata.progressPercentage)'
+```
+
+Wait until `done` is true and `metadata.operationState` is `SUCCESSFUL`. Stop if
+the operation reports an error, failure, or cancellation. Compare counts and
+deterministic field checksums for representative top-level and nested documents
+before deleting the isolated drill database. Freeze the returned destination
+name and UID from that exact operation; revalidate both immediately before
+cleanup. Use the managed-backup section's guarded delete-protection and final
+ETag cleanup pattern, substituting the exact clone source and
+`restore-drill` ID regex. Never reuse a prior drill ID or directly delete by
+name alone.
+
+## Managed-backup restore drill
+
+Status: **tested successfully on 2026-07-18**; evidence is recorded below. A
+`READY` backup and a documented schedule alone do not prove the restore path.
+Repeat this independent drill at least quarterly after OIDC
+health monitoring is operational. The drill executor must use a separate,
+time-limited elevated identity approved for restore and temporary-database
+deletion; never grant those permissions to the health-check service account.
+
+### 1. Freeze exact inputs
+
+Record the selected backup resource name, its `snapshotTime`, `database`,
+`databaseUid`, and exact `READY` state. Confirm its UID matches the current
+source database UID. Generate a unique destination such as
+`backup-drill-20260718-a1b2c3`, require it to match
+`^backup-drill-[0-9]{8}-[a-z0-9]{6}$`, and prove `databases describe` returns
+`NOT_FOUND` before starting. Never reuse an existing database.
+
+```bash
+export ALLPLAYS_FIRESTORE_PROJECT_ID='YOUR_PROJECT_ID'
+export ALLPLAYS_BACKUP_RESOURCE='projects/YOUR_PROJECT_ID/locations/LOCATION/backups/BACKUP_ID'
+export ALLPLAYS_BACKUP_SNAPSHOT_TIME='YYYY-MM-DDTHH:MM:SS.ffffffZ'
+export ALLPLAYS_BACKUP_DRILL_DATABASE='backup-drill-YYYYMMDD-abcdef'
+
+gcloud firestore databases restore \
+  --project="$ALLPLAYS_FIRESTORE_PROJECT_ID" \
+  --source-backup="$ALLPLAYS_BACKUP_RESOURCE" \
+  --destination-database="$ALLPLAYS_BACKUP_DRILL_DATABASE"
+```
+
+Monitor the exact returned operation until it is done and successful. Do not
+validate or delete while the restore is pending.
+
+### 2. Compare deterministic sample checksums
+
+Counts alone can miss corrupted field values. Before restoring, select at least
+five stable source documents spanning `users`, `teams`, `accessCodes`, and a
+nested team collection. For every selected document:
+
+1. fetch the source document through the Firestore REST API using the elevated
+   drill identity;
+2. require its `updateTime` to be at or before the selected backup
+   `snapshotTime`—otherwise it is not valid evidence for that backup;
+3. canonicalize only the REST document's `fields` object with `jq -cS`;
+4. compute SHA-256 over those canonical bytes; and
+5. record `documentPath<TAB>sha256` in a temporary manifest sorted bytewise by
+   exact path.
+
+After the restore succeeds, fetch those exact paths from the isolated database,
+canonicalize and hash them identically, sort the restored manifest, and require
+both `cmp` of the manifests and the SHA-256 of the complete manifests to match.
+Keep exact paths only in the restricted temporary workspace or sealed operator
+evidence. Before committing drill evidence, replace every access-code document
+ID with `[redacted]`; the ID is itself a redeemable secret, so do not print it,
+commit it, or preserve it in reversible encoding. Do not print field values or
+store raw document JSON in drill evidence. Record only redacted path labels,
+per-document hashes, aggregate manifest hash, counts, backup resource, database
+UID, snapshot time, restore operation, and result.
+
+For example, the canonical field hash for a fetched document is:
+
+```bash
+jq -ceS '.fields // {}' exact-document.json | openssl dgst -sha256 | awk '{print $2}'
+```
+
+Use a fresh temporary directory created with `mktemp -d` for raw responses,
+restrict it to the operator, and remove it after the evidence manifest is
+sealed. A missing document, REST error, invalid JSON, source `updateTime` after
+the backup snapshot, empty sample, or hash mismatch fails the drill. Counts
+captured from the live source after the backup are contextual inventory, not
+snapshot-consistent proof: record and investigate count drift, but fail on a
+count mismatch only when both counts refer to the same snapshot. Do not redirect
+production traffic to the drill database.
+
+### 3. Delete only the exact isolated target
+
+Deletion requires an explicit resource-name guard. Set an immutable expected
+value from the recorded drill plan, reject `(default)`, reject an invalid drill
+ID, and compare the described resource name before deletion:
+
+```bash
+set -euo pipefail
+readonly EXPECTED_BACKUP_DRILL_DATABASE='backup-drill-YYYYMMDD-abcdef'
+readonly EXPECTED_BACKUP_RESOURCE='projects/YOUR_PROJECT_ID/locations/LOCATION/backups/BACKUP_ID'
+readonly EXPECTED_BACKUP_DRILL_UID='UID_FROM_EXACT_COMPLETED_RESTORE_OPERATION'
+readonly EXPECTED_BACKUP_RESTORE_OPERATION='EXACT_RESTORE_OPERATION_RECORDED_AND_MONITORED_ABOVE'
+readonly EXPECTED_SOURCE_DATABASE_UID='SOURCE_UID_RECORDED_BEFORE_RESTORE'
+test "$ALLPLAYS_BACKUP_DRILL_DATABASE" = "$EXPECTED_BACKUP_DRILL_DATABASE"
+test "$ALLPLAYS_BACKUP_DRILL_DATABASE" != '(default)'
+printf '%s' "$ALLPLAYS_BACKUP_DRILL_DATABASE" | grep -Eq '^backup-drill-[0-9]{8}-[a-z0-9]{6}$'
+
+target_before_json="$(gcloud firestore databases describe \
+  --project="$ALLPLAYS_FIRESTORE_PROJECT_ID" \
+  --database="$ALLPLAYS_BACKUP_DRILL_DATABASE" \
+  --format=json)"
+actual_resource="$(jq -r '.name' <<< "$target_before_json")"
+actual_uid="$(jq -r '.uid' <<< "$target_before_json")"
+actual_etag="$(jq -r '.etag' <<< "$target_before_json")"
+actual_source_backup="$(jq -r '.sourceInfo.backup.backup' <<< "$target_before_json")"
+test "$actual_resource" = "projects/$ALLPLAYS_FIRESTORE_PROJECT_ID/databases/$EXPECTED_BACKUP_DRILL_DATABASE"
+test "$actual_uid" = "$EXPECTED_BACKUP_DRILL_UID"
+test -n "$actual_etag"
+test "$actual_source_backup" = "$EXPECTED_BACKUP_RESOURCE"
+
+# Re-read the exact restore operation that was recorded and monitored above.
+# Database.sourceInfo.progress is not part of the documented cleanup contract.
+restore_operation_json="$(gcloud firestore operations describe \
+  "$EXPECTED_BACKUP_RESTORE_OPERATION" \
+  --project="$ALLPLAYS_FIRESTORE_PROJECT_ID" \
+  --format=json)"
+jq -e \
+  --arg backup "$EXPECTED_BACKUP_RESOURCE" \
+  --arg uid "$EXPECTED_BACKUP_DRILL_UID" \
+  '.done == true
+    and (.error == null)
+    and .metadata.operationState == "SUCCESSFUL"
+    and .metadata.backup == $backup
+    and .response.uid == $uid' \
+  <<< "$restore_operation_json" >/dev/null
+
+source_before_json="$(gcloud firestore databases describe \
+  --project="$ALLPLAYS_FIRESTORE_PROJECT_ID" \
+  --database='(default)' \
+  --format=json)"
+test "$(jq -r '.name' <<< "$source_before_json")" = "projects/$ALLPLAYS_FIRESTORE_PROJECT_ID/databases/(default)"
+test "$(jq -r '.uid' <<< "$source_before_json")" = "$EXPECTED_SOURCE_DATABASE_UID"
+test "$(jq -r '.deleteProtectionState' <<< "$source_before_json")" = 'DELETE_PROTECTION_ENABLED'
+
+# A restored database inherits source delete protection. Disable it only after
+# the exact isolated resource and exact backup origin have passed every guard.
+# The Database ETag captured by the same guarded read is a precondition on this
+# PATCH. A concurrent database change therefore fails instead of being erased.
+set +x
+allplays_access_token="$(gcloud auth print-access-token)"
+protection_update_body="$(jq -cn \
+  --arg name "$actual_resource" \
+  --arg etag "$actual_etag" \
+  '{name: $name, deleteProtectionState: "DELETE_PROTECTION_DISABLED", etag: $etag}')"
+protection_update_response="$(curl --fail-with-body --silent --show-error \
+  --request PATCH \
+  --header "Authorization: Bearer $allplays_access_token" \
+  --header 'Content-Type: application/json' \
+  --data "$protection_update_body" \
+  "https://firestore.googleapis.com/v1/$actual_resource?updateMask=deleteProtectionState")"
+unset protection_update_body
+protection_update_operation="$(jq -er '.name' <<< "$protection_update_response")"
+test -n "$protection_update_operation"
+
+# Poll only the operation returned by the conditional PATCH. Do not continue
+# until it is complete and successful.
+protection_update_complete=false
+for attempt_number in {1..120}; do
+  protection_update_operation_json="$(curl --fail-with-body --silent --show-error \
+    --header "Authorization: Bearer $allplays_access_token" \
+    "https://firestore.googleapis.com/v1/$protection_update_operation")"
+  test "$(jq -r '.name' <<< "$protection_update_operation_json")" = "$protection_update_operation"
+  test "$(jq -r '.error // empty' <<< "$protection_update_operation_json")" = ''
+  if test "$(jq -r '.done // false' <<< "$protection_update_operation_json")" = true; then
+    test "$(jq -r '.metadata.operationState // empty' <<< "$protection_update_operation_json")" = 'SUCCESSFUL'
+    protection_update_complete=true
+    break
+  fi
+  sleep 5
+done
+unset allplays_access_token
+test "$protection_update_complete" = true
+
+target_after_json="$(gcloud firestore databases describe \
+  --project="$ALLPLAYS_FIRESTORE_PROJECT_ID" \
+  --database="$EXPECTED_BACKUP_DRILL_DATABASE" \
+  --format=json)"
+test "$(jq -r '.name' <<< "$target_after_json")" = "$actual_resource"
+test "$(jq -r '.uid' <<< "$target_after_json")" = "$EXPECTED_BACKUP_DRILL_UID"
+test "$(jq -r '.deleteProtectionState' <<< "$target_after_json")" = 'DELETE_PROTECTION_DISABLED'
+post_update_etag="$(jq -r '.etag' <<< "$target_after_json")"
+test -n "$post_update_etag"
+
+# Do not read the target again between this ETag capture and conditional delete.
+gcloud firestore databases delete \
+  --project="$ALLPLAYS_FIRESTORE_PROJECT_ID" \
+  --database="$EXPECTED_BACKUP_DRILL_DATABASE" \
+  --etag="$post_update_etag" \
+  --quiet
+```
+
+Monitor the exact deletion operation to success, then require an exact describe
+of that destination to return `NOT_FOUND`. Finally describe `(default)` and
+require its delete protection still equals `DELETE_PROTECTION_ENABLED`, then
+re-run the read-only posture verifier. If any guard fails, stop; do not broaden
+the target or use a wildcard. Recheck the immutable source UID both before and
+after cleanup. Never disable delete protection on `(default)`.
+
+## Recovery drill evidence
+
+### 2026-07-18 managed-backup restore drill
+
+- Source: `projects/game-flow-c6311/databases/(default)`
+- Source database UID: `523d6949-79b4-4368-b4cd-57c164d3451d`
+- Backup: `projects/game-flow-c6311/locations/nam5/backups/d51ba64c-aa47-4372-a7fc-b78813ad6669`
+- Backup snapshot: `2026-07-18T09:33:36.275104Z`
+- Temporary destination: `backup-drill-20260718-a7c9e2`
+- Restored database UID: `37bac8e6-78b4-4eb6-bd60-a8b622331d9b`
+- Restore operation: `projects/game-flow-c6311/databases/backup-drill-20260718-a7c9e2/operations/mx0zIraoYL22TrR45si6NxAqNW1hbgQiChAaGg`
+- Restore completed successfully: `2026-07-18T11:41:29.185967Z`
+- Canonical five-document manifest SHA-256:
+  `48945c35c303427aa31e0619436a4a2b9b82b4077aed9ffc54bd94eb973beb68`
+
+The source samples all had `updateTime` at or before the backup snapshot. The
+source and restored manifests matched byte-for-byte:
+
+| Document path | Canonical `fields` SHA-256 |
+| --- | --- |
+| `accessCodes/[redacted]` | `2b06412c629472e0a7d51cbbc2b11513b648f577e708c4a08de323296b9bbf0f` |
+| `teams/0JSOplS6f99GIYNS8Sk7` | `c7eaf6e36f772f6a8598b8c4d5f18e256b5a8fdbc6a91c08441f06ddcedba0bc` |
+| `teams/0JSOplS6f99GIYNS8Sk7/games/U9EZjzu4jJnLzJuzNfPY` | `9bbc433c6ec88acd6e6adb090766fe01b58551ce908e8700591846b81ea587f6` |
+| `users/1dfqx9IzBaVlYBg8ll54xF3Igbw2` | `ba75189f5add3c711ebcc3951ff51a842a0a7d37c7c8f29de36ccf4acc71c1e7` |
+| `users/2NLQcX7wodVueeSTnsAPGRqBQ7E3` | `b050fd2ce25b43cbb0bfb096181742e750e84f094030db80f7596a0835a4b3ee` |
+
+The contextual live-source and restored counts also matched: `users=40`,
+`teams=50`, `accessCodes=88`, and the sampled nested games collection `=1`.
+The manifest, rather than those post-snapshot live counts, is the deterministic
+content proof.
+
+The restored target inherited delete protection. Cleanup first proved its exact
+name, UID, backup origin, and completed state while independently confirming the
+source UID and source delete protection. It then disabled protection only on the
+isolated target, recaptured that target's rotating ETag, and conditionally
+deleted it with that ETag. Deletion operation
+`projects/game-flow-c6311/databases/backup-drill-20260718-a7c9e2/operations/A8r-_YAQBtLt0Y8IDBoHEHfyiPAQBtLtzsAICwodGg`
+reported delete time `2026-07-18T11:45:39.962576Z`. The destination then
+returned `NOT_FOUND`; `(default)` retained UID
+`523d6949-79b4-4368-b4cd-57c164d3451d`, delete protection, and PITR. No traffic
+was moved, no source data was changed, and no raw document values were retained.
+
+### 2026-07-18 PITR clone drill
+
+- Source: `projects/game-flow-c6311/databases/(default)`
+- Snapshot: `2026-07-18T02:40:00Z`
+- Temporary destination: `restore-drill-20260718a`
+- Clone operation:
+  `projects/game-flow-c6311/databases/restore-drill-20260718a/operations/-HVvaGoOJpVFQ07xUd7VExAqNW1hbgQiDBAaGg`
+- Clone completed: `2026-07-18T03:17:05.747809Z`
+- Validation result: all sampled source and clone counts matched.
+
+| Collection path | Source | Clone |
+| --- | ---: | ---: |
+| `users` | 40 | 40 |
+| `teams` | 50 | 50 |
+| `accessCodes` | 88 | 88 |
+| `teams/0JSOplS6f99GIYNS8Sk7/games` | 1 | 1 |
+| `teams/0JSOplS6f99GIYNS8Sk7/statTrackerConfigs` | 2 | 2 |
+
+The isolated clone was deleted at `2026-07-18T03:22:45.217550Z` by operation
+`projects/game-flow-c6311/databases/restore-drill-20260718a/operations/Z96ZsBAG0uvlsQgLGgcQAoe96qAQBtLr0IkIDAodGg`.
+After cleanup, the temporary database returned `NOT_FOUND`; the source still
+reported PITR and delete protection enabled. No production traffic was moved
+and the source database was not changed by the drill.
+
+This PITR evidence proves only the clone path and count sample performed on that
+date. It does not claim field-checksum validation for the PITR clone; the
+separate managed-backup evidence above provides the deterministic field-hash
+restore proof.
+
+## Incident recovery
+
+1. Stop the writer that caused corruption before restoring anything.
+2. Record the incident window and choose a PITR minute immediately before it.
+3. Clone or restore into a new database and validate data there.
+4. Do not redirect production clients until owners approve the validated data
+   and a rollback plan exists.
+5. Preserve the affected source database until the incident is closed.
+
+PITR and backups incur Google Cloud storage and restore charges. Do not disable
+them to address a transient billing alert; investigate usage and retention.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "test:smoke:visual:update": "playwright test --config=playwright.smoke.config.js --grep @visual --update-snapshots",
     "test:smoke:team-fallback": "playwright test tests/smoke/team-fallback-regressions.spec.js --config=playwright.smoke.config.js --reporter=line",
     "ci:firebase-rules": "node scripts/validate-firebase-rules-ci.mjs",
+    "ops:verify-firestore-recovery": "node scripts/verify-firestore-recovery.mjs",
+    "ops:verify-firestore-recovery-identity": "node scripts/verify-firestore-recovery-identity.mjs",
     "stage:pages": "node scripts/stage-pages-bundle.mjs",
     "app:build-help-index": "node scripts/build-app-help-knowledge-index.mjs",
     "app:check-bundle-size": "node scripts/check-app-bundle-size.mjs",

--- a/scripts/reconcile-firestore-recovery-issue.mjs
+++ b/scripts/reconcile-firestore-recovery-issue.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+export const RECOVERY_REPOSITORY = 'pauljsnider/allplays';
+export const RECOVERY_ISSUE_TITLE = '[Recovery] Firestore recovery posture is unverified';
+export const RECOVERY_ISSUE_MARKER = '<!-- allplays-firestore-recovery-health -->';
+export const RECOVERY_ISSUE_ASSIGNEE = 'pauljsnider';
+export const RECOVERY_ISSUE_AUTHOR = 'github-actions[bot]';
+export const RECOVERY_ISSUE_AUTHOR_ID = 41898282;
+export const RECOVERY_ISSUE_LABEL = 'recovery-monitor';
+
+const VERIFY_RESULTS = new Set(['success', 'failure', 'cancelled', 'skipped']);
+
+function required(environment, name) {
+    const value = String(environment[name] || '').trim();
+    if (!value) throw new Error(`${name} is required to reconcile the recovery incident.`);
+    return value;
+}
+
+function parseIssueSearch(output) {
+    let parsed;
+    try {
+        parsed = JSON.parse(String(output || ''));
+    } catch (error) {
+        throw new Error('GitHub returned invalid JSON while searching for recovery incidents.', { cause: error });
+    }
+    if (
+        parsed == null
+        || typeof parsed !== 'object'
+        || Array.isArray(parsed)
+        || !Number.isSafeInteger(parsed.total_count)
+        || parsed.total_count < 0
+        || parsed.total_count > 100
+        || parsed.incomplete_results !== false
+        || !Array.isArray(parsed.items)
+        || parsed.items.length !== parsed.total_count
+    ) {
+        throw new Error('GitHub recovery incident search response is incomplete or invalid.');
+    }
+    return parsed.items;
+}
+
+export function planRecoveryIssueReconciliation(verifyResult, issues) {
+    if (!VERIFY_RESULTS.has(verifyResult)) {
+        throw new Error(`Unexpected recovery verification result: ${verifyResult || '<empty>'}.`);
+    }
+    if (!Array.isArray(issues)) throw new Error('Recovery issues must be an array.');
+
+    const exactIssues = issues.filter((issue) => issue?.title === RECOVERY_ISSUE_TITLE);
+    if (exactIssues.length > 1) {
+        throw new Error('More than one exact Firestore recovery incident exists; refusing ambiguous mutation.');
+    }
+
+    const issue = exactIssues[0] || null;
+    if (issue) {
+        if (!Number.isSafeInteger(issue.number) || issue.number < 1) {
+            throw new Error('The managed recovery incident has an invalid issue number.');
+        }
+        const issueState = String(issue.state || '').toUpperCase();
+        if (!['OPEN', 'CLOSED'].includes(issueState)) {
+            throw new Error('The managed recovery incident has an invalid state.');
+        }
+        if (
+            issue.user?.id !== RECOVERY_ISSUE_AUTHOR_ID
+            || issue.user?.type !== 'Bot'
+            || issue.user?.login !== RECOVERY_ISSUE_AUTHOR
+        ) {
+            throw new Error('Exact recovery issue title exists but was not created by github-actions[bot]; refusing to mutate an untrusted issue.');
+        }
+        if (!Array.isArray(issue.labels) || !issue.labels.some((label) => label?.name === RECOVERY_ISSUE_LABEL)) {
+            throw new Error('Exact recovery issue title exists without the bot-only recovery label; refusing to mutate it.');
+        }
+        if (!String(issue.body || '').includes(RECOVERY_ISSUE_MARKER)) {
+            throw new Error('Exact recovery issue title exists without the managed marker; refusing to edit it.');
+        }
+    }
+
+    if (verifyResult === 'success') {
+        return {
+            action: String(issue?.state || '').toUpperCase() === 'OPEN' ? 'close' : 'none',
+            issueNumber: issue?.number || null,
+            healthy: true
+        };
+    }
+
+    return {
+        action: issue == null
+            ? 'create'
+            : String(issue.state).toUpperCase() === 'CLOSED' ? 'reopen' : 'update',
+        issueNumber: issue?.number || null,
+        healthy: false
+    };
+}
+
+export function buildRecoveryFailureBody({ verifyResult, runUrl, runbookUrl }) {
+    return [
+        RECOVERY_ISSUE_MARKER,
+        '',
+        'The scheduled Firestore recovery check is failing or did not complete successfully.',
+        '',
+        `Latest result: ${verifyResult}. Run: ${runUrl}`,
+        `Runbook: ${runbookUrl}`
+    ].join('\n');
+}
+
+export function runGh(args) {
+    try {
+        return execFileSync('gh', args, {
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'inherit'],
+            timeout: 60 * 1000,
+            maxBuffer: 2 * 1024 * 1024
+        });
+    } catch (error) {
+        const reason = error?.code === 'ETIMEDOUT' ? ' The command timed out after one minute.' : '';
+        throw new Error(`GitHub recovery incident command failed.${reason}`, { cause: error });
+    }
+}
+
+export function reconcileRecoveryIssue(
+    { verifyResult, repository, runUrl, runbookUrl },
+    { executeGh = runGh } = {}
+) {
+    if (repository !== RECOVERY_REPOSITORY) {
+        throw new Error(`Recovery incident reconciliation may run only in ${RECOVERY_REPOSITORY}.`);
+    }
+
+    const issueOutput = executeGh([
+        'api', '--method', 'GET', 'search/issues',
+        '-f', `q=repo:${repository} is:issue author:app/github-actions in:title "${RECOVERY_ISSUE_TITLE}"`,
+        '-f', 'per_page=100'
+    ]);
+    const plan = planRecoveryIssueReconciliation(verifyResult, parseIssueSearch(issueOutput));
+    const failureBody = buildRecoveryFailureBody({ verifyResult, runUrl, runbookUrl });
+
+    if (plan.action === 'close') {
+        executeGh([
+            'issue', 'close', String(plan.issueNumber),
+            '--repo', repository,
+            '--reason', 'completed',
+            '--comment', `Recovery posture verified successfully in ${runUrl}. Closing the managed incident.`
+        ]);
+    } else if (plan.action === 'create') {
+        executeGh([
+            'issue', 'create',
+            '--repo', repository,
+            '--assignee', RECOVERY_ISSUE_ASSIGNEE,
+            '--label', RECOVERY_ISSUE_LABEL,
+            '--title', RECOVERY_ISSUE_TITLE,
+            '--body', failureBody
+        ]);
+    } else if (plan.action === 'reopen') {
+        executeGh(['issue', 'reopen', String(plan.issueNumber), '--repo', repository]);
+        executeGh(['issue', 'edit', String(plan.issueNumber), '--repo', repository, '--body', failureBody]);
+        executeGh([
+            'issue', 'comment', String(plan.issueNumber),
+            '--repo', repository,
+            '--body', `Recovery posture failed again. Investigate ${runUrl}.`
+        ]);
+    } else if (plan.action === 'update') {
+        executeGh(['issue', 'edit', String(plan.issueNumber), '--repo', repository, '--body', failureBody]);
+    }
+
+    return plan;
+}
+
+export function reconcileRecoveryIssueFromEnvironment(environment = process.env, dependencies = {}) {
+    const verifyResult = required(environment, 'VERIFY_RESULT');
+    const repository = required(environment, 'GITHUB_REPOSITORY');
+    const serverUrl = required(environment, 'GITHUB_SERVER_URL').replace(/\/+$/, '');
+    const runId = required(environment, 'GITHUB_RUN_ID');
+    required(environment, 'GH_TOKEN');
+
+    const runUrl = `${serverUrl}/${repository}/actions/runs/${runId}`;
+    const runbookUrl = `${serverUrl}/${repository}/blob/master/docs/firestore-recovery-runbook.md#health-check-failure`;
+    const result = reconcileRecoveryIssue(
+        { verifyResult, repository, runUrl, runbookUrl },
+        dependencies
+    );
+
+    if (!result.healthy) {
+        console.error(`::error title=Firestore recovery health check failed::Result=${verifyResult}. Treat recovery posture as unverified. Inspect ${runUrl} and follow ${runbookUrl}.`);
+        const summaryPath = String(environment.GITHUB_STEP_SUMMARY || '').trim();
+        if (summaryPath) {
+            appendFileSync(summaryPath, [
+                '## Firestore recovery posture is unverified',
+                '',
+                `Verification result: \`${verifyResult}\``,
+                '',
+                `1. [Inspect the failed health run](${runUrl}).`,
+                `2. [Follow the health-check failure runbook](${runbookUrl}).`,
+                '3. Do not disable PITR, backup schedules, or delete protection while investigating.',
+                '4. Escalate to the production owner if a control is absent, a backup is stale, or OIDC cannot authenticate.',
+                ''
+            ].join('\n'), { encoding: 'utf8' });
+        }
+        process.exitCode = 1;
+    }
+
+    return result;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    try {
+        reconcileRecoveryIssueFromEnvironment();
+    } catch (error) {
+        console.error(`::error title=Recovery incident reconciliation failed::${error?.message || 'Unknown reconciliation failure.'}`);
+        process.exitCode = 1;
+    }
+}

--- a/scripts/verify-firestore-recovery-identity.mjs
+++ b/scripts/verify-firestore-recovery-identity.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url';
+
+export const EXPECTED_RECOVERY_REPOSITORY = 'pauljsnider/allplays';
+export const EXPECTED_RECOVERY_REPOSITORY_ID = '1106220007';
+export const EXPECTED_RECOVERY_REPOSITORY_OWNER_ID = '211066188';
+export const EXPECTED_RECOVERY_REF = 'refs/heads/master';
+export const EXPECTED_RECOVERY_WORKFLOW_REF = `${EXPECTED_RECOVERY_REPOSITORY}/.github/workflows/firestore-recovery-health.yml@${EXPECTED_RECOVERY_REF}`;
+export const EXPECTED_RECOVERY_PROJECT_ID = 'game-flow-c6311';
+export const EXPECTED_RECOVERY_PROVIDER = 'projects/982493478258/locations/global/workloadIdentityPools/github-actions/providers/allplays-recovery';
+export const EXPECTED_RECOVERY_SERVICE_ACCOUNT = 'allplays-firestore-recovery@game-flow-c6311.iam.gserviceaccount.com';
+
+const PROVIDER_PATTERN = /^projects\/(\d+)\/locations\/global\/workloadIdentityPools\/([a-z][a-z0-9-]{3,31})\/providers\/([a-z][a-z0-9-]{3,31})$/;
+const SERVICE_ACCOUNT_PATTERN = /^([a-z][a-z0-9-]{4,28}[a-z0-9])@([a-z][a-z0-9-]{4,28}[a-z0-9])\.iam\.gserviceaccount\.com$/;
+
+function required(environment, name, failures) {
+    const value = String(environment[name] || '').trim();
+    if (!value) failures.push(`${name} is not configured.`);
+    return value;
+}
+
+export function evaluateRecoveryWorkflowIdentity(environment = process.env) {
+    const failures = [];
+    const projectId = required(environment, 'FIREBASE_PROJECT_ID', failures);
+    const workloadIdentityProvider = required(
+        environment,
+        'FIRESTORE_RECOVERY_WORKLOAD_IDENTITY_PROVIDER',
+        failures
+    );
+    const serviceAccount = required(environment, 'FIRESTORE_RECOVERY_SERVICE_ACCOUNT', failures);
+    const repository = required(environment, 'GITHUB_REPOSITORY', failures);
+    const repositoryId = required(environment, 'GITHUB_REPOSITORY_ID', failures);
+    const repositoryOwnerId = required(environment, 'GITHUB_REPOSITORY_OWNER_ID', failures);
+    const ref = required(environment, 'GITHUB_REF', failures);
+    const workflowRef = required(environment, 'GITHUB_WORKFLOW_REF', failures);
+
+    const providerMatch = workloadIdentityProvider.match(PROVIDER_PATTERN);
+    if (workloadIdentityProvider && !providerMatch) {
+        failures.push('FIRESTORE_RECOVERY_WORKLOAD_IDENTITY_PROVIDER is not a canonical provider resource name.');
+    } else if (providerMatch && workloadIdentityProvider !== EXPECTED_RECOVERY_PROVIDER) {
+        failures.push(`FIRESTORE_RECOVERY_WORKLOAD_IDENTITY_PROVIDER must be ${EXPECTED_RECOVERY_PROVIDER}.`);
+    }
+
+    const serviceAccountMatch = serviceAccount.match(SERVICE_ACCOUNT_PATTERN);
+    if (serviceAccount && !serviceAccountMatch) {
+        failures.push('FIRESTORE_RECOVERY_SERVICE_ACCOUNT is not a valid service-account email.');
+    } else if (serviceAccountMatch && projectId && serviceAccountMatch[2] !== projectId) {
+        failures.push('FIRESTORE_RECOVERY_SERVICE_ACCOUNT does not belong to FIREBASE_PROJECT_ID.');
+    } else if (serviceAccountMatch && serviceAccount !== EXPECTED_RECOVERY_SERVICE_ACCOUNT) {
+        failures.push(`FIRESTORE_RECOVERY_SERVICE_ACCOUNT must be ${EXPECTED_RECOVERY_SERVICE_ACCOUNT}.`);
+    }
+
+    if (projectId && projectId !== EXPECTED_RECOVERY_PROJECT_ID) {
+        failures.push(`FIREBASE_PROJECT_ID must be ${EXPECTED_RECOVERY_PROJECT_ID}.`);
+    }
+
+    if (repository && repository !== EXPECTED_RECOVERY_REPOSITORY) {
+        failures.push(`Recovery verification may run only in ${EXPECTED_RECOVERY_REPOSITORY}.`);
+    }
+    if (repositoryId && repositoryId !== EXPECTED_RECOVERY_REPOSITORY_ID) {
+        failures.push(`Recovery verification requires immutable repository ID ${EXPECTED_RECOVERY_REPOSITORY_ID}.`);
+    }
+    if (repositoryOwnerId && repositoryOwnerId !== EXPECTED_RECOVERY_REPOSITORY_OWNER_ID) {
+        failures.push(`Recovery verification requires immutable repository-owner ID ${EXPECTED_RECOVERY_REPOSITORY_OWNER_ID}.`);
+    }
+    if (ref && ref !== EXPECTED_RECOVERY_REF) {
+        failures.push(`Recovery verification may run only from ${EXPECTED_RECOVERY_REF}.`);
+    }
+    if (workflowRef && workflowRef !== EXPECTED_RECOVERY_WORKFLOW_REF) {
+        failures.push(`Recovery verification must use ${EXPECTED_RECOVERY_WORKFLOW_REF}.`);
+    }
+
+    return {
+        healthy: failures.length === 0,
+        failures,
+        projectId,
+        workloadIdentityProvider,
+        serviceAccount,
+        repositoryId,
+        repositoryOwnerId,
+        providerProjectNumber: providerMatch?.[1] || null
+    };
+}
+
+export function verifyRecoveryWorkflowIdentity(environment = process.env) {
+    const result = evaluateRecoveryWorkflowIdentity(environment);
+    if (!result.healthy) {
+        throw new Error([
+            'Firestore recovery OIDC preflight failed:',
+            ...result.failures.map((failure) => `- ${failure}`),
+            'Configure the production environment variables and the exact GitHub-to-Google trust described in docs/firestore-recovery-runbook.md.'
+        ].join('\n'));
+    }
+
+    console.log(JSON.stringify({
+        healthy: true,
+        projectId: result.projectId,
+        providerProjectNumber: result.providerProjectNumber,
+        repositoryId: result.repositoryId,
+        repositoryOwnerId: result.repositoryOwnerId,
+        serviceAccount: result.serviceAccount
+    }, null, 2));
+    return result;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    try {
+        verifyRecoveryWorkflowIdentity();
+    } catch (error) {
+        console.error(error?.message || 'Firestore recovery OIDC preflight failed.');
+        process.exitCode = 1;
+    }
+}

--- a/scripts/verify-firestore-recovery.mjs
+++ b/scripts/verify-firestore-recovery.mjs
@@ -1,0 +1,411 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+export const DEFAULT_DATABASE_ID = '(default)';
+export const DEFAULT_MAX_BACKUP_AGE_HOURS = 36;
+export const MAX_MAX_BACKUP_AGE_HOURS = 7 * 24;
+export const MINIMUM_DAILY_RETENTION_SECONDS = 14 * 24 * 60 * 60;
+export const MAX_FUTURE_CLOCK_SKEW_MS = 10 * 60 * 1000;
+export const MINIMUM_BACKUP_REMAINING_HOURS = 6;
+export const EXPECTED_PRODUCTION_PROJECT_ID = 'game-flow-c6311';
+export const EXPECTED_PRODUCTION_DAILY_SCHEDULE = 'projects/game-flow-c6311/databases/(default)/backupSchedules/8a7f67fe-c6eb-4a4e-8a48-20e96e9fdf57';
+export const EXPECTED_PRODUCTION_DAILY_SCHEDULE_CREATE_TIME = '2026-07-18T02:42:05.213778Z';
+
+const PROJECT_ID_PATTERN = /^[a-z][a-z0-9-]{4,28}[a-z0-9]$/;
+const DATABASE_ID_PATTERN = /^(?:\(default\)|[a-z][a-z0-9-]{2,61}[a-z0-9])$/;
+const GOOGLE_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$/;
+const UUID_V4_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function durationSeconds(value) {
+    const match = String(value || '').trim().match(/^(\d+(?:\.\d{1,9})?)s$/);
+    if (!match) return null;
+
+    const seconds = Number(match[1]);
+    return Number.isFinite(seconds) ? seconds : null;
+}
+
+function timestampMillis(value) {
+    if (typeof value !== 'string' || !GOOGLE_TIMESTAMP_PATTERN.test(value)) return null;
+    const parsed = Date.parse(value);
+    if (!Number.isFinite(parsed)) return null;
+
+    const inputSecond = `${value.slice(0, 19)}Z`;
+    const parsedSecond = `${new Date(parsed).toISOString().slice(0, 19)}Z`;
+    return inputSecond === parsedSecond ? parsed : null;
+}
+
+function backupTimestamp(backup) {
+    return timestampMillis(backup?.snapshotTime);
+}
+
+function finiteBoundedHours(value) {
+    const hours = typeof value === 'number' ? value : Number(String(value).trim());
+    return Number.isFinite(hours) && hours >= 1 && hours <= MAX_MAX_BACKUP_AGE_HOURS
+        ? hours
+        : null;
+}
+
+function backupLabel(backup) {
+    return String(backup?.name || '<unnamed backup>');
+}
+
+function isExactDailyRecurrence(value) {
+    if (value == null || typeof value !== 'object' || Array.isArray(value)) return false;
+    return Object.getPrototypeOf(value) === Object.prototype && Object.keys(value).length === 0;
+}
+
+function isCanonicalScheduleName(name, expectedDatabaseName) {
+    if (typeof name !== 'string' || typeof expectedDatabaseName !== 'string') return false;
+    const prefix = `${expectedDatabaseName}/backupSchedules/`;
+    if (!name.startsWith(prefix)) return false;
+    const scheduleId = name.slice(prefix.length);
+    return /^[A-Za-z0-9][A-Za-z0-9-]{0,127}$/.test(scheduleId);
+}
+
+function isCanonicalBackupName(name, expectedDatabaseName) {
+    if (typeof name !== 'string' || typeof expectedDatabaseName !== 'string') return false;
+    const databaseMatch = expectedDatabaseName.match(/^projects\/([a-z][a-z0-9-]{4,28}[a-z0-9])\/databases\/(?:\(default\)|[a-z][a-z0-9-]{2,61}[a-z0-9])$/);
+    if (!databaseMatch) return false;
+    const backupMatch = name.match(/^projects\/([a-z][a-z0-9-]{4,28}[a-z0-9])\/locations\/([a-z0-9-]+)\/backups\/([0-9a-f-]+)$/i);
+    return backupMatch != null
+        && backupMatch[1] === databaseMatch[1]
+        && backupMatch[2].length > 0
+        && UUID_V4_PATTERN.test(backupMatch[3]);
+}
+
+export function evaluateFirestoreRecoveryPosture({
+    database,
+    schedules = [],
+    backups = [],
+    now = Date.now(),
+    maxBackupAgeHours = DEFAULT_MAX_BACKUP_AGE_HOURS,
+    expectedDatabaseName = null,
+    expectedDailyScheduleName = null,
+    expectedDailyScheduleCreateTime = null
+} = {}) {
+    const failures = [];
+    const notices = [];
+    const nowMillis = Number(now);
+    const boundedMaxBackupAgeHours = finiteBoundedHours(maxBackupAgeHours);
+
+    if (!Number.isFinite(nowMillis) || nowMillis < 0) {
+        failures.push('The verifier clock is invalid.');
+    }
+    if (boundedMaxBackupAgeHours == null) {
+        failures.push(`Maximum backup age must be a finite number from 1 through ${MAX_MAX_BACKUP_AGE_HOURS} hours.`);
+    }
+    if (!Array.isArray(schedules)) {
+        failures.push('Backup schedules response is not an array.');
+        schedules = [];
+    }
+    if (!Array.isArray(backups)) {
+        failures.push('Backups response is not an array.');
+        backups = [];
+    }
+
+    if (database?.pointInTimeRecoveryEnablement !== 'POINT_IN_TIME_RECOVERY_ENABLED') {
+        failures.push('Point-in-time recovery is not enabled.');
+    }
+    if (database?.deleteProtectionState !== 'DELETE_PROTECTION_ENABLED') {
+        failures.push('Database delete protection is not enabled.');
+    }
+    if (expectedDatabaseName != null && database?.name !== expectedDatabaseName) {
+        failures.push(`The database metadata name must be ${expectedDatabaseName}.`);
+    }
+
+    const currentDatabaseUid = typeof database?.uid === 'string' ? database.uid.trim() : '';
+    if (!UUID_V4_PATTERN.test(currentDatabaseUid)) {
+        failures.push('The current database UID is unavailable or invalid, so backup lineage cannot be verified.');
+    }
+
+    if (
+        expectedDatabaseName != null
+        && schedules.some((schedule) => !isCanonicalScheduleName(schedule?.name, expectedDatabaseName))
+    ) {
+        failures.push(`Every backup schedule must be a canonical child of ${expectedDatabaseName}.`);
+    }
+
+    const dailySchedules = schedules.filter((schedule) => isExactDailyRecurrence(schedule?.dailyRecurrence));
+    if (dailySchedules.length === 0) {
+        failures.push('No daily managed-backup schedule exists.');
+    } else if (dailySchedules.length > 1) {
+        failures.push('More than one daily managed-backup schedule exists; expected exactly one.');
+    }
+    const dailySchedule = dailySchedules[0] || null;
+
+    if (
+        expectedDailyScheduleName != null
+        && dailySchedule?.name !== expectedDailyScheduleName
+    ) {
+        failures.push(`The daily managed-backup schedule must be ${expectedDailyScheduleName}; refusing a recreated schedule that could reset the first-backup grace window.`);
+    }
+    if (
+        expectedDailyScheduleCreateTime != null
+        && dailySchedule?.createTime !== expectedDailyScheduleCreateTime
+    ) {
+        failures.push(`The daily managed-backup schedule creation time must remain ${expectedDailyScheduleCreateTime}; refusing a replaced schedule or reset grace window.`);
+    }
+
+    if (dailySchedule) {
+        const retentionSeconds = durationSeconds(dailySchedule.retention);
+        if (retentionSeconds == null || retentionSeconds < MINIMUM_DAILY_RETENTION_SECONDS) {
+            failures.push('The daily managed-backup retention is shorter than 14 days or invalid.');
+        }
+    }
+
+    const usableNow = Number.isFinite(nowMillis) && nowMillis >= 0 ? nowMillis : null;
+    const scheduleCreatedAt = timestampMillis(dailySchedule?.createTime);
+    if (dailySchedule && scheduleCreatedAt == null) {
+        failures.push('The daily managed-backup schedule creation timestamp is missing or invalid.');
+    } else if (
+        dailySchedule
+        && usableNow != null
+        && scheduleCreatedAt > usableNow + MAX_FUTURE_CLOCK_SKEW_MS
+    ) {
+        failures.push('The daily managed-backup schedule creation timestamp is materially in the future.');
+    }
+
+    const currentLineageBackups = UUID_V4_PATTERN.test(currentDatabaseUid)
+        ? backups.filter((backup) => (
+            typeof backup?.databaseUid === 'string'
+            && backup.databaseUid.trim() === currentDatabaseUid
+        ))
+        : [];
+    const validReadyBackups = [];
+
+    for (const backup of currentLineageBackups) {
+        if (backup?.state !== 'READY') continue;
+
+        let validMetadata = true;
+        if (!UUID_V4_PATTERN.test(String(backup?.databaseUid || '').trim())) {
+            failures.push(`Ready backup ${backupLabel(backup)} has an invalid database UID.`);
+            validMetadata = false;
+        }
+        if (expectedDatabaseName != null && backup?.database !== expectedDatabaseName) {
+            failures.push(`Ready backup ${backupLabel(backup)} does not belong to ${expectedDatabaseName}.`);
+            validMetadata = false;
+        }
+        if (expectedDatabaseName != null && !isCanonicalBackupName(backup?.name, expectedDatabaseName)) {
+            failures.push(`Ready backup ${backupLabel(backup)} has a missing or invalid canonical resource name.`);
+            validMetadata = false;
+        }
+
+        const capturedAt = backupTimestamp(backup);
+        if (capturedAt == null) {
+            failures.push(`Ready backup ${backupLabel(backup)} has a missing or invalid snapshot timestamp.`);
+            validMetadata = false;
+        }
+        if (capturedAt != null && usableNow != null && capturedAt > usableNow + MAX_FUTURE_CLOCK_SKEW_MS) {
+            failures.push(`Backup ${backupLabel(backup)} has a snapshot timestamp materially in the future.`);
+            validMetadata = false;
+        }
+
+        const expiresAt = timestampMillis(backup?.expireTime);
+        if (expiresAt == null) {
+            failures.push(`Ready backup ${backupLabel(backup)} has a missing or invalid expiration timestamp.`);
+            validMetadata = false;
+        } else if (
+            usableNow != null
+            && expiresAt <= usableNow + MINIMUM_BACKUP_REMAINING_HOURS * 60 * 60 * 1000
+        ) {
+            failures.push(`Ready backup ${backupLabel(backup)} expires before the next six-hour health-check window.`);
+            validMetadata = false;
+        }
+
+        if (validMetadata) {
+            validReadyBackups.push({ backup, capturedAt });
+        }
+    }
+
+    validReadyBackups.sort((left, right) => right.capturedAt - left.capturedAt);
+    const newestBackup = validReadyBackups[0]?.backup || null;
+
+    if (newestBackup) {
+        const newestAt = validReadyBackups[0].capturedAt;
+        if (
+            usableNow != null
+            && boundedMaxBackupAgeHours != null
+            && usableNow - newestAt > boundedMaxBackupAgeHours * 60 * 60 * 1000
+        ) {
+            failures.push(`The newest ready backup is older than ${boundedMaxBackupAgeHours} hours.`);
+        }
+    } else if (dailySchedule && scheduleCreatedAt != null && usableNow != null) {
+        const scheduleAgeMs = usableNow - scheduleCreatedAt;
+        const graceMs = DEFAULT_MAX_BACKUP_AGE_HOURS * 60 * 60 * 1000;
+        if (scheduleAgeMs < -MAX_FUTURE_CLOCK_SKEW_MS) {
+            // The future-timestamp failure above is already the actionable cause.
+        } else if (scheduleAgeMs > graceMs) {
+            failures.push('The daily schedule has not produced a ready backup within its initial 36-hour window.');
+        } else {
+            notices.push('Daily schedule is within its initial 36-hour window; the first backup is still pending.');
+        }
+    }
+
+    return {
+        healthy: failures.length === 0,
+        failures,
+        notices,
+        dailySchedule,
+        newestBackup
+    };
+}
+
+function readFlag(argv, name, fallback) {
+    const separatedIndexes = argv
+        .map((argument, index) => argument === name ? index : -1)
+        .filter((index) => index >= 0);
+    const prefix = `${name}=`;
+    const assignments = argv.filter((argument) => String(argument).startsWith(prefix));
+
+    if (separatedIndexes.length + assignments.length > 1) {
+        throw new Error(`${name} may be supplied only once.`);
+    }
+    if (separatedIndexes.length === 1) {
+        const value = argv[separatedIndexes[0] + 1];
+        if (value == null || String(value).startsWith('--')) {
+            throw new Error(`${name} requires a value.`);
+        }
+        return String(value).trim();
+    }
+    if (assignments.length === 1) return String(assignments[0]).slice(prefix.length).trim();
+    return String(fallback ?? '').trim();
+}
+
+function validateKnownFlags(argv) {
+    const known = new Set(['--project', '--database', '--max-backup-age-hours']);
+    for (let index = 0; index < argv.length; index += 1) {
+        const argument = String(argv[index]);
+        const name = argument.split('=', 1)[0];
+        if (!known.has(name)) throw new Error(`Unknown recovery verifier argument: ${argument}`);
+        if (!argument.includes('=')) index += 1;
+    }
+}
+
+export function parseFirestoreRecoveryArgs(argv = process.argv.slice(2), environment = process.env) {
+    validateKnownFlags(argv);
+
+    const projectId = readFlag(argv, '--project', environment.FIREBASE_PROJECT_ID || '');
+    const databaseId = readFlag(argv, '--database', environment.FIRESTORE_DATABASE_ID || DEFAULT_DATABASE_ID);
+    const maxBackupAgeValue = readFlag(
+        argv,
+        '--max-backup-age-hours',
+        environment.FIRESTORE_MAX_BACKUP_AGE_HOURS || String(DEFAULT_MAX_BACKUP_AGE_HOURS)
+    );
+    const maxBackupAgeHours = finiteBoundedHours(maxBackupAgeValue);
+
+    if (!projectId) {
+        throw new Error('Set FIREBASE_PROJECT_ID or pass --project before checking Firestore recovery.');
+    }
+    if (!PROJECT_ID_PATTERN.test(projectId)) {
+        throw new Error('The Firestore project ID is invalid.');
+    }
+    if (!DATABASE_ID_PATTERN.test(databaseId)) {
+        throw new Error('The Firestore database ID is invalid.');
+    }
+    if (maxBackupAgeHours == null) {
+        throw new Error(`--max-backup-age-hours must be a finite number from 1 through ${MAX_MAX_BACKUP_AGE_HOURS}.`);
+    }
+
+    return { projectId, databaseId, maxBackupAgeHours };
+}
+
+export function runGcloudJson(args) {
+    try {
+        const output = execFileSync('gcloud', args, {
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'inherit'],
+            timeout: 2 * 60 * 1000,
+            maxBuffer: 10 * 1024 * 1024
+        });
+        return JSON.parse(output || 'null');
+    } catch (error) {
+        const command = args
+            .filter((argument) => !String(argument).startsWith('--format='))
+            .slice(0, 4)
+            .join(' ');
+        const reason = error?.code === 'ETIMEDOUT' ? ' The command timed out after two minutes.' : '';
+        throw new Error(
+            `gcloud ${command} failed.${reason} Verify Cloud SDK installation, OIDC authentication, project access, and the three recovery metadata permissions.`,
+            { cause: error }
+        );
+    }
+}
+
+function requireArray(value, label) {
+    if (!Array.isArray(value)) throw new Error(`gcloud returned an invalid ${label} response; expected a JSON array.`);
+    return value;
+}
+
+export function collectFirestoreRecoveryPosture(
+    { projectId, databaseId, maxBackupAgeHours },
+    { runJson = runGcloudJson, now = Date.now() } = {}
+) {
+    const databaseName = `projects/${projectId}/databases/${databaseId}`;
+    const database = runJson([
+        'firestore', 'databases', 'describe',
+        `--project=${projectId}`,
+        `--database=${databaseId}`,
+        '--format=json'
+    ]);
+    const schedules = requireArray(runJson([
+        'firestore', 'backups', 'schedules', 'list',
+        `--project=${projectId}`,
+        `--database=${databaseId}`,
+        '--format=json'
+    ]), 'backup schedules');
+    const backups = requireArray(runJson([
+        'firestore', 'backups', 'list',
+        `--project=${projectId}`,
+        '--format=json'
+    ]), 'backups').filter((backup) => String(backup?.database || '') === databaseName);
+
+    return evaluateFirestoreRecoveryPosture({
+        database,
+        schedules,
+        backups,
+        now,
+        maxBackupAgeHours,
+        expectedDatabaseName: databaseName,
+        expectedDailyScheduleName: (
+            projectId === EXPECTED_PRODUCTION_PROJECT_ID
+            && databaseId === DEFAULT_DATABASE_ID
+        ) ? EXPECTED_PRODUCTION_DAILY_SCHEDULE : null,
+        expectedDailyScheduleCreateTime: (
+            projectId === EXPECTED_PRODUCTION_PROJECT_ID
+            && databaseId === DEFAULT_DATABASE_ID
+        ) ? EXPECTED_PRODUCTION_DAILY_SCHEDULE_CREATE_TIME : null
+    });
+}
+
+export function verifyFirestoreRecovery(
+    argv = process.argv.slice(2),
+    environment = process.env,
+    dependencies = {}
+) {
+    const options = parseFirestoreRecoveryArgs(argv, environment);
+    const result = collectFirestoreRecoveryPosture(options, dependencies);
+
+    console.log(JSON.stringify({
+        projectId: options.projectId,
+        databaseId: options.databaseId,
+        healthy: result.healthy,
+        failures: result.failures,
+        notices: result.notices,
+        dailySchedule: result.dailySchedule?.name || null,
+        newestBackup: result.newestBackup?.name || null
+    }, null, 2));
+
+    if (!result.healthy) process.exitCode = 1;
+    return result;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    try {
+        verifyFirestoreRecovery();
+    } catch (error) {
+        console.error(error?.message || 'Firestore recovery verification failed.');
+        process.exitCode = 1;
+    }
+}

--- a/spec/firestore-backup-strategy.md
+++ b/spec/firestore-backup-strategy.md
@@ -1,8 +1,19 @@
 # Firestore Backup Strategy
 
-This repo (static site + Firebase) does not encode Firestore backup behavior.
-Backups for Firestore are configured in Google Cloud (the Firebase project), not in
-`firebase.json` / `firestore.rules` / `firestore.indexes.json`.
+Firestore recovery controls are configured in Google Cloud rather than
+`firebase.json`. Production has PITR, delete protection, and a daily managed
+backup with at least 14 days of retention. The repository verifies that external
+posture in `.github/workflows/firestore-recovery-health.yml`; commands, IAM
+boundaries, failure response, and drill evidence are in
+`docs/firestore-recovery-runbook.md`.
+
+The 2026-07-18 PITR clone drill completed successfully and its isolated clone
+was deleted. That evidence covers representative count comparisons only. A
+separate 2026-07-18 managed-backup restore also completed successfully: five
+snapshot-eligible canonical document hashes matched exactly, contextual counts
+matched, ETag-guarded cleanup completed, and the isolated target returned
+`NOT_FOUND`. Neither drill is inferred from a healthy metadata check; both have
+explicit evidence in `docs/firestore-recovery-runbook.md`.
 
 ## Goals
 
@@ -10,11 +21,11 @@ Backups for Firestore are configured in Google Cloud (the Firebase project), not
 - Be able to restore specific collections or the entire database.
 - Keep operational cost and complexity reasonable.
 
-## Recommended Approach
+## Implemented Approach
 
 ### 1) Enable Firestore Managed Backups / PITR (Primary)
 
-Use Firestore managed backups / point-in-time recovery (PITR) in the GCP Console.
+Use Firestore managed backups and point-in-time recovery (PITR).
 
 Why:
 
@@ -27,7 +38,7 @@ Notes:
 - Configure retention based on how quickly you want to detect issues (typical: 7-30 days).
 - Document the restore workflow and who has permission to run restores.
 
-### 2) Scheduled Exports to Cloud Storage (Secondary, for longer retention)
+### 2) Scheduled Exports to Cloud Storage (Optional longer retention)
 
 Set up a scheduled Firestore export to a Cloud Storage bucket (daily or weekly).
 
@@ -46,16 +57,19 @@ Export scope:
 - Full export (simplest), or
 - Collection-level exports if you want to reduce cost/size (requires discipline to keep a list).
 
-## Restore Playbook (What We Should Document)
+## Restore Playbook
 
-- When to use PITR restore vs export restore
-- Who can approve/execute a restore
-- Expected downtime / impact on the app
-- Post-restore validation checklist (sample queries, key pages to load)
+See `docs/firestore-recovery-runbook.md`. Health monitoring uses a dedicated
+keyless metadata reader and cannot restore, delete, deploy, or read application
+documents. Restore drills use a separately approved, time-limited identity and
+must validate an isolated target before any deletion or traffic decision.
 
 ## Minimum Operational Checklist
 
-- Confirm PITR/managed backups are enabled in the Firebase project
+- Run `npm run ops:verify-firestore-recovery` with the metadata reader
+- Confirm the GitHub OIDC preflight and exact workload identity condition pass
+- Route workflow failures to the production owner and exercise that route
+- Complete and record quarterly PITR and managed-backup restore drills
 - Confirm a Storage bucket exists for exports (if doing scheduled exports)
 - Confirm IAM roles for the account that runs exports/restores
 - Confirm alerts/notifications for failed exports (if scheduled exports exist)
@@ -74,4 +88,3 @@ If/when we tighten privacy, the recommended pattern is:
 
 This also makes future backups/restores more obviously sensitive: restoring private
 data should be more tightly controlled.
-

--- a/tests/unit/firestore-recovery-delivery-contract.test.js
+++ b/tests/unit/firestore-recovery-delivery-contract.test.js
@@ -1,0 +1,178 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+function readSource(path) {
+    return readFileSync(new URL(`../../${path}`, import.meta.url), 'utf8');
+}
+
+const workflow = readSource('.github/workflows/firestore-recovery-health.yml');
+const runbook = readSource('docs/firestore-recovery-runbook.md');
+const strategy = readSource('spec/firestore-backup-strategy.md');
+const packageSource = readSource('package.json');
+const verifier = readSource('scripts/verify-firestore-recovery.mjs');
+const issueReconciler = readSource('scripts/reconcile-firestore-recovery-issue.mjs');
+
+describe('Firestore recovery delivery contract', () => {
+    it('uses fail-closed keyless OIDC before gcloud without any JSON credential secret', () => {
+        const preflightIndex = workflow.indexOf('node scripts/verify-firestore-recovery-identity.mjs');
+        const authIndex = workflow.indexOf('uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093');
+        const setupIndex = workflow.indexOf('uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db');
+        const verifyIndex = workflow.indexOf('run: npm run ops:verify-firestore-recovery');
+
+        expect(workflow).toContain('id-token: write');
+        expect(workflow).toContain('workload_identity_provider: ${{ vars.FIRESTORE_RECOVERY_WORKLOAD_IDENTITY_PROVIDER }}');
+        expect(workflow).toContain('service_account: ${{ vars.FIRESTORE_RECOVERY_SERVICE_ACCOUNT }}');
+        expect(workflow).toContain('create_credentials_file: true');
+        expect(workflow).toContain('cleanup_credentials: true');
+        expect(workflow).not.toContain('credentials_json');
+        expect(workflow).not.toContain('SERVICE_ACCOUNT_GAME_FLOW_C6311 }}');
+        expect(workflow).not.toContain('npm ci');
+        expect(preflightIndex).toBeGreaterThan(-1);
+        expect(authIndex).toBeGreaterThan(preflightIndex);
+        expect(setupIndex).toBeGreaterThan(authIndex);
+        expect(verifyIndex).toBeGreaterThan(setupIndex);
+    });
+
+    it('bounds the health job and escalates ordinary failure or timeout in a separate job', () => {
+        expect(workflow).toMatch(/verify-recovery:[\s\S]*?timeout-minutes: 10/);
+        expect(workflow).toContain('reconcile-recovery-status:');
+        expect(workflow).toContain('if: ${{ always() }}');
+        expect(workflow).toMatch(/reconcile-recovery-status:[\s\S]*?timeout-minutes: 5/);
+        expect(workflow).toMatch(/reconcile-recovery-status:[\s\S]*?issues: write/);
+        expect(workflow).toContain('run: node scripts/reconcile-firestore-recovery-issue.mjs');
+        expect(issueReconciler).toContain('Firestore recovery posture is unverified');
+        expect(issueReconciler).toContain('<!-- allplays-firestore-recovery-health -->');
+        expect(issueReconciler).toContain("RECOVERY_ISSUE_AUTHOR_ID = 41898282");
+        expect(issueReconciler).toContain("RECOVERY_ISSUE_AUTHOR = 'github-actions[bot]'");
+        expect(issueReconciler).toContain("RECOVERY_ISSUE_LABEL = 'recovery-monitor'");
+        expect(issueReconciler).toContain("issue.user?.type !== 'Bot'");
+        expect(issueReconciler).toContain('refusing ambiguous mutation');
+        expect(issueReconciler).toContain('docs/firestore-recovery-runbook.md#health-check-failure');
+        expect(issueReconciler).toContain('process.exitCode = 1');
+        expect(issueReconciler).toContain('author:app/github-actions');
+        expect(runbook).toContain('public-user title/marker copies are ignored');
+        expect(runbook).toContain('That issue handles explicit workflow failures but is not a dead-man.');
+        expect(runbook).toMatch(/route\s+failures from the `firestore-recovery-health` workflow/);
+        expect(runbook).toContain("latest `event=schedule` run");
+        expect(runbook).toContain('outside this repository\'s GitHub Actions');
+    });
+
+    it('keeps the verifier commands available and the documented invocation executable', () => {
+        expect(packageSource).toContain('"ops:verify-firestore-recovery": "node scripts/verify-firestore-recovery.mjs"');
+        expect(packageSource).toContain('"ops:verify-firestore-recovery-identity": "node scripts/verify-firestore-recovery-identity.mjs"');
+        expect(runbook).toContain('npm run ops:verify-firestore-recovery -- --project="$ALLPLAYS_FIRESTORE_PROJECT_ID"');
+    });
+
+    it('documents the exact least-privilege Google and GitHub identity contract', () => {
+        expect(runbook).toContain('datastore.databases.getMetadata');
+        expect(runbook).toContain('datastore.backupSchedules.list');
+        expect(runbook).toContain('datastore.backups.list');
+        expect(runbook).toContain('roles/iam.workloadIdentityUser');
+        expect(runbook).toContain('does not need Service Account Token Creator');
+        expect(runbook).toContain('projects/982493478258/locations/global/workloadIdentityPools/github-actions/providers/allplays-recovery');
+        expect(runbook).toContain('allplays-firestore-recovery@game-flow-c6311.iam.gserviceaccount.com');
+        expect(runbook).toContain('attribute.repository_id=assertion.repository_id');
+        expect(runbook).toContain('attribute.repository_owner_id=assertion.repository_owner_id');
+        expect(runbook).toContain('attribute.workflow_ref=assertion.workflow_ref');
+        expect(runbook).toContain("assertion.repository_id == '1106220007' && assertion.repository_owner_id == '211066188'");
+        expect(runbook).toContain('attribute.repository_id/1106220007');
+        expect(runbook).not.toContain('attribute.repository=assertion.repository');
+        expect(runbook).toContain('pauljsnider/allplays/.github/workflows/firestore-recovery-health.yml@refs/heads/master');
+        expect(runbook).toContain('no user-managed key');
+        expect(runbook).toContain('zero user-managed keys');
+        expect(runbook).toContain('pool/provider `ACTIVE`');
+        expect(runbook).toContain('first workflow dispatch\nand scheduled heartbeat still must succeed');
+    });
+
+    it('keeps restore drills isolated and deletion guarded to one exact target', () => {
+        expect(runbook).toContain('Never restore over `(default)`');
+        expect(runbook).toContain('--destination-database="$ALLPLAYS_PITR_DRILL_DATABASE"');
+        expect(runbook).toContain('--destination-database="$ALLPLAYS_BACKUP_DRILL_DATABASE"');
+        expect(runbook).toContain('set -euo pipefail');
+        expect(runbook).toContain("test \"$ALLPLAYS_BACKUP_DRILL_DATABASE\" != '(default)'");
+        expect(runbook).toContain('^backup-drill-[0-9]{8}-[a-z0-9]{6}$');
+        expect(runbook).toContain('test "$actual_resource" = "projects/$ALLPLAYS_FIRESTORE_PROJECT_ID/databases/$EXPECTED_BACKUP_DRILL_DATABASE"');
+        expect(runbook).toContain('test "$actual_uid" = "$EXPECTED_BACKUP_DRILL_UID"');
+        expect(runbook).toContain('test -n "$actual_etag"');
+        expect(runbook).toContain('test "$actual_source_backup" = "$EXPECTED_BACKUP_RESOURCE"');
+        expect(runbook).toContain("readonly EXPECTED_BACKUP_RESTORE_OPERATION='EXACT_RESTORE_OPERATION_RECORDED_AND_MONITORED_ABOVE'");
+        expect(runbook).toContain('.metadata.operationState == "SUCCESSFUL"');
+        expect(runbook).toContain('.metadata.backup == $backup');
+        expect(runbook).toContain('.response.uid == $uid');
+        expect(runbook).not.toContain("'.sourceInfo.progress'");
+        expect(runbook).toContain('"https://firestore.googleapis.com/v1/$actual_resource?updateMask=deleteProtectionState"');
+        expect(runbook).toContain('{name: $name, deleteProtectionState: "DELETE_PROTECTION_DISABLED", etag: $etag}');
+        expect(runbook).toContain('test "$(jq -r \'.name\' <<< "$protection_update_operation_json")" = "$protection_update_operation"');
+        expect(runbook).toContain('test "$protection_update_complete" = true');
+        expect(runbook).not.toContain('--no-delete-protection');
+        expect(runbook).toContain("test \"$(jq -r '.deleteProtectionState' <<< \"$target_after_json\")\" = 'DELETE_PROTECTION_DISABLED'");
+        expect(runbook).toContain('--etag="$post_update_etag"');
+        expect(runbook).toContain('EXPECTED_SOURCE_DATABASE_UID');
+        expect(runbook).toContain('--database="$EXPECTED_BACKUP_DRILL_DATABASE"');
+        expect(runbook).toContain('return `NOT_FOUND`');
+        expect(runbook).toContain('Never disable delete protection on `(default)`');
+        expect(runbook).not.toContain('--database=*');
+    });
+
+    it('gives PITR drills the same unique-target and ETag cleanup boundary', () => {
+        expect(runbook).toContain("^restore-drill-[0-9]{8}-[a-z0-9]{6}$");
+        expect(runbook).toContain('Require an exact describe of this destination to return NOT_FOUND first.');
+        expect(runbook).toContain('Freeze the returned destination\nname and UID');
+        expect(runbook).toContain('final\nETag cleanup pattern');
+        expect(runbook).toContain('Never reuse a prior drill ID or directly delete by\nname alone');
+    });
+
+    it('requires and records deterministic managed-backup content evidence beyond counts', () => {
+        expect(runbook).toContain('Status: **tested successfully on 2026-07-18**');
+        expect(runbook).toContain('require its `updateTime` to be at or before the selected backup');
+        expect(runbook).toContain("jq -ceS '.fields // {}'");
+        expect(runbook).toContain("record `documentPath<TAB>sha256`");
+        expect(runbook).toMatch(/require\s+both `cmp` of the manifests and the SHA-256 of the complete manifests to match/);
+        expect(runbook).toContain('replace every access-code document\nID with `[redacted]`');
+        expect(runbook).toContain('`accessCodes/[redacted]`');
+        expect(runbook).not.toMatch(/accessCodes\/[A-Za-z0-9]{20}/);
+        expect(runbook).toContain('Do not print field values');
+        expect(runbook).toContain('Counts\ncaptured from the live source after the backup are contextual inventory');
+        expect(runbook).toContain('48945c35c303427aa31e0619436a4a2b9b82b4077aed9ffc54bd94eb973beb68');
+        expect(runbook).toContain("recaptured that target's rotating ETag");
+        expect(strategy).toContain('ETag-guarded cleanup');
+        expect(strategy).toContain('managed-backup restore also completed successfully');
+    });
+
+    it('preserves the successful PITR evidence without upgrading its claim', () => {
+        expect(runbook).toContain('2026-07-18 PITR clone drill');
+        expect(runbook).toContain('2026-07-18T02:40:00Z');
+        expect(runbook).toContain('restore-drill-20260718a');
+        expect(runbook).toContain('all sampled source and clone counts matched');
+        expect(runbook).toContain('It does not claim field-checksum validation for the PITR clone');
+        expect(strategy).toContain('PITR clone drill completed successfully');
+    });
+
+    it('keeps command execution bounded and failure output actionable', () => {
+        expect(verifier).toContain('timeout: 2 * 60 * 1000');
+        expect(verifier).toContain("error?.code === 'ETIMEDOUT'");
+        expect(verifier).toContain('OIDC authentication');
+        expect(verifier).toContain('the three recovery metadata permissions');
+    });
+
+    it('uses a six-hour cadence, immutable action revisions, and an exact Cloud SDK', () => {
+        expect(workflow).toContain("cron: '17 */6 * * *'");
+        expect(workflow).toContain('actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd');
+        expect(workflow).toContain('actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444');
+        expect(workflow).toContain('google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093');
+        expect(workflow).toContain('google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db');
+        expect(workflow).toContain("version: '557.0.0'");
+        expect(workflow).not.toMatch(/uses: [^\n]+@v\d+\s*$/m);
+    });
+
+    it('pins the production schedule and never treats backup createTime as snapshot evidence', () => {
+        expect(verifier).toContain('8a7f67fe-c6eb-4a4e-8a48-20e96e9fdf57');
+        expect(verifier).toContain('2026-07-18T02:42:05.213778Z');
+        expect(verifier).toContain('return timestampMillis(backup?.snapshotTime);');
+        expect(verifier).not.toContain('snapshotTime ?? backup?.createTime');
+        expect(verifier).toContain('MINIMUM_BACKUP_REMAINING_HOURS = 6');
+        expect(runbook).toContain('a valid `expireTime` beyond\nthe next six-hour health-check window');
+        expect(runbook).toContain('Recreating or replacing that schedule fails verification');
+        expect(runbook).toContain("a backup's\n`createTime` is never accepted as a freshness substitute");
+    });
+});

--- a/tests/unit/firestore-recovery-identity.test.js
+++ b/tests/unit/firestore-recovery-identity.test.js
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    evaluateRecoveryWorkflowIdentity,
+    EXPECTED_RECOVERY_REF,
+    EXPECTED_RECOVERY_REPOSITORY,
+    EXPECTED_RECOVERY_REPOSITORY_ID,
+    EXPECTED_RECOVERY_REPOSITORY_OWNER_ID,
+    EXPECTED_RECOVERY_WORKFLOW_REF,
+    verifyRecoveryWorkflowIdentity
+} from '../../scripts/verify-firestore-recovery-identity.mjs';
+
+function healthyEnvironment() {
+    return {
+        FIREBASE_PROJECT_ID: 'game-flow-c6311',
+        FIRESTORE_RECOVERY_WORKLOAD_IDENTITY_PROVIDER: 'projects/982493478258/locations/global/workloadIdentityPools/github-actions/providers/allplays-recovery',
+        FIRESTORE_RECOVERY_SERVICE_ACCOUNT: 'allplays-firestore-recovery@game-flow-c6311.iam.gserviceaccount.com',
+        GITHUB_REPOSITORY: EXPECTED_RECOVERY_REPOSITORY,
+        GITHUB_REPOSITORY_ID: EXPECTED_RECOVERY_REPOSITORY_ID,
+        GITHUB_REPOSITORY_OWNER_ID: EXPECTED_RECOVERY_REPOSITORY_OWNER_ID,
+        GITHUB_REF: EXPECTED_RECOVERY_REF,
+        GITHUB_WORKFLOW_REF: EXPECTED_RECOVERY_WORKFLOW_REF
+    };
+}
+
+describe('Firestore recovery workflow identity preflight', () => {
+    it('accepts only the exact configured keyless identity boundary', () => {
+        expect(evaluateRecoveryWorkflowIdentity(healthyEnvironment())).toMatchObject({
+            healthy: true,
+            failures: [],
+            projectId: 'game-flow-c6311',
+            providerProjectNumber: '982493478258',
+            repositoryId: '1106220007',
+            repositoryOwnerId: '211066188',
+            serviceAccount: 'allplays-firestore-recovery@game-flow-c6311.iam.gserviceaccount.com'
+        });
+    });
+
+    it('fails closed and names every missing input', () => {
+        expect(evaluateRecoveryWorkflowIdentity({})).toMatchObject({
+            healthy: false,
+            failures: expect.arrayContaining([
+                'FIREBASE_PROJECT_ID is not configured.',
+                'FIRESTORE_RECOVERY_WORKLOAD_IDENTITY_PROVIDER is not configured.',
+                'FIRESTORE_RECOVERY_SERVICE_ACCOUNT is not configured.',
+                'GITHUB_REPOSITORY is not configured.',
+                'GITHUB_REPOSITORY_ID is not configured.',
+                'GITHUB_REPOSITORY_OWNER_ID is not configured.',
+                'GITHUB_REF is not configured.',
+                'GITHUB_WORKFLOW_REF is not configured.'
+            ])
+        });
+    });
+
+    it.each([
+        ['projects/not-a-number/locations/global/workloadIdentityPools/github-actions/providers/allplays-recovery'],
+        ['projects/982493478258/locations/us/workloadIdentityPools/github-actions/providers/allplays-recovery'],
+        ['projects/982493478258/locations/global/workloadIdentityPools/x/providers/allplays-recovery'],
+        ['projects/982493478258/locations/global/workloadIdentityPools/github-actions/providers/../other']
+    ])('rejects a non-canonical provider resource %s', (provider) => {
+        const environment = healthyEnvironment();
+        environment.FIRESTORE_RECOVERY_WORKLOAD_IDENTITY_PROVIDER = provider;
+        expect(evaluateRecoveryWorkflowIdentity(environment).failures).toContain(
+            'FIRESTORE_RECOVERY_WORKLOAD_IDENTITY_PROVIDER is not a canonical provider resource name.'
+        );
+    });
+
+    it('rejects an invalid service-account email and a valid account from another project', () => {
+        const invalid = healthyEnvironment();
+        invalid.FIRESTORE_RECOVERY_SERVICE_ACCOUNT = 'not-an-account';
+        expect(evaluateRecoveryWorkflowIdentity(invalid).failures).toContain(
+            'FIRESTORE_RECOVERY_SERVICE_ACCOUNT is not a valid service-account email.'
+        );
+
+        const crossProject = healthyEnvironment();
+        crossProject.FIRESTORE_RECOVERY_SERVICE_ACCOUNT = 'allplays-firestore-recovery@other-project.iam.gserviceaccount.com';
+        expect(evaluateRecoveryWorkflowIdentity(crossProject).failures).toContain(
+            'FIRESTORE_RECOVERY_SERVICE_ACCOUNT does not belong to FIREBASE_PROJECT_ID.'
+        );
+    });
+
+    it('rejects canonical but unexpected project, provider, and same-project service account values', () => {
+        const unexpectedProvider = healthyEnvironment();
+        unexpectedProvider.FIRESTORE_RECOVERY_WORKLOAD_IDENTITY_PROVIDER = 'projects/999999999999/locations/global/workloadIdentityPools/github-actions/providers/allplays-recovery';
+        expect(evaluateRecoveryWorkflowIdentity(unexpectedProvider).failures).toEqual([
+            expect.stringMatching(/must be projects\/982493478258/)
+        ]);
+
+        const unexpectedAccount = healthyEnvironment();
+        unexpectedAccount.FIRESTORE_RECOVERY_SERVICE_ACCOUNT = 'another-firestore-reader@game-flow-c6311.iam.gserviceaccount.com';
+        expect(evaluateRecoveryWorkflowIdentity(unexpectedAccount).failures).toEqual([
+            expect.stringMatching(/must be allplays-firestore-recovery@/)
+        ]);
+
+        const unexpectedProject = healthyEnvironment();
+        unexpectedProject.FIREBASE_PROJECT_ID = 'another-project';
+        unexpectedProject.FIRESTORE_RECOVERY_SERVICE_ACCOUNT = 'allplays-firestore-recovery@another-project.iam.gserviceaccount.com';
+        expect(evaluateRecoveryWorkflowIdentity(unexpectedProject).failures).toEqual(expect.arrayContaining([
+            expect.stringMatching(/SERVICE_ACCOUNT must be allplays-firestore-recovery@game-flow-c6311/),
+            'FIREBASE_PROJECT_ID must be game-flow-c6311.'
+        ]));
+    });
+
+    it.each([
+        ['GITHUB_REPOSITORY', 'attacker/fork', /only in pauljsnider\/allplays/],
+        ['GITHUB_REPOSITORY_ID', '999999999', /immutable repository ID 1106220007/],
+        ['GITHUB_REPOSITORY_OWNER_ID', '999999999', /immutable repository-owner ID 211066188/],
+        ['GITHUB_REF', 'refs/heads/feature', /only from refs\/heads\/master/],
+        ['GITHUB_WORKFLOW_REF', 'pauljsnider/allplays/.github/workflows/other.yml@refs/heads/master', /must use pauljsnider\/allplays/]
+    ])('rejects a mismatched %s claim', (name, value, message) => {
+        const environment = healthyEnvironment();
+        environment[name] = value;
+        expect(evaluateRecoveryWorkflowIdentity(environment).failures).toEqual([
+            expect.stringMatching(message)
+        ]);
+    });
+
+    it('throws an actionable aggregate error instead of continuing to authentication', () => {
+        expect(() => verifyRecoveryWorkflowIdentity({})).toThrow(/OIDC preflight failed:[\s\S]*production environment variables/);
+    });
+});

--- a/tests/unit/firestore-recovery-issue.test.js
+++ b/tests/unit/firestore-recovery-issue.test.js
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    buildRecoveryFailureBody,
+    planRecoveryIssueReconciliation,
+    reconcileRecoveryIssue,
+    RECOVERY_ISSUE_AUTHOR,
+    RECOVERY_ISSUE_AUTHOR_ID,
+    RECOVERY_ISSUE_LABEL,
+    RECOVERY_ISSUE_MARKER,
+    RECOVERY_ISSUE_TITLE,
+    RECOVERY_REPOSITORY
+} from '../../scripts/reconcile-firestore-recovery-issue.mjs';
+
+const runUrl = 'https://github.com/pauljsnider/allplays/actions/runs/123';
+const runbookUrl = 'https://github.com/pauljsnider/allplays/blob/master/docs/firestore-recovery-runbook.md#health-check-failure';
+
+function managedIssue(overrides = {}) {
+    return {
+        number: 42,
+        title: RECOVERY_ISSUE_TITLE,
+        state: 'OPEN',
+        body: `${RECOVERY_ISSUE_MARKER}\nmanaged`,
+        user: { id: RECOVERY_ISSUE_AUTHOR_ID, login: RECOVERY_ISSUE_AUTHOR, type: 'Bot' },
+        labels: [{ name: RECOVERY_ISSUE_LABEL }],
+        ...overrides
+    };
+}
+
+function runReconciliation(verifyResult, issues) {
+    const calls = [];
+    const executeGh = (args) => {
+        calls.push(args);
+        return calls.length === 1 ? JSON.stringify({
+            total_count: issues.length,
+            incomplete_results: false,
+            items: issues
+        }) : '';
+    };
+    const result = reconcileRecoveryIssue({
+        verifyResult,
+        repository: RECOVERY_REPOSITORY,
+        runUrl,
+        runbookUrl
+    }, { executeGh });
+    return { calls, result };
+}
+
+describe('Firestore recovery issue planning', () => {
+    it('does nothing for a healthy run without an open managed incident', () => {
+        expect(planRecoveryIssueReconciliation('success', [])).toEqual({
+            action: 'none', issueNumber: null, healthy: true
+        });
+        expect(planRecoveryIssueReconciliation('success', [managedIssue({ state: 'CLOSED' })])).toEqual({
+            action: 'none', issueNumber: 42, healthy: true
+        });
+    });
+
+    it('closes an open incident only after success', () => {
+        expect(planRecoveryIssueReconciliation('success', [managedIssue()])).toEqual({
+            action: 'close', issueNumber: 42, healthy: true
+        });
+    });
+
+    it.each(['failure', 'cancelled', 'skipped'])
+    ('creates, updates, or reopens a managed incident after %s', (verifyResult) => {
+        expect(planRecoveryIssueReconciliation(verifyResult, []).action).toBe('create');
+        expect(planRecoveryIssueReconciliation(verifyResult, [managedIssue()]).action).toBe('update');
+        expect(planRecoveryIssueReconciliation(
+            verifyResult,
+            [managedIssue({ state: 'CLOSED' })]
+        ).action).toBe('reopen');
+    });
+
+    it('treats an exact-title issue from a public user as an untrusted collision', () => {
+        expect(() => planRecoveryIssueReconciliation('failure', [managedIssue({
+            user: { id: 123, login: 'untrusted-user', type: 'User' }
+        })])).toThrow(/not created by github-actions\[bot\].*untrusted issue/);
+    });
+
+    it('requires the bot-only label and management marker', () => {
+        expect(() => planRecoveryIssueReconciliation('failure', [managedIssue({ labels: [] })]))
+            .toThrow(/without the bot-only recovery label/);
+        expect(() => planRecoveryIssueReconciliation('failure', [managedIssue({ body: 'copied title' })]))
+            .toThrow(/without the managed marker/);
+    });
+
+    it('refuses duplicates, malformed issue identity, states, and results', () => {
+        expect(() => planRecoveryIssueReconciliation('failure', [managedIssue(), managedIssue({ number: 43 })]))
+            .toThrow(/More than one exact/);
+        expect(() => planRecoveryIssueReconciliation('failure', [managedIssue({ number: 0 })]))
+            .toThrow(/invalid issue number/);
+        expect(() => planRecoveryIssueReconciliation('failure', [managedIssue({ state: 'UNKNOWN' })]))
+            .toThrow(/invalid state/);
+        expect(() => planRecoveryIssueReconciliation('timed_out', []))
+            .toThrow(/Unexpected recovery verification result/);
+        expect(() => planRecoveryIssueReconciliation('failure', null))
+            .toThrow(/must be an array/);
+    });
+});
+
+describe('Firestore recovery issue mutation behavior', () => {
+    it('creates one labeled, assigned incident on failure', () => {
+        const { calls, result } = runReconciliation('failure', []);
+        expect(result).toMatchObject({ action: 'create', healthy: false });
+        expect(calls).toHaveLength(2);
+        expect(calls[0]).toContain(`q=repo:${RECOVERY_REPOSITORY} is:issue author:app/github-actions in:title "${RECOVERY_ISSUE_TITLE}"`);
+        expect(calls[1]).toEqual(expect.arrayContaining([
+            'issue', 'create',
+            '--assignee', 'pauljsnider',
+            '--label', RECOVERY_ISSUE_LABEL,
+            '--title', RECOVERY_ISSUE_TITLE
+        ]));
+        expect(calls[1].at(-1)).toContain(RECOVERY_ISSUE_MARKER);
+        expect(calls[1].at(-1)).toContain(runUrl);
+    });
+
+    it('updates an existing open incident without adding repetitive comments', () => {
+        const { calls } = runReconciliation('failure', [managedIssue()]);
+        expect(calls).toHaveLength(2);
+        expect(calls[1].slice(0, 4)).toEqual(['issue', 'edit', '42', '--repo']);
+    });
+
+    it('reopens, updates, and comments once when failure recurs', () => {
+        const { calls } = runReconciliation('cancelled', [managedIssue({ state: 'CLOSED' })]);
+        expect(calls.map((call) => call.slice(0, 2))).toEqual([
+            ['api', '--method'],
+            ['issue', 'reopen'],
+            ['issue', 'edit'],
+            ['issue', 'comment']
+        ]);
+    });
+
+    it('closes the exact open managed issue on recovery', () => {
+        const { calls, result } = runReconciliation('success', [managedIssue()]);
+        expect(result).toMatchObject({ action: 'close', healthy: true });
+        expect(calls).toHaveLength(2);
+        expect(calls[1]).toEqual(expect.arrayContaining([
+            'issue', 'close', '42', '--reason', 'completed'
+        ]));
+    });
+
+    it('does not mutate anything when recovery is healthy and no incident exists', () => {
+        const { calls, result } = runReconciliation('success', []);
+        expect(result.action).toBe('none');
+        expect(calls).toHaveLength(1);
+    });
+
+    it('refuses a repository outside the exact production repository before listing issues', () => {
+        let called = false;
+        expect(() => reconcileRecoveryIssue({
+            verifyResult: 'failure',
+            repository: 'attacker/fork',
+            runUrl,
+            runbookUrl
+        }, { executeGh: () => { called = true; } })).toThrow(/only in pauljsnider\/allplays/);
+        expect(called).toBe(false);
+    });
+
+    it('fails closed on invalid GitHub JSON', () => {
+        expect(() => reconcileRecoveryIssue({
+            verifyResult: 'failure',
+            repository: RECOVERY_REPOSITORY,
+            runUrl,
+            runbookUrl
+        }, { executeGh: () => 'not-json' })).toThrow(/invalid JSON/);
+    });
+
+    it('fails closed on incomplete or over-broad GitHub search results', () => {
+        for (const response of [
+            { total_count: 1, incomplete_results: true, items: [] },
+            { total_count: 101, incomplete_results: false, items: [] },
+            { total_count: 1, incomplete_results: false, items: [] },
+            { total_count: 1, incomplete_results: false, items: null }
+        ]) {
+            expect(() => reconcileRecoveryIssue({
+                verifyResult: 'failure',
+                repository: RECOVERY_REPOSITORY,
+                runUrl,
+                runbookUrl
+            }, { executeGh: () => JSON.stringify(response) })).toThrow(/incomplete or invalid/);
+        }
+    });
+
+    it('builds a marker-protected body with exact evidence links', () => {
+        expect(buildRecoveryFailureBody({ verifyResult: 'failure', runUrl, runbookUrl })).toBe([
+            RECOVERY_ISSUE_MARKER,
+            '',
+            'The scheduled Firestore recovery check is failing or did not complete successfully.',
+            '',
+            `Latest result: failure. Run: ${runUrl}`,
+            `Runbook: ${runbookUrl}`
+        ].join('\n'));
+    });
+});

--- a/tests/unit/firestore-recovery-posture.test.js
+++ b/tests/unit/firestore-recovery-posture.test.js
@@ -1,0 +1,482 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    collectFirestoreRecoveryPosture,
+    evaluateFirestoreRecoveryPosture,
+    EXPECTED_PRODUCTION_DAILY_SCHEDULE,
+    EXPECTED_PRODUCTION_DAILY_SCHEDULE_CREATE_TIME,
+    MAX_FUTURE_CLOCK_SKEW_MS,
+    MAX_MAX_BACKUP_AGE_HOURS,
+    parseFirestoreRecoveryArgs
+} from '../../scripts/verify-firestore-recovery.mjs';
+
+const now = Date.parse('2026-07-18T12:00:00Z');
+const currentDatabaseUid = '523d6949-79b4-4368-b4cd-57c164d3451d';
+const retiredDatabaseUid = '6d8dc48d-5e2f-4cee-8f74-5325ad0847fd';
+const demoDatabaseName = 'projects/demo-project/databases/(default)';
+const demoScheduleName = `${demoDatabaseName}/backupSchedules/8a7f67fe-c6eb-4a4e-8a48-20e96e9fdf57`;
+const demoBackupName = 'projects/demo-project/locations/nam5/backups/d51ba64c-aa47-4372-a7fc-b78813ad6669';
+
+function healthyInput() {
+    return {
+        now,
+        database: {
+            name: demoDatabaseName,
+            uid: currentDatabaseUid,
+            pointInTimeRecoveryEnablement: 'POINT_IN_TIME_RECOVERY_ENABLED',
+            deleteProtectionState: 'DELETE_PROTECTION_ENABLED'
+        },
+        schedules: [{
+            name: demoScheduleName,
+            dailyRecurrence: {},
+            retention: '1209600s',
+            createTime: '2026-07-17T12:00:00Z'
+        }],
+        backups: [{
+            name: demoBackupName,
+            database: demoDatabaseName,
+            databaseUid: currentDatabaseUid,
+            state: 'READY',
+            snapshotTime: '2026-07-18T06:00:00Z',
+            expireTime: '2026-08-01T06:00:00Z'
+        }]
+    };
+}
+
+describe('Firestore recovery CLI arguments', () => {
+    it('requires an explicit project instead of silently targeting production', () => {
+        expect(() => parseFirestoreRecoveryArgs([], {})).toThrow(/FIREBASE_PROJECT_ID.*--project/);
+    });
+
+    it('supports environment, separated, and npm-forwarded assignment flags', () => {
+        expect(parseFirestoreRecoveryArgs([], { FIREBASE_PROJECT_ID: 'demo-project' })).toEqual({
+            projectId: 'demo-project',
+            databaseId: '(default)',
+            maxBackupAgeHours: 36
+        });
+        expect(parseFirestoreRecoveryArgs(['--project', 'demo-project'], {})).toMatchObject({
+            projectId: 'demo-project'
+        });
+        expect(parseFirestoreRecoveryArgs(['--project=demo-project'], {})).toMatchObject({
+            projectId: 'demo-project'
+        });
+    });
+
+    it.each(['NaN', 'Infinity', '-Infinity', '0', '-1', '169', '1e309', ''])
+    ('rejects an unsafe maximum backup age of %j', (value) => {
+        expect(() => parseFirestoreRecoveryArgs([
+            '--project=demo-project',
+            `--max-backup-age-hours=${value}`
+        ], {})).toThrow(/finite number from 1 through 168/);
+    });
+
+    it('accepts the finite maximum boundary and decimals inside the boundary', () => {
+        expect(parseFirestoreRecoveryArgs([
+            '--project=demo-project',
+            `--max-backup-age-hours=${MAX_MAX_BACKUP_AGE_HOURS}`
+        ], {})).toMatchObject({ maxBackupAgeHours: 168 });
+        expect(parseFirestoreRecoveryArgs([
+            '--project=demo-project',
+            '--max-backup-age-hours=1.5'
+        ], {})).toMatchObject({ maxBackupAgeHours: 1.5 });
+    });
+
+    it('rejects unknown, duplicate, missing-value, malformed project, and malformed database flags', () => {
+        expect(() => parseFirestoreRecoveryArgs(['--project=demo-project', '--typo=yes'], {})).toThrow(/Unknown/);
+        expect(() => parseFirestoreRecoveryArgs(['--project=demo-project', '--project=other-project'], {})).toThrow(/only once/);
+        expect(() => parseFirestoreRecoveryArgs(['--project', '--database=(default)'], {})).toThrow(/requires a value/);
+        expect(() => parseFirestoreRecoveryArgs(['--project=INVALID'], {})).toThrow(/project ID is invalid/);
+        expect(() => parseFirestoreRecoveryArgs(['--project=demo-project', '--database=../default'], {})).toThrow(/database ID is invalid/);
+    });
+});
+
+describe('Firestore recovery posture', () => {
+    it('accepts PITR, delete protection, 14-day retention, exact READY state, matching UID, and a fresh backup', () => {
+        expect(evaluateFirestoreRecoveryPosture(healthyInput())).toMatchObject({
+            healthy: true,
+            failures: [],
+            notices: [],
+            newestBackup: { name: demoBackupName }
+        });
+    });
+
+    it('fails closed when recovery controls are absent or too weak', () => {
+        const result = evaluateFirestoreRecoveryPosture({
+            now,
+            database: {},
+            schedules: [{ dailyRecurrence: {}, retention: '604800s', createTime: '2026-07-01T00:00:00Z' }],
+            backups: []
+        });
+
+        expect(result.healthy).toBe(false);
+        expect(result.failures).toEqual(expect.arrayContaining([
+            'Point-in-time recovery is not enabled.',
+            'Database delete protection is not enabled.',
+            'The current database UID is unavailable or invalid, so backup lineage cannot be verified.',
+            'The daily managed-backup retention is shorter than 14 days or invalid.',
+            'The daily schedule has not produced a ready backup within its initial 36-hour window.'
+        ]));
+    });
+
+    it.each([undefined, null, '', 'not-a-duration', '1209599.999999999s', 'Infinitys'])
+    ('rejects invalid or short retention %j', (retention) => {
+        const input = healthyInput();
+        input.schedules[0].retention = retention;
+        const result = evaluateFirestoreRecoveryPosture(input);
+        expect(result.healthy).toBe(false);
+        expect(result.failures).toContain('The daily managed-backup retention is shorter than 14 days or invalid.');
+    });
+
+    it('accepts fractional duration syntax at or beyond the 14-day floor', () => {
+        const input = healthyInput();
+        input.schedules[0].retention = '1209600.000000001s';
+        expect(evaluateFirestoreRecoveryPosture(input).healthy).toBe(true);
+    });
+
+    it('fails if no daily schedule exists or if metadata reports multiple daily schedules', () => {
+        const missing = healthyInput();
+        missing.schedules = [{ weeklyRecurrence: {}, retention: '1209600s' }];
+        expect(evaluateFirestoreRecoveryPosture(missing).failures).toContain('No daily managed-backup schedule exists.');
+
+        const duplicate = healthyInput();
+        duplicate.schedules.push({
+            dailyRecurrence: {},
+            retention: '1209600s',
+            createTime: '2026-07-17T12:00:00Z'
+        });
+        expect(evaluateFirestoreRecoveryPosture(duplicate).failures).toContain(
+            'More than one daily managed-backup schedule exists; expected exactly one.'
+        );
+    });
+
+    it('fails when the newest completed backup is stale', () => {
+        const input = healthyInput();
+        input.backups[0].snapshotTime = '2026-07-15T00:00:00Z';
+
+        expect(evaluateFirestoreRecoveryPosture(input)).toMatchObject({
+            healthy: false,
+            failures: ['The newest ready backup is older than 36 hours.']
+        });
+    });
+
+    it.each([
+        ['missing', undefined, false],
+        ['unknown', 'UNKNOWN', true],
+        ['creating', 'CREATING', true],
+        ['lowercase ready', 'ready', true],
+        ['null', null, true],
+        ['number', 1, true],
+        ['boolean', true, true],
+        ['object', { value: 'READY' }, true]
+    ])('rejects a backup whose state is %s', (_description, state, hasState) => {
+        const input = healthyInput();
+        input.schedules[0].createTime = '2026-07-16T00:00:00Z';
+        if (hasState) input.backups[0].state = state;
+        else delete input.backups[0].state;
+
+        expect(evaluateFirestoreRecoveryPosture(input)).toMatchObject({
+            healthy: false,
+            failures: ['The daily schedule has not produced a ready backup within its initial 36-hour window.'],
+            newestBackup: null
+        });
+    });
+
+    it('does not let a newer non-ready backup hide a fresh exact-ready backup', () => {
+        const input = healthyInput();
+        input.backups.push({
+            name: 'backup-creating',
+            databaseUid: currentDatabaseUid,
+            state: 'CREATING',
+            snapshotTime: '2026-07-18T11:00:00Z'
+        });
+
+        expect(evaluateFirestoreRecoveryPosture(input)).toMatchObject({
+            healthy: true,
+            newestBackup: { name: demoBackupName }
+        });
+    });
+
+    it('allows only the documented first-backup grace window, including its exact boundary', () => {
+        const exactBoundary = healthyInput();
+        exactBoundary.schedules[0].createTime = new Date(now - 36 * 60 * 60 * 1000).toISOString();
+        exactBoundary.backups = [];
+        expect(evaluateFirestoreRecoveryPosture(exactBoundary)).toMatchObject({
+            healthy: true,
+            notices: [expect.stringContaining('initial 36-hour window')]
+        });
+
+        const beyondBoundary = structuredClone(exactBoundary);
+        beyondBoundary.schedules[0].createTime = new Date(now - 36 * 60 * 60 * 1000 - 1).toISOString();
+        expect(evaluateFirestoreRecoveryPosture(beyondBoundary)).toMatchObject({
+            healthy: false,
+            failures: ['The daily schedule has not produced a ready backup within its initial 36-hour window.']
+        });
+    });
+
+    it('allows ordinary clock skew but rejects a materially future schedule timestamp', () => {
+        const skewed = healthyInput();
+        skewed.backups = [];
+        skewed.schedules[0].createTime = new Date(now + MAX_FUTURE_CLOCK_SKEW_MS).toISOString();
+        expect(evaluateFirestoreRecoveryPosture(skewed)).toMatchObject({ healthy: true });
+
+        const future = structuredClone(skewed);
+        future.schedules[0].createTime = new Date(now + MAX_FUTURE_CLOCK_SKEW_MS + 1).toISOString();
+        expect(evaluateFirestoreRecoveryPosture(future)).toMatchObject({
+            healthy: false,
+            failures: ['The daily managed-backup schedule creation timestamp is materially in the future.'],
+            notices: []
+        });
+    });
+
+    it('rejects missing, malformed, non-UTC, and impossible schedule timestamps', () => {
+        for (const createTime of [
+            undefined,
+            'not-a-time',
+            '2026-07-18',
+            '2026-07-18T02:42:05-05:00',
+            '2026-02-31T02:42:05Z'
+        ]) {
+            const input = healthyInput();
+            input.backups = [];
+            input.schedules[0].createTime = createTime;
+            expect(evaluateFirestoreRecoveryPosture(input).failures).toContain(
+                'The daily managed-backup schedule creation timestamp is missing or invalid.'
+            );
+        }
+    });
+
+    it('allows backup clock skew but rejects materially future backup timestamps', () => {
+        const skewed = healthyInput();
+        skewed.backups[0].snapshotTime = new Date(now + MAX_FUTURE_CLOCK_SKEW_MS).toISOString();
+        expect(evaluateFirestoreRecoveryPosture(skewed)).toMatchObject({ healthy: true });
+
+        const future = structuredClone(skewed);
+        future.backups[0].snapshotTime = new Date(now + MAX_FUTURE_CLOCK_SKEW_MS + 1).toISOString();
+        expect(evaluateFirestoreRecoveryPosture(future)).toMatchObject({
+            healthy: false,
+            failures: [`Backup ${demoBackupName} has a snapshot timestamp materially in the future.`],
+            newestBackup: null
+        });
+    });
+
+    it('fails a ready backup with a missing, malformed, non-UTC, or impossible timestamp', () => {
+        for (const timestamp of [
+            undefined,
+            '',
+            'not-a-time',
+            '2026-07-18',
+            '2026-07-18T06:00:00-05:00',
+            '2026-02-31T06:00:00Z'
+        ]) {
+            const input = healthyInput();
+            input.backups[0].snapshotTime = timestamp;
+            expect(evaluateFirestoreRecoveryPosture(input).failures).toContain(
+                `Ready backup ${demoBackupName} has a missing or invalid snapshot timestamp.`
+            );
+        }
+    });
+
+    it('never substitutes createTime for a missing ready-backup snapshotTime', () => {
+        const input = healthyInput();
+        input.schedules[0].createTime = '2026-07-16T00:00:00Z';
+        delete input.backups[0].snapshotTime;
+        input.backups[0].createTime = '2026-07-18T11:59:00Z';
+
+        const result = evaluateFirestoreRecoveryPosture(input);
+        expect(result.healthy).toBe(false);
+        expect(result.failures).toEqual(expect.arrayContaining([
+            `Ready backup ${demoBackupName} has a missing or invalid snapshot timestamp.`,
+            'The daily schedule has not produced a ready backup within its initial 36-hour window.'
+        ]));
+        expect(result.newestBackup).toBeNull();
+    });
+
+    it.each([
+        ['missing', undefined],
+        ['malformed', 'not-a-time'],
+        ['expired', '2026-07-18T11:59:59Z'],
+        ['before next check', '2026-07-18T18:00:00Z']
+    ])('rejects a ready backup whose expiration is %s', (_description, expireTime) => {
+        const input = healthyInput();
+        input.schedules[0].createTime = '2026-07-16T00:00:00Z';
+        input.backups[0].expireTime = expireTime;
+
+        const result = evaluateFirestoreRecoveryPosture(input);
+        expect(result.healthy).toBe(false);
+        expect(result.newestBackup).toBeNull();
+        expect(result.failures).toContain(
+            expireTime == null || expireTime === 'not-a-time'
+                ? `Ready backup ${demoBackupName} has a missing or invalid expiration timestamp.`
+                : `Ready backup ${demoBackupName} expires before the next six-hour health-check window.`
+        );
+    });
+
+    it('requires a ready backup to name the exact database and canonical backup resource', () => {
+        const wrongDatabase = healthyInput();
+        wrongDatabase.expectedDatabaseName = demoDatabaseName;
+        wrongDatabase.backups[0].database = 'projects/demo-project/databases/other';
+        expect(evaluateFirestoreRecoveryPosture(wrongDatabase).failures).toContain(
+            `Ready backup ${demoBackupName} does not belong to ${demoDatabaseName}.`
+        );
+
+        for (const name of [undefined, '', 'backup-1', 'projects/demo-project/locations/nam5/backups/not-a-uuid']) {
+            const malformedName = healthyInput();
+            malformedName.expectedDatabaseName = demoDatabaseName;
+            malformedName.backups[0].name = name;
+            expect(evaluateFirestoreRecoveryPosture(malformedName).failures).toContain(
+                `Ready backup ${name || '<unnamed backup>'} has a missing or invalid canonical resource name.`
+            );
+        }
+    });
+
+    it('refuses a recreated production schedule instead of resetting initial grace', () => {
+        const input = healthyInput();
+        input.backups = [];
+        input.schedules[0].name = `${EXPECTED_PRODUCTION_DAILY_SCHEDULE}-replacement`;
+        input.schedules[0].createTime = new Date(now).toISOString();
+        input.expectedDailyScheduleName = EXPECTED_PRODUCTION_DAILY_SCHEDULE;
+
+        const result = evaluateFirestoreRecoveryPosture(input);
+        expect(result.healthy).toBe(false);
+        expect(result.failures).toContain(
+            `The daily managed-backup schedule must be ${EXPECTED_PRODUCTION_DAILY_SCHEDULE}; refusing a recreated schedule that could reset the first-backup grace window.`
+        );
+    });
+
+    it('pins the original production schedule creation time as well as its name', () => {
+        const input = healthyInput();
+        input.schedules[0].name = EXPECTED_PRODUCTION_DAILY_SCHEDULE;
+        input.schedules[0].createTime = '2026-07-18T11:59:00Z';
+        input.expectedDailyScheduleName = EXPECTED_PRODUCTION_DAILY_SCHEDULE;
+        input.expectedDailyScheduleCreateTime = EXPECTED_PRODUCTION_DAILY_SCHEDULE_CREATE_TIME;
+
+        expect(evaluateFirestoreRecoveryPosture(input).failures).toContain(
+            `The daily managed-backup schedule creation time must remain ${EXPECTED_PRODUCTION_DAILY_SCHEDULE_CREATE_TIME}; refusing a replaced schedule or reset grace window.`
+        );
+    });
+
+    it.each([false, true, '', 'daily', [], 0, 1, { unexpected: true }])
+    ('rejects malformed dailyRecurrence metadata %j', (dailyRecurrence) => {
+        const input = healthyInput();
+        input.schedules[0].dailyRecurrence = dailyRecurrence;
+        const result = evaluateFirestoreRecoveryPosture(input);
+        expect(result.healthy).toBe(false);
+        expect(result.failures).toContain('No daily managed-backup schedule exists.');
+    });
+
+    it('requires exact database and canonical schedule resource names when scoped', () => {
+        const input = healthyInput();
+        input.expectedDatabaseName = 'projects/demo-project/databases/(default)';
+        input.database.name = 'projects/other-project/databases/(default)';
+        input.schedules[0].name = 'projects/demo-project/databases/other/backupSchedules/daily';
+
+        expect(evaluateFirestoreRecoveryPosture(input).failures).toEqual(expect.arrayContaining([
+            'The database metadata name must be projects/demo-project/databases/(default).',
+            'Every backup schedule must be a canonical child of projects/demo-project/databases/(default).'
+        ]));
+    });
+
+    it('rejects a fresh backup from an older database incarnation', () => {
+        const input = healthyInput();
+        input.schedules[0].createTime = '2026-07-16T00:00:00Z';
+        input.backups[0].databaseUid = retiredDatabaseUid;
+
+        expect(evaluateFirestoreRecoveryPosture(input)).toMatchObject({
+            healthy: false,
+            failures: ['The daily schedule has not produced a ready backup within its initial 36-hour window.'],
+            newestBackup: null
+        });
+    });
+
+    it('treats old-incarnation backups as absent during the genuine initial grace window', () => {
+        const input = healthyInput();
+        input.schedules[0].createTime = '2026-07-18T02:42:05Z';
+        input.backups[0].databaseUid = retiredDatabaseUid;
+
+        expect(evaluateFirestoreRecoveryPosture(input)).toMatchObject({
+            healthy: true,
+            failures: [],
+            notices: [expect.stringContaining('initial 36-hour window')],
+            newestBackup: null
+        });
+    });
+
+    it('fails closed when current database UID, response arrays, verifier clock, or direct age threshold is invalid', () => {
+        const missingUid = healthyInput();
+        delete missingUid.database.uid;
+        expect(evaluateFirestoreRecoveryPosture(missingUid).failures).toContain(
+            'The current database UID is unavailable or invalid, so backup lineage cannot be verified.'
+        );
+
+        const nonStringUid = healthyInput();
+        nonStringUid.database.uid = 123;
+        nonStringUid.backups[0].databaseUid = 123;
+        expect(evaluateFirestoreRecoveryPosture(nonStringUid).failures).toContain(
+            'The current database UID is unavailable or invalid, so backup lineage cannot be verified.'
+        );
+
+        const malformed = healthyInput();
+        malformed.schedules = null;
+        malformed.backups = {};
+        malformed.now = Infinity;
+        malformed.maxBackupAgeHours = Infinity;
+        expect(evaluateFirestoreRecoveryPosture(malformed).failures).toEqual(expect.arrayContaining([
+            'The verifier clock is invalid.',
+            'Maximum backup age must be a finite number from 1 through 168 hours.',
+            'Backup schedules response is not an array.',
+            'Backups response is not an array.'
+        ]));
+    });
+});
+
+describe('Firestore recovery resource collection', () => {
+    it('uses exact database resource equality before evaluating backups', () => {
+        const database = healthyInput().database;
+        database.name = demoDatabaseName;
+        const schedules = healthyInput().schedules;
+        schedules[0].name = demoScheduleName;
+        const responses = [
+            database,
+            schedules,
+            [
+                {
+                    ...healthyInput().backups[0],
+                    database: 'projects/demo-project/databases/(default)'
+                },
+                {
+                    ...healthyInput().backups[0],
+                    name: 'suffix-collision',
+                    snapshotTime: '2026-07-18T11:00:00Z',
+                    database: 'projects/another-project/databases/(default)'
+                }
+            ]
+        ];
+        const calls = [];
+        const runJson = (args) => {
+            calls.push(args);
+            return responses.shift();
+        };
+
+        const result = collectFirestoreRecoveryPosture({
+            projectId: 'demo-project',
+            databaseId: '(default)',
+            maxBackupAgeHours: 36
+        }, { runJson, now });
+
+        expect(result).toMatchObject({ healthy: true, newestBackup: { name: demoBackupName } });
+        expect(calls).toEqual([
+            expect.arrayContaining(['firestore', 'databases', 'describe', '--project=demo-project', '--database=(default)']),
+            expect.arrayContaining(['firestore', 'backups', 'schedules', 'list', '--project=demo-project', '--database=(default)']),
+            expect.arrayContaining(['firestore', 'backups', 'list', '--project=demo-project'])
+        ]);
+    });
+
+    it('throws an actionable failure for non-array gcloud list responses', () => {
+        const runJson = (args) => args.includes('schedules') ? {} : healthyInput().database;
+        expect(() => collectFirestoreRecoveryPosture({
+            projectId: 'demo-project',
+            databaseId: '(default)',
+            maxBackupAgeHours: 36
+        }, { runJson, now })).toThrow(/invalid backup schedules response.*JSON array/);
+    });
+});


### PR DESCRIPTION
## What changed and why

- Adds fail-closed Firestore recovery posture verification for PITR, delete protection, the exact production daily schedule, immutable UUIDv4 database lineage, canonical backup identity, exact `READY` state, snapshot freshness, and expiration beyond the next health window.
- Adds a six-hour keyless GitHub OIDC health workflow with immutable repository IDs, exact repository/ref/workflow trust, pinned action revisions/Cloud SDK, job timeouts, and a durable incident reconciler.
- Makes incident reconciliation resistant to public lookalike issues by restricting GitHub search to the unforgeable Actions-app author, then requiring exact bot ID/login/type, label, marker, complete results, and an exact result count before mutation.
- Documents least-privilege WIF provisioning, guarded PITR/managed-backup drills, incident response, and external dead-man requirements.
- Records successful 2026-07-18 PITR and managed-backup restore drills. The managed restore matched five canonical field hashes byte-for-byte, matched contextual counts, and was removed while production retained PITR/delete protection.
- Redacts access-code document IDs from committed recovery evidence and adds a regression that rejects a committed 20-character access-code path.

## Safety boundaries

- Health identity has only `datastore.databases.getMetadata`, `datastore.backupSchedules.list`, and `datastore.backups.list`; it cannot read app documents, restore, delete, deploy, or write cloud data.
- WIF trust uses immutable repository ID `1106220007` and owner ID `211066188`, plus exact master/workflow claims. No JSON key or Token Creator role.
- Restores never target `(default)`. Cleanup requires exact target name/UID/origin, independently verifies source identity/protection, passes the target's current ETag as a precondition to the protection-changing REST PATCH, polls only the returned operation, and passes the resulting ETag to delete.
- The dedicated `recovery-monitor` label is provisioned. The PR remains draft with `security-review-needed` and `do-not-merge` until exact-head review/CI, the first successful master workflow dispatch, and an exercised external dead-man route.

## Validation

- `npm test` — 646 files passed, 3 skipped; 4,539 tests passed, 78 skipped
- focused recovery suite — 101/101
- Firestore/Storage emulator authorization suite — 67/67
- Playwright smoke — 227 passed, 18 intentionally skipped after both legacy and Vite targets were started
- `npm run app:build` — TypeScript, production bundle, 231 artifacts, and 718-node bundle visualizer verified
- live read-only recovery verifier — healthy against the current production UID, pinned schedule, exact canonical `READY` backup, and expiration window
- `npm run test:coverage-map` — all HTML/React/Cloud Functions accounted
- `npm run ci:firebase-rules`
- workflow YAML parse, exact GitHub Actions-author search, Node syntax, tracked-secret scan, and `git diff --check`
- managed-backup restore — exact operation success, five-document manifest SHA-256 `48945c35c303427aa31e0619436a4a2b9b82b4077aed9ffc54bd94eb973beb68`, isolated target `NOT_FOUND` after conditional cleanup, source posture still healthy

## External production state

- WIF pool/provider, dedicated service account, exact three-permission role, immutable GitHub claims, production environment variables, and zero user-managed keys were reconciled and verified on 2026-07-18.
- The manual OIDC workflow dispatch can run only after this exact workflow exists on `master`.
- An independent dead-man timer outside GitHub Actions remains required and will be installed/exercised before the merge hold is considered fully cleared.
