### PR TITLE
Invoke recovery verifier directly

### DIFF
--- a/.github/workflows/firestore-recovery-health.yml
+++ b/.github/workflows/firestore-recovery-health.yml
@@ -50,7 +50,7 @@ jobs:
           version: '557.0.0'
 
       - name: Verify PITR, delete protection, and managed backups
-        run: npm run ops:verify-firestore-recovery
+        run: node scripts/verify-firestore-recovery.mjs
 
   reconcile-recovery-status:
     needs: verify-recovery

--- a/tests/smoke/app-messages.spec.js
+++ b/tests/smoke/app-messages.spec.js
@@ -290,24 +290,31 @@ async function mockMessagesModules(page, options = {}) {
                         }
                     ];
                     if (options.includeLastMessages === false && options.onPreview) {
-                        setTimeout(() => options.onPreview({
-                            teamId: 'team-1',
-                            lastMessage: msg({ id: 'last-1', text: 'Practice packet is posted.' }),
-                            preferredConversationId: null,
-                            isMuted: false
-                        }), ${options.previewDelayMs || 0});
-                        setTimeout(() => options.onPreview({
-                            teamId: 'team-2',
-                            lastMessage: msg({ id: 'last-2', text: 'Tournament schedule changed.', senderName: 'Morgan' }),
-                            preferredConversationId: null,
-                            isMuted: false
-                        }), ${options.previewDelayMs || 0});
-                        setTimeout(() => options.onPreview({
-                            teamId: 'team-3',
-                            lastMessage: msg({ id: 'last-3', text: 'Lineup card is ready.', senderName: 'Coach Lee' }),
-                            preferredConversationId: null,
-                            isMuted: true
-                        }), ${options.previewDelayMs || 0});
+                        const emitPreviews = () => {
+                            options.onPreview({
+                                teamId: 'team-1',
+                                lastMessage: msg({ id: 'last-1', text: 'Practice packet is posted.' }),
+                                preferredConversationId: null,
+                                isMuted: false
+                            });
+                            options.onPreview({
+                                teamId: 'team-2',
+                                lastMessage: msg({ id: 'last-2', text: 'Tournament schedule changed.', senderName: 'Morgan' }),
+                                preferredConversationId: null,
+                                isMuted: false
+                            });
+                            options.onPreview({
+                                teamId: 'team-3',
+                                lastMessage: msg({ id: 'last-3', text: 'Lineup card is ready.', senderName: 'Coach Lee' }),
+                                preferredConversationId: null,
+                                isMuted: true
+                            });
+                        };
+                        if (${Boolean(options.deferPreviews)}) {
+                            window.__releaseChatPreviews = emitPreviews;
+                        } else {
+                            setTimeout(emitPreviews, ${options.previewDelayMs || 0});
+                        }
                     }
                     return { teams };
                 }
@@ -678,7 +685,7 @@ test('messages team thread retries a failed subscription in place on mobile', as
 });
 
 test('messages inbox stays interactive while previews hydrate on inbox and desktop routes', async ({ page, baseURL }) => {
-    await mockMessagesModules(page, { previewDelayMs: 600 });
+    await mockMessagesModules(page, { deferPreviews: true });
     await page.goto(appUrl(baseURL, '/messages'), { waitUntil: 'domcontentloaded' });
 
     await waitForMessagesRoute(page, page.getByRole('heading', { name: 'Conversations', exact: true }));
@@ -689,6 +696,7 @@ test('messages inbox stays interactive while previews hydrate on inbox and deskt
     await page.getByPlaceholder('Search conversations').fill('Falcons');
     await expect(page.getByRole('link', { name: /Falcons/ }).first()).toBeVisible();
     await page.getByPlaceholder('Search conversations').fill('');
+    await page.evaluate(() => window.__releaseChatPreviews());
     await expect(bearsInboxRow).toContainText('Coach Jamie: Practice packet is posted.', { timeout: 5000 });
     await expect(page.getByRole('link', { name: /Falcons/ }).first()).toContainText('Coach Lee: Lineup card is ready.');
 
@@ -699,6 +707,7 @@ test('messages inbox stays interactive while previews hydrate on inbox and deskt
     await expect(page.getByRole('link', { name: /Bears/ }).first()).toBeVisible();
     await expect(page.locator('.messages-chat-pane')).toContainText('Bring both jerseys.');
     await expect(page.locator('.messages-list-pane')).toContainText('No messages yet');
+    await page.evaluate(() => window.__releaseChatPreviews());
     await expect(page.locator('.messages-list-pane')).toContainText('Coach Jamie: Practice packet is posted.', { timeout: 5000 });
     await expect(page.locator('.messages-list-pane')).toContainText('Coach Lee: Lineup card is ready.');
 });

--- a/tests/unit/firestore-recovery-delivery-contract.test.js
+++ b/tests/unit/firestore-recovery-delivery-contract.test.js
@@ -17,7 +17,7 @@ describe('Firestore recovery delivery contract', () => {
         const preflightIndex = workflow.indexOf('node scripts/verify-firestore-recovery-identity.mjs');
         const authIndex = workflow.indexOf('uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093');
         const setupIndex = workflow.indexOf('uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db');
-        const verifyIndex = workflow.indexOf('run: npm run ops:verify-firestore-recovery');
+        const verifyIndex = workflow.indexOf('run: node scripts/verify-firestore-recovery.mjs');
 
         expect(workflow).toContain('id-token: write');
         expect(workflow).toContain('workload_identity_provider: ${{ vars.FIRESTORE_RECOVERY_WORKLOAD_IDENTITY_PROVIDER }}');
@@ -27,6 +27,7 @@ describe('Firestore recovery delivery contract', () => {
         expect(workflow).not.toContain('credentials_json');
         expect(workflow).not.toContain('SERVICE_ACCOUNT_GAME_FLOW_C6311 }}');
         expect(workflow).not.toContain('npm ci');
+        expect(workflow).not.toContain('npm run ops:verify-firestore-recovery');
         expect(preflightIndex).toBeGreaterThan(-1);
         expect(authIndex).toBeGreaterThan(preflightIndex);
         expect(setupIndex).toBeGreaterThan(authIndex);


### PR DESCRIPTION
## Summary
- invoke the pinned Firestore recovery verifier directly with Node
- remove npm script-shell and local node_modules binary shadowing from the scheduled trust path
- stabilize the deferred message-preview smoke with an explicit release signal instead of a timer race
- add regression coverage for both trust-path and hydration-order behavior

## Validation
- original exact recovery head passed 42 focused recovery identity, posture, issue, and delivery-contract tests
- current exact-head GitHub CI and independent reviews are required before merge
- workflow blob remains exactly `1c01ee7e8d3c6fb713078db1c9b1267bbd82bf3f`

## Rollout gate
After merge, a manual recovery run is only a canary. The external dead-man observers remain undeployed until a new `event=schedule` run succeeds on this exact direct-Node workflow blob.