### PR TITLE
Secure preview deployment trust boundary

### DIFF
--- a/.github/workflows/deploy-preview-trusted.yml
+++ b/.github/workflows/deploy-preview-trusted.yml
@@ -1,0 +1,235 @@
+name: deploy-preview-trusted
+
+on:
+  workflow_run:
+    workflows:
+      - deploy-preview
+    types:
+      - completed
+
+permissions: {}
+
+concurrency:
+  group: trusted-preview-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  deploy-preview:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: firebase-preview-trusted
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: write
+
+    steps:
+      # workflow_run executes this workflow from the default branch. Only that
+      # trusted branch is checked out; the triggering PR is never checked out.
+      - name: Checkout trusted default-branch verifier
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Verify triggering run, pull request, and named artifact
+        id: verify_trigger
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          WORKFLOW_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$WORKFLOW_RUN_ID" =~ ^[1-9][0-9]*$ ]] || [[ ! "$WORKFLOW_PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Invalid triggering run or pull-request identity." >&2
+            exit 1
+          fi
+          run_json="$RUNNER_TEMP/firebase-preview-run.json"
+          pr_json="$RUNNER_TEMP/firebase-preview-pr.json"
+          artifacts_json="$RUNNER_TEMP/firebase-preview-artifacts.json"
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$WORKFLOW_RUN_ID" > "$run_json"
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$WORKFLOW_PR_NUMBER" > "$pr_json"
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$WORKFLOW_RUN_ID/artifacts?per_page=100" > "$artifacts_json"
+          node scripts/verify-preview-deploy-trigger.mjs \
+            --event "$GITHUB_EVENT_PATH" \
+            --run "$run_json" \
+            --pull-request "$pr_json" \
+            --artifacts "$artifacts_json" \
+            --output "$GITHUB_OUTPUT"
+
+      - name: Download only the verified triggering-run artifact
+        env:
+          ARTIFACT_ID: ${{ steps.verify_trigger.outputs.artifact_id }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Verified artifact ID is invalid." >&2
+            exit 1
+          fi
+          archive="$RUNNER_TEMP/firebase-preview-hosting-bundle.zip"
+          gh api \
+            -H 'Accept: application/vnd.github+json' \
+            "repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID/zip" > "$archive"
+          echo "PREVIEW_ARTIFACT_ARCHIVE=$archive" >> "$GITHUB_ENV"
+
+      - name: Validate and extract untrusted Hosting content
+        run: |
+          set -euo pipefail
+          site_dir="$RUNNER_TEMP/firebase-preview-site"
+          python3 scripts/extract-preview-hosting-artifact.py \
+            --archive "$PREVIEW_ARTIFACT_ARCHIVE" \
+            --destination "$site_dir"
+          echo "FIREBASE_PREVIEW_SITE=$site_dir" >> "$GITHUB_ENV"
+
+      - name: Generate Firebase config from trusted default branch
+        run: |
+          set -euo pipefail
+          config_file="$RUNNER_TEMP/firebase-preview.generated.json"
+          node scripts/write-firebase-hosting-config.mjs "$FIREBASE_PREVIEW_SITE" "$config_file"
+          echo "FIREBASE_PREVIEW_CONFIG=$config_file" >> "$GITHUB_ENV"
+
+      - name: Install trusted Firebase CLI without lifecycle scripts
+        run: npm ci --ignore-scripts
+
+      - name: Re-verify current pull-request head before credentials
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.verify_trigger.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            exit 1
+          fi
+          current_pr_json="$RUNNER_TEMP/firebase-preview-current-pr.json"
+          recheck_output="$RUNNER_TEMP/firebase-preview-recheck.outputs"
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > "$current_pr_json"
+          node scripts/verify-preview-deploy-trigger.mjs \
+            --event "$GITHUB_EVENT_PATH" \
+            --run "$RUNNER_TEMP/firebase-preview-run.json" \
+            --pull-request "$current_pr_json" \
+            --artifacts "$RUNNER_TEMP/firebase-preview-artifacts.json" \
+            --output "$recheck_output"
+
+      # The credential is unavailable until all identity, archive, extracted
+      # shape, and trusted-config checks have completed successfully.
+      - name: Configure Firebase service account
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311 }}
+        run: |
+          set -euo pipefail
+          credentials_file="$RUNNER_TEMP/firebase-service-account.json"
+          umask 077
+          printf '%s' "$FIREBASE_SERVICE_ACCOUNT" > "$credentials_file"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$credentials_file" >> "$GITHUB_ENV"
+
+      - name: Deploy fixed Firebase Hosting preview channel
+        id: deploy_preview
+        env:
+          CURRENT_CHANNEL: pr-${{ steps.verify_trigger.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$CURRENT_CHANNEL" =~ ^pr-[1-9][0-9]*$ ]]; then
+            echo "Verified preview channel is invalid." >&2
+            exit 1
+          fi
+          log_file="$RUNNER_TEMP/firebase-preview-deploy.log"
+
+          deploy_preview_channel() {
+            : > "$log_file"
+            ./node_modules/.bin/firebase hosting:channel:deploy "$CURRENT_CHANNEL" --project game-flow-c6311 --config "$FIREBASE_PREVIEW_CONFIG" --expires 7d --non-interactive 2>&1 | tee "$log_file"
+          }
+
+          skip_preview() {
+            local reason="$1"
+            {
+              echo "### Firebase preview skipped"
+              echo
+              echo "$reason"
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "preview_url=" >> "$GITHUB_OUTPUT"
+            echo "preview_skip_reason=$reason" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          skip_preview_for_quota() {
+            skip_preview "Firebase Hosting preview channel quota was reached. Build and regression checks completed successfully, so this deploy-only preview limitation did not fail the PR."
+          }
+
+          skip_preview_for_auth() {
+            skip_preview "Firebase Hosting preview deploy authentication was unavailable for this run. Build and regression checks completed successfully, so this deploy-only preview limitation did not fail the PR."
+          }
+
+          skip_preview_for_release_target() {
+            skip_preview "Firebase Hosting preview channel release target was unavailable for this run. Build and regression checks completed successfully, so this deploy-only preview limitation did not fail the PR."
+          }
+
+          preview_deploy_hit_quota() {
+            grep -Eiq 'HTTP Error: 429|channel quota reached' "$log_file"
+          }
+
+          preview_deploy_hit_auth_error() {
+            grep -Eiq 'Failed to authenticate|Command requires authentication|Unable to read the credential file specified by the GOOGLE_APPLICATION_CREDENTIALS' "$log_file"
+          }
+
+          preview_deploy_hit_release_target_error() {
+            grep -Eiq "HTTP Error: 400, Can't release to .*resource doesn't exist or isn't a valid release target" "$log_file"
+          }
+
+          if ! deploy_preview_channel; then
+            if preview_deploy_hit_auth_error; then
+              skip_preview_for_auth
+            fi
+            if preview_deploy_hit_release_target_error; then
+              skip_preview_for_release_target
+            fi
+            if preview_deploy_hit_quota; then
+              skip_preview_for_quota
+            fi
+            exit 1
+          fi
+
+          preview_url="$(grep -Eo 'https://[^ ]+' "$log_file" | tail -n1)"
+          if [[ -z "$preview_url" ]]; then
+            echo "Failed to extract preview URL from Firebase deploy output." >&2
+            exit 1
+          fi
+          echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
+          echo "preview_skip_reason=" >> "$GITHUB_OUTPUT"
+
+      - name: Remove Firebase credential file
+        if: always()
+        run: rm -f "$RUNNER_TEMP/firebase-service-account.json"
+
+      - name: Report preview URL on verified pull request
+        if: success()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.verify_trigger.outputs.pr_number }}
+          PREVIEW_URL: ${{ steps.deploy_preview.outputs.preview_url }}
+          PREVIEW_SKIP_REASON: ${{ steps.deploy_preview.outputs.preview_skip_reason }}
+          JQ_FILTER: '.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("<!-- allplays-preview-url -->")) | .id'
+        run: |
+          set -euo pipefail
+          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            exit 1
+          fi
+          marker='<!-- allplays-preview-url -->'
+          if [[ -n "$PREVIEW_URL" ]]; then
+            body="$(printf '%s\n\nPreview URL: %s' "$marker" "$PREVIEW_URL")"
+          else
+            body="$(printf '%s\n\nFirebase preview skipped: %s' "$marker" "${PREVIEW_SKIP_REASON:-Firebase Hosting preview was unavailable for this run.}")"
+          fi
+          comment_id="$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --jq "$JQ_FILTER" | head -n1)"
+          if [[ -n "$comment_id" ]]; then
+            gh api "repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" --method PATCH -f body="$body" >/dev/null
+          else
+            gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --method POST -f body="$body" >/dev/null
+          fi

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -7,6 +7,11 @@ on:
       - synchronize
       - reopened
 
+# Pull-request-controlled code runs here, so this workflow has no repository
+# permissions and receives no privileged secrets. Its only deploy input is an
+# untrusted, staged Hosting artifact consumed by the trusted workflow_run job.
+permissions: {}
+
 concurrency:
   group: preview-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -17,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout pull request merge
         run: |
           git init .
           git remote add origin https://github.com/${{ github.repository }}.git
@@ -25,13 +30,13 @@ jobs:
           git checkout --force refs/remotes/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: npm
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           distribution: temurin
           java-version: 21
@@ -68,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout pull request merge
         run: |
           git init .
           git remote add origin https://github.com/${{ github.repository }}.git
@@ -76,7 +81,7 @@ jobs:
           git checkout --force refs/remotes/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: npm
@@ -100,23 +105,18 @@ jobs:
 
       - name: Upload server log on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: preview-regression-guards-http-log
           path: /tmp/allplays-preview-regression-guards.log
 
-  deploy:
+  build-preview-artifact:
     if: github.event.pull_request.head.repo.full_name == github.repository
     needs: [unit-tests, regression-guards]
     runs-on: ubuntu-latest
-    permissions:
-      checks: write
-      contents: read
-      issues: write
-      pull-requests: write
 
     steps:
-      - name: Checkout
+      - name: Checkout pull request merge
         run: |
           git init .
           git remote add origin https://github.com/${{ github.repository }}.git
@@ -124,7 +124,7 @@ jobs:
           git checkout --force refs/remotes/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: npm
@@ -150,196 +150,17 @@ jobs:
       - name: Build React app
         run: npm run app:build
 
-      - name: Stage Firebase preview bundle
+      - name: Stage untrusted Firebase Hosting bundle
         env:
           ALLPLAYS_APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY: ${{ vars.APP_CHECK_PREVIEW_RECAPTCHA_ENTERPRISE_SITE_KEY }}
           ALLPLAYS_APP_CHECK_ENFORCEMENT_READY: ${{ vars.APP_CHECK_ENFORCEMENT_READY }}
-        run: |
-          site_dir="$RUNNER_TEMP/firebase-preview-site"
-          config_file="$GITHUB_WORKSPACE/.firebase-preview.generated.json"
-          node scripts/stage-pages-bundle.mjs "$site_dir"
-          node scripts/write-firebase-hosting-config.mjs "$site_dir" "$config_file"
-          echo "FIREBASE_PREVIEW_CONFIG=$config_file" >> "$GITHUB_ENV"
+        run: node scripts/stage-pages-bundle.mjs "$RUNNER_TEMP/firebase-preview-site"
 
-      - name: Configure Firebase service account
-        run: |
-          credentials_file="$RUNNER_TEMP/firebase-service-account.json"
-          printf '%s' '${{ secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311 }}' > "$credentials_file"
-          echo "GOOGLE_APPLICATION_CREDENTIALS=$credentials_file" >> "$GITHUB_ENV"
-
-      - name: Prune stale Firebase preview channels
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CURRENT_CHANNEL: pr-${{ github.event.pull_request.number }}
-          KEEP_RECENT_OPEN_PR_CHANNELS: '20'
-        run: |
-          set -euo pipefail
-          open_pr_numbers_file="$RUNNER_TEMP/firebase-preview-open-pr-numbers.txt"
-          if ! gh pr list --repo "${{ github.repository }}" --state open --limit 200 --json number,updatedAt --jq 'sort_by(.updatedAt) | reverse | .[].number' > "$open_pr_numbers_file"; then
-            echo "Warning: unable to list open PRs; skipping stale Firebase preview channel pruning."
-            exit 0
-          fi
-
-          channels_file="$RUNNER_TEMP/firebase-preview-channels.txt"
-          channels_log="$RUNNER_TEMP/firebase-preview-channels.log"
-          keep_file="$RUNNER_TEMP/firebase-preview-keep.txt"
-          prune_file="$RUNNER_TEMP/firebase-preview-prune.txt"
-          {
-            echo "$CURRENT_CHANNEL"
-            head -n "$KEEP_RECENT_OPEN_PR_CHANNELS" "$open_pr_numbers_file" | sed 's/^/pr-/'
-          } | sed '/^$/d' | sort -u > "$keep_file"
-          if ! ./node_modules/.bin/firebase hosting:channel:list --site game-flow-c6311 --project game-flow-c6311 > "$channels_file" 2>"$channels_log"; then
-            echo "Warning: unable to list Firebase preview channels; skipping stale Firebase preview channel pruning." >&2
-            cat "$channels_log" >&2
-            exit 0
-          fi
-          awk -F '│' 'NF > 2 {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2); if ($2 ~ /^pr-/) print $2 }' "$channels_file" | sort -u > "$prune_file"
-
-          delete_channel() {
-            local channel="$1"
-            local delete_log="$RUNNER_TEMP/firebase-preview-delete-$channel.log"
-            if ! ./node_modules/.bin/firebase hosting:channel:delete "$channel" --site game-flow-c6311 --project game-flow-c6311 --force >"$delete_log" 2>&1; then
-              if grep -Eq 'HTTP Error: 404|Not Found' "$delete_log"; then
-                echo "Skipping already-missing Firebase preview channel: $channel"
-                return 0
-              fi
-              cat "$delete_log" >&2
-              return 1
-            fi
-          }
-
-          while read -r channel; do
-            if [ -z "$channel" ] || grep -qx "$channel" "$keep_file"; then
-              continue
-            fi
-            delete_channel "$channel"
-          done < "$prune_file"
-
-      - name: Deploy Firebase Hosting preview
-        id: deploy_preview
-        env:
-          CURRENT_CHANNEL: pr-${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          log_file="$RUNNER_TEMP/firebase-preview-deploy.log"
-
-          deploy_preview_channel() {
-            : > "$log_file"
-            ./node_modules/.bin/firebase hosting:channel:deploy "$CURRENT_CHANNEL" --project game-flow-c6311 --config "$FIREBASE_PREVIEW_CONFIG" --expires 7d --non-interactive 2>&1 | tee "$log_file"
-          }
-
-          skip_preview() {
-            local reason="$1"
-            {
-              echo "### Firebase preview skipped"
-              echo
-              echo "$reason"
-            } >> "$GITHUB_STEP_SUMMARY"
-            echo "preview_url=" >> "$GITHUB_OUTPUT"
-            echo "preview_skip_reason=$reason" >> "$GITHUB_OUTPUT"
-            exit 0
-          }
-
-          skip_preview_for_quota() {
-            skip_preview "Firebase Hosting preview channel quota was reached. Build and regression checks completed successfully, so this deploy-only preview limitation did not fail the PR."
-          }
-
-          skip_preview_for_auth() {
-            skip_preview "Firebase Hosting preview deploy authentication was unavailable for this run. Build and regression checks completed successfully, so this deploy-only preview limitation did not fail the PR."
-          }
-
-          skip_preview_for_release_target() {
-            skip_preview "Firebase Hosting preview channel release target was unavailable for this run. Build and regression checks completed successfully, so this deploy-only preview limitation did not fail the PR."
-          }
-
-          preview_deploy_hit_quota() {
-            grep -Eiq 'HTTP Error: 429|channel quota reached' "$log_file"
-          }
-
-          preview_deploy_hit_auth_error() {
-            grep -Eiq 'Failed to authenticate|Command requires authentication|Unable to read the credential file specified by the GOOGLE_APPLICATION_CREDENTIALS' "$log_file"
-          }
-
-          preview_deploy_hit_release_target_error() {
-            grep -Eiq "HTTP Error: 400, Can't release to .*resource doesn't exist or isn't a valid release target" "$log_file"
-          }
-
-          delete_oldest_preview_channel() {
-            channels_file="$RUNNER_TEMP/firebase-preview-channels-retry.txt"
-            delete_log="$RUNNER_TEMP/firebase-preview-delete-retry.log"
-            if ! ./node_modules/.bin/firebase hosting:channel:list --site game-flow-c6311 --project game-flow-c6311 > "$channels_file"; then
-              skip_preview_for_quota
-            fi
-            oldest_channel="$(awk -F '│' 'NF > 3 {
-              channel=$2
-              release_time=$3
-              gsub(/^[[:space:]]+|[[:space:]]+$/, "", channel)
-              gsub(/^[[:space:]]+|[[:space:]]+$/, "", release_time)
-              if (channel ~ /^pr-/ && channel != ENVIRON["CURRENT_CHANNEL"]) {
-                print release_time "\t" channel
-              }
-            }' "$channels_file" | sort | head -n1 | cut -f2)"
-            if [ -z "$oldest_channel" ]; then
-              skip_preview_for_quota
-            fi
-            echo "Deleting oldest Firebase preview channel to free quota: $oldest_channel"
-            if ! ./node_modules/.bin/firebase hosting:channel:delete "$oldest_channel" --site game-flow-c6311 --project game-flow-c6311 --force >"$delete_log" 2>&1; then
-              skip_preview_for_quota
-            fi
-          }
-
-          if ! deploy_preview_channel; then
-            if preview_deploy_hit_auth_error; then
-              skip_preview_for_auth
-            fi
-            if preview_deploy_hit_release_target_error; then
-              skip_preview_for_release_target
-            fi
-            if ! preview_deploy_hit_quota; then
-              exit 1
-            fi
-            delete_oldest_preview_channel
-            if ! deploy_preview_channel; then
-              if preview_deploy_hit_quota; then
-                skip_preview_for_quota
-              fi
-              if preview_deploy_hit_auth_error; then
-                skip_preview_for_auth
-              fi
-              if preview_deploy_hit_release_target_error; then
-                skip_preview_for_release_target
-              fi
-              exit 1
-            fi
-          fi
-
-          preview_url="$(grep -Eo 'https://[^ ]+' "$log_file" | tail -n1)"
-          if [ -z "$preview_url" ]; then
-            echo "Failed to extract preview URL from Firebase deploy output." >&2
-            exit 1
-          fi
-          echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
-          echo "preview_skip_reason=" >> "$GITHUB_OUTPUT"
-
-      - name: Report preview URL on pull request
-        if: success()
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PREVIEW_URL: ${{ steps.deploy_preview.outputs.preview_url }}
-          PREVIEW_SKIP_REASON: ${{ steps.deploy_preview.outputs.preview_skip_reason }}
-          JQ_FILTER: '.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("<!-- allplays-preview-url -->")) | .id'
-        run: |
-          set -euo pipefail
-          marker='<!-- allplays-preview-url -->'
-          if [ -n "$PREVIEW_URL" ]; then
-            body="$(printf '%s\n\nPreview URL: %s' "$marker" "$PREVIEW_URL")"
-          else
-            body="$(printf '%s\n\nFirebase preview skipped: %s' "$marker" "${PREVIEW_SKIP_REASON:-Firebase Hosting preview was unavailable for this run.}")"
-          fi
-          comment_id="$(gh api --paginate repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments --jq "$JQ_FILTER" | head -n1)"
-          if [ -n "$comment_id" ]; then
-            gh api repos/${{ github.repository }}/issues/comments/"$comment_id" --method PATCH -f body="$body" >/dev/null
-          else
-            gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments --method POST -f body="$body" >/dev/null
-          fi
+      - name: Upload staged Firebase Hosting bundle
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: firebase-preview-hosting-bundle
+          path: ${{ runner.temp }}/firebase-preview-site
+          if-no-files-found: error
+          include-hidden-files: true
+          retention-days: 1

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -7,6 +7,9 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 concurrency:
   group: post-deploy-smoke-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
@@ -15,15 +18,18 @@ jobs:
   post-deploy-smoke:
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'master'
     runs-on: ubuntu-latest
+    environment:
+      name: production-smoke
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/scheduled-prod-smoke.yml
+++ b/.github/workflows/scheduled-prod-smoke.yml
@@ -5,6 +5,9 @@ on:
     - cron: '*/15 * * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: scheduled-prod-smoke
   cancel-in-progress: true
@@ -12,15 +15,18 @@ concurrency:
 jobs:
   scheduled-prod-smoke:
     runs-on: ubuntu-latest
+    environment:
+      name: production-smoke
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: master
+          persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: npm

--- a/docs/preview-deploy-trust-boundary.md
+++ b/docs/preview-deploy-trust-boundary.md
@@ -1,0 +1,86 @@
+# Firebase preview deployment trust boundary
+
+## Required invariants
+
+The `deploy-preview` pull-request workflow executes untrusted PR code. It must
+never receive a Firebase credential or a repository token with write
+permissions. It may only test, build, stage public Hosting content, and upload
+the single `firebase-preview-hosting-bundle` artifact.
+
+The `deploy-preview-trusted` workflow is the only preview deployer. GitHub runs
+its `workflow_run` definition from the default branch. It checks out only the
+default branch, validates the completed run and current open PR through the
+GitHub API, downloads only the verified triggering-run artifact, safely
+validates and extracts public files, and generates Firebase configuration from
+trusted default-branch code. It never checks out, imports, executes, or sources
+PR code or PR-provided Firebase configuration.
+
+`FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311` must remain absent from repository
+and organization secrets. It may exist only as an environment secret in
+`firebase-preview-trusted` and `production`. Both environments must retain a
+protected/default-branch-only deployment policy. This is essential: a
+same-repository PR can edit its own `pull_request` workflow and reference any
+repository-level secret, even when the default-branch version does not.
+
+`SMOKE_AUTH_EMAIL` and `SMOKE_AUTH_PASSWORD` must also remain absent from
+repository and organization secrets. They may exist only in the protected
+`production-smoke` environment used by `post-deploy-smoke` and
+`scheduled-prod-smoke`. Those workflows execute only default/protected-branch
+code, have read-only repository permissions, and must keep checkout credentials
+disabled. Rotate the smoke password immediately if either value is ever exposed
+outside that environment.
+
+The trusted workflow may deploy only the verified PR's fixed `pr-N` Firebase
+Hosting channel. It must not prune, delete, or select another channel. All
+third-party actions in both workflows must remain pinned to full commit SHAs.
+
+## Review and operational checks
+
+Before merging a change to either preview workflow:
+
+1. Run `npm run test:unit:ci`, `npm run test:functions:auth-email`,
+   `npm run app:build`, and the focused preview trust-boundary tests.
+2. Confirm `gh secret list --repo pauljsnider/allplays` lists none of
+   `FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311`, `SMOKE_AUTH_EMAIL`, or
+   `SMOKE_AUTH_PASSWORD`.
+3. Confirm `gh secret list --repo pauljsnider/allplays --env production` and
+   `--env firebase-preview-trusted` each list the credential.
+4. Confirm all three GitHub environments still restrict deployments to
+   protected/default-branch code before allowing a credentialed run. Confirm
+   `production-smoke` contains only the rotated least-privilege smoke fixture
+   credentials.
+5. Review the exact PR head SHA after all requested automated reviews and CI
+   complete. Any new commit invalidates prior review evidence.
+
+The first `workflow_run` preview cannot execute until this workflow and its
+trusted verifier scripts are present on the default branch. The PR workflow's
+artifact build remains testable before merge; the first post-merge PR run is
+the deployment canary.
+
+## JSON-key rotation and retirement
+
+Use the following sequence without printing JSON key material:
+
+1. Record the old and replacement GCP service-account key IDs in the private
+   incident record. Store the replacement JSON only in the two protected GitHub
+   environments; never store it as a repository or organization secret.
+2. Validate an exact-default-branch production deploy and a same-repository PR
+   preview deploy with the replacement key. Confirm the preview deploy targets
+   only `pr-N`, the expected URL is commented on that PR, and the credential
+   cleanup step runs.
+3. Query Cloud Audit Logs for the old key ID across its full GitHub exposure
+   window, including `authenticationInfo.serviceAccountKeyName`, and inspect
+   same-repository Actions runs for unexpected credentialed workflow changes or
+   Firebase operations. Preserve suspicious run IDs and audit entries.
+4. Disable the old GCP service-account key after both canaries pass. Re-run the
+   production and preview canaries, then permanently delete the old key after
+   the agreed observation window. If either canary fails, re-enable only long
+   enough to diagnose; do not restore a repository-level secret.
+5. Reconfirm the repository secret is absent and both environment policies are
+   intact after retirement.
+
+The long-term target is keyless GitHub OIDC/Workload Identity Federation with a
+dedicated preview principal. Bind trust to this repository, the trusted
+workflow identity, and the default branch; grant only the Firebase Hosting
+operations required to release a preview channel. Validate OIDC canaries, then
+delete the remaining JSON key and remove the JSON environment secrets.

--- a/scripts/extract-preview-hosting-artifact.py
+++ b/scripts/extract-preview-hosting-artifact.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Validate and safely extract an untrusted Firebase Hosting artifact."""
+
+import argparse
+import os
+from pathlib import Path, PurePosixPath
+import shutil
+import stat
+import zipfile
+
+
+MAX_ARCHIVE_BYTES = 100 * 1024 * 1024
+MAX_UNCOMPRESSED_BYTES = 250 * 1024 * 1024
+MAX_SINGLE_FILE_BYTES = 50 * 1024 * 1024
+MAX_ENTRIES = 20_000
+REQUIRED_FILES = {'.nojekyll', 'index.html', 'app/index.html'}
+FORBIDDEN_ROOT_NAMES = {
+    '.git',
+    '.github',
+    'android',
+    'apps',
+    'firebase.json',
+    'firestore.indexes.json',
+    'firestore.rules',
+    'functions',
+    'ios',
+    'node_modules',
+    'package-lock.json',
+    'package.json',
+    'scripts',
+    'spec',
+    'storage.rules',
+    'tests',
+}
+FORBIDDEN_PUBLIC_CLAIMS = {
+    '.well-known/apple-app-site-association',
+    '.well-known/assetlinks.json',
+}
+ALLOWED_HIDDEN_PATHS = {
+    '.nojekyll',
+    '.well-known/allplays-runtime-config.json',
+}
+
+
+class ArtifactValidationError(RuntimeError):
+    """Raised when an untrusted artifact fails closed validation."""
+
+
+def fail(message: str) -> None:
+    raise ArtifactValidationError(f'Preview Hosting artifact rejected: {message}')
+
+
+def normalized_entry_path(info: zipfile.ZipInfo) -> PurePosixPath:
+    name = info.filename
+    if not name or '\x00' in name or '\\' in name or name.startswith('/'):
+        fail('archive contains an empty, absolute, NUL, or backslash path')
+    trimmed = name[:-1] if name.endswith('/') else name
+    raw_parts = trimmed.split('/')
+    if not trimmed or any(part in {'', '.', '..'} for part in raw_parts):
+        fail('archive contains an ambiguous or traversing path')
+    if any(ord(character) < 32 or ord(character) == 127 for character in name):
+        fail('archive contains a control character in a path')
+    path = PurePosixPath(trimmed)
+    if path.is_absolute() or ':' in path.parts[0]:
+        fail('archive contains an absolute or drive-qualified path')
+    return path
+
+
+def validate_entry_type(info: zipfile.ZipInfo) -> None:
+    unix_mode = (info.external_attr >> 16) & 0xFFFF
+    file_type = stat.S_IFMT(unix_mode)
+    allowed_types = {0, stat.S_IFREG, stat.S_IFDIR}
+    if file_type not in allowed_types or file_type == stat.S_IFLNK:
+        fail('archive contains a symlink or special file')
+    if info.is_dir() and file_type == stat.S_IFREG:
+        fail('archive directory metadata claims a regular file')
+    if not info.is_dir() and file_type == stat.S_IFDIR:
+        fail('archive file metadata claims a directory')
+    if info.flag_bits & 0x1:
+        fail('archive contains an encrypted entry')
+
+
+def inspect_archive(archive_path: Path) -> tuple[list[tuple[zipfile.ZipInfo, PurePosixPath]], int]:
+    archive_size = archive_path.stat().st_size
+    if archive_size <= 0 or archive_size > MAX_ARCHIVE_BYTES:
+        fail(f'archive size must be between 1 and {MAX_ARCHIVE_BYTES} bytes')
+
+    try:
+        archive = zipfile.ZipFile(archive_path)
+    except (OSError, zipfile.BadZipFile) as error:
+        fail(f'archive is not a valid ZIP: {error}')
+
+    with archive:
+        entries = archive.infolist()
+        if not entries or len(entries) > MAX_ENTRIES:
+            fail(f'archive entry count must be between 1 and {MAX_ENTRIES}')
+
+        inspected = []
+        seen = set()
+        total_bytes = 0
+        file_paths = set()
+        for info in entries:
+            path = normalized_entry_path(info)
+            normalized = path.as_posix()
+            if normalized in seen:
+                fail('archive contains duplicate normalized paths')
+            seen.add(normalized)
+            validate_entry_type(info)
+            if path.parts[0] in FORBIDDEN_ROOT_NAMES:
+                fail(f'archive contains forbidden root path {path.parts[0]}')
+            if normalized in FORBIDDEN_PUBLIC_CLAIMS:
+                fail(f'archive contains unpublished public association claim {normalized}')
+            if any(part.startswith('.') for part in path.parts) and normalized not in ALLOWED_HIDDEN_PATHS:
+                fail(f'archive contains unexpected hidden path {normalized}')
+            if info.file_size < 0 or info.file_size > MAX_SINGLE_FILE_BYTES:
+                fail(f'entry {normalized} exceeds the per-file size limit')
+            total_bytes += info.file_size
+            if total_bytes > MAX_UNCOMPRESSED_BYTES:
+                fail(f'archive exceeds {MAX_UNCOMPRESSED_BYTES} uncompressed bytes')
+            if not info.is_dir():
+                file_paths.add(normalized)
+            inspected.append((info, path))
+
+        missing = sorted(REQUIRED_FILES - file_paths)
+        if missing:
+            fail(f'archive is missing required Hosting files: {", ".join(missing)}')
+        return inspected, total_bytes
+
+
+def ensure_empty_destination(destination: Path) -> None:
+    if destination.exists() or destination.is_symlink():
+        if destination.is_symlink() or not destination.is_dir():
+            fail('destination must be a real directory')
+        if any(destination.iterdir()):
+            fail('destination must be empty')
+    else:
+        destination.mkdir(parents=True, mode=0o700)
+
+
+def extract_archive(archive_path: Path, destination: Path) -> tuple[int, int]:
+    inspected, expected_total = inspect_archive(archive_path)
+    ensure_empty_destination(destination)
+    destination_resolved = destination.resolve(strict=True)
+    extracted_total = 0
+    extracted_files = 0
+
+    with zipfile.ZipFile(archive_path) as archive:
+        for info, relative_path in inspected:
+            target = destination.joinpath(*relative_path.parts)
+            target_parent = target if info.is_dir() else target.parent
+            target_parent.mkdir(parents=True, exist_ok=True, mode=0o755)
+            if target_parent.resolve(strict=True) != destination_resolved and destination_resolved not in target_parent.resolve(strict=True).parents:
+                fail('archive extraction target escaped the destination')
+            if info.is_dir():
+                continue
+
+            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+            descriptor = os.open(target, flags, 0o644)
+            written = 0
+            try:
+                with os.fdopen(descriptor, 'wb') as output, archive.open(info, 'r') as source:
+                    while True:
+                        chunk = source.read(64 * 1024)
+                        if not chunk:
+                            break
+                        written += len(chunk)
+                        extracted_total += len(chunk)
+                        if written > info.file_size or written > MAX_SINGLE_FILE_BYTES:
+                            fail('extracted file exceeded its declared or allowed size')
+                        if extracted_total > MAX_UNCOMPRESSED_BYTES:
+                            fail('extracted content exceeded the total size limit')
+                        output.write(chunk)
+            except Exception:
+                target.unlink(missing_ok=True)
+                raise
+            if written != info.file_size:
+                fail('extracted file size did not match ZIP metadata')
+            extracted_files += 1
+
+    if extracted_total != expected_total:
+        fail('extracted total size did not match validated ZIP metadata')
+
+    verified_total = 0
+    verified_files = 0
+    for root, directories, files in os.walk(destination, followlinks=False):
+        root_path = Path(root)
+        for name in [*directories, *files]:
+            item = root_path / name
+            mode = item.lstat().st_mode
+            if stat.S_ISLNK(mode) or not (stat.S_ISDIR(mode) or stat.S_ISREG(mode)):
+                fail('extracted tree contains a symlink or special file')
+        for name in files:
+            item = root_path / name
+            verified_total += item.stat().st_size
+            verified_files += 1
+
+    if verified_total != extracted_total or verified_files != extracted_files:
+        fail('extracted tree changed during verification')
+    return extracted_files, extracted_total
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--archive', required=True, type=Path)
+    parser.add_argument('--destination', required=True, type=Path)
+    args = parser.parse_args()
+
+    archive = args.archive.resolve(strict=True)
+    destination = args.destination.resolve(strict=False)
+    try:
+        file_count, byte_count = extract_archive(archive, destination)
+    except Exception:
+        if destination.exists() and destination.is_dir() and not destination.is_symlink():
+            shutil.rmtree(destination)
+        raise
+    print(f'Validated and extracted {file_count} Hosting files ({byte_count} bytes).')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -128,7 +128,8 @@ export function validateFirebaseRulesCi() {
     const gameEventsRules = (firestoreRules.match(/match \/events\/\{eventId} \{[\s\S]*?\n\s*}/) || [''])[0];
     const aggregatedStatsRules = (firestoreRules.match(/match \/aggregatedStats\/\{statId} \{[\s\S]*?\n\s*}/) || [''])[0];
     const deployProd = readText('.github/workflows/deploy-prod.yml');
-    const deployPreview = readText('.github/workflows/deploy-preview.yml');
+    const deployPreviewBuild = readText('.github/workflows/deploy-preview.yml');
+    const deployPreviewTrusted = readText('.github/workflows/deploy-preview-trusted.yml');
     const regressionGuards = readText('.github/workflows/regression-guards.yml');
 
     if (firebaseJson.firestore?.rules !== 'firestore.rules') {
@@ -204,9 +205,9 @@ export function validateFirebaseRulesCi() {
     validateProductionDeployCommand(deployProd);
     assertMatches(deployProd, /needs:\s*\[\s*unit-tests\s*,\s*regression-guards\s*\]/, 'Production deploy gate');
 
-    assertMatches(deployPreview, /needs:\s*\[\s*unit-tests\s*,\s*regression-guards\s*\]/, 'Preview deploy gate');
-    validatePreviewDeployCommand(deployPreview);
-    assertPreviewDeploySkipHandling(deployPreview);
+    assertMatches(deployPreviewBuild, /needs:\s*\[\s*unit-tests\s*,\s*regression-guards\s*\]/, 'Preview artifact build gate');
+    validatePreviewDeployCommand(deployPreviewTrusted);
+    assertPreviewDeploySkipHandling(deployPreviewTrusted);
 
     assertIncludes(storageRules, 'match /game-clips/{teamId}/{gameId}/{userId}/{fileName}', 'Scoped Storage game clip rules');
     assertIncludes(storageRules, 'allow get: if canAccessTeamMedia(teamId);', 'Scoped Storage game clip read rules');

--- a/scripts/verify-preview-deploy-trigger.mjs
+++ b/scripts/verify-preview-deploy-trigger.mjs
@@ -112,23 +112,9 @@ export function verifyPreviewDeployTrigger({ event, run, pullRequest, artifacts 
         fail(`named artifact exceeds ${MAX_PREVIEW_ARCHIVE_BYTES} compressed bytes.`);
     }
     const expectedArchivePath = `/repos/${repository}/actions/artifacts/${artifactId}/zip`;
-    try {
-        const archiveUrl = new URL(artifact.archive_download_url);
-        if (
-            archiveUrl.protocol !== 'https:'
-            || archiveUrl.username
-            || archiveUrl.password
-            || archiveUrl.hostname !== 'api.github.com'
-            || archiveUrl.port
-            || archiveUrl.pathname !== expectedArchivePath
-            || archiveUrl.search
-            || archiveUrl.hash
-        ) {
-            fail('named artifact archive URL does not match its verified GitHub artifact ID.');
-        }
-    } catch (error) {
-        if (error?.message?.startsWith('Preview deploy trust check failed:')) throw error;
-        fail('named artifact archive URL is invalid.');
+    const expectedArchiveUrl = `https://api.github.com${expectedArchivePath}`;
+    if (artifact.archive_download_url !== expectedArchiveUrl) {
+        fail('named artifact archive URL does not exactly match its verified GitHub artifact ID.');
     }
 
     return {

--- a/scripts/verify-preview-deploy-trigger.mjs
+++ b/scripts/verify-preview-deploy-trigger.mjs
@@ -1,0 +1,179 @@
+import fs from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+export const PREVIEW_WORKFLOW_NAME = 'deploy-preview';
+export const PREVIEW_WORKFLOW_PATH = '.github/workflows/deploy-preview.yml';
+export const PREVIEW_ARTIFACT_NAME = 'firebase-preview-hosting-bundle';
+export const MAX_PREVIEW_ARCHIVE_BYTES = 100 * 1024 * 1024;
+
+function fail(message) {
+    throw new Error(`Preview deploy trust check failed: ${message}`);
+}
+
+function requirePositiveInteger(value, label) {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+        fail(`${label} must be a positive safe integer.`);
+    }
+    return value;
+}
+
+function requireSha(value, label) {
+    if (typeof value !== 'string' || !/^[0-9a-f]{40}$/.test(value)) {
+        fail(`${label} must be a full lowercase Git commit SHA.`);
+    }
+    return value;
+}
+
+function readJson(filePath, label) {
+    try {
+        return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    } catch (error) {
+        fail(`${label} is not valid JSON: ${error.message}`);
+    }
+}
+
+export function verifyPreviewDeployTrigger({ event, run, pullRequest, artifacts }) {
+    const repository = event?.repository?.full_name;
+    if (typeof repository !== 'string' || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
+        fail('event repository identity is invalid.');
+    }
+
+    const eventRun = event?.workflow_run;
+    if (!eventRun || eventRun.name !== PREVIEW_WORKFLOW_NAME) {
+        fail(`event must come from ${PREVIEW_WORKFLOW_NAME}.`);
+    }
+    if (eventRun.event !== 'pull_request' || eventRun.status !== 'completed' || eventRun.conclusion !== 'success') {
+        fail('triggering workflow must be a completed successful pull_request run.');
+    }
+
+    const runId = requirePositiveInteger(eventRun.id, 'event workflow run ID');
+    if (requirePositiveInteger(run?.id, 'API workflow run ID') !== runId) {
+        fail('event and API workflow run IDs do not match.');
+    }
+    if (
+        run.name !== PREVIEW_WORKFLOW_NAME
+        || run.path !== PREVIEW_WORKFLOW_PATH
+        || run.event !== 'pull_request'
+        || run.status !== 'completed'
+        || run.conclusion !== 'success'
+    ) {
+        fail('API workflow run identity, path, event, or conclusion is invalid.');
+    }
+    if (
+        eventRun.repository?.full_name !== repository
+        || eventRun.head_repository?.full_name !== repository
+        || run.repository?.full_name !== repository
+        || run.head_repository?.full_name !== repository
+    ) {
+        fail('triggering workflow and head repository must both match this repository.');
+    }
+
+    const eventHeadSha = requireSha(eventRun.head_sha, 'event head SHA');
+    const runHeadSha = requireSha(run.head_sha, 'API workflow run head SHA');
+    if (eventHeadSha !== runHeadSha) {
+        fail('event and API workflow run head SHAs do not match.');
+    }
+
+    const eventPullRequests = eventRun.pull_requests;
+    if (!Array.isArray(eventPullRequests) || eventPullRequests.length !== 1) {
+        fail('triggering workflow must identify exactly one pull request.');
+    }
+    const prNumber = requirePositiveInteger(eventPullRequests[0]?.number, 'event pull-request number');
+    if (requirePositiveInteger(pullRequest?.number, 'API pull-request number') !== prNumber) {
+        fail('event and API pull-request numbers do not match.');
+    }
+    if (
+        pullRequest.state !== 'open'
+        || pullRequest.base?.repo?.full_name !== repository
+        || pullRequest.head?.repo?.full_name !== repository
+        || pullRequest.head?.sha !== runHeadSha
+        || pullRequest.head?.ref !== run.head_branch
+    ) {
+        fail('pull request must remain open with a same-repository head matching the triggering run.');
+    }
+
+    const namedArtifacts = Array.isArray(artifacts?.artifacts)
+        ? artifacts.artifacts.filter((artifact) => artifact?.name === PREVIEW_ARTIFACT_NAME)
+        : [];
+    if (namedArtifacts.length !== 1) {
+        fail(`triggering run must contain exactly one ${PREVIEW_ARTIFACT_NAME} artifact.`);
+    }
+    const artifact = namedArtifacts[0];
+    const artifactId = requirePositiveInteger(artifact.id, 'artifact ID');
+    const artifactRunId = requirePositiveInteger(artifact.workflow_run?.id, 'artifact workflow run ID');
+    if (artifactRunId !== runId) {
+        fail('named artifact does not belong to the triggering run.');
+    }
+    if (artifact.expired !== false) {
+        fail('named artifact is expired.');
+    }
+    const archiveBytes = requirePositiveInteger(artifact.size_in_bytes, 'artifact archive size');
+    if (archiveBytes > MAX_PREVIEW_ARCHIVE_BYTES) {
+        fail(`named artifact exceeds ${MAX_PREVIEW_ARCHIVE_BYTES} compressed bytes.`);
+    }
+    const expectedArchivePath = `/repos/${repository}/actions/artifacts/${artifactId}/zip`;
+    try {
+        const archiveUrl = new URL(artifact.archive_download_url);
+        if (
+            archiveUrl.protocol !== 'https:'
+            || archiveUrl.username
+            || archiveUrl.password
+            || archiveUrl.hostname !== 'api.github.com'
+            || archiveUrl.port
+            || archiveUrl.pathname !== expectedArchivePath
+            || archiveUrl.search
+            || archiveUrl.hash
+        ) {
+            fail('named artifact archive URL does not match its verified GitHub artifact ID.');
+        }
+    } catch (error) {
+        if (error?.message?.startsWith('Preview deploy trust check failed:')) throw error;
+        fail('named artifact archive URL is invalid.');
+    }
+
+    return {
+        artifactId,
+        headSha: runHeadSha,
+        prNumber,
+        repository,
+        runId
+    };
+}
+
+function parseCliArgs(args) {
+    const options = {};
+    for (let index = 0; index < args.length; index += 2) {
+        const key = args[index];
+        const value = args[index + 1];
+        if (!key?.startsWith('--') || !value) {
+            throw new Error('Expected --event, --run, --pull-request, --artifacts, and --output paths.');
+        }
+        options[key.slice(2)] = value;
+    }
+    for (const required of ['event', 'run', 'pull-request', 'artifacts', 'output']) {
+        if (!options[required]) {
+            throw new Error(`Missing required --${required} path.`);
+        }
+    }
+    return options;
+}
+
+function appendWorkflowOutputs(outputPath, result) {
+    fs.appendFileSync(
+        outputPath,
+        `artifact_id=${result.artifactId}\nhead_sha=${result.headSha}\npr_number=${result.prNumber}\n`,
+        { encoding: 'utf8', mode: 0o600 }
+    );
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+    const options = parseCliArgs(process.argv.slice(2));
+    const result = verifyPreviewDeployTrigger({
+        event: readJson(options.event, 'workflow_run event'),
+        run: readJson(options.run, 'workflow run response'),
+        pullRequest: readJson(options['pull-request'], 'pull-request response'),
+        artifacts: readJson(options.artifacts, 'artifact-list response')
+    });
+    appendWorkflowOutputs(options.output, result);
+    console.log(`Verified trusted preview inputs for PR #${result.prNumber}.`);
+}

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -1,0 +1,453 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+    MAX_PREVIEW_ARCHIVE_BYTES,
+    verifyPreviewDeployTrigger
+} from '../../scripts/verify-preview-deploy-trigger.mjs';
+import { stagePagesBundle } from '../../scripts/stage-pages-bundle.mjs';
+import { writeFirebaseHostingConfig } from '../../scripts/write-firebase-hosting-config.mjs';
+
+const repoRoot = path.resolve(import.meta.dirname, '../..');
+const pullRequestWorkflow = fs.readFileSync(
+    path.join(repoRoot, '.github', 'workflows', 'deploy-preview.yml'),
+    'utf8'
+);
+const trustedWorkflow = fs.readFileSync(
+    path.join(repoRoot, '.github', 'workflows', 'deploy-preview-trusted.yml'),
+    'utf8'
+);
+const postDeploySmokeWorkflow = fs.readFileSync(
+    path.join(repoRoot, '.github', 'workflows', 'post-deploy-smoke.yml'),
+    'utf8'
+);
+const scheduledProdSmokeWorkflow = fs.readFileSync(
+    path.join(repoRoot, '.github', 'workflows', 'scheduled-prod-smoke.yml'),
+    'utf8'
+);
+const trustBoundaryRunbook = fs.readFileSync(
+    path.join(repoRoot, 'docs', 'preview-deploy-trust-boundary.md'),
+    'utf8'
+);
+const tempDirectories = [];
+
+function validTriggerFixture() {
+    const repository = 'pauljsnider/allplays';
+    const runId = 29647460622;
+    const prNumber = 4032;
+    const headSha = 'dc655278753f7cdd3c7b3f4f9bc54deff999cdc4';
+    return {
+        event: {
+            repository: { full_name: repository },
+            workflow_run: {
+                id: runId,
+                name: 'deploy-preview',
+                event: 'pull_request',
+                status: 'completed',
+                conclusion: 'success',
+                head_sha: headSha,
+                repository: { full_name: repository },
+                head_repository: { full_name: repository },
+                pull_requests: [{ number: prNumber }]
+            }
+        },
+        run: {
+            id: runId,
+            name: 'deploy-preview',
+            path: '.github/workflows/deploy-preview.yml',
+            event: 'pull_request',
+            status: 'completed',
+            conclusion: 'success',
+            head_sha: headSha,
+            head_branch: 'security/payment-authority-followup',
+            repository: { full_name: repository },
+            head_repository: { full_name: repository }
+        },
+        pullRequest: {
+            number: prNumber,
+            state: 'open',
+            base: { repo: { full_name: repository } },
+            head: {
+                repo: { full_name: repository },
+                ref: 'security/payment-authority-followup',
+                sha: headSha
+            }
+        },
+        artifacts: {
+            artifacts: [{
+                id: 50001,
+                name: 'firebase-preview-hosting-bundle',
+                expired: false,
+                size_in_bytes: 1024,
+                archive_download_url: 'https://api.github.com/repos/pauljsnider/allplays/actions/artifacts/50001/zip',
+                workflow_run: { id: runId }
+            }]
+        }
+    };
+}
+
+function makeTempDirectory() {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'allplays-preview-trust-'));
+    tempDirectories.push(directory);
+    return directory;
+}
+
+function createZip(archivePath, entries) {
+    const python = String.raw`
+import json, os, stat, zipfile
+entries = json.loads(os.environ['PREVIEW_ZIP_ENTRIES'])
+with zipfile.ZipFile(os.environ['PREVIEW_ZIP_PATH'], 'w', zipfile.ZIP_DEFLATED) as archive:
+    for entry in entries:
+        if entry.get('type') == 'symlink':
+            info = zipfile.ZipInfo(entry['name'])
+            info.create_system = 3
+            info.external_attr = (stat.S_IFLNK | 0o777) << 16
+            archive.writestr(info, entry.get('content', 'index.html'))
+        else:
+            archive.writestr(entry['name'], entry.get('content', 'content'))
+`;
+    const result = spawnSync('python3', ['-c', python], {
+        encoding: 'utf8',
+        env: {
+            ...process.env,
+            PREVIEW_ZIP_ENTRIES: JSON.stringify(entries),
+            PREVIEW_ZIP_PATH: archivePath
+        }
+    });
+    expect(result.status, result.stderr).toBe(0);
+}
+
+function zipDirectory(sourcePath, archivePath) {
+    const python = String.raw`
+import os, zipfile
+source = os.environ['PREVIEW_ZIP_SOURCE']
+with zipfile.ZipFile(os.environ['PREVIEW_ZIP_PATH'], 'w', zipfile.ZIP_DEFLATED) as archive:
+    for root, directories, files in os.walk(source):
+        directories.sort()
+        files.sort()
+        for name in files:
+            path = os.path.join(root, name)
+            archive.write(path, os.path.relpath(path, source).replace(os.sep, '/'))
+`;
+    const result = spawnSync('python3', ['-c', python], {
+        encoding: 'utf8',
+        env: {
+            ...process.env,
+            PREVIEW_ZIP_PATH: archivePath,
+            PREVIEW_ZIP_SOURCE: sourcePath
+        }
+    });
+    expect(result.status, result.stderr).toBe(0);
+}
+
+function writeFile(filePath, contents = '') {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, contents);
+}
+
+function extractZip(entries) {
+    const directory = makeTempDirectory();
+    const archivePath = path.join(directory, 'artifact.zip');
+    const destinationPath = path.join(directory, 'site');
+    createZip(archivePath, entries);
+    const result = spawnSync('python3', [
+        path.join(repoRoot, 'scripts', 'extract-preview-hosting-artifact.py'),
+        '--archive', archivePath,
+        '--destination', destinationPath
+    ], { encoding: 'utf8' });
+    return { destinationPath, result };
+}
+
+afterEach(() => {
+    while (tempDirectories.length) {
+        fs.rmSync(tempDirectories.pop(), { recursive: true, force: true });
+    }
+});
+
+describe('preview deployment workflow trust boundary', () => {
+    it('keeps pull-request code completely outside the credentialed deploy job', () => {
+        expect(pullRequestWorkflow).toContain('permissions: {}');
+        expect(pullRequestWorkflow).not.toMatch(/\$\{\{\s*secrets\./);
+        expect(pullRequestWorkflow).not.toContain('FIREBASE_SERVICE_ACCOUNT');
+        expect(pullRequestWorkflow).not.toContain('GOOGLE_APPLICATION_CREDENTIALS');
+        expect(pullRequestWorkflow).not.toContain('hosting:channel:deploy');
+        expect(pullRequestWorkflow).not.toContain('write-firebase-hosting-config');
+        expect(pullRequestWorkflow).not.toMatch(/^\s+\w[\w-]*:\s+write\s*$/m);
+        expect(pullRequestWorkflow).toContain('name: firebase-preview-hosting-bundle');
+        expect(pullRequestWorkflow).toContain('include-hidden-files: true');
+        expect(pullRequestWorkflow).toMatch(/build-preview-artifact:[\s\S]*needs: \[unit-tests, regression-guards\]/);
+    });
+
+    it('runs the credentialed deploy only from trusted default-branch code', () => {
+        expect(trustedWorkflow).toContain('workflow_run:');
+        expect(trustedWorkflow).toContain('name: firebase-preview-trusted');
+        expect(trustedWorkflow).toContain('ref: ${{ github.event.repository.default_branch }}');
+        expect(trustedWorkflow).toContain('persist-credentials: false');
+        expect(trustedWorkflow).not.toContain('refs/pull/');
+        expect(trustedWorkflow).not.toContain('github.event.workflow_run.head_sha');
+        expect(trustedWorkflow).not.toContain('actions/download-artifact');
+        expect(trustedWorkflow).not.toContain('hosting:channel:delete');
+        expect(trustedWorkflow).not.toContain('hosting:channel:list');
+        expect(trustedWorkflow).toContain('actions/runs/$WORKFLOW_RUN_ID/artifacts?per_page=100');
+        expect(trustedWorkflow).toContain('actions/artifacts/$ARTIFACT_ID/zip');
+        expect(trustedWorkflow).toContain('scripts/extract-preview-hosting-artifact.py');
+        expect(trustedWorkflow).toContain('node scripts/write-firebase-hosting-config.mjs "$FIREBASE_PREVIEW_SITE"');
+        expect(trustedWorkflow).toContain('CURRENT_CHANNEL: pr-${{ steps.verify_trigger.outputs.pr_number }}');
+        expect(trustedWorkflow).toContain('hosting:channel:deploy "$CURRENT_CHANNEL" --project game-flow-c6311');
+    });
+
+    it('withholds the Firebase credential until identity, archive, shape, config, and install checks pass', () => {
+        const triggerIndex = trustedWorkflow.indexOf('node scripts/verify-preview-deploy-trigger.mjs');
+        const downloadIndex = trustedWorkflow.indexOf('actions/artifacts/$ARTIFACT_ID/zip');
+        const extractionIndex = trustedWorkflow.indexOf('python3 scripts/extract-preview-hosting-artifact.py');
+        const configIndex = trustedWorkflow.indexOf('node scripts/write-firebase-hosting-config.mjs');
+        const installIndex = trustedWorkflow.indexOf('run: npm ci --ignore-scripts');
+        const recheckIndex = trustedWorkflow.indexOf('name: Re-verify current pull-request head before credentials');
+        const credentialIndex = trustedWorkflow.indexOf('secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311');
+        const deployIndex = trustedWorkflow.indexOf('hosting:channel:deploy');
+        const cleanupIndex = trustedWorkflow.indexOf('name: Remove Firebase credential file');
+        const commentIndex = trustedWorkflow.indexOf('name: Report preview URL on verified pull request');
+
+        expect(triggerIndex).toBeGreaterThan(-1);
+        expect(downloadIndex).toBeGreaterThan(triggerIndex);
+        expect(extractionIndex).toBeGreaterThan(downloadIndex);
+        expect(configIndex).toBeGreaterThan(extractionIndex);
+        expect(installIndex).toBeGreaterThan(configIndex);
+        expect(recheckIndex).toBeGreaterThan(installIndex);
+        expect(credentialIndex).toBeGreaterThan(recheckIndex);
+        expect(deployIndex).toBeGreaterThan(credentialIndex);
+        expect(cleanupIndex).toBeGreaterThan(deployIndex);
+        expect(commentIndex).toBeGreaterThan(cleanupIndex);
+        expect(trustedWorkflow.slice(cleanupIndex, commentIndex)).toContain('if: always()');
+    });
+
+    it('pins every third-party action used by both preview workflows', () => {
+        for (const workflow of [
+            pullRequestWorkflow,
+            trustedWorkflow,
+            postDeploySmokeWorkflow,
+            scheduledProdSmokeWorkflow
+        ]) {
+            const uses = [...workflow.matchAll(/^\s*uses:\s+([^\s#]+)/gm)].map((match) => match[1]);
+            expect(uses.length).toBeGreaterThan(0);
+            for (const action of uses) {
+                expect(action).toMatch(/^[^@]+@[0-9a-f]{40}$/);
+            }
+        }
+    });
+
+    it('keeps production smoke credentials in a protected trusted environment', () => {
+        for (const workflow of [postDeploySmokeWorkflow, scheduledProdSmokeWorkflow]) {
+            expect(workflow).toContain('name: production-smoke');
+            expect(workflow).toContain('permissions:\n  contents: read');
+            expect(workflow).toContain('persist-credentials: false');
+            expect(workflow).toContain('SMOKE_AUTH_EMAIL: ${{ secrets.SMOKE_AUTH_EMAIL }}');
+            expect(workflow).toContain('SMOKE_AUTH_PASSWORD: ${{ secrets.SMOKE_AUTH_PASSWORD }}');
+            expect(workflow).not.toContain('pull_request:');
+            expect(workflow).not.toMatch(/^\s+\w[\w-]*:\s+write\s*$/m);
+        }
+        expect(postDeploySmokeWorkflow).toContain("github.event.workflow_run.head_branch == 'master'");
+        expect(postDeploySmokeWorkflow).toContain('workflows:\n      - deploy-prod');
+        expect(scheduledProdSmokeWorkflow).toContain('ref: master');
+    });
+
+    it('documents the environment-only credential and exact-head operational contract', () => {
+        expect(trustBoundaryRunbook).toContain('must remain absent from repository');
+        expect(trustBoundaryRunbook).toContain('firebase-preview-trusted');
+        expect(trustBoundaryRunbook).toContain('production-smoke');
+        expect(trustBoundaryRunbook).toContain('SMOKE_AUTH_EMAIL');
+        expect(trustBoundaryRunbook).toContain('protected/default-branch-only deployment policy');
+        expect(trustBoundaryRunbook).toContain('Any new commit invalidates prior review evidence.');
+        expect(trustBoundaryRunbook).toContain('Cloud Audit Logs for the old key ID');
+        expect(trustBoundaryRunbook).toContain('Workload Identity Federation');
+    });
+});
+
+describe('preview deployment trigger verification', () => {
+    it('accepts an exact same-repository run, pull request head, and named artifact', () => {
+        expect(verifyPreviewDeployTrigger(validTriggerFixture())).toEqual({
+            artifactId: 50001,
+            headSha: 'dc655278753f7cdd3c7b3f4f9bc54deff999cdc4',
+            prNumber: 4032,
+            repository: 'pauljsnider/allplays',
+            runId: 29647460622
+        });
+    });
+
+    it('rejects fork identity, stale pull-request heads, and unsuccessful runs', () => {
+        const forkFixture = validTriggerFixture();
+        forkFixture.run.head_repository.full_name = 'attacker/allplays';
+        expect(() => verifyPreviewDeployTrigger(forkFixture)).toThrow(/head repository must both match/);
+
+        const staleFixture = validTriggerFixture();
+        staleFixture.pullRequest.head.sha = '1111111111111111111111111111111111111111';
+        expect(() => verifyPreviewDeployTrigger(staleFixture)).toThrow(/head matching the triggering run/);
+
+        const failedFixture = validTriggerFixture();
+        failedFixture.event.workflow_run.conclusion = 'failure';
+        expect(() => verifyPreviewDeployTrigger(failedFixture)).toThrow(/completed successful/);
+    });
+
+    it('rejects duplicate, expired, cross-run, and oversized named artifacts', () => {
+        const duplicateFixture = validTriggerFixture();
+        duplicateFixture.artifacts.artifacts.push({ ...duplicateFixture.artifacts.artifacts[0], id: 50002 });
+        expect(() => verifyPreviewDeployTrigger(duplicateFixture)).toThrow(/exactly one/);
+
+        const expiredFixture = validTriggerFixture();
+        expiredFixture.artifacts.artifacts[0].expired = true;
+        expect(() => verifyPreviewDeployTrigger(expiredFixture)).toThrow(/expired/);
+
+        const crossRunFixture = validTriggerFixture();
+        crossRunFixture.artifacts.artifacts[0].workflow_run.id += 1;
+        expect(() => verifyPreviewDeployTrigger(crossRunFixture)).toThrow(/does not belong/);
+
+        const oversizedFixture = validTriggerFixture();
+        oversizedFixture.artifacts.artifacts[0].size_in_bytes = MAX_PREVIEW_ARCHIVE_BYTES + 1;
+        expect(() => verifyPreviewDeployTrigger(oversizedFixture)).toThrow(/exceeds/);
+    });
+
+    it('binds the archive URL to the verified GitHub host, repository, and artifact ID', () => {
+        for (const archiveUrl of [
+            'https://api.github.com/repos/attacker/allplays/actions/artifacts/50001/zip',
+            'https://api.github.com/repos/pauljsnider/allplays/actions/artifacts/99999/zip',
+            'https://api.github.com.evil.example/repos/pauljsnider/allplays/actions/artifacts/50001/zip',
+            'https://api.github.com/repos/pauljsnider/allplays/actions/artifacts/50001/zip?redirect=evil'
+        ]) {
+            const fixture = validTriggerFixture();
+            fixture.artifacts.artifacts[0].archive_download_url = archiveUrl;
+            expect(() => verifyPreviewDeployTrigger(fixture)).toThrow(/archive URL/);
+        }
+    });
+});
+
+describe('preview Hosting archive validation', () => {
+    const requiredEntries = [
+        { name: '.nojekyll', content: '' },
+        { name: 'index.html', content: '<html>legacy</html>' },
+        { name: 'app/index.html', content: '<html>app</html>' }
+    ];
+
+    it('extracts a bounded regular-file Hosting tree', () => {
+        const { destinationPath, result } = extractZip([
+            ...requiredEntries,
+            { name: 'js/app.js', content: 'console.log("preview")' }
+        ]);
+
+        expect(result.status, result.stderr).toBe(0);
+        expect(fs.readFileSync(path.join(destinationPath, 'app', 'index.html'), 'utf8')).toContain('app');
+        expect(result.stdout).toContain('Validated and extracted 4 Hosting files');
+    });
+
+    it('rejects traversal paths, symlinks, and repository/deploy configuration', () => {
+        const traversal = extractZip([...requiredEntries, { name: '../escape.txt', content: 'escape' }]);
+        expect(traversal.result.status).not.toBe(0);
+        expect(traversal.result.stderr).toContain('ambiguous or traversing path');
+
+        const symlink = extractZip([...requiredEntries, {
+            name: 'linked-index.html',
+            type: 'symlink',
+            content: 'index.html'
+        }]);
+        expect(symlink.result.status).not.toBe(0);
+        expect(symlink.result.stderr).toContain('symlink or special file');
+
+        const config = extractZip([...requiredEntries, { name: 'firebase.json', content: '{}' }]);
+        expect(config.result.status).not.toBe(0);
+        expect(config.result.stderr).toContain('forbidden root path firebase.json');
+
+        const hiddenConfig = extractZip([...requiredEntries, { name: '.firebaserc', content: '{}' }]);
+        expect(hiddenConfig.result.status).not.toBe(0);
+        expect(hiddenConfig.result.stderr).toContain('unexpected hidden path .firebaserc');
+    });
+
+    it('requires the exact staged Hosting artifact shape', () => {
+        const missingApp = extractZip(requiredEntries.filter((entry) => entry.name !== 'app/index.html'));
+        expect(missingApp.result.status).not.toBe(0);
+        expect(missingApp.result.stderr).toContain('missing required Hosting files: app/index.html');
+
+        const unpublishedClaim = extractZip([
+            ...requiredEntries,
+            { name: '.well-known/assetlinks.json', content: '[]' }
+        ]);
+        expect(unpublishedClaim.result.status).not.toBe(0);
+        expect(unpublishedClaim.result.stderr).toContain('unpublished public association claim');
+    });
+
+    it('accepts the real stage-to-ZIP shape and generates config only from trusted source', () => {
+        const directory = makeTempDirectory();
+        const trustedRoot = path.join(directory, 'trusted-default-branch');
+        const stagedSite = path.join(directory, 'staged-site');
+        const archivePath = path.join(directory, 'artifact.zip');
+        const extractedSite = path.join(directory, 'extracted-site');
+        const generatedConfig = path.join(directory, 'trusted-preview.generated.json');
+        const originalSiteKey = process.env.ALLPLAYS_APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY;
+        const originalEnforcement = process.env.ALLPLAYS_APP_CHECK_ENFORCEMENT_READY;
+
+        writeFile(path.join(trustedRoot, 'index.html'), '<html><head></head><body>legacy</body></html>');
+        writeFile(path.join(trustedRoot, 'apps', 'app', 'dist', 'index.html'), '<html><head></head><body>app</body></html>');
+        writeFile(path.join(trustedRoot, '.well-known', 'apple-app-site-association'), '{"placeholder":true}');
+        writeFile(path.join(trustedRoot, '.well-known', 'assetlinks.json'), '[]');
+        writeFile(path.join(trustedRoot, 'firebase.json'), JSON.stringify({
+            hosting: {
+                site: 'game-flow-c6311',
+                public: '.',
+                ignore: ['firebase.json', '**/.*', '**/node_modules/**'],
+                headers: [
+                    {
+                        source: '**',
+                        headers: [
+                            { key: 'Content-Security-Policy', value: "default-src 'self'; script-src 'self'" },
+                            { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' }
+                        ]
+                    },
+                    {
+                        source: '/widget-scoreboard.html',
+                        headers: [{ key: 'Content-Security-Policy', value: "default-src 'self'; script-src 'self'" }]
+                    }
+                ]
+            }
+        }));
+
+        try {
+            process.env.ALLPLAYS_APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY = 'public-preview-site-key_123';
+            process.env.ALLPLAYS_APP_CHECK_ENFORCEMENT_READY = 'true';
+            stagePagesBundle(stagedSite, { rootDir: trustedRoot });
+        } finally {
+            if (originalSiteKey === undefined) delete process.env.ALLPLAYS_APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY;
+            else process.env.ALLPLAYS_APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY = originalSiteKey;
+            if (originalEnforcement === undefined) delete process.env.ALLPLAYS_APP_CHECK_ENFORCEMENT_READY;
+            else process.env.ALLPLAYS_APP_CHECK_ENFORCEMENT_READY = originalEnforcement;
+        }
+
+        expect(fs.existsSync(path.join(stagedSite, '.well-known', 'apple-app-site-association'))).toBe(false);
+        expect(fs.existsSync(path.join(stagedSite, '.well-known', 'assetlinks.json'))).toBe(false);
+        expect(fs.existsSync(path.join(stagedSite, 'firebase.json'))).toBe(false);
+
+        zipDirectory(stagedSite, archivePath);
+        const extraction = spawnSync('python3', [
+            path.join(repoRoot, 'scripts', 'extract-preview-hosting-artifact.py'),
+            '--archive', archivePath,
+            '--destination', extractedSite
+        ], { encoding: 'utf8' });
+        expect(extraction.status, extraction.stderr).toBe(0);
+
+        writeFirebaseHostingConfig(extractedSite, generatedConfig, { rootDir: trustedRoot });
+        const config = JSON.parse(fs.readFileSync(generatedConfig, 'utf8'));
+        expect(config.hosting.site).toBe('game-flow-c6311');
+        expect(config.hosting.public).toBe(path.resolve(extractedSite));
+        expect(config.hosting.ignore).not.toContain('**/.*');
+        expect(fs.existsSync(path.join(extractedSite, 'firebase.json'))).toBe(false);
+        expect(JSON.parse(
+            fs.readFileSync(path.join(extractedSite, '.well-known', 'allplays-runtime-config.json'), 'utf8')
+        )).toEqual({
+            appCheck: {
+                enabled: true,
+                recaptchaEnterpriseSiteKey: 'public-preview-site-key_123',
+                isTokenAutoRefreshEnabled: true
+            }
+        });
+    });
+});

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -314,6 +314,8 @@ describe('preview deployment trigger verification', () => {
             'https://api.github.com/repos/attacker/allplays/actions/artifacts/50001/zip',
             'https://api.github.com/repos/pauljsnider/allplays/actions/artifacts/99999/zip',
             'https://api.github.com.evil.example/repos/pauljsnider/allplays/actions/artifacts/50001/zip',
+            'https://:@api.github.com/repos/pauljsnider/allplays/actions/artifacts/50001/zip',
+            'https://@api.github.com/repos/pauljsnider/allplays/actions/artifacts/50001/zip',
             'https://api.github.com/repos/pauljsnider/allplays/actions/artifacts/50001/zip?redirect=evil'
         ]) {
             const fixture = validTriggerFixture();


### PR DESCRIPTION
## DO NOT MERGE — SECURITY REVIEW REQUIRED

### What changed

- split Firebase preview CI into an unprivileged `pull_request` build/artifact workflow and a protected default-branch `workflow_run` deployer
- validate same-repository run/PR identity, exact current head SHA, successful conclusion, exact artifact name/run ownership, exact GitHub archive URL, compressed size, safe ZIP paths/types, no symlinks, extracted size, and required Hosting shape before credentials
- generate Firebase config only from trusted default-branch code, deploy only the fixed verified `pr-N` Hosting channel, remove the credential file, and comment the preview URL
- move post-deploy and scheduled production smoke jobs onto the protected `production-smoke` environment with read-only permissions
- pin every third-party action touched by this change
- add adversarial static/runtime contracts and a credential rotation/runbook

### Root cause and impact

The prior same-repository PR job checked out and executed PR-controlled npm/build/staging code before injecting a repository-level Firebase service-account JSON key and a write-capable repository token. A collaborator or compromised writer could alter workflow or lifecycle code and exfiltrate or misuse that credential. Repository-scoped smoke credentials had the same cross-workflow exposure class.

This PR makes PR-controlled execution artifact-only and keeps all credentials in protected environments reached only by trusted default/protected-branch workflows.

### Validation

- `npm run test:unit:ci`: 4,551 passed / 78 skipped; emulator subset 67 passed after using the repository-documented Android Studio JDK
- `npm run test:functions:auth-email`: 49 passed
- `npm run app:build`: passed; 231 production files and bundle visualizer verified
- focused preview trust suite: 14 passed, including empty-userinfo URL regressions
- `npm run ci:firebase-rules`: passed
- actionlint v1.7.7 on all four touched workflows: passed
- Ruby YAML parse, Node syntax check, Python compile, and `git diff --check`: passed
- live Actions artifact canary: downloaded artifact 8430723561, safely extracted 525 files / 15,398,018 bytes, and generated trusted Hosting config successfully
- live GitHub API fixture confirmed workflow run head SHA equals current PR head and artifact URL shape matches the verifier

### Review feedback addressed

- Amazon Q exact-head review on the prior commit identified empty URL userinfo normalization. Commit `ed09f079` now requires raw archive URL equality to the exact expected GitHub API URL; this is stricter than parsed username/password checks and has regression coverage for `https://:@...` and `https://@...`.

### External security state / blockers

- `firebase-preview-trusted`, `production`, and `production-smoke` environments are protected-branches-only
- Firebase JSON credential is environment-only; repository-level Firebase secret is absent
- **Before merge:** finish rotating/moving `SMOKE_AUTH_EMAIL` and `SMOKE_AUTH_PASSWORD` into `production-smoke`, delete both repository secrets, and verify metadata
- **Before merge:** obtain security-focused Codex and PaulBot reviews anchored to exact final head `ed09f0796afef8816afca50684e063be2e95f98e`; any new commit invalidates prior review evidence
- **After replacement-key canaries:** inspect Cloud Audit Logs/Actions history for the old key ID, disable it, rerun canaries, then delete it after the observation window
- long-term: replace JSON credentials with repository/workflow/default-branch-bound Workload Identity Federation and a least-privilege preview principal

This PR intentionally does not fix unrelated residual audit findings.