### PR TITLE
Invoke recovery verifier directly

### DIFF
--- a/.github/workflows/firestore-recovery-health.yml
+++ b/.github/workflows/firestore-recovery-health.yml
@@ -50,7 +50,7 @@ jobs:
           version: '557.0.0'
 
       - name: Verify PITR, delete protection, and managed backups
-        run: npm run ops:verify-firestore-recovery
+        run: node scripts/verify-firestore-recovery.mjs
 
   reconcile-recovery-status:
     needs: verify-recovery

--- a/tests/unit/firestore-recovery-delivery-contract.test.js
+++ b/tests/unit/firestore-recovery-delivery-contract.test.js
@@ -17,7 +17,7 @@ describe('Firestore recovery delivery contract', () => {
         const preflightIndex = workflow.indexOf('node scripts/verify-firestore-recovery-identity.mjs');
         const authIndex = workflow.indexOf('uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093');
         const setupIndex = workflow.indexOf('uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db');
-        const verifyIndex = workflow.indexOf('run: npm run ops:verify-firestore-recovery');
+        const verifyIndex = workflow.indexOf('run: node scripts/verify-firestore-recovery.mjs');
 
         expect(workflow).toContain('id-token: write');
         expect(workflow).toContain('workload_identity_provider: ${{ vars.FIRESTORE_RECOVERY_WORKLOAD_IDENTITY_PROVIDER }}');
@@ -27,6 +27,7 @@ describe('Firestore recovery delivery contract', () => {
         expect(workflow).not.toContain('credentials_json');
         expect(workflow).not.toContain('SERVICE_ACCOUNT_GAME_FLOW_C6311 }}');
         expect(workflow).not.toContain('npm ci');
+        expect(workflow).not.toContain('npm run ops:verify-firestore-recovery');
         expect(preflightIndex).toBeGreaterThan(-1);
         expect(authIndex).toBeGreaterThan(preflightIndex);
         expect(setupIndex).toBeGreaterThan(authIndex);


### PR DESCRIPTION
## Summary
- invoke the pinned Firestore recovery verifier directly with Node
- remove npm script-shell and local node_modules binary shadowing from the scheduled trust path
- add a delivery-contract regression forbidding the npm invocation

## Validation
- 42 focused recovery identity, posture, issue, and delivery-contract tests pass
- workflow blob is exactly 1c01ee7e8d3c6fb713078db1c9b1267bbd82bf3f

## Ordering hold
Keep this draft until payment authority PR #4032 merges. Then rebase onto exact master, rerun CI/reviews, merge, run a manual recovery canary, and wait for a new exact scheduled success before deploying the external observers.