### PR TITLE
Use keyless Firebase deploy authentication

### DIFF
--- a/.github/workflows/deploy-preview-trusted.yml
+++ b/.github/workflows/deploy-preview-trusted.yml
@@ -26,6 +26,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      id-token: write
       issues: write
       pull-requests: write
 
@@ -119,15 +120,15 @@ jobs:
 
       # The credential is unavailable until all identity, archive, extracted
       # shape, and trusted-config checks have completed successfully.
-      - name: Configure Firebase service account
-        env:
-          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311 }}
-        run: |
-          set -euo pipefail
-          credentials_file="$RUNNER_TEMP/firebase-service-account.json"
-          umask 077
-          printf '%s' "$FIREBASE_SERVICE_ACCOUNT" > "$credentials_file"
-          echo "GOOGLE_APPLICATION_CREDENTIALS=$credentials_file" >> "$GITHUB_ENV"
+      - name: Authenticate to Google Cloud through exact-workflow OIDC
+        id: google_auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ vars.FIREBASE_DEPLOY_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.FIREBASE_DEPLOY_SERVICE_ACCOUNT }}
+          project_id: game-flow-c6311
+          create_credentials_file: true
+          cleanup_credentials: true
 
       - name: Deploy fixed Firebase Hosting preview channel
         id: deploy_preview
@@ -220,9 +221,15 @@ jobs:
           echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
           echo "preview_skip_reason=" >> "$GITHUB_OUTPUT"
 
-      - name: Remove Firebase credential file
+      - name: Remove ephemeral Google credential file
         if: always()
-        run: rm -f "$RUNNER_TEMP/firebase-service-account.json"
+        env:
+          GOOGLE_CREDENTIAL_FILE: ${{ steps.google_auth.outputs.credentials_file_path }}
+        run: |
+          set -euo pipefail
+          if [[ -n "$GOOGLE_CREDENTIAL_FILE" ]]; then
+            rm -f -- "$GOOGLE_CREDENTIAL_FILE"
+          fi
 
       - name: Report preview URL on verified pull request
         if: success()

--- a/.github/workflows/deploy-preview-trusted.yml
+++ b/.github/workflows/deploy-preview-trusted.yml
@@ -238,10 +238,14 @@ jobs:
 
           deploy_preview_channel() {
             : > "$log_file"
+            set +e
             (
               cd "$bundle"
               node "$firebase_cli" hosting:channel:deploy "$CURRENT_CHANNEL" --project game-flow-c6311 --config "$firebase_config" --expires 7d --non-interactive
             ) 2>&1 | tee "$log_file"
+            local deploy_status="${PIPESTATUS[0]}"
+            set -e
+            return "$deploy_status"
           }
 
           skip_preview() {
@@ -276,6 +280,10 @@ jobs:
             grep -Eiq 'Failed to authenticate|Command requires authentication|Unable to read the credential file' "$log_file"
           }
 
+          preview_deploy_hit_auth_domain_sync_error() {
+            grep -Eiq 'Unable to add channel domain to Firebase Auth|Unable to sync Firebase Auth state' "$log_file"
+          }
+
           preview_deploy_hit_release_target_error() {
             grep -Eiq "HTTP Error: 400, Can't release to .*resource doesn't exist or isn't a valid release target" "$log_file"
           }
@@ -293,6 +301,10 @@ jobs:
             if preview_deploy_hit_quota; then
               skip_preview_for_quota
             fi
+            exit 1
+          fi
+          if preview_deploy_hit_auth_domain_sync_error; then
+            echo "Firebase Hosting deployed, but its Auth authorized-domain sync failed; refusing to report a partially functional preview." >&2
             exit 1
           fi
 

--- a/.github/workflows/deploy-preview-trusted.yml
+++ b/.github/workflows/deploy-preview-trusted.yml
@@ -14,21 +14,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deploy-preview:
+  prepare-preview:
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    environment:
-      name: firebase-preview-trusted
     permissions:
       actions: read
       contents: read
-      id-token: write
-      issues: write
-      pull-requests: write
+      pull-requests: read
+    outputs:
+      artifact_id: ${{ steps.verify_trigger.outputs.artifact_id }}
+      head_sha: ${{ steps.verify_trigger.outputs.head_sha }}
+      pr_number: ${{ steps.verify_trigger.outputs.pr_number }}
 
     steps:
       # workflow_run executes this workflow from the default branch. Only that
@@ -80,26 +80,38 @@ jobs:
             "repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID/zip" > "$archive"
           echo "PREVIEW_ARTIFACT_ARCHIVE=$archive" >> "$GITHUB_ENV"
 
-      - name: Validate and extract untrusted Hosting content
+      - name: Validate and extract untrusted Hosting content without OIDC
         run: |
           set -euo pipefail
-          site_dir="$RUNNER_TEMP/firebase-preview-site"
+          stage_dir="$RUNNER_TEMP/firebase-preview-ready"
+          site_dir="$stage_dir/site"
+          mkdir -p "$stage_dir/context"
           python3 scripts/extract-preview-hosting-artifact.py \
             --archive "$PREVIEW_ARTIFACT_ARCHIVE" \
             --destination "$site_dir"
-          echo "FIREBASE_PREVIEW_SITE=$site_dir" >> "$GITHUB_ENV"
+          echo "FIREBASE_PREVIEW_STAGE=$stage_dir" >> "$GITHUB_ENV"
 
-      - name: Generate Firebase config from trusted default branch
+      - name: Generate relocatable Firebase config from trusted code
         run: |
           set -euo pipefail
-          config_file="$RUNNER_TEMP/firebase-preview.generated.json"
-          node scripts/write-firebase-hosting-config.mjs "$FIREBASE_PREVIEW_SITE" "$config_file"
-          echo "FIREBASE_PREVIEW_CONFIG=$config_file" >> "$GITHUB_ENV"
+          config_file="$FIREBASE_PREVIEW_STAGE/firebase-preview.generated.json"
+          node scripts/write-firebase-hosting-config.mjs "$FIREBASE_PREVIEW_STAGE/site" "$config_file"
+          jq '.hosting.public = "site"' "$config_file" > "$config_file.tmp"
+          mv "$config_file.tmp" "$config_file"
 
-      - name: Install trusted Firebase CLI without lifecycle scripts
-        run: npm ci --ignore-scripts
+      - name: Install isolated Firebase CLI without OIDC or lifecycle scripts
+        run: |
+          set -euo pipefail
+          npm install \
+            --prefix "$FIREBASE_PREVIEW_STAGE/firebase-cli" \
+            --ignore-scripts \
+            --no-audit \
+            --no-fund \
+            --package-lock=false \
+            firebase-tools@15.24.0
+          node "$FIREBASE_PREVIEW_STAGE/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js" --version
 
-      - name: Re-verify current pull-request head before credentials
+      - name: Re-verify current pull-request head before trusted handoff
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.verify_trigger.outputs.pr_number }}
@@ -117,9 +129,69 @@ jobs:
             --pull-request "$current_pr_json" \
             --artifacts "$RUNNER_TEMP/firebase-preview-artifacts.json" \
             --output "$recheck_output"
+          cp "$GITHUB_EVENT_PATH" "$FIREBASE_PREVIEW_STAGE/context/event.json"
+          cp "$RUNNER_TEMP/firebase-preview-run.json" "$FIREBASE_PREVIEW_STAGE/context/run.json"
+          cp "$RUNNER_TEMP/firebase-preview-artifacts.json" "$FIREBASE_PREVIEW_STAGE/context/artifacts.json"
+          cp scripts/verify-preview-deploy-trigger.mjs "$FIREBASE_PREVIEW_STAGE/context/verify-preview-deploy-trigger.mjs"
 
-      # The credential is unavailable until all identity, archive, extracted
-      # shape, and trusted-config checks have completed successfully.
+      - name: Upload sanitized trusted deploy handoff
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: firebase-preview-trusted-ready
+          path: ${{ runner.temp }}/firebase-preview-ready
+          if-no-files-found: error
+          include-hidden-files: true
+          retention-days: 1
+
+  deploy-preview:
+    needs: prepare-preview
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    environment:
+      name: firebase-preview-trusted
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      pull-requests: read
+    outputs:
+      preview_skip_reason: ${{ steps.deploy_preview.outputs.preview_skip_reason }}
+      preview_url: ${{ steps.deploy_preview.outputs.preview_url }}
+
+    steps:
+      # This artifact was produced by the no-OIDC job in this exact trusted
+      # workflow run. The raw pull-request artifact never enters this job.
+      - name: Download sanitized trusted deploy handoff
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: firebase-preview-trusted-ready
+          path: ${{ runner.temp }}/firebase-preview-ready
+
+      - name: Validate trusted handoff without executing artifact content
+        env:
+          ARTIFACT_ID: ${{ needs.prepare-preview.outputs.artifact_id }}
+          HEAD_SHA: ${{ needs.prepare-preview.outputs.head_sha }}
+          PR_NUMBER: ${{ needs.prepare-preview.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          bundle="$RUNNER_TEMP/firebase-preview-ready"
+          if [[ ! "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]] || [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]] || [[ ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Trusted handoff identity is invalid." >&2
+            exit 1
+          fi
+          test -d "$bundle/site"
+          test -f "$bundle/firebase-preview.generated.json"
+          test -f "$bundle/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js"
+          test -f "$bundle/context/event.json"
+          test -f "$bundle/context/run.json"
+          test -f "$bundle/context/artifacts.json"
+          test -f "$bundle/context/verify-preview-deploy-trigger.mjs"
+          if [[ -n "$(find "$bundle" -type l -print -quit)" ]]; then
+            echo "Trusted handoff must not contain symbolic links." >&2
+            exit 1
+          fi
+          jq -e '.hosting.public == "site" and .hosting.site == "game-flow-c6311"' "$bundle/firebase-preview.generated.json" >/dev/null
+
       - name: Authenticate to Google Cloud through exact-workflow OIDC
         id: google_auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
@@ -134,13 +206,18 @@ jobs:
         id: deploy_preview
         timeout-minutes: 4
         env:
-          CURRENT_CHANNEL: pr-${{ steps.verify_trigger.outputs.pr_number }}
+          ARTIFACT_ID: ${{ needs.prepare-preview.outputs.artifact_id }}
+          CURRENT_CHANNEL: pr-${{ needs.prepare-preview.outputs.pr_number }}
+          EXPECTED_HEAD_SHA: ${{ needs.prepare-preview.outputs.head_sha }}
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ steps.verify_trigger.outputs.pr_number }}
+          PR_NUMBER: ${{ needs.prepare-preview.outputs.pr_number }}
         run: |
           set -euo pipefail
-          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]] || [[ "$CURRENT_CHANNEL" != "pr-$PR_NUMBER" ]]; then
-            echo "Verified pull request or preview channel is invalid." >&2
+          bundle="$RUNNER_TEMP/firebase-preview-ready"
+          firebase_cli="$bundle/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js"
+          firebase_config="$bundle/firebase-preview.generated.json"
+          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]] || [[ "$CURRENT_CHANNEL" != "pr-$PR_NUMBER" ]] || [[ ! "$EXPECTED_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Verified pull request, head, or preview channel is invalid." >&2
             exit 1
           fi
           log_file="$RUNNER_TEMP/firebase-preview-deploy.log"
@@ -149,17 +226,22 @@ jobs:
             local current_pr_json="$RUNNER_TEMP/firebase-preview-pre-deploy-pr.json"
             local recheck_output="$RUNNER_TEMP/firebase-preview-pre-deploy.outputs"
             gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > "$current_pr_json"
-            node scripts/verify-preview-deploy-trigger.mjs \
-              --event "$GITHUB_EVENT_PATH" \
-              --run "$RUNNER_TEMP/firebase-preview-run.json" \
+            node "$bundle/context/verify-preview-deploy-trigger.mjs" \
+              --event "$bundle/context/event.json" \
+              --run "$bundle/context/run.json" \
               --pull-request "$current_pr_json" \
-              --artifacts "$RUNNER_TEMP/firebase-preview-artifacts.json" \
+              --artifacts "$bundle/context/artifacts.json" \
               --output "$recheck_output"
+            grep -Fxq "head_sha=$EXPECTED_HEAD_SHA" "$recheck_output"
+            grep -Fxq "artifact_id=$ARTIFACT_ID" "$recheck_output"
           }
 
           deploy_preview_channel() {
             : > "$log_file"
-            ./node_modules/.bin/firebase hosting:channel:deploy "$CURRENT_CHANNEL" --project game-flow-c6311 --config "$FIREBASE_PREVIEW_CONFIG" --expires 7d --non-interactive 2>&1 | tee "$log_file"
+            (
+              cd "$bundle"
+              node "$firebase_cli" hosting:channel:deploy "$CURRENT_CHANNEL" --project game-flow-c6311 --config "$firebase_config" --expires 7d --non-interactive
+            ) 2>&1 | tee "$log_file"
           }
 
           skip_preview() {
@@ -198,7 +280,7 @@ jobs:
             grep -Eiq "HTTP Error: 400, Can't release to .*resource doesn't exist or isn't a valid release target" "$log_file"
           }
 
-          # Keep this check adjacent to the external write. A newer PR head
+          # Keep this check adjacent to the only Firebase write. A newer PR head
           # cancels this PR-scoped job and also fails this exact-head binding.
           recheck_current_head
           if ! deploy_preview_channel; then
@@ -237,20 +319,55 @@ jobs:
             echo "GOOGLE_GHA_CREDS_PATH="
           } >> "$GITHUB_ENV"
 
-      - name: Report preview URL on verified pull request
-        if: success()
+  report-preview:
+    needs: [prepare-preview, deploy-preview]
+    if: needs.deploy-preview.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout trusted default-branch verifier
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Report preview URL on the still-current pull request
         continue-on-error: true
         env:
+          EXPECTED_ARTIFACT_ID: ${{ needs.prepare-preview.outputs.artifact_id }}
+          EXPECTED_HEAD_SHA: ${{ needs.prepare-preview.outputs.head_sha }}
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ steps.verify_trigger.outputs.pr_number }}
-          PREVIEW_URL: ${{ steps.deploy_preview.outputs.preview_url }}
-          PREVIEW_SKIP_REASON: ${{ steps.deploy_preview.outputs.preview_skip_reason }}
+          PREVIEW_SKIP_REASON: ${{ needs.deploy-preview.outputs.preview_skip_reason }}
+          PREVIEW_URL: ${{ needs.deploy-preview.outputs.preview_url }}
+          PR_NUMBER: ${{ needs.prepare-preview.outputs.pr_number }}
           JQ_FILTER: '.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("<!-- allplays-preview-url -->")) | .id'
         run: |
           set -euo pipefail
-          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]] || [[ ! "$EXPECTED_ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]] || [[ ! "$EXPECTED_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
             exit 1
           fi
+          run_json="$RUNNER_TEMP/firebase-preview-report-run.json"
+          pr_json="$RUNNER_TEMP/firebase-preview-report-pr.json"
+          artifacts_json="$RUNNER_TEMP/firebase-preview-report-artifacts.json"
+          verify_output="$RUNNER_TEMP/firebase-preview-report.outputs"
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/${{ github.event.workflow_run.id }}" > "$run_json"
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > "$pr_json"
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/${{ github.event.workflow_run.id }}/artifacts?per_page=100" > "$artifacts_json"
+          node scripts/verify-preview-deploy-trigger.mjs \
+            --event "$GITHUB_EVENT_PATH" \
+            --run "$run_json" \
+            --pull-request "$pr_json" \
+            --artifacts "$artifacts_json" \
+            --output "$verify_output"
+          grep -Fxq "head_sha=$EXPECTED_HEAD_SHA" "$verify_output"
+          grep -Fxq "artifact_id=$EXPECTED_ARTIFACT_ID" "$verify_output"
+
           marker='<!-- allplays-preview-url -->'
           if [[ -n "$PREVIEW_URL" ]]; then
             body="$(printf '%s\n\nPreview URL: %s' "$marker" "$PREVIEW_URL")"
@@ -258,18 +375,6 @@ jobs:
             body="$(printf '%s\n\nFirebase preview skipped: %s' "$marker" "${PREVIEW_SKIP_REASON:-Firebase Hosting preview was unavailable for this run.}")"
           fi
           comment_id="$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --jq "$JQ_FILTER" | head -n1)"
-
-          # Bind the comment write to the same still-current head immediately
-          # before updating the shared pull-request comment.
-          current_pr_json="$RUNNER_TEMP/firebase-preview-pre-comment-pr.json"
-          recheck_output="$RUNNER_TEMP/firebase-preview-pre-comment.outputs"
-          gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > "$current_pr_json"
-          node scripts/verify-preview-deploy-trigger.mjs \
-            --event "$GITHUB_EVENT_PATH" \
-            --run "$RUNNER_TEMP/firebase-preview-run.json" \
-            --pull-request "$current_pr_json" \
-            --artifacts "$RUNNER_TEMP/firebase-preview-artifacts.json" \
-            --output "$recheck_output"
           if [[ -n "$comment_id" ]]; then
             gh api "repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" --method PATCH -f body="$body" >/dev/null
           else

--- a/.github/workflows/deploy-preview-trusted.yml
+++ b/.github/workflows/deploy-preview-trusted.yml
@@ -221,12 +221,23 @@ jobs:
             exit 1
           fi
           log_file="$RUNNER_TEMP/firebase-preview-deploy.log"
+          verifier="$bundle/context/verify-preview-deploy-trigger.mjs"
+          if [[ ! -f "$verifier" ]]; then
+            echo "Trusted preview verifier is missing." >&2
+            exit 1
+          fi
+          test ! -L "$verifier" || {
+            echo "Trusted preview verifier must not be a symbolic link." >&2
+            exit 1
+          }
+          expected_verifier_sha256='bbf7426f259fb7cd400980249d55a92c46c2804e343d11d763f1e9e448c6e82b'
+          printf '%s  %s\n' "$expected_verifier_sha256" "$verifier" | sha256sum --check --strict
 
           recheck_current_head() {
             local current_pr_json="$RUNNER_TEMP/firebase-preview-pre-deploy-pr.json"
             local recheck_output="$RUNNER_TEMP/firebase-preview-pre-deploy.outputs"
             gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > "$current_pr_json"
-            node "$bundle/context/verify-preview-deploy-trigger.mjs" \
+            node "$verifier" \
               --event "$bundle/context/event.json" \
               --run "$bundle/context/run.json" \
               --pull-request "$current_pr_json" \

--- a/.github/workflows/deploy-preview-trusted.yml
+++ b/.github/workflows/deploy-preview-trusted.yml
@@ -370,11 +370,27 @@ jobs:
 
           marker='<!-- allplays-preview-url -->'
           if [[ -n "$PREVIEW_URL" ]]; then
-            body="$(printf '%s\n\nPreview URL: %s' "$marker" "$PREVIEW_URL")"
+            body="$(printf '%s\n\nPreview for commit `%s`: %s' "$marker" "$EXPECTED_HEAD_SHA" "$PREVIEW_URL")"
           else
-            body="$(printf '%s\n\nFirebase preview skipped: %s' "$marker" "${PREVIEW_SKIP_REASON:-Firebase Hosting preview was unavailable for this run.}")"
+            body="$(printf '%s\n\nFirebase preview for commit `%s` skipped: %s' "$marker" "$EXPECTED_HEAD_SHA" "${PREVIEW_SKIP_REASON:-Firebase Hosting preview was unavailable for this run.}")"
           fi
           comment_id="$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --jq "$JQ_FILTER" | head -n1)"
+
+          # Comment discovery can take long enough for a synchronize event to
+          # land. Re-read and re-bind the exact PR head after that network call
+          # so the shared comment write is adjacent to a fresh verifier result.
+          current_pr_json="$RUNNER_TEMP/firebase-preview-pre-comment-pr.json"
+          recheck_output="$RUNNER_TEMP/firebase-preview-pre-comment.outputs"
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > "$current_pr_json"
+          node scripts/verify-preview-deploy-trigger.mjs \
+            --event "$GITHUB_EVENT_PATH" \
+            --run "$run_json" \
+            --pull-request "$current_pr_json" \
+            --artifacts "$artifacts_json" \
+            --output "$recheck_output"
+          grep -Fxq "head_sha=$EXPECTED_HEAD_SHA" "$recheck_output"
+          grep -Fxq "artifact_id=$EXPECTED_ARTIFACT_ID" "$recheck_output"
+
           if [[ -n "$comment_id" ]]; then
             gh api "repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" --method PATCH -f body="$body" >/dev/null
           else

--- a/.github/workflows/deploy-preview-trusted.yml
+++ b/.github/workflows/deploy-preview-trusted.yml
@@ -186,8 +186,8 @@ jobs:
           test -f "$bundle/context/run.json"
           test -f "$bundle/context/artifacts.json"
           test -f "$bundle/context/verify-preview-deploy-trigger.mjs"
-          if [[ -n "$(find "$bundle" -type l -print -quit)" ]]; then
-            echo "Trusted handoff must not contain symbolic links." >&2
+          if [[ -n "$(find "$bundle/site" -type l -print -quit)" ]]; then
+            echo "Untrusted Hosting content must not contain symbolic links." >&2
             exit 1
           fi
           jq -e '.hosting.public == "site" and .hosting.site == "game-flow-c6311"' "$bundle/firebase-preview.generated.json" >/dev/null

--- a/.github/workflows/deploy-preview-trusted.yml
+++ b/.github/workflows/deploy-preview-trusted.yml
@@ -132,6 +132,7 @@ jobs:
 
       - name: Deploy fixed Firebase Hosting preview channel
         id: deploy_preview
+        timeout-minutes: 4
         env:
           CURRENT_CHANNEL: pr-${{ steps.verify_trigger.outputs.pr_number }}
           GH_TOKEN: ${{ github.token }}
@@ -190,7 +191,7 @@ jobs:
           }
 
           preview_deploy_hit_auth_error() {
-            grep -Eiq 'Failed to authenticate|Command requires authentication|Unable to read the credential file specified by the GOOGLE_APPLICATION_CREDENTIALS' "$log_file"
+            grep -Eiq 'Failed to authenticate|Command requires authentication|Unable to read the credential file' "$log_file"
           }
 
           preview_deploy_hit_release_target_error() {
@@ -230,6 +231,11 @@ jobs:
           if [[ -n "$GOOGLE_CREDENTIAL_FILE" ]]; then
             rm -f -- "$GOOGLE_CREDENTIAL_FILE"
           fi
+          {
+            echo "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE="
+            echo "GOOGLE_APPLICATION_CREDENTIALS="
+            echo "GOOGLE_GHA_CREDS_PATH="
+          } >> "$GITHUB_ENV"
 
       - name: Report preview URL on verified pull request
         if: success()

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -126,15 +126,6 @@ jobs:
       - name: Install Functions dependencies
         run: npm ci --prefix functions
 
-      - name: Authenticate to Google Cloud through exact-workflow OIDC
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
-        with:
-          workload_identity_provider: ${{ vars.FIREBASE_DEPLOY_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.FIREBASE_DEPLOY_SERVICE_ACCOUNT }}
-          project_id: game-flow-c6311
-          create_credentials_file: true
-          cleanup_credentials: true
-
       - name: Detect Storage rules changes
         id: storage_rules
         shell: bash
@@ -188,7 +179,23 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # Resolve/download the exact CLI before requesting the five-minute GitHub
+      # OIDC credential. Credentialed steps below are each bounded to four minutes.
+      - name: Prime exact Firebase deploy CLI
+        run: npx firebase-tools@14.25.0 --version
+
+      - name: Authenticate Storage deploy through exact-workflow OIDC
+        id: google_auth_storage
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ vars.FIREBASE_DEPLOY_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.FIREBASE_DEPLOY_SERVICE_ACCOUNT }}
+          project_id: game-flow-c6311
+          create_credentials_file: true
+          cleanup_credentials: true
+
       - name: Deploy Firebase Storage rules when available
+        timeout-minutes: 4
         shell: bash
         env:
           STORAGE_RULES_CHANGED: ${{ steps.storage_rules.outputs.changed }}
@@ -219,7 +226,33 @@ jobs:
           fi
           exit "$storage_status"
 
+      - name: Remove Storage deploy credential
+        if: always()
+        env:
+          GOOGLE_CREDENTIAL_FILE: ${{ steps.google_auth_storage.outputs.credentials_file_path }}
+        run: |
+          set -euo pipefail
+          if [[ -n "$GOOGLE_CREDENTIAL_FILE" ]]; then
+            rm -f -- "$GOOGLE_CREDENTIAL_FILE"
+          fi
+          {
+            echo "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE="
+            echo "GOOGLE_APPLICATION_CREDENTIALS="
+            echo "GOOGLE_GHA_CREDS_PATH="
+          } >> "$GITHUB_ENV"
+
+      - name: Authenticate production deploy through exact-workflow OIDC
+        id: google_auth_production
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ vars.FIREBASE_DEPLOY_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.FIREBASE_DEPLOY_SERVICE_ACCOUNT }}
+          project_id: game-flow-c6311
+          create_credentials_file: true
+          cleanup_credentials: true
+
       - name: Deploy Firebase production
+        timeout-minutes: 4
         shell: bash
         env:
           FIRESTORE_CONFIG_CHANGED: ${{ steps.firestore_config.outputs.changed }}
@@ -270,4 +303,14 @@ jobs:
             # production deployment. Do not make a redundant Rules API write: an
             # unrelated Rules API outage must not fail a Hosting/Functions-only fix.
             retry_firebase_deploy "hosting,functions" "application"
+          fi
+
+      - name: Remove production deploy credential
+        if: always()
+        env:
+          GOOGLE_CREDENTIAL_FILE: ${{ steps.google_auth_production.outputs.credentials_file_path }}
+        run: |
+          set -euo pipefail
+          if [[ -n "$GOOGLE_CREDENTIAL_FILE" ]]; then
+            rm -f -- "$GOOGLE_CREDENTIAL_FILE"
           fi

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -81,15 +81,16 @@ jobs:
           name: prod-regression-guards-http-log
           path: /tmp/allplays-prod-regression-guards.log
 
-  deploy:
+  prepare-deploy:
     needs: [unit-tests, regression-guards]
     runs-on: ubuntu-latest
-    environment: production
     permissions:
       actions: read
-      checks: write
       contents: read
-      id-token: write
+    outputs:
+      firestore_changed: ${{ steps.firestore_config.outputs.changed }}
+      head_sha: ${{ steps.handoff_identity.outputs.head_sha }}
+      storage_changed: ${{ steps.storage_rules.outputs.changed }}
 
     steps:
       - name: Checkout
@@ -117,11 +118,17 @@ jobs:
           ALLPLAYS_APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY: ${{ vars.APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY }}
           ALLPLAYS_APP_CHECK_ENFORCEMENT_READY: ${{ vars.APP_CHECK_ENFORCEMENT_READY }}
         run: |
-          site_dir="$RUNNER_TEMP/firebase-prod-site"
-          config_file="$GITHUB_WORKSPACE/.firebase-prod.generated.json"
+          set -euo pipefail
+          bundle_dir="$RUNNER_TEMP/firebase-production-ready"
+          site_dir="$bundle_dir/site"
+          config_file="$bundle_dir/firebase-prod.generated.json"
+          mkdir -p "$bundle_dir"
           node scripts/stage-pages-bundle.mjs "$site_dir"
           node scripts/write-firebase-hosting-config.mjs "$site_dir" "$config_file"
-          echo "FIREBASE_PROD_CONFIG=$config_file" >> "$GITHUB_ENV"
+          jq '.hosting.public = "site"' "$config_file" > "$config_file.tmp"
+          mv "$config_file.tmp" "$config_file"
+          cp firestore.rules firestore.indexes.json storage.rules "$bundle_dir/"
+          echo "FIREBASE_PRODUCTION_BUNDLE=$bundle_dir" >> "$GITHUB_ENV"
 
       - name: Install Functions dependencies
         run: npm ci --prefix functions
@@ -179,10 +186,91 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # Resolve/download the exact CLI before requesting the five-minute GitHub
-      # OIDC credential. Credentialed steps below are each bounded to four minutes.
-      - name: Prime exact Firebase deploy CLI
-        run: npx firebase-tools@14.25.0 --version
+      - name: Copy installed Functions runtime into trusted handoff
+        run: |
+          set -euo pipefail
+          cp -R functions "$FIREBASE_PRODUCTION_BUNDLE/functions"
+
+      - name: Install isolated Firebase deploy CLI without OIDC or lifecycle scripts
+        run: |
+          set -euo pipefail
+          npm install \
+            --prefix "$FIREBASE_PRODUCTION_BUNDLE/firebase-cli" \
+            --ignore-scripts \
+            --no-audit \
+            --no-fund \
+            --package-lock=false \
+            firebase-tools@14.25.0
+          node "$FIREBASE_PRODUCTION_BUNDLE/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js" --version
+
+      - name: Bind handoff to exact production commit
+        id: handoff_identity
+        run: |
+          set -euo pipefail
+          if [[ ! "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            exit 1
+          fi
+          printf '%s\n' "$GITHUB_SHA" > "$FIREBASE_PRODUCTION_BUNDLE/head-sha"
+          echo "head_sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Upload trusted production deploy handoff
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: firebase-production-trusted-ready
+          path: ${{ runner.temp }}/firebase-production-ready
+          if-no-files-found: error
+          include-hidden-files: true
+          retention-days: 1
+
+  deploy:
+    needs: prepare-deploy
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+
+    steps:
+      # Only the fixed artifact produced by the no-OIDC preparation job enters
+      # this job. No checkout, dependency install, build, or lifecycle script
+      # shares the production identity boundary.
+      - name: Download trusted production deploy handoff
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: firebase-production-trusted-ready
+          path: ${{ runner.temp }}/firebase-production-ready
+
+      - name: Validate trusted production handoff without executing its code
+        env:
+          FIRESTORE_CONFIG_CHANGED: ${{ needs.prepare-deploy.outputs.firestore_changed }}
+          PREPARED_HEAD_SHA: ${{ needs.prepare-deploy.outputs.head_sha }}
+          STORAGE_RULES_CHANGED: ${{ needs.prepare-deploy.outputs.storage_changed }}
+        run: |
+          set -euo pipefail
+          bundle="$RUNNER_TEMP/firebase-production-ready"
+          if [[ "$PREPARED_HEAD_SHA" != "$GITHUB_SHA" ]] || [[ ! "$PREPARED_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Production handoff commit does not match this workflow run." >&2
+            exit 1
+          fi
+          if [[ "$FIRESTORE_CONFIG_CHANGED" != "true" && "$FIRESTORE_CONFIG_CHANGED" != "false" ]]; then
+            echo "Invalid Firestore change state." >&2
+            exit 1
+          fi
+          if [[ "$STORAGE_RULES_CHANGED" != "true" && "$STORAGE_RULES_CHANGED" != "false" ]]; then
+            echo "Invalid Storage change state." >&2
+            exit 1
+          fi
+          grep -Fxq "$GITHUB_SHA" "$bundle/head-sha"
+          test -d "$bundle/site"
+          test -d "$bundle/functions"
+          test -f "$bundle/firestore.rules"
+          test -f "$bundle/firestore.indexes.json"
+          test -f "$bundle/storage.rules"
+          test -f "$bundle/firebase-prod.generated.json"
+          test -f "$bundle/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js"
+          jq -e '.hosting.public == "site" and .hosting.site == "game-flow-c6311" and .functions.source == "functions"' "$bundle/firebase-prod.generated.json" >/dev/null
+          echo "FIREBASE_PRODUCTION_BUNDLE=$bundle" >> "$GITHUB_ENV"
 
       - name: Authenticate Storage deploy through exact-workflow OIDC
         id: google_auth_storage
@@ -198,12 +286,17 @@ jobs:
         timeout-minutes: 4
         shell: bash
         env:
-          STORAGE_RULES_CHANGED: ${{ steps.storage_rules.outputs.changed }}
+          STORAGE_RULES_CHANGED: ${{ needs.prepare-deploy.outputs.storage_changed }}
         run: |
           set -euo pipefail
+          firebase_cli="$FIREBASE_PRODUCTION_BUNDLE/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js"
+          firebase_config="$FIREBASE_PRODUCTION_BUNDLE/firebase-prod.generated.json"
           storage_log="$RUNNER_TEMP/firebase-storage-deploy.log"
           set +e
-          npx firebase-tools@14.25.0 deploy --only storage --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive 2>&1 | tee "$storage_log"
+          (
+            cd "$FIREBASE_PRODUCTION_BUNDLE"
+            node "$firebase_cli" deploy --only storage --project game-flow-c6311 --config "$firebase_config" --non-interactive
+          ) 2>&1 | tee "$storage_log"
           storage_status="${PIPESTATUS[0]}"
           set -e
 
@@ -255,9 +348,11 @@ jobs:
         timeout-minutes: 4
         shell: bash
         env:
-          FIRESTORE_CONFIG_CHANGED: ${{ steps.firestore_config.outputs.changed }}
+          FIRESTORE_CONFIG_CHANGED: ${{ needs.prepare-deploy.outputs.firestore_changed }}
         run: |
           set -euo pipefail
+          firebase_cli="$FIREBASE_PRODUCTION_BUNDLE/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js"
+          firebase_config="$FIREBASE_PRODUCTION_BUNDLE/firebase-prod.generated.json"
           transient_pattern='(^|[^[:alnum:]])(429|500|502|503|504)([^[:alnum:]]|$)|HTTP Error:[[:space:]]*409,[[:space:]]*Requested entity already exists|service[[:space:]_-]+unavailable|econnreset|connection[[:space:]_-]+reset|network[[:space:]_-]+reset|etimedout|timed[[:space:]_-]+out|timeout'
 
           retry_firebase_deploy() {
@@ -269,7 +364,10 @@ jobs:
             for ((attempt = 1; attempt <= max_attempts; attempt += 1)); do
               deploy_log="$RUNNER_TEMP/firebase-${deploy_label}-deploy-attempt-${attempt}.log"
               set +e
-              npx firebase-tools@14.25.0 deploy --only "$deploy_targets" --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive 2>&1 | tee "$deploy_log"
+              (
+                cd "$FIREBASE_PRODUCTION_BUNDLE"
+                node "$firebase_cli" deploy --only "$deploy_targets" --project game-flow-c6311 --config "$firebase_config" --non-interactive
+              ) 2>&1 | tee "$deploy_log"
               deploy_status="${PIPESTATUS[0]}"
               set -e
 
@@ -314,3 +412,8 @@ jobs:
           if [[ -n "$GOOGLE_CREDENTIAL_FILE" ]]; then
             rm -f -- "$GOOGLE_CREDENTIAL_FILE"
           fi
+          {
+            echo "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE="
+            echo "GOOGLE_APPLICATION_CREDENTIALS="
+            echo "GOOGLE_GHA_CREDS_PATH="
+          } >> "$GITHUB_ENV"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -186,10 +186,17 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Copy installed Functions runtime into trusted handoff
+      - name: Archive installed Functions runtime into trusted handoff
         run: |
           set -euo pipefail
-          cp -R functions "$FIREBASE_PRODUCTION_BUNDLE/functions"
+          # actions/upload-artifact intentionally normalizes file modes and
+          # does not preserve symlinks. Keep the installed Functions runtime
+          # inside tar so npm executable bits and .bin links survive handoff.
+          tar --format=posix \
+            -cf "$FIREBASE_PRODUCTION_BUNDLE/functions-runtime.tar" \
+            functions
+          mkdir -p "$FIREBASE_PRODUCTION_BUNDLE/context"
+          cp scripts/extract-production-functions-handoff.py "$FIREBASE_PRODUCTION_BUNDLE/context/"
 
       - name: Install isolated Firebase deploy CLI without OIDC or lifecycle scripts
         run: |
@@ -243,7 +250,7 @@ jobs:
           name: firebase-production-trusted-ready
           path: ${{ runner.temp }}/firebase-production-ready
 
-      - name: Validate trusted production handoff without executing its code
+      - name: Validate and extract trusted production handoff before OIDC
         env:
           FIRESTORE_CONFIG_CHANGED: ${{ needs.prepare-deploy.outputs.firestore_changed }}
           PREPARED_HEAD_SHA: ${{ needs.prepare-deploy.outputs.head_sha }}
@@ -265,13 +272,17 @@ jobs:
           fi
           grep -Fxq "$GITHUB_SHA" "$bundle/head-sha"
           test -d "$bundle/site"
-          test -d "$bundle/functions"
+          test -f "$bundle/functions-runtime.tar"
+          test -f "$bundle/context/extract-production-functions-handoff.py"
           test -f "$bundle/firestore.rules"
           test -f "$bundle/firestore.indexes.json"
           test -f "$bundle/storage.rules"
           test -f "$bundle/firebase-prod.generated.json"
           test -f "$bundle/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js"
           jq -e '.hosting.public == "site" and .hosting.site == "game-flow-c6311" and .functions.source == "functions"' "$bundle/firebase-prod.generated.json" >/dev/null
+          python3 "$bundle/context/extract-production-functions-handoff.py" \
+            "$bundle/functions-runtime.tar" \
+            "$bundle"
           echo "FIREBASE_PRODUCTION_BUNDLE=$bundle" >> "$GITHUB_ENV"
 
       - name: Authenticate Storage deploy through exact-workflow OIDC

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -220,7 +220,9 @@ jobs:
           path: ${{ runner.temp }}/firebase-production-ready
           if-no-files-found: error
           include-hidden-files: true
-          retention-days: 1
+          # Keep the trusted, credential-free handoff available across
+          # production approval queues and environment wait timers.
+          retention-days: 30
 
   deploy:
     needs: prepare-deploy

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -15,16 +15,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: npm
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           distribution: temurin
           java-version: 21
@@ -49,10 +49,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: npm
@@ -76,7 +76,7 @@ jobs:
 
       - name: Upload server log on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: prod-regression-guards-http-log
           path: /tmp/allplays-prod-regression-guards.log
@@ -89,15 +89,16 @@ jobs:
       actions: read
       checks: write
       contents: read
+      id-token: write
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: npm
@@ -125,11 +126,14 @@ jobs:
       - name: Install Functions dependencies
         run: npm ci --prefix functions
 
-      - name: Configure Firebase service account
-        run: |
-          credentials_file="$RUNNER_TEMP/firebase-service-account.json"
-          printf '%s' '${{ secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311 }}' > "$credentials_file"
-          echo "GOOGLE_APPLICATION_CREDENTIALS=$credentials_file" >> "$GITHUB_ENV"
+      - name: Authenticate to Google Cloud through exact-workflow OIDC
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ vars.FIREBASE_DEPLOY_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.FIREBASE_DEPLOY_SERVICE_ACCOUNT }}
+          project_id: game-flow-c6311
+          create_credentials_file: true
+          cleanup_credentials: true
 
       - name: Detect Storage rules changes
         id: storage_rules
@@ -262,8 +266,8 @@ jobs:
             retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"
             retry_firebase_deploy "hosting,functions" "application"
           else
-            # Publish user-facing code first so an unrelated Rules API outage cannot
-            # prevent Hosting and Functions-only fixes from reaching production.
+            # No authorization/index drift exists relative to the last successful
+            # production deployment. Do not make a redundant Rules API write: an
+            # unrelated Rules API outage must not fail a Hosting/Functions-only fix.
             retry_firebase_deploy "hosting,functions" "application"
-            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"
           fi

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -274,12 +274,18 @@ jobs:
           test -d "$bundle/site"
           test -f "$bundle/functions-runtime.tar"
           test -f "$bundle/context/extract-production-functions-handoff.py"
+          test ! -L "$bundle/context/extract-production-functions-handoff.py"
           test -f "$bundle/firestore.rules"
           test -f "$bundle/firestore.indexes.json"
           test -f "$bundle/storage.rules"
           test -f "$bundle/firebase-prod.generated.json"
           test -f "$bundle/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js"
           jq -e '.hosting.public == "site" and .hosting.site == "game-flow-c6311" and .functions.source == "functions"' "$bundle/firebase-prod.generated.json" >/dev/null
+          expected_extractor_sha256='0acd0a7041df6ffc53befb388c6591efd149d4f82d4cfed2ea37d7349394165f'
+          printf '%s  %s\n' \
+            "$expected_extractor_sha256" \
+            "$bundle/context/extract-production-functions-handoff.py" \
+            | sha256sum --check --strict -
           python3 "$bundle/context/extract-production-functions-handoff.py" \
             "$bundle/functions-runtime.tar" \
             "$bundle"

--- a/.github/workflows/regression-guards.yml
+++ b/.github/workflows/regression-guards.yml
@@ -25,6 +25,10 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
 
       - name: Validate Firebase rules and deploy gates
         run: npm run ci:firebase-rules

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ _project-docs/
 # Firebase - NEVER commit these
 .firebaserc
 .firebase-*.generated.json
+gha-creds-*.json
 firebase-debug.log
 firebase-debug.*.log
 firestore-debug.log

--- a/docs/preview-deploy-trust-boundary.md
+++ b/docs/preview-deploy-trust-boundary.md
@@ -34,8 +34,14 @@ the immutable repository and owner IDs, `refs/heads/master`, and the exact
 workflows. Each service account's `roles/iam.workloadIdentityUser` binding must
 be narrower still: only its exact workflow_ref may impersonate it.
 
-The preview deploy uses a dedicated service account with only Firebase Hosting
-Admin and Service Usage API Keys Viewer. It must never share the production
+The preview deploy uses a dedicated service account with Firebase Hosting
+Admin, Service Usage API Keys Viewer, and the project custom role
+`allplaysPreviewAuthDomainUpdater`. That custom role contains only
+`firebaseauth.configs.get` and `firebaseauth.configs.update`, which the pinned
+Firebase CLI needs to add and prune preview channel domains in Firebase Auth.
+Do not replace it with Identity Platform Admin or another broad Auth role. The
+workflow treats the CLI's otherwise non-fatal Auth-domain warnings as a failed,
+partially functional preview. The preview identity must never share the production
 deployer. Generated `gha-creds-*.json` ADC files are ignored by Git, removed
 explicitly before the PR comment write, and also registered for authentication
 action cleanup. `FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311` must remain absent
@@ -99,8 +105,11 @@ Use the following sequence without printing JSON key material:
    before broadening the provider condition.
 3. Bind the production deploy workflow only to the production service account.
    Bind the trusted-preview workflow only to its dedicated preview service
-   account, with `roles/firebasehosting.admin` and
-   `roles/serviceusage.apiKeysViewer`. Do not grant preview project Editor,
+   account, with `roles/firebasehosting.admin`,
+   `roles/serviceusage.apiKeysViewer`, and the project custom role
+   `allplaysPreviewAuthDomainUpdater` containing only
+   `firebaseauth.configs.get` and `firebaseauth.configs.update`. Do not grant
+   preview project Editor, Identity Platform Admin,
    Functions, Firestore, Storage, or production-service-account impersonation.
 4. Validate the next exact-default-branch production deploy. A rules-changing
    release must still deploy Firestore rules/indexes before application code;

--- a/docs/preview-deploy-trust-boundary.md
+++ b/docs/preview-deploy-trust-boundary.md
@@ -12,11 +12,19 @@ its `workflow_run` definition from the default branch. It checks out only the
 default branch, validates the completed run and current open PR through the
 GitHub API, downloads only the verified triggering-run artifact, safely
 validates and extracts public files, and generates Firebase configuration from
-trusted default-branch code. It never checks out, imports, executes, or sources
-PR code or PR-provided Firebase configuration.
+trusted default-branch code in a job with no OIDC permission. That job installs
+the isolated Firebase CLI and uploads a sanitized same-run handoff. Only a
+minimal dependent deploy job can request OIDC; the raw PR artifact, checkout,
+dependency installation, and configuration generation never enter that job.
+The deploy job never checks out, imports, executes, or sources PR code or
+PR-provided Firebase configuration.
 
 Firebase deploy workflows authenticate with GitHub OIDC and Google Workload
 Identity Federation. They must never reference a JSON service-account key.
+Production dependency installation, app/function preparation, rule-change
+detection, and bundle construction also run in a no-OIDC job. The production
+identity exists only in a minimal dependent deploy job that consumes the fixed
+same-run handoff; it performs no checkout, package installation, or build.
 `FIREBASE_DEPLOY_WORKLOAD_IDENTITY_PROVIDER` and
 `FIREBASE_DEPLOY_SERVICE_ACCOUNT` are environment variables in
 `firebase-preview-trusted` and `production`; both environments must retain a

--- a/docs/preview-deploy-trust-boundary.md
+++ b/docs/preview-deploy-trust-boundary.md
@@ -15,12 +15,25 @@ validates and extracts public files, and generates Firebase configuration from
 trusted default-branch code. It never checks out, imports, executes, or sources
 PR code or PR-provided Firebase configuration.
 
-`FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311` must remain absent from repository
-and organization secrets. It may exist only as an environment secret in
-`firebase-preview-trusted` and `production`. Both environments must retain a
-protected/default-branch-only deployment policy. This is essential: a
-same-repository PR can edit its own `pull_request` workflow and reference any
-repository-level secret, even when the default-branch version does not.
+Firebase deploy workflows authenticate with GitHub OIDC and Google Workload
+Identity Federation. They must never reference a JSON service-account key.
+`FIREBASE_DEPLOY_WORKLOAD_IDENTITY_PROVIDER` and
+`FIREBASE_DEPLOY_SERVICE_ACCOUNT` are environment variables in
+`firebase-preview-trusted` and `production`; both environments must retain a
+protected/default-branch-only deployment policy. The Google provider must bind
+the immutable repository and owner IDs, `refs/heads/master`, and the exact
+`workflow_ref` values for the recovery, production, and trusted-preview
+workflows. Each service account's `roles/iam.workloadIdentityUser` binding must
+be narrower still: only its exact workflow_ref may impersonate it.
+
+The preview deploy uses a dedicated service account with only Firebase Hosting
+Admin and Service Usage API Keys Viewer. It must never share the production
+deployer. Generated `gha-creds-*.json` ADC files are ignored by Git, removed
+explicitly before the PR comment write, and also registered for authentication
+action cleanup. `FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311` must remain absent
+from repository and organization secrets. A transitional copy may remain in
+the two protected environments only until both OIDC canaries pass; no workflow
+may reference it during that observation window.
 
 `SMOKE_AUTH_EMAIL` and `SMOKE_AUTH_PASSWORD` must also remain absent from
 repository and organization secrets. They may exist only in the protected
@@ -48,8 +61,10 @@ Before merging a change to either preview workflow:
 2. Confirm `gh secret list --repo pauljsnider/allplays` lists none of
    `FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311`, `SMOKE_AUTH_EMAIL`, or
    `SMOKE_AUTH_PASSWORD`.
-3. Confirm `gh secret list --repo pauljsnider/allplays --env production` and
-   `--env firebase-preview-trusted` each list the credential.
+3. Confirm the `production` and `firebase-preview-trusted` environments each
+   define `FIREBASE_DEPLOY_WORKLOAD_IDENTITY_PROVIDER` and
+   `FIREBASE_DEPLOY_SERVICE_ACCOUNT`, and that the service-account values are
+   different. Confirm neither workflow references a JSON credential secret.
 4. Confirm all three GitHub environments still restrict deployments to
    protected/default-branch code before allowing a credentialed run. Confirm
    `production-smoke` contains only the rotated least-privilege smoke fixture
@@ -62,30 +77,43 @@ trusted verifier scripts are present on the default branch. The PR workflow's
 artifact build remains testable before merge; the first post-merge PR run is
 the deployment canary.
 
-## JSON-key rotation and retirement
+## Workload Identity cutover and JSON-key retirement
 
 Use the following sequence without printing JSON key material:
 
-1. Record the old and replacement GCP service-account key IDs in the private
-   incident record. Store the replacement JSON only in the two protected GitHub
-   environments; never store it as a repository or organization secret.
-2. Validate an exact-default-branch production deploy and a same-repository PR
-   preview deploy with the replacement key. Confirm the preview deploy targets
-   only `pr-N`, the expected URL is commented on that PR, and the credential
-   cleanup step runs.
-3. Query Cloud Audit Logs for the old key ID across its full GitHub exposure
+1. Before changing IAM, export the provider, both service-account IAM policies,
+   project role bindings, environment variables, environment secrets, and the
+   remaining key ID to a private rollback record. Do not print key JSON.
+2. Keep one provider for the GitHub issuer. Its CEL condition must require
+   repository ID `1106220007`, owner ID `211066188`, master, and one of the
+   three exact workflow_ref values. Replace the recovery service account's
+   repository-wide impersonation binding with its exact workflow_ref binding
+   before broadening the provider condition.
+3. Bind the production deploy workflow only to the production service account.
+   Bind the trusted-preview workflow only to its dedicated preview service
+   account, with `roles/firebasehosting.admin` and
+   `roles/serviceusage.apiKeysViewer`. Do not grant preview project Editor,
+   Functions, Firestore, Storage, or production-service-account impersonation.
+4. Validate the next exact-default-branch production deploy. A rules-changing
+   release must still deploy Firestore rules/indexes before application code;
+   a rules-unchanged release must skip the redundant Rules API call. Then run a
+   same-repository PR preview and confirm it targets only `pr-N`, comments the
+   expected URL, and removes its ephemeral ADC file before commenting.
+5. Query Cloud Audit Logs for the old key ID across its full GitHub exposure
    window, including `authenticationInfo.serviceAccountKeyName`, and inspect
    same-repository Actions runs for unexpected credentialed workflow changes or
    Firebase operations. Preserve suspicious run IDs and audit entries.
-4. Disable the old GCP service-account key after both canaries pass. Re-run the
-   production and preview canaries, then permanently delete the old key after
-   the agreed observation window. If either canary fails, re-enable only long
-   enough to diagnose; do not restore a repository-level secret.
-5. Reconfirm the repository secret is absent and both environment policies are
-   intact after retirement.
+6. After both OIDC canaries pass, delete the unused JSON secrets from both
+   environments, rerun both canaries, and permanently delete the remaining GCP
+   service-account key. Reconfirm the repository secret is absent and both
+   environment policies are intact.
 
-The long-term target is keyless GitHub OIDC/Workload Identity Federation with a
-dedicated preview principal. Bind trust to this repository, the trusted
-workflow identity, and the default branch; grant only the Firebase Hosting
-operations required to release a preview channel. Validate OIDC canaries, then
-delete the remaining JSON key and remove the JSON environment secrets.
+If OIDC authentication fails, leave the current production release untouched,
+restore the recorded IAM/environment state, and revert the workflow commit.
+Only the protected environment JSON secret may be used for a time-bounded
+rollback; never recreate a repository-level secret.
+
+Primary references: Google Cloud's deployment-pipeline Workload Identity
+Federation guide, Workload Identity Federation best practices, the pinned
+`google-github-actions/auth` documentation, and Firebase's predefined Hosting
+role documentation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,8 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-router-dom": "^7.18.1",
-        "vitest": "^4.1.10"
+        "vitest": "^4.1.10",
+        "yaml": "^2.8.3"
       },
       "engines": {
         "node": ">=22",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-router-dom": "^7.18.1",
-    "vitest": "^4.1.10"
+    "vitest": "^4.1.10",
+    "yaml": "^2.8.3"
   },
   "dependencies": {
     "@capacitor-firebase/app-check": "8.3.0",

--- a/scripts/extract-production-functions-handoff.py
+++ b/scripts/extract-production-functions-handoff.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Validate and extract the trusted production Functions runtime handoff."""
+
+from __future__ import annotations
+
+import os
+import posixpath
+import stat
+import sys
+import tarfile
+from pathlib import Path
+
+MAX_MEMBERS = 50_000
+MAX_UNCOMPRESSED_BYTES = 512 * 1024 * 1024
+FUNCTIONS_ROOT = "functions"
+REQUIRED_BIN_LINK = "functions/node_modules/.bin/firebase-functions"
+REQUIRED_BIN_TARGET = "functions/node_modules/firebase-functions/lib/bin/firebase-functions.js"
+
+
+def fail(message: str) -> None:
+    raise ValueError(message)
+
+
+def is_within_functions(path: str) -> bool:
+    return path.startswith(f"{FUNCTIONS_ROOT}/")
+
+
+def validate_member(member: tarfile.TarInfo, seen: set[str]) -> int:
+    name = member.name
+    normalized = posixpath.normpath(name)
+    if not name or name.startswith("/") or normalized in ("", "."):
+        fail(f"unsafe Functions archive path: {name!r}")
+    if normalized != name.rstrip("/") or ".." in name.split("/"):
+        fail(f"non-canonical Functions archive path: {name}")
+    if normalized != FUNCTIONS_ROOT and not is_within_functions(normalized):
+        fail(f"Functions archive escaped its fixed root: {name}")
+    if normalized in seen:
+        fail(f"duplicate Functions archive member: {name}")
+    seen.add(normalized)
+
+    if not (member.isfile() or member.isdir() or member.issym() or member.islnk()):
+        fail(f"special file is forbidden in Functions archive: {name}")
+
+    if member.issym():
+        resolved = posixpath.normpath(posixpath.join(posixpath.dirname(normalized), member.linkname))
+        if posixpath.isabs(member.linkname) or not is_within_functions(resolved):
+            fail(f"unsafe Functions symlink: {name} -> {member.linkname}")
+    elif member.islnk():
+        resolved = posixpath.normpath(member.linkname)
+        if posixpath.isabs(member.linkname) or not is_within_functions(resolved):
+            fail(f"unsafe Functions hard link: {name} -> {member.linkname}")
+
+    return member.size if member.isfile() else 0
+
+
+def validate_archive(archive: tarfile.TarFile) -> list[tarfile.TarInfo]:
+    members = archive.getmembers()
+    if not members:
+        fail("Functions runtime archive is empty")
+    if len(members) > MAX_MEMBERS:
+        fail("Functions runtime archive contains too many members")
+
+    seen: set[str] = set()
+    total_size = 0
+    for member in members:
+        total_size += validate_member(member, seen)
+        if total_size > MAX_UNCOMPRESSED_BYTES:
+            fail("Functions runtime archive exceeds the uncompressed size limit")
+
+    if FUNCTIONS_ROOT not in seen:
+        fail("Functions runtime archive is missing its fixed root")
+    return members
+
+
+def validate_extracted_runtime(destination: Path) -> None:
+    functions_root = destination / FUNCTIONS_ROOT
+    bin_link = destination / REQUIRED_BIN_LINK
+    bin_target = destination / REQUIRED_BIN_TARGET
+    if functions_root.is_symlink() or not functions_root.is_dir():
+        fail("extracted Functions root is not a real directory")
+    if not bin_link.is_symlink():
+        fail("firebase-functions .bin entry is not a preserved symlink")
+    if not bin_target.is_file() or bin_target.is_symlink():
+        fail("firebase-functions executable target is missing or unsafe")
+
+    root_real = functions_root.resolve(strict=True)
+    link_real = bin_link.resolve(strict=True)
+    if os.path.commonpath((str(root_real), str(link_real))) != str(root_real):
+        fail("firebase-functions .bin link resolves outside the Functions root")
+    if link_real != bin_target.resolve(strict=True):
+        fail("firebase-functions .bin link resolves to an unexpected target")
+    if not stat.S_IMODE(bin_target.stat().st_mode) & 0o111:
+        fail("firebase-functions executable mode was not preserved")
+    if not os.access(bin_link, os.X_OK):
+        fail("firebase-functions .bin entry is not executable")
+
+
+def extract_handoff(archive_path: Path, destination: Path) -> None:
+    if not archive_path.is_file() or archive_path.is_symlink():
+        fail("Functions runtime archive is missing or is a symlink")
+    if not destination.is_dir() or destination.is_symlink():
+        fail("Functions handoff destination must be a real directory")
+    if os.path.lexists(destination / FUNCTIONS_ROOT):
+        fail("Functions handoff destination is not empty at the fixed root")
+
+    with tarfile.open(archive_path, mode="r:*") as archive:
+        members = validate_archive(archive)
+        try:
+            archive.extractall(destination, members=members, filter="fully_trusted")
+        except TypeError:  # Python versions before extraction filters.
+            archive.extractall(destination, members=members)
+    validate_extracted_runtime(destination)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print(f"usage: {argv[0]} ARCHIVE DESTINATION", file=sys.stderr)
+        return 2
+    try:
+        extract_handoff(Path(argv[1]), Path(argv[2]))
+    except (OSError, tarfile.TarError, ValueError) as error:
+        print(f"production Functions handoff rejected: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -35,7 +35,7 @@ export function assertPreviewDeploySkipHandling(deployPreview) {
     assertIncludes(deployPreview, "HTTP Error: 400, Can't release to .*resource doesn't exist or isn't a valid release target", 'Preview deploy release target error classifier');
     assertIncludes(deployPreview, 'preview_skip_reason=', 'Preview deploy skipped reason output');
     assertIncludes(deployPreview, 'skip_preview_for_release_target', 'Preview deploy release target skip');
-    assertIncludes(deployPreview, 'PREVIEW_SKIP_REASON: ${{ steps.deploy_preview.outputs.preview_skip_reason }}', 'Preview deploy skipped reason PR comment');
+    assertIncludes(deployPreview, 'PREVIEW_SKIP_REASON: ${{ needs.deploy-preview.outputs.preview_skip_reason }}', 'Preview deploy skipped reason PR comment');
 }
 
 export function extractMatchBlock(text, startMarker) {
@@ -53,7 +53,7 @@ export function validatePreviewDeployCommand(deployPreview) {
     if (/hosting:channel:deploy[^\n]*--site/.test(deployPreview)) {
         throw new Error('Preview deploy must not pass --site to hosting:channel:deploy; firebase-tools 15 rejects that option.');
     }
-    assertMatches(deployPreview, /\.\/node_modules\/\.bin\/firebase hosting:channel:deploy "\$CURRENT_CHANNEL" --project game-flow-c6311 --config "\$FIREBASE_PREVIEW_CONFIG"/, 'Preview deploy installed Firebase CLI project/config arguments');
+    assertMatches(deployPreview, /node "\$firebase_cli" hosting:channel:deploy "\$CURRENT_CHANNEL" --project game-flow-c6311 --config "\$firebase_config"/, 'Preview deploy installed Firebase CLI project/config arguments');
 }
 
 export function validateFirebaseDeployWorkloadIdentity(workflow, label) {
@@ -80,11 +80,41 @@ export function validateFirebaseDeployWorkloadIdentity(workflow, label) {
     };
     visit(parsed);
 
-    const hasOidcPermission = objects.some((value) =>
-        value.permissions && value.permissions['id-token'] === 'write'
-    );
-    if (!hasOidcPermission) {
+    const jobs = parsed?.jobs && typeof parsed.jobs === 'object' ? Object.values(parsed.jobs) : [];
+    const oidcJobs = jobs.filter((job) => job?.permissions?.['id-token'] === 'write');
+    if (oidcJobs.length === 0) {
         throw new Error(`${label} OIDC token permission is missing: id-token: write`);
+    }
+
+    for (const job of oidcJobs) {
+        const jobText = JSON.stringify(job);
+        if (/npm (?:ci|install)|stage-pages-bundle|extract-preview-hosting-artifact|write-firebase-hosting-config|actions\/artifacts\/[^/]+\/zip/.test(jobText)) {
+            throw new Error(`${label} dependency, build, and raw-artifact preparation must run in a separate no-OIDC job.`);
+        }
+        if (!Array.isArray(job.steps)) {
+            throw new Error(`${label} credentialed deploy job has no valid step list.`);
+        }
+        if (job.steps.some((step) => typeof step?.uses === 'string' &&
+            !/^actions\/download-artifact@[0-9a-f]{40}$/.test(step.uses) &&
+            !/^google-github-actions\/auth@/.test(step.uses)
+        )) {
+            throw new Error(`${label} credentialed deploy job contains an unapproved action.`);
+        }
+        if (!job.steps.some((step) =>
+            typeof step.uses === 'string' && /^actions\/download-artifact@[0-9a-f]{40}$/.test(step.uses)
+        )) {
+            throw new Error(`${label} credentialed deploy job must consume only a pinned trusted handoff artifact.`);
+        }
+    }
+
+    for (const job of jobs) {
+        if (!Array.isArray(job?.steps)) continue;
+        const hasPreparation = job.steps.some((step) => typeof step?.run === 'string' &&
+            /npm (?:ci|install)|stage-pages-bundle|extract-preview-hosting-artifact|write-firebase-hosting-config/.test(step.run)
+        );
+        if (hasPreparation && job.permissions?.['id-token'] === 'write') {
+            throw new Error(`${label} no-OIDC preparation boundary is missing.`);
+        }
     }
 
     const authSteps = objects.filter((value) =>
@@ -121,7 +151,7 @@ export function validateFirebaseDeployWorkloadIdentity(workflow, label) {
         for (let index = 0; index < object.steps.length; index += 1) {
             const step = object.steps[index];
             if (!step || typeof step.run !== 'string' ||
-                !/(?:firebase-tools@\S+|(?:^|\/)firebase)\s+(?:hosting:channel:)?deploy\b/m.test(step.run)) {
+                !/(?:firebase-tools@\S+|(?:^|\/)firebase|node\s+"\$firebase_cli")\s+(?:hosting:channel:)?deploy\b/m.test(step.run)) {
                 continue;
             }
             deployStepCount += 1;
@@ -182,7 +212,7 @@ export function validateFirebaseDeployWorkloadIdentity(workflow, label) {
 }
 
 export function validateProductionDeployCommand(deployProd) {
-    const deployCommands = Array.from(deployProd.matchAll(/^\s*npx firebase-tools@\S+ deploy\b[^\n]*$/gm), match => match[0]);
+    const deployCommands = Array.from(deployProd.matchAll(/^\s*(?:npx firebase-tools@\S+|node "\$firebase_cli") deploy\b[^\n]*$/gm), match => match[0]);
     const deployCommand = deployCommands.find(command => /--only(?:=|\s+)"\$deploy_targets"/.test(command)) || '';
     if (!deployCommand) {
         throw new Error('Production Firebase deploy command is missing.');
@@ -210,7 +240,7 @@ export function validateProductionDeployCommand(deployProd) {
     if (deployProd.includes('git diff --quiet "${{ github.event.before }}" "${{ github.sha }}" -- firestore.rules firestore.indexes.json')) {
         throw new Error('Production Firestore changes must not use the immediately previous push as the deploy baseline.');
     }
-    assertIncludes(deployProd, 'FIRESTORE_CONFIG_CHANGED: ${{ steps.firestore_config.outputs.changed }}', 'Production Firestore change output');
+    assertIncludes(deployProd, 'FIRESTORE_CONFIG_CHANGED: ${{ needs.prepare-deploy.outputs.firestore_changed }}', 'Production Firestore change output');
     assertIncludes(deployProd, 'if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then', 'Production Firestore change ordering');
     const changedBranchStart = deployProd.indexOf('if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then');
     const unchangedBranchStart = deployProd.indexOf('\n          else', changedBranchStart);
@@ -229,15 +259,15 @@ export function validateProductionDeployCommand(deployProd) {
 
     const storageDeployCommand = deployCommands.find(command => /--only(?:=|\s+)storage(?:\s|$)/.test(command)) || '';
     assertMatches(storageDeployCommand, /--project game-flow-c6311(?:\s|$)/, 'Production Storage rules deploy project');
-    assertMatches(storageDeployCommand, /--config "\$FIREBASE_PROD_CONFIG"(?:\s|$)/, 'Production Storage rules generated config');
+    assertMatches(storageDeployCommand, /--config "\$firebase_config"(?:\s|$)/, 'Production Storage rules generated config');
     assertIncludes(deployProd, 'fetch-depth: 0', 'Production Storage rules change history');
     assertIncludes(deployProd, 'git diff --quiet "${{ github.event.before }}" "${{ github.sha }}" -- storage.rules', 'Production Storage rules change detection');
-    assertIncludes(deployProd, 'STORAGE_RULES_CHANGED: ${{ steps.storage_rules.outputs.changed }}', 'Production Storage rules change output');
+    assertIncludes(deployProd, 'STORAGE_RULES_CHANGED: ${{ needs.prepare-deploy.outputs.storage_changed }}', 'Production Storage rules change output');
     assertIncludes(deployProd, "sed -E 's/\\x1B\\[[0-9;]*[[:alpha:]]//g' \"$storage_log\" > \"$storage_plain_log\"", 'Production Storage rules ANSI log normalization');
     assertIncludes(deployProd, '[[ "$STORAGE_RULES_CHANGED" != "true" ]]', 'Production Storage rules unchanged-only skip');
     assertIncludes(deployProd, 'exit "$storage_status"', 'Production Storage rules changed failure');
     assertMatches(deployCommand, /(?:^|\s)--project game-flow-c6311(?:\s|$)/, 'Production Firebase deploy project');
-    assertMatches(deployCommand, /(?:^|\s)--config "\$FIREBASE_PROD_CONFIG"(?:\s|$)/, 'Production Firebase generated config');
+    assertMatches(deployCommand, /(?:^|\s)--config "\$firebase_config"(?:\s|$)/, 'Production Firebase generated config');
 }
 
 export function validateFirebaseRulesCi() {

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -191,7 +191,8 @@ export function validateFirebaseDeployWorkloadIdentity(workflow, label) {
     ]);
     for (const object of objects) {
         for (const key of Object.keys(object)) {
-            if (forbiddenMappingKeys.has(key.trim().toLowerCase())) {
+            const normalizedKey = key.trim().toLowerCase();
+            if (forbiddenMappingKeys.has(normalizedKey) || /^firebase[a-z0-9_]*token$/.test(normalizedKey)) {
                 throw new Error(`${label} must not use a long-lived Google service-account key or static ADC input.`);
             }
         }
@@ -202,10 +203,11 @@ export function validateFirebaseDeployWorkloadIdentity(workflow, label) {
         .filter((line) => !/^\s*echo\s+["'](?:CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE|GOOGLE_APPLICATION_CREDENTIALS|GOOGLE_GHA_CREDS_PATH)=["']\s*$/.test(line))
         .join('\n');
     const forbiddenScalarPatterns = [
-        /\$\{\{\s*secrets\./i,
+        /\bsecrets\b/i,
         /CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE/i,
         /credentials[\s_-]*json\s*:/i,
         /\bFIREBASE[A-Z0-9_]*TOKEN\b/i,
+        /\bFIREBASE_[^\n]{0,64}TOKEN\b/i,
         /GOOGLE_APPLICATION_CREDENTIALS/i,
         /GOOGLE_GHA_CREDS_PATH/i,
         /gcloud\s+auth\s+activate-service-account/i,

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -199,7 +199,10 @@ export function validateFirebaseDeployWorkloadIdentity(workflow, label) {
     }
 
     const scalarPolicyText = scalarStrings
-        .flatMap((value) => value.split('\n'))
+        // Bash removes an escaped physical newline before parsing tokens. Do
+        // the same before policy matching so `--\\\ntoken` and split env names
+        // cannot hide a forbidden credential path across workflow lines.
+        .flatMap((value) => value.replace(/\\\r?\n/g, '').split('\n'))
         .filter((line) => !/^\s*echo\s+["'](?:CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE|GOOGLE_APPLICATION_CREDENTIALS|GOOGLE_GHA_CREDS_PATH)=["']\s*$/.test(line))
         .join('\n');
     const forbiddenScalarPatterns = [

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -205,6 +205,12 @@ export function validateFirebaseDeployWorkloadIdentity(workflow, label) {
         .flatMap((value) => value.replace(/\\\r?\n/g, '').split('\n'))
         .filter((line) => !/^\s*echo\s+["'](?:CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE|GOOGLE_APPLICATION_CREDENTIALS|GOOGLE_GHA_CREDS_PATH)=["']\s*$/.test(line))
         .join('\n');
+    // Shell concatenates adjacent quoted and unquoted word fragments. Mirror
+    // that behavior for environment-like identifiers so constructs such as
+    // GOOGLE_"APPLICATION"_CREDENTIALS cannot bypass the static-key guard.
+    const normalizedCredentialPolicyText = scalarPolicyText
+        .replace(/(["'])([A-Z0-9_]*)\1/gi, '$2')
+        .replace(/(?<=[A-Z0-9_])["'](?=[A-Z0-9_])/gi, '');
     const forbiddenScalarPatterns = [
         /\bsecrets\b/i,
         /CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE/i,
@@ -220,7 +226,7 @@ export function validateFirebaseDeployWorkloadIdentity(workflow, label) {
         /secrets\.[A-Z0-9_]*(?:SERVICE_ACCOUNT|GOOGLE[^\s}]*(?:KEY|CREDENTIAL))/i,
         /["']?type["']?\s*:\s*["']service_account["']/i
     ];
-    if (forbiddenScalarPatterns.some((pattern) => pattern.test(scalarPolicyText))) {
+    if (forbiddenScalarPatterns.some((pattern) => pattern.test(normalizedCredentialPolicyText))) {
         throw new Error(`${label} must not use a long-lived Google service-account key or static ADC input.`);
     }
 }

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -53,7 +53,12 @@ export function validatePreviewDeployCommand(deployPreview) {
     if (/hosting:channel:deploy[^\n]*--site/.test(deployPreview)) {
         throw new Error('Preview deploy must not pass --site to hosting:channel:deploy; firebase-tools 15 rejects that option.');
     }
+    if (/hosting:channel:deploy[^\n]*--no-authorized-domains/.test(deployPreview)) {
+        throw new Error('Preview deploy must preserve Firebase Auth authorized-domain synchronization.');
+    }
     assertMatches(deployPreview, /node "\$firebase_cli" hosting:channel:deploy "\$CURRENT_CHANNEL" --project game-flow-c6311 --config "\$firebase_config"/, 'Preview deploy installed Firebase CLI project/config arguments');
+    assertIncludes(deployPreview, 'preview_deploy_hit_auth_domain_sync_error()', 'Preview deploy Auth-domain sync failure guard');
+    assertIncludes(deployPreview, 'refusing to report a partially functional preview', 'Preview deploy Auth-domain fail-closed message');
 }
 
 export function validateFirebaseDeployWorkloadIdentity(workflow, label) {

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -203,6 +203,8 @@ export function validateFirebaseDeployWorkloadIdentity(workflow, label) {
         /GOOGLE_APPLICATION_CREDENTIALS/i,
         /gcloud\s+auth\s+activate-service-account/i,
         /--key-file(?:=|\s)/i,
+        /--token(?:=|\s)/i,
+        /secrets\.[A-Z0-9_]*FIREBASE[A-Z0-9_]*TOKEN/i,
         /secrets\.[A-Z0-9_]*(?:SERVICE_ACCOUNT|GOOGLE[^\s}]*(?:KEY|CREDENTIAL))/i,
         /["']?type["']?\s*:\s*["']service_account["']/i
     ];

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -181,10 +181,13 @@ export function validateFirebaseDeployWorkloadIdentity(workflow, label) {
     }
 
     const forbiddenMappingKeys = new Set([
+        'cloudsdk_auth_credential_file_override',
         'credentials_json',
+        'firebase_deploy_token',
         'firebase_token',
         'google_application_credentials',
-        'google_credentials'
+        'google_credentials',
+        'google_gha_creds_path'
     ]);
     for (const object of objects) {
         for (const key of Object.keys(object)) {
@@ -199,8 +202,12 @@ export function validateFirebaseDeployWorkloadIdentity(workflow, label) {
         .filter((line) => !/^\s*echo\s+["'](?:CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE|GOOGLE_APPLICATION_CREDENTIALS|GOOGLE_GHA_CREDS_PATH)=["']\s*$/.test(line))
         .join('\n');
     const forbiddenScalarPatterns = [
+        /\$\{\{\s*secrets\./i,
+        /CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE/i,
         /credentials[\s_-]*json\s*:/i,
+        /\bFIREBASE[A-Z0-9_]*TOKEN\b/i,
         /GOOGLE_APPLICATION_CREDENTIALS/i,
+        /GOOGLE_GHA_CREDS_PATH/i,
         /gcloud\s+auth\s+activate-service-account/i,
         /--key-file(?:=|\s)/i,
         /--token(?:=|\s)/i,

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
+import { parse as parseYaml } from 'yaml';
 
 function readText(path) {
     return readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
@@ -56,28 +57,127 @@ export function validatePreviewDeployCommand(deployPreview) {
 }
 
 export function validateFirebaseDeployWorkloadIdentity(workflow, label) {
-    assertIncludes(workflow, 'id-token: write', `${label} OIDC token permission`);
-    assertMatches(
-        workflow,
-        /uses: google-github-actions\/auth@[0-9a-f]{40}(?:\s+# v3)?/,
-        `${label} pinned Google authentication action`
+    let parsed;
+    try {
+        parsed = parseYaml(workflow);
+    } catch (error) {
+        throw new Error(`${label} workflow YAML is invalid: ${error.message}`);
+    }
+
+    const objects = [];
+    const scalarStrings = [];
+    const visit = (value) => {
+        if (Array.isArray(value)) {
+            for (const item of value) visit(item);
+            return;
+        }
+        if (value && typeof value === 'object') {
+            objects.push(value);
+            for (const child of Object.values(value)) visit(child);
+            return;
+        }
+        if (typeof value === 'string') scalarStrings.push(value);
+    };
+    visit(parsed);
+
+    const hasOidcPermission = objects.some((value) =>
+        value.permissions && value.permissions['id-token'] === 'write'
     );
-    assertIncludes(
-        workflow,
-        'workload_identity_provider: ${{ vars.FIREBASE_DEPLOY_WORKLOAD_IDENTITY_PROVIDER }}',
-        `${label} workload identity provider variable`
+    if (!hasOidcPermission) {
+        throw new Error(`${label} OIDC token permission is missing: id-token: write`);
+    }
+
+    const authSteps = objects.filter((value) =>
+        typeof value.uses === 'string' && value.uses.startsWith('google-github-actions/auth@')
     );
-    assertIncludes(
-        workflow,
-        'service_account: ${{ vars.FIREBASE_DEPLOY_SERVICE_ACCOUNT }}',
-        `${label} service account variable`
-    );
-    assertIncludes(workflow, 'project_id: game-flow-c6311', `${label} Firebase project binding`);
-    assertIncludes(workflow, 'create_credentials_file: true', `${label} ADC credential file`);
-    assertIncludes(workflow, 'cleanup_credentials: true', `${label} credential cleanup`);
-    if (workflow.includes('secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311') ||
-        workflow.includes('credentials_json:')) {
-        throw new Error(`${label} must not use a long-lived Google service-account key.`);
+    if (authSteps.length === 0 || authSteps.some((step) =>
+        !/^google-github-actions\/auth@[0-9a-f]{40}$/.test(step.uses)
+    )) {
+        throw new Error(`${label} pinned Google authentication action did not match an exact commit.`);
+    }
+
+    for (const step of authSteps) {
+        const inputs = step.with || {};
+        if (inputs.workload_identity_provider !== '${{ vars.FIREBASE_DEPLOY_WORKLOAD_IDENTITY_PROVIDER }}') {
+            throw new Error(`${label} workload identity provider variable is missing or changed.`);
+        }
+        if (inputs.service_account !== '${{ vars.FIREBASE_DEPLOY_SERVICE_ACCOUNT }}') {
+            throw new Error(`${label} service account variable is missing or changed.`);
+        }
+        if (inputs.project_id !== 'game-flow-c6311') {
+            throw new Error(`${label} Firebase project binding is missing or changed.`);
+        }
+        if (inputs.create_credentials_file !== true) {
+            throw new Error(`${label} ADC credential file must be enabled.`);
+        }
+        if (inputs.cleanup_credentials !== true) {
+            throw new Error(`${label} credential cleanup must be enabled.`);
+        }
+    }
+
+    let deployStepCount = 0;
+    for (const object of objects) {
+        if (!Array.isArray(object.steps)) continue;
+        for (let index = 0; index < object.steps.length; index += 1) {
+            const step = object.steps[index];
+            if (!step || typeof step.run !== 'string' ||
+                !/(?:firebase-tools@\S+|(?:^|\/)firebase)\s+(?:hosting:channel:)?deploy\b/m.test(step.run)) {
+                continue;
+            }
+            deployStepCount += 1;
+            if (!Number.isInteger(step['timeout-minutes']) || step['timeout-minutes'] > 4) {
+                throw new Error(`${label} credentialed deploy steps must have a four-minute timeout.`);
+            }
+            const authStep = object.steps[index - 1];
+            if (!authStep || typeof authStep.uses !== 'string' ||
+                !/^google-github-actions\/auth@[0-9a-f]{40}$/.test(authStep.uses)) {
+                throw new Error(`${label} must authenticate immediately before each Firebase deploy step.`);
+            }
+
+            const npxCli = step.run.match(/npx\s+(firebase-tools@[^\s]+)\s+deploy\b/);
+            if (npxCli) {
+                const primedBeforeAuth = object.steps.slice(0, index - 1).some((candidate) =>
+                    typeof candidate?.run === 'string' &&
+                    candidate.run.includes(`npx ${npxCli[1]} --version`)
+                );
+                if (!primedBeforeAuth) {
+                    throw new Error(`${label} must resolve the exact Firebase CLI before requesting OIDC.`);
+                }
+            }
+        }
+    }
+    if (deployStepCount === 0) {
+        throw new Error(`${label} Firebase deploy step is missing.`);
+    }
+
+    const forbiddenMappingKeys = new Set([
+        'credentials_json',
+        'firebase_token',
+        'google_application_credentials',
+        'google_credentials'
+    ]);
+    for (const object of objects) {
+        for (const key of Object.keys(object)) {
+            if (forbiddenMappingKeys.has(key.trim().toLowerCase())) {
+                throw new Error(`${label} must not use a long-lived Google service-account key or static ADC input.`);
+            }
+        }
+    }
+
+    const scalarPolicyText = scalarStrings
+        .flatMap((value) => value.split('\n'))
+        .filter((line) => !/^\s*echo\s+["'](?:CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE|GOOGLE_APPLICATION_CREDENTIALS|GOOGLE_GHA_CREDS_PATH)=["']\s*$/.test(line))
+        .join('\n');
+    const forbiddenScalarPatterns = [
+        /credentials[\s_-]*json\s*:/i,
+        /GOOGLE_APPLICATION_CREDENTIALS/i,
+        /gcloud\s+auth\s+activate-service-account/i,
+        /--key-file(?:=|\s)/i,
+        /secrets\.[A-Z0-9_]*(?:SERVICE_ACCOUNT|GOOGLE[^\s}]*(?:KEY|CREDENTIAL))/i,
+        /["']?type["']?\s*:\s*["']service_account["']/i
+    ];
+    if (forbiddenScalarPatterns.some((pattern) => pattern.test(scalarPolicyText))) {
+        throw new Error(`${label} must not use a long-lived Google service-account key or static ADC input.`);
     }
 }
 

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -55,6 +55,32 @@ export function validatePreviewDeployCommand(deployPreview) {
     assertMatches(deployPreview, /\.\/node_modules\/\.bin\/firebase hosting:channel:deploy "\$CURRENT_CHANNEL" --project game-flow-c6311 --config "\$FIREBASE_PREVIEW_CONFIG"/, 'Preview deploy installed Firebase CLI project/config arguments');
 }
 
+export function validateFirebaseDeployWorkloadIdentity(workflow, label) {
+    assertIncludes(workflow, 'id-token: write', `${label} OIDC token permission`);
+    assertMatches(
+        workflow,
+        /uses: google-github-actions\/auth@[0-9a-f]{40}(?:\s+# v3)?/,
+        `${label} pinned Google authentication action`
+    );
+    assertIncludes(
+        workflow,
+        'workload_identity_provider: ${{ vars.FIREBASE_DEPLOY_WORKLOAD_IDENTITY_PROVIDER }}',
+        `${label} workload identity provider variable`
+    );
+    assertIncludes(
+        workflow,
+        'service_account: ${{ vars.FIREBASE_DEPLOY_SERVICE_ACCOUNT }}',
+        `${label} service account variable`
+    );
+    assertIncludes(workflow, 'project_id: game-flow-c6311', `${label} Firebase project binding`);
+    assertIncludes(workflow, 'create_credentials_file: true', `${label} ADC credential file`);
+    assertIncludes(workflow, 'cleanup_credentials: true', `${label} credential cleanup`);
+    if (workflow.includes('secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311') ||
+        workflow.includes('credentials_json:')) {
+        throw new Error(`${label} must not use a long-lived Google service-account key.`);
+    }
+}
+
 export function validateProductionDeployCommand(deployProd) {
     const deployCommands = Array.from(deployProd.matchAll(/^\s*npx firebase-tools@\S+ deploy\b[^\n]*$/gm), match => match[0]);
     const deployCommand = deployCommands.find(command => /--only(?:=|\s+)"\$deploy_targets"/.test(command)) || '';
@@ -94,8 +120,11 @@ export function validateProductionDeployCommand(deployProd) {
     if (changedBranch.indexOf('"firestore"') > changedBranch.indexOf('"application"')) {
         throw new Error('Production Firestore deploy must run first when its configuration changed.');
     }
-    if (unchangedBranch.indexOf('"application"') > unchangedBranch.indexOf('"firestore"')) {
-        throw new Error('Production application deploy must run first when Firestore configuration is unchanged.');
+    if (!unchangedBranch.includes('"application"')) {
+        throw new Error('Production application deploy is missing when Firestore configuration is unchanged.');
+    }
+    if (unchangedBranch.includes('"firestore"')) {
+        throw new Error('Production must not redeploy unchanged Firestore configuration.');
     }
 
     const storageDeployCommand = deployCommands.find(command => /--only(?:=|\s+)storage(?:\s|$)/.test(command)) || '';
@@ -203,10 +232,12 @@ export function validateFirebaseRulesCi() {
     assertIncludes(firestoreRules, 'isNestedChatMessageCreateValid(', 'Nested chat create rules');
 
     validateProductionDeployCommand(deployProd);
+    validateFirebaseDeployWorkloadIdentity(deployProd, 'Production deploy');
     assertMatches(deployProd, /needs:\s*\[\s*unit-tests\s*,\s*regression-guards\s*\]/, 'Production deploy gate');
 
     assertMatches(deployPreviewBuild, /needs:\s*\[\s*unit-tests\s*,\s*regression-guards\s*\]/, 'Preview artifact build gate');
     validatePreviewDeployCommand(deployPreviewTrusted);
+    validateFirebaseDeployWorkloadIdentity(deployPreviewTrusted, 'Trusted preview deploy');
     assertPreviewDeploySkipHandling(deployPreviewTrusted);
 
     assertIncludes(storageRules, 'match /game-clips/{teamId}/{gameId}/{userId}/{fileName}', 'Scoped Storage game clip rules');

--- a/tests/unit/auth-email-resend-routing.test.js
+++ b/tests/unit/auth-email-resend-routing.test.js
@@ -116,12 +116,13 @@ describe('authentication email delivery routing', () => {
         const firebaseDeployCommands = productionSource
             .split('\n')
             .map(line => line.trim())
-            .filter(line => /^(run: )?npx firebase-tools@14\.25\.0 deploy/.test(line));
+            .filter(line => /^node "\$firebase_cli" deploy/.test(line));
 
         expect(firebaseDeployCommands).toEqual([
-            'npx firebase-tools@14.25.0 deploy --only storage --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive 2>&1 | tee "$storage_log"',
-            'npx firebase-tools@14.25.0 deploy --only "$deploy_targets" --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive 2>&1 | tee "$deploy_log"'
+            'node "$firebase_cli" deploy --only storage --project game-flow-c6311 --config "$firebase_config" --non-interactive',
+            'node "$firebase_cli" deploy --only "$deploy_targets" --project game-flow-c6311 --config "$firebase_config" --non-interactive'
         ]);
+        expect(productionSource).toContain('firebase-tools@14.25.0');
         expect(productionSource).toContain('[[ "$STORAGE_RULES_CHANGED" != "true" ]]');
         expect(productionSource).toContain('exit "$storage_status"');
         expect(productionSource.match(/--force/g) ?? []).toHaveLength(0);

--- a/tests/unit/auth-email-resend-routing.test.js
+++ b/tests/unit/auth-email-resend-routing.test.js
@@ -135,7 +135,8 @@ describe('authentication email delivery routing', () => {
         const changedBranch = productionSource.slice(changedBranchStart, unchangedBranchStart);
         const unchangedBranch = productionSource.slice(unchangedBranchStart, conditionalEnd);
         expect(changedBranch.indexOf('"firestore"')).toBeLessThan(changedBranch.indexOf('"application"'));
-        expect(unchangedBranch.indexOf('"application"')).toBeLessThan(unchangedBranch.indexOf('"firestore"'));
+        expect(unchangedBranch).toContain('"application"');
+        expect(unchangedBranch).not.toContain('"firestore"');
     });
 
     it('retries only transient production deploy failures and fails fast otherwise', () => {

--- a/tests/unit/firebase-deploy-workload-identity.test.js
+++ b/tests/unit/firebase-deploy-workload-identity.test.js
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -9,6 +10,9 @@ function read(path) {
 
 const production = read('.github/workflows/deploy-prod.yml');
 const preview = read('.github/workflows/deploy-preview-trusted.yml');
+const productionExtractorSha256 = createHash('sha256')
+    .update(read('scripts/extract-production-functions-handoff.py'))
+    .digest('hex');
 
 function workflowJobs(source) {
     return Object.values(parseYaml(source).jobs);
@@ -75,6 +79,7 @@ describe('Firebase deploy Workload Identity boundary', () => {
         const cliInstall = production.indexOf('name: Install isolated Firebase deploy CLI without OIDC');
         const functionsArchive = production.indexOf('name: Archive installed Functions runtime into trusted handoff');
         const handoff = production.indexOf('name: Upload trusted production deploy handoff');
+        const extractorHashCheck = production.indexOf(`expected_extractor_sha256='${productionExtractorSha256}'`);
         const functionsExtract = production.indexOf('python3 "$bundle/context/extract-production-functions-handoff.py"');
         const storageAuth = production.indexOf('name: Authenticate Storage deploy through exact-workflow OIDC');
         const storageDeploy = production.indexOf('name: Deploy Firebase Storage rules when available');
@@ -85,7 +90,10 @@ describe('Firebase deploy Workload Identity boundary', () => {
         expect(cliInstall).toBeGreaterThan(firestoreDetection);
         expect(functionsArchive).toBeGreaterThan(firestoreDetection);
         expect(handoff).toBeGreaterThan(cliInstall);
-        expect(functionsExtract).toBeGreaterThan(handoff);
+        expect(extractorHashCheck).toBeGreaterThan(handoff);
+        expect(functionsExtract).toBeGreaterThan(extractorHashCheck);
+        expect(production.slice(extractorHashCheck, functionsExtract)).toContain('sha256sum --check --strict');
+        expect(production.slice(handoff, extractorHashCheck)).toContain('test ! -L');
         expect(storageAuth).toBeGreaterThan(functionsExtract);
         expect(storageAuth).toBeGreaterThan(handoff);
         expect(storageDeploy).toBeGreaterThan(storageAuth);

--- a/tests/unit/firebase-deploy-workload-identity.test.js
+++ b/tests/unit/firebase-deploy-workload-identity.test.js
@@ -73,7 +73,9 @@ describe('Firebase deploy Workload Identity boundary', () => {
     it('keeps production build and dependency work outside the minimal OIDC deploy job', () => {
         const firestoreDetection = production.indexOf('name: Detect Firestore configuration changes');
         const cliInstall = production.indexOf('name: Install isolated Firebase deploy CLI without OIDC');
+        const functionsArchive = production.indexOf('name: Archive installed Functions runtime into trusted handoff');
         const handoff = production.indexOf('name: Upload trusted production deploy handoff');
+        const functionsExtract = production.indexOf('python3 "$bundle/context/extract-production-functions-handoff.py"');
         const storageAuth = production.indexOf('name: Authenticate Storage deploy through exact-workflow OIDC');
         const storageDeploy = production.indexOf('name: Deploy Firebase Storage rules when available');
         const storageCleanup = production.indexOf('name: Remove Storage deploy credential');
@@ -81,7 +83,10 @@ describe('Firebase deploy Workload Identity boundary', () => {
         const productionDeploy = production.indexOf('name: Deploy Firebase production');
 
         expect(cliInstall).toBeGreaterThan(firestoreDetection);
+        expect(functionsArchive).toBeGreaterThan(firestoreDetection);
         expect(handoff).toBeGreaterThan(cliInstall);
+        expect(functionsExtract).toBeGreaterThan(handoff);
+        expect(storageAuth).toBeGreaterThan(functionsExtract);
         expect(storageAuth).toBeGreaterThan(handoff);
         expect(storageDeploy).toBeGreaterThan(storageAuth);
         expect(storageCleanup).toBeGreaterThan(storageDeploy);
@@ -96,6 +101,9 @@ describe('Firebase deploy Workload Identity boundary', () => {
         expect(JSON.stringify(oidcJobs[0])).not.toMatch(/npm (?:ci|install)|stage-pages-bundle|write-firebase-hosting-config/);
         expect(JSON.stringify(oidcJobs[0])).toMatch(/actions\/download-artifact@[0-9a-f]{40}/);
         expect(production).toMatch(/name: Upload trusted production deploy handoff[\s\S]*retention-days: 30/);
+        expect(production).toContain('functions-runtime.tar');
+        expect(production).toContain('cp scripts/extract-production-functions-handoff.py "$FIREBASE_PRODUCTION_BUNDLE/context/"');
+        expect(production).not.toContain('cp -R functions "$FIREBASE_PRODUCTION_BUNDLE/functions"');
     });
 
     it('keeps rule-changing releases rules-first and skips unchanged rule writes', () => {

--- a/tests/unit/firebase-deploy-workload-identity.test.js
+++ b/tests/unit/firebase-deploy-workload-identity.test.js
@@ -29,8 +29,11 @@ describe('Firebase deploy Workload Identity boundary', () => {
             expect(workflow).toContain('create_credentials_file: true');
             expect(workflow).toContain('cleanup_credentials: true');
             expect(workflow).not.toContain('secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311');
-            expect(workflow).not.toContain('credentials_json:');
+            expect(workflow).not.toMatch(/credentials_json\s*:/i);
+            expect(workflow).not.toMatch(/^\s*GOOGLE_APPLICATION_CREDENTIALS\s*:\s*\S+/m);
         }
+        expect(production.match(/google-github-actions\/auth@[0-9a-f]{40}/g)).toHaveLength(2);
+        expect(preview.match(/google-github-actions\/auth@[0-9a-f]{40}/g)).toHaveLength(1);
     });
 
     it('withholds preview OIDC until all untrusted input checks finish', () => {
@@ -39,6 +42,7 @@ describe('Firebase deploy Workload Identity boundary', () => {
         const install = preview.indexOf('run: npm ci --ignore-scripts');
         const exactHeadCheck = preview.indexOf('name: Re-verify current pull-request head before credentials');
         const authentication = preview.indexOf('uses: google-github-actions/auth@');
+        const deployStep = preview.indexOf('name: Deploy fixed Firebase Hosting preview channel');
         const deploy = preview.indexOf('hosting:channel:deploy "$CURRENT_CHANNEL"');
         const cleanup = preview.indexOf('name: Remove ephemeral Google credential file');
         const comment = preview.indexOf('name: Report preview URL on verified pull request');
@@ -51,6 +55,29 @@ describe('Firebase deploy Workload Identity boundary', () => {
         expect(deploy).toBeGreaterThan(authentication);
         expect(cleanup).toBeGreaterThan(deploy);
         expect(comment).toBeGreaterThan(cleanup);
+        expect(preview.slice(authentication, deployStep)).not.toContain('- name:');
+        expect(preview.slice(deployStep, cleanup)).toContain('timeout-minutes: 4');
+    });
+
+    it('refreshes production OIDC after every preflight and bounds each credentialed deploy', () => {
+        const firestoreDetection = production.indexOf('name: Detect Firestore configuration changes');
+        const primeCli = production.indexOf('name: Prime exact Firebase deploy CLI');
+        const storageAuth = production.indexOf('name: Authenticate Storage deploy through exact-workflow OIDC');
+        const storageDeploy = production.indexOf('name: Deploy Firebase Storage rules when available');
+        const storageCleanup = production.indexOf('name: Remove Storage deploy credential');
+        const productionAuth = production.indexOf('name: Authenticate production deploy through exact-workflow OIDC');
+        const productionDeploy = production.indexOf('name: Deploy Firebase production');
+
+        expect(primeCli).toBeGreaterThan(firestoreDetection);
+        expect(storageAuth).toBeGreaterThan(primeCli);
+        expect(storageDeploy).toBeGreaterThan(storageAuth);
+        expect(storageCleanup).toBeGreaterThan(storageDeploy);
+        expect(productionAuth).toBeGreaterThan(storageCleanup);
+        expect(productionDeploy).toBeGreaterThan(productionAuth);
+        expect(production.slice(storageAuth, storageDeploy)).not.toContain('run:');
+        expect(production.slice(productionAuth, productionDeploy)).not.toContain('run:');
+        expect(production.slice(storageDeploy, storageCleanup)).toContain('timeout-minutes: 4');
+        expect(production.slice(productionDeploy)).toContain('timeout-minutes: 4');
     });
 
     it('keeps rule-changing releases rules-first and skips unchanged rule writes', () => {

--- a/tests/unit/firebase-deploy-workload-identity.test.js
+++ b/tests/unit/firebase-deploy-workload-identity.test.js
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { parse as parseYaml } from 'yaml';
 
 function read(path) {
     return readFileSync(resolve(process.cwd(), path), 'utf8');
@@ -8,6 +9,10 @@ function read(path) {
 
 const production = read('.github/workflows/deploy-prod.yml');
 const preview = read('.github/workflows/deploy-preview-trusted.yml');
+
+function workflowJobs(source) {
+    return Object.values(parseYaml(source).jobs);
+}
 
 function expectPinnedActions(workflow) {
     const actions = [...workflow.matchAll(/^\s*uses:\s+([^\s#]+)/gm)].map((match) => match[1]);
@@ -36,40 +41,48 @@ describe('Firebase deploy Workload Identity boundary', () => {
         expect(preview.match(/google-github-actions\/auth@[0-9a-f]{40}/g)).toHaveLength(1);
     });
 
-    it('withholds preview OIDC until all untrusted input checks finish', () => {
+    it('keeps raw preview input and dependency preparation in a separate no-OIDC job', () => {
         const archiveCheck = preview.indexOf('python3 scripts/extract-preview-hosting-artifact.py');
         const trustedConfig = preview.indexOf('node scripts/write-firebase-hosting-config.mjs');
-        const install = preview.indexOf('run: npm ci --ignore-scripts');
-        const exactHeadCheck = preview.indexOf('name: Re-verify current pull-request head before credentials');
+        const install = preview.indexOf('firebase-tools@15.24.0');
+        const exactHeadCheck = preview.indexOf('name: Re-verify current pull-request head before trusted handoff');
+        const handoff = preview.indexOf('name: Upload sanitized trusted deploy handoff');
         const authentication = preview.indexOf('uses: google-github-actions/auth@');
         const deployStep = preview.indexOf('name: Deploy fixed Firebase Hosting preview channel');
         const deploy = preview.indexOf('hosting:channel:deploy "$CURRENT_CHANNEL"');
         const cleanup = preview.indexOf('name: Remove ephemeral Google credential file');
-        const comment = preview.indexOf('name: Report preview URL on verified pull request');
+        const comment = preview.indexOf('name: Report preview URL on the still-current pull request');
 
         expect(archiveCheck).toBeGreaterThan(-1);
         expect(trustedConfig).toBeGreaterThan(archiveCheck);
         expect(install).toBeGreaterThan(trustedConfig);
         expect(exactHeadCheck).toBeGreaterThan(install);
-        expect(authentication).toBeGreaterThan(exactHeadCheck);
+        expect(handoff).toBeGreaterThan(exactHeadCheck);
+        expect(authentication).toBeGreaterThan(handoff);
         expect(deploy).toBeGreaterThan(authentication);
         expect(cleanup).toBeGreaterThan(deploy);
         expect(comment).toBeGreaterThan(cleanup);
+        const oidcJobs = workflowJobs(preview).filter((job) => job.permissions?.['id-token'] === 'write');
+        expect(oidcJobs).toHaveLength(1);
+        expect(JSON.stringify(oidcJobs[0])).not.toMatch(/npm (?:ci|install)|extract-preview-hosting-artifact|write-firebase-hosting-config/);
+        expect(JSON.stringify(oidcJobs[0])).toMatch(/actions\/download-artifact@[0-9a-f]{40}/);
         expect(preview.slice(authentication, deployStep)).not.toContain('- name:');
         expect(preview.slice(deployStep, cleanup)).toContain('timeout-minutes: 4');
     });
 
-    it('refreshes production OIDC after every preflight and bounds each credentialed deploy', () => {
+    it('keeps production build and dependency work outside the minimal OIDC deploy job', () => {
         const firestoreDetection = production.indexOf('name: Detect Firestore configuration changes');
-        const primeCli = production.indexOf('name: Prime exact Firebase deploy CLI');
+        const cliInstall = production.indexOf('name: Install isolated Firebase deploy CLI without OIDC');
+        const handoff = production.indexOf('name: Upload trusted production deploy handoff');
         const storageAuth = production.indexOf('name: Authenticate Storage deploy through exact-workflow OIDC');
         const storageDeploy = production.indexOf('name: Deploy Firebase Storage rules when available');
         const storageCleanup = production.indexOf('name: Remove Storage deploy credential');
         const productionAuth = production.indexOf('name: Authenticate production deploy through exact-workflow OIDC');
         const productionDeploy = production.indexOf('name: Deploy Firebase production');
 
-        expect(primeCli).toBeGreaterThan(firestoreDetection);
-        expect(storageAuth).toBeGreaterThan(primeCli);
+        expect(cliInstall).toBeGreaterThan(firestoreDetection);
+        expect(handoff).toBeGreaterThan(cliInstall);
+        expect(storageAuth).toBeGreaterThan(handoff);
         expect(storageDeploy).toBeGreaterThan(storageAuth);
         expect(storageCleanup).toBeGreaterThan(storageDeploy);
         expect(productionAuth).toBeGreaterThan(storageCleanup);
@@ -78,6 +91,10 @@ describe('Firebase deploy Workload Identity boundary', () => {
         expect(production.slice(productionAuth, productionDeploy)).not.toContain('run:');
         expect(production.slice(storageDeploy, storageCleanup)).toContain('timeout-minutes: 4');
         expect(production.slice(productionDeploy)).toContain('timeout-minutes: 4');
+        const oidcJobs = workflowJobs(production).filter((job) => job.permissions?.['id-token'] === 'write');
+        expect(oidcJobs).toHaveLength(1);
+        expect(JSON.stringify(oidcJobs[0])).not.toMatch(/npm (?:ci|install)|stage-pages-bundle|write-firebase-hosting-config/);
+        expect(JSON.stringify(oidcJobs[0])).toMatch(/actions\/download-artifact@[0-9a-f]{40}/);
     });
 
     it('keeps rule-changing releases rules-first and skips unchanged rule writes', () => {

--- a/tests/unit/firebase-deploy-workload-identity.test.js
+++ b/tests/unit/firebase-deploy-workload-identity.test.js
@@ -13,6 +13,9 @@ const preview = read('.github/workflows/deploy-preview-trusted.yml');
 const productionExtractorSha256 = createHash('sha256')
     .update(read('scripts/extract-production-functions-handoff.py'))
     .digest('hex');
+const previewVerifierSha256 = createHash('sha256')
+    .update(read('scripts/verify-preview-deploy-trigger.mjs'))
+    .digest('hex');
 
 function workflowJobs(source) {
     return Object.values(parseYaml(source).jobs);
@@ -53,6 +56,8 @@ describe('Firebase deploy Workload Identity boundary', () => {
         const handoff = preview.indexOf('name: Upload sanitized trusted deploy handoff');
         const authentication = preview.indexOf('uses: google-github-actions/auth@');
         const deployStep = preview.indexOf('name: Deploy fixed Firebase Hosting preview channel');
+        const verifierHashCheck = preview.indexOf(`expected_verifier_sha256='${previewVerifierSha256}'`);
+        const verifierExecution = preview.indexOf('node "$verifier"');
         const deploy = preview.indexOf('hosting:channel:deploy "$CURRENT_CHANNEL"');
         const cleanup = preview.indexOf('name: Remove ephemeral Google credential file');
         const comment = preview.indexOf('name: Report preview URL on the still-current pull request');
@@ -63,6 +68,10 @@ describe('Firebase deploy Workload Identity boundary', () => {
         expect(exactHeadCheck).toBeGreaterThan(install);
         expect(handoff).toBeGreaterThan(exactHeadCheck);
         expect(authentication).toBeGreaterThan(handoff);
+        expect(verifierHashCheck).toBeGreaterThan(authentication);
+        expect(verifierExecution).toBeGreaterThan(verifierHashCheck);
+        expect(preview.slice(deployStep, verifierHashCheck)).toContain('test ! -L');
+        expect(preview.slice(verifierHashCheck, verifierExecution)).toContain('sha256sum --check --strict');
         expect(deploy).toBeGreaterThan(authentication);
         expect(cleanup).toBeGreaterThan(deploy);
         expect(comment).toBeGreaterThan(cleanup);

--- a/tests/unit/firebase-deploy-workload-identity.test.js
+++ b/tests/unit/firebase-deploy-workload-identity.test.js
@@ -95,6 +95,7 @@ describe('Firebase deploy Workload Identity boundary', () => {
         expect(oidcJobs).toHaveLength(1);
         expect(JSON.stringify(oidcJobs[0])).not.toMatch(/npm (?:ci|install)|stage-pages-bundle|write-firebase-hosting-config/);
         expect(JSON.stringify(oidcJobs[0])).toMatch(/actions\/download-artifact@[0-9a-f]{40}/);
+        expect(production).toMatch(/name: Upload trusted production deploy handoff[\s\S]*retention-days: 30/);
     });
 
     it('keeps rule-changing releases rules-first and skips unchanged rule writes', () => {

--- a/tests/unit/firebase-deploy-workload-identity.test.js
+++ b/tests/unit/firebase-deploy-workload-identity.test.js
@@ -1,0 +1,68 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function read(path) {
+    return readFileSync(resolve(process.cwd(), path), 'utf8');
+}
+
+const production = read('.github/workflows/deploy-prod.yml');
+const preview = read('.github/workflows/deploy-preview-trusted.yml');
+
+function expectPinnedActions(workflow) {
+    const actions = [...workflow.matchAll(/^\s*uses:\s+([^\s#]+)/gm)].map((match) => match[1]);
+    expect(actions.length).toBeGreaterThan(0);
+    for (const action of actions) {
+        expect(action).toMatch(/^[^@]+@[0-9a-f]{40}$/);
+    }
+}
+
+describe('Firebase deploy Workload Identity boundary', () => {
+    it('uses only pinned keyless authentication in both credentialed deployers', () => {
+        for (const workflow of [production, preview]) {
+            expectPinnedActions(workflow);
+            expect(workflow).toContain('id-token: write');
+            expect(workflow).toMatch(/google-github-actions\/auth@[0-9a-f]{40}/);
+            expect(workflow).toContain('workload_identity_provider: ${{ vars.FIREBASE_DEPLOY_WORKLOAD_IDENTITY_PROVIDER }}');
+            expect(workflow).toContain('service_account: ${{ vars.FIREBASE_DEPLOY_SERVICE_ACCOUNT }}');
+            expect(workflow).toContain('project_id: game-flow-c6311');
+            expect(workflow).toContain('create_credentials_file: true');
+            expect(workflow).toContain('cleanup_credentials: true');
+            expect(workflow).not.toContain('secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311');
+            expect(workflow).not.toContain('credentials_json:');
+        }
+    });
+
+    it('withholds preview OIDC until all untrusted input checks finish', () => {
+        const archiveCheck = preview.indexOf('python3 scripts/extract-preview-hosting-artifact.py');
+        const trustedConfig = preview.indexOf('node scripts/write-firebase-hosting-config.mjs');
+        const install = preview.indexOf('run: npm ci --ignore-scripts');
+        const exactHeadCheck = preview.indexOf('name: Re-verify current pull-request head before credentials');
+        const authentication = preview.indexOf('uses: google-github-actions/auth@');
+        const deploy = preview.indexOf('hosting:channel:deploy "$CURRENT_CHANNEL"');
+        const cleanup = preview.indexOf('name: Remove ephemeral Google credential file');
+        const comment = preview.indexOf('name: Report preview URL on verified pull request');
+
+        expect(archiveCheck).toBeGreaterThan(-1);
+        expect(trustedConfig).toBeGreaterThan(archiveCheck);
+        expect(install).toBeGreaterThan(trustedConfig);
+        expect(exactHeadCheck).toBeGreaterThan(install);
+        expect(authentication).toBeGreaterThan(exactHeadCheck);
+        expect(deploy).toBeGreaterThan(authentication);
+        expect(cleanup).toBeGreaterThan(deploy);
+        expect(comment).toBeGreaterThan(cleanup);
+    });
+
+    it('keeps rule-changing releases rules-first and skips unchanged rule writes', () => {
+        const changedStart = production.indexOf('if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then');
+        const unchangedStart = production.indexOf('\n          else', changedStart);
+        const end = production.indexOf('\n          fi', unchangedStart);
+        const changed = production.slice(changedStart, unchangedStart);
+        const unchanged = production.slice(unchangedStart, end);
+
+        expect(changed.indexOf('"firestore"')).toBeGreaterThan(-1);
+        expect(changed.indexOf('"firestore"')).toBeLessThan(changed.indexOf('"application"'));
+        expect(unchanged).toContain('"application"');
+        expect(unchanged).not.toContain('"firestore"');
+    });
+});

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -32,6 +32,7 @@ const trustBoundaryRunbook = fs.readFileSync(
     path.join(repoRoot, 'docs', 'preview-deploy-trust-boundary.md'),
     'utf8'
 );
+const gitignore = fs.readFileSync(path.join(repoRoot, '.gitignore'), 'utf8');
 const tempDirectories = [];
 
 function validTriggerFixture() {
@@ -238,9 +239,9 @@ describe('preview deployment workflow trust boundary', () => {
         const configIndex = trustedWorkflow.indexOf('node scripts/write-firebase-hosting-config.mjs');
         const installIndex = trustedWorkflow.indexOf('run: npm ci --ignore-scripts');
         const recheckIndex = trustedWorkflow.indexOf('name: Re-verify current pull-request head before credentials');
-        const credentialIndex = trustedWorkflow.indexOf('secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311');
+        const credentialIndex = trustedWorkflow.indexOf('uses: google-github-actions/auth@');
         const deployIndex = trustedWorkflow.indexOf('hosting:channel:deploy');
-        const cleanupIndex = trustedWorkflow.indexOf('name: Remove Firebase credential file');
+        const cleanupIndex = trustedWorkflow.indexOf('name: Remove ephemeral Google credential file');
         const commentIndex = trustedWorkflow.indexOf('name: Report preview URL on verified pull request');
 
         expect(triggerIndex).toBeGreaterThan(-1);
@@ -254,6 +255,12 @@ describe('preview deployment workflow trust boundary', () => {
         expect(cleanupIndex).toBeGreaterThan(deployIndex);
         expect(commentIndex).toBeGreaterThan(cleanupIndex);
         expect(trustedWorkflow.slice(cleanupIndex, commentIndex)).toContain('if: always()');
+        expect(trustedWorkflow).toContain('id-token: write');
+        expect(trustedWorkflow).toContain('workload_identity_provider: ${{ vars.FIREBASE_DEPLOY_WORKLOAD_IDENTITY_PROVIDER }}');
+        expect(trustedWorkflow).toContain('service_account: ${{ vars.FIREBASE_DEPLOY_SERVICE_ACCOUNT }}');
+        expect(trustedWorkflow).toContain('cleanup_credentials: true');
+        expect(trustedWorkflow).not.toContain('secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311');
+        expect(gitignore).toContain('gha-creds-*.json');
     });
 
     it('pins every third-party action used by both preview workflows', () => {
@@ -286,8 +293,8 @@ describe('preview deployment workflow trust boundary', () => {
         expect(scheduledProdSmokeWorkflow).toContain('ref: master');
     });
 
-    it('documents the environment-only credential and exact-head operational contract', () => {
-        expect(trustBoundaryRunbook).toContain('must remain absent from repository');
+    it('documents the keyless credential and exact-head operational contract', () => {
+        expect(trustBoundaryRunbook).toContain('must remain absent');
         expect(trustBoundaryRunbook).toContain('firebase-preview-trusted');
         expect(trustBoundaryRunbook).toContain('production-smoke');
         expect(trustBoundaryRunbook).toContain('SMOKE_AUTH_EMAIL');
@@ -297,6 +304,9 @@ describe('preview deployment workflow trust boundary', () => {
         expect(trustBoundaryRunbook).toContain('Any new commit invalidates prior review evidence.');
         expect(trustBoundaryRunbook).toContain('Cloud Audit Logs for the old key ID');
         expect(trustBoundaryRunbook).toContain('Workload Identity Federation');
+        expect(trustBoundaryRunbook).toContain('FIREBASE_DEPLOY_WORKLOAD_IDENTITY_PROVIDER');
+        expect(trustBoundaryRunbook).toContain('FIREBASE_DEPLOY_SERVICE_ACCOUNT');
+        expect(trustBoundaryRunbook).toContain('exact workflow_ref');
     });
 });
 

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -211,6 +211,9 @@ describe('preview deployment workflow trust boundary', () => {
         expect(trustedWorkflow).toContain('node scripts/write-firebase-hosting-config.mjs "$FIREBASE_PREVIEW_STAGE/site"');
         expect(trustedWorkflow).toContain('CURRENT_CHANNEL: pr-${{ needs.prepare-preview.outputs.pr_number }}');
         expect(trustedWorkflow).toContain('node "$firebase_cli" hosting:channel:deploy "$CURRENT_CHANNEL" --project game-flow-c6311');
+        expect(trustedWorkflow).not.toContain('--no-authorized-domains');
+        expect(trustedWorkflow).toContain('preview_deploy_hit_auth_domain_sync_error()');
+        expect(trustedWorkflow).toContain('refusing to report a partially functional preview');
         expect(trustedWorkflow).toContain('find "$bundle/site" -type l');
         expect(trustedWorkflow).not.toContain('find "$bundle" -type l');
     });
@@ -322,6 +325,9 @@ describe('preview deployment workflow trust boundary', () => {
         expect(trustBoundaryRunbook).toContain('FIREBASE_DEPLOY_WORKLOAD_IDENTITY_PROVIDER');
         expect(trustBoundaryRunbook).toContain('FIREBASE_DEPLOY_SERVICE_ACCOUNT');
         expect(trustBoundaryRunbook).toContain('exact workflow_ref');
+        expect(trustBoundaryRunbook).toContain('allplaysPreviewAuthDomainUpdater');
+        expect(trustBoundaryRunbook).toContain('`firebaseauth.configs.get` and `firebaseauth.configs.update`');
+        expect(trustBoundaryRunbook).toContain('Do not replace it with Identity Platform Admin');
     });
 });
 

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -218,17 +218,26 @@ describe('preview deployment workflow trust boundary', () => {
         const preDeployCheckIndex = trustedWorkflow.indexOf('firebase-preview-pre-deploy-pr.json');
         const deployWriteIndex = trustedWorkflow.indexOf('hosting:channel:deploy "$CURRENT_CHANNEL"');
         const commentStepIndex = trustedWorkflow.indexOf('name: Report preview URL on the still-current pull request');
-        const preCommentCheckIndex = trustedWorkflow.indexOf('firebase-preview-report-pr.json');
+        const commentDiscoveryIndex = trustedWorkflow.indexOf('comment_id="$(gh api --paginate');
+        const preCommentCheckIndex = trustedWorkflow.indexOf('firebase-preview-pre-comment-pr.json');
         const commentWriteIndex = trustedWorkflow.indexOf('issues/comments/$comment_id');
 
         expect(preDeployCheckIndex).toBeGreaterThan(deployStepIndex);
         expect(deployWriteIndex).toBeGreaterThan(preDeployCheckIndex);
         expect(preCommentCheckIndex).toBeGreaterThan(commentStepIndex);
+        expect(preCommentCheckIndex).toBeGreaterThan(commentDiscoveryIndex);
         expect(commentWriteIndex).toBeGreaterThan(preCommentCheckIndex);
         expect(trustedWorkflow).toMatch(/recheck_current_head\n\s+if ! deploy_preview_channel/);
         expect(trustedWorkflow.slice(preCommentCheckIndex, commentWriteIndex)).toContain(
             'node scripts/verify-preview-deploy-trigger.mjs'
         );
+        expect(trustedWorkflow.slice(preCommentCheckIndex, commentWriteIndex)).toContain(
+            'grep -Fxq "head_sha=$EXPECTED_HEAD_SHA"'
+        );
+        expect(trustedWorkflow.slice(preCommentCheckIndex, commentWriteIndex)).toContain(
+            'grep -Fxq "artifact_id=$EXPECTED_ARTIFACT_ID"'
+        );
+        expect(trustedWorkflow).toContain('Preview for commit `%s`: %s');
         expect(trustedWorkflow.match(/verify-preview-deploy-trigger\.mjs/g).length).toBeGreaterThanOrEqual(5);
     });
 

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -211,6 +211,8 @@ describe('preview deployment workflow trust boundary', () => {
         expect(trustedWorkflow).toContain('node scripts/write-firebase-hosting-config.mjs "$FIREBASE_PREVIEW_STAGE/site"');
         expect(trustedWorkflow).toContain('CURRENT_CHANNEL: pr-${{ needs.prepare-preview.outputs.pr_number }}');
         expect(trustedWorkflow).toContain('node "$firebase_cli" hosting:channel:deploy "$CURRENT_CHANNEL" --project game-flow-c6311');
+        expect(trustedWorkflow).toContain('find "$bundle/site" -type l');
+        expect(trustedWorkflow).not.toContain('find "$bundle" -type l');
     });
 
     it('rechecks the exact pull-request head immediately before deploy and comment writes', () => {

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -202,23 +202,23 @@ describe('preview deployment workflow trust boundary', () => {
         expect(trustedWorkflow).toContain('persist-credentials: false');
         expect(trustedWorkflow).not.toContain('refs/pull/');
         expect(trustedWorkflow).not.toContain('github.event.workflow_run.head_sha');
-        expect(trustedWorkflow).not.toContain('actions/download-artifact');
+        expect(trustedWorkflow).toMatch(/actions\/download-artifact@[0-9a-f]{40}/);
         expect(trustedWorkflow).not.toContain('hosting:channel:delete');
         expect(trustedWorkflow).not.toContain('hosting:channel:list');
         expect(trustedWorkflow).toContain('actions/runs/$WORKFLOW_RUN_ID/artifacts?per_page=100');
         expect(trustedWorkflow).toContain('actions/artifacts/$ARTIFACT_ID/zip');
         expect(trustedWorkflow).toContain('scripts/extract-preview-hosting-artifact.py');
-        expect(trustedWorkflow).toContain('node scripts/write-firebase-hosting-config.mjs "$FIREBASE_PREVIEW_SITE"');
-        expect(trustedWorkflow).toContain('CURRENT_CHANNEL: pr-${{ steps.verify_trigger.outputs.pr_number }}');
-        expect(trustedWorkflow).toContain('hosting:channel:deploy "$CURRENT_CHANNEL" --project game-flow-c6311');
+        expect(trustedWorkflow).toContain('node scripts/write-firebase-hosting-config.mjs "$FIREBASE_PREVIEW_STAGE/site"');
+        expect(trustedWorkflow).toContain('CURRENT_CHANNEL: pr-${{ needs.prepare-preview.outputs.pr_number }}');
+        expect(trustedWorkflow).toContain('node "$firebase_cli" hosting:channel:deploy "$CURRENT_CHANNEL" --project game-flow-c6311');
     });
 
     it('rechecks the exact pull-request head immediately before deploy and comment writes', () => {
         const deployStepIndex = trustedWorkflow.indexOf('name: Deploy fixed Firebase Hosting preview channel');
         const preDeployCheckIndex = trustedWorkflow.indexOf('firebase-preview-pre-deploy-pr.json');
         const deployWriteIndex = trustedWorkflow.indexOf('hosting:channel:deploy "$CURRENT_CHANNEL"');
-        const commentStepIndex = trustedWorkflow.indexOf('name: Report preview URL on verified pull request');
-        const preCommentCheckIndex = trustedWorkflow.indexOf('firebase-preview-pre-comment-pr.json');
+        const commentStepIndex = trustedWorkflow.indexOf('name: Report preview URL on the still-current pull request');
+        const preCommentCheckIndex = trustedWorkflow.indexOf('firebase-preview-report-pr.json');
         const commentWriteIndex = trustedWorkflow.indexOf('issues/comments/$comment_id');
 
         expect(preDeployCheckIndex).toBeGreaterThan(deployStepIndex);
@@ -229,20 +229,21 @@ describe('preview deployment workflow trust boundary', () => {
         expect(trustedWorkflow.slice(preCommentCheckIndex, commentWriteIndex)).toContain(
             'node scripts/verify-preview-deploy-trigger.mjs'
         );
-        expect(trustedWorkflow.match(/node scripts\/verify-preview-deploy-trigger\.mjs/g)).toHaveLength(4);
+        expect(trustedWorkflow.match(/verify-preview-deploy-trigger\.mjs/g).length).toBeGreaterThanOrEqual(5);
     });
 
-    it('withholds the Firebase credential until identity, archive, shape, config, and install checks pass', () => {
+    it('keeps raw artifact validation and dependency installation outside the OIDC job', () => {
         const triggerIndex = trustedWorkflow.indexOf('node scripts/verify-preview-deploy-trigger.mjs');
         const downloadIndex = trustedWorkflow.indexOf('actions/artifacts/$ARTIFACT_ID/zip');
         const extractionIndex = trustedWorkflow.indexOf('python3 scripts/extract-preview-hosting-artifact.py');
         const configIndex = trustedWorkflow.indexOf('node scripts/write-firebase-hosting-config.mjs');
-        const installIndex = trustedWorkflow.indexOf('run: npm ci --ignore-scripts');
-        const recheckIndex = trustedWorkflow.indexOf('name: Re-verify current pull-request head before credentials');
+        const installIndex = trustedWorkflow.indexOf('firebase-tools@15.24.0');
+        const recheckIndex = trustedWorkflow.indexOf('name: Re-verify current pull-request head before trusted handoff');
+        const handoffIndex = trustedWorkflow.indexOf('name: Upload sanitized trusted deploy handoff');
         const credentialIndex = trustedWorkflow.indexOf('uses: google-github-actions/auth@');
         const deployIndex = trustedWorkflow.indexOf('hosting:channel:deploy');
         const cleanupIndex = trustedWorkflow.indexOf('name: Remove ephemeral Google credential file');
-        const commentIndex = trustedWorkflow.indexOf('name: Report preview URL on verified pull request');
+        const commentIndex = trustedWorkflow.indexOf('name: Report preview URL on the still-current pull request');
 
         expect(triggerIndex).toBeGreaterThan(-1);
         expect(downloadIndex).toBeGreaterThan(triggerIndex);
@@ -250,11 +251,14 @@ describe('preview deployment workflow trust boundary', () => {
         expect(configIndex).toBeGreaterThan(extractionIndex);
         expect(installIndex).toBeGreaterThan(configIndex);
         expect(recheckIndex).toBeGreaterThan(installIndex);
-        expect(credentialIndex).toBeGreaterThan(recheckIndex);
+        expect(handoffIndex).toBeGreaterThan(recheckIndex);
+        expect(credentialIndex).toBeGreaterThan(handoffIndex);
         expect(deployIndex).toBeGreaterThan(credentialIndex);
         expect(cleanupIndex).toBeGreaterThan(deployIndex);
         expect(commentIndex).toBeGreaterThan(cleanupIndex);
         expect(trustedWorkflow.slice(cleanupIndex, commentIndex)).toContain('if: always()');
+        expect(trustedWorkflow.slice(0, credentialIndex)).toContain('permissions:\n      actions: read\n      contents: read\n      pull-requests: read');
+        expect(trustedWorkflow.slice(credentialIndex)).not.toContain('npm install');
         expect(trustedWorkflow).toContain('id-token: write');
         expect(trustedWorkflow).toContain('workload_identity_provider: ${{ vars.FIREBASE_DEPLOY_WORKLOAD_IDENTITY_PROVIDER }}');
         expect(trustedWorkflow).toContain('service_account: ${{ vars.FIREBASE_DEPLOY_SERVICE_ACCOUNT }}');

--- a/tests/unit/production-functions-handoff.test.js
+++ b/tests/unit/production-functions-handoff.test.js
@@ -1,0 +1,129 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import {
+    chmodSync,
+    lstatSync,
+    mkdtempSync,
+    mkdirSync,
+    readlinkSync,
+    rmSync,
+    statSync,
+    symlinkSync,
+    writeFileSync
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const extractor = resolve('scripts/extract-production-functions-handoff.py');
+const temporaryRoots = [];
+
+function makeRoot() {
+    const root = mkdtempSync(join(tmpdir(), 'allplays-functions-handoff-'));
+    temporaryRoots.push(root);
+    mkdirSync(join(root, 'source'));
+    mkdirSync(join(root, 'destination'));
+    return root;
+}
+
+function createValidRuntime(root) {
+    const functionsRoot = join(root, 'source', 'functions');
+    const binDirectory = join(functionsRoot, 'node_modules', '.bin');
+    const targetDirectory = join(functionsRoot, 'node_modules', 'firebase-functions', 'lib', 'bin');
+    mkdirSync(binDirectory, { recursive: true });
+    mkdirSync(targetDirectory, { recursive: true });
+    const target = join(targetDirectory, 'firebase-functions.js');
+    writeFileSync(target, '#!/usr/bin/env node\n');
+    chmodSync(target, 0o755);
+    symlinkSync('../firebase-functions/lib/bin/firebase-functions.js', join(binDirectory, 'firebase-functions'));
+}
+
+function createTar(root) {
+    const archive = join(root, 'functions-runtime.tar');
+    execFileSync('tar', ['-C', join(root, 'source'), '-cf', archive, 'functions'], {
+        env: { ...process.env, COPYFILE_DISABLE: '1' }
+    });
+    chmodSync(archive, 0o644);
+    return archive;
+}
+
+function createSyntheticTar(root, pythonBody) {
+    const archive = join(root, 'functions-runtime.tar');
+    execFileSync('python3', ['-c', `import io, sys, tarfile\n${pythonBody}`, archive]);
+    return archive;
+}
+
+function runExtractor(archive, destination) {
+    return spawnSync('python3', [extractor, archive, destination], { encoding: 'utf8' });
+}
+
+afterEach(() => {
+    while (temporaryRoots.length) {
+        rmSync(temporaryRoots.pop(), { recursive: true, force: true });
+    }
+});
+
+describe('production Functions handoff extraction', () => {
+    it('preserves the npm bin symlink and executable target through a 0644 artifact', () => {
+        const root = makeRoot();
+        createValidRuntime(root);
+        const archive = createTar(root);
+        const destination = join(root, 'destination');
+
+        const result = runExtractor(archive, destination);
+
+        expect(result.status, result.stderr).toBe(0);
+        const binLink = join(destination, 'functions', 'node_modules', '.bin', 'firebase-functions');
+        const binTarget = join(destination, 'functions', 'node_modules', 'firebase-functions', 'lib', 'bin', 'firebase-functions.js');
+        expect(lstatSync(binLink).isSymbolicLink()).toBe(true);
+        expect(readlinkSync(binLink)).toBe('../firebase-functions/lib/bin/firebase-functions.js');
+        expect(statSync(binTarget).mode & 0o111).toBe(0o111);
+    });
+
+    it('rejects traversal before writing outside the destination', () => {
+        const root = makeRoot();
+        const archive = createSyntheticTar(root, `
+with tarfile.open(sys.argv[1], 'w') as archive:
+    root = tarfile.TarInfo('functions')
+    root.type = tarfile.DIRTYPE
+    archive.addfile(root)
+    payload = b'escape'
+    item = tarfile.TarInfo('../escape')
+    item.size = len(payload)
+    archive.addfile(item, io.BytesIO(payload))`);
+
+        const result = runExtractor(archive, join(root, 'destination'));
+
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('non-canonical Functions archive path');
+        expect(() => statSync(join(root, 'escape'))).toThrow();
+    });
+
+    it('rejects a symlink that resolves outside the fixed Functions root', () => {
+        const root = makeRoot();
+        const archive = createSyntheticTar(root, `
+with tarfile.open(sys.argv[1], 'w') as archive:
+    root = tarfile.TarInfo('functions')
+    root.type = tarfile.DIRTYPE
+    archive.addfile(root)
+    link = tarfile.TarInfo('functions/node_modules/.bin/firebase-functions')
+    link.type = tarfile.SYMTYPE
+    link.linkname = '../../../../escape'
+    archive.addfile(link)`);
+
+        const result = runExtractor(archive, join(root, 'destination'));
+
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('unsafe Functions symlink');
+    });
+
+    it('fails closed when the required executable runtime is absent', () => {
+        const root = makeRoot();
+        mkdirSync(join(root, 'source', 'functions'));
+        const archive = createTar(root);
+
+        const result = runExtractor(archive, join(root, 'destination'));
+
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('firebase-functions .bin entry is not a preserved symlink');
+    });
+});

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -46,14 +46,14 @@ service firebase.storage {
     it('guards Firebase preview deploy command compatibility with the pinned Firebase CLI', () => {
         const validPreviewDeployStep = `
       - name: Deploy preview channel
-        run: ./node_modules/.bin/firebase hosting:channel:deploy "$CURRENT_CHANNEL" --project game-flow-c6311 --config "$FIREBASE_PREVIEW_CONFIG"
+        run: node "$firebase_cli" hosting:channel:deploy "$CURRENT_CHANNEL" --project game-flow-c6311 --config "$firebase_config"
 `;
 
         expect(() => validatePreviewDeployCommand(validPreviewDeployStep)).not.toThrow();
 
         expect(() => validatePreviewDeployCommand(`
       - name: Deploy preview channel
-        run: ./node_modules/.bin/firebase hosting:channel:deploy "$CURRENT_CHANNEL" --site allplays-preview --project game-flow-c6311 --config "$FIREBASE_PREVIEW_CONFIG"
+        run: node "$firebase_cli" hosting:channel:deploy "$CURRENT_CHANNEL" --site allplays-preview --project game-flow-c6311 --config "$firebase_config"
 `)).toThrow('Preview deploy must not pass --site');
 
         expect(() => validatePreviewDeployCommand(`
@@ -97,16 +97,16 @@ service firebase.storage {
           git diff --quiet "$last_success_sha" "$GITHUB_SHA" -- firestore.rules firestore.indexes.json
       - name: Deploy Firebase Storage rules when available
         env:
-          STORAGE_RULES_CHANGED: \${{ steps.storage_rules.outputs.changed }}
+          STORAGE_RULES_CHANGED: \${{ needs.prepare-deploy.outputs.storage_changed }}
         run: |
-          npx firebase-tools@14.25.0 deploy --only storage --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive
+          node "$firebase_cli" deploy --only storage --project game-flow-c6311 --config "$firebase_config" --non-interactive
           sed -E 's/\\x1B\\[[0-9;]*[[:alpha:]]//g' "$storage_log" > "$storage_plain_log"
           if [[ "$STORAGE_RULES_CHANGED" != "true" ]]; then exit 0; fi
           exit "$storage_status"
             transient_pattern='HTTP Error:[[:space:]]*409,[[:space:]]*Requested entity already exists'
-            npx firebase-tools@14.25.0 deploy --only "$deploy_targets" --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive
+            node "$firebase_cli" deploy --only "$deploy_targets" --project game-flow-c6311 --config "$firebase_config" --non-interactive
           env:
-            FIRESTORE_CONFIG_CHANGED: \${{ steps.firestore_config.outputs.changed }}
+            FIRESTORE_CONFIG_CHANGED: \${{ needs.prepare-deploy.outputs.firestore_changed }}
           if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then
             retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"
             retry_firebase_deploy "hosting,functions" "application"
@@ -155,23 +155,31 @@ service firebase.storage {
 
     it('requires pinned keyless Google authentication for Firebase deployers', () => {
         const validWorkflow = `
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Prime exact Firebase deploy CLI
-        run: npx firebase-tools@14.25.0 --version
-      - name: Authenticate to Google Cloud through exact-workflow OIDC
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
-        with:
-          workload_identity_provider: \${{ vars.FIREBASE_DEPLOY_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: \${{ vars.FIREBASE_DEPLOY_SERVICE_ACCOUNT }}
-          project_id: game-flow-c6311
-          create_credentials_file: true
-          cleanup_credentials: true
-      - name: Deploy Firebase
-        timeout-minutes: 4
-        run: npx firebase-tools@14.25.0 deploy --only hosting --project game-flow-c6311
+    jobs:
+      prepare:
+        permissions:
+          contents: read
+        steps:
+          - name: Install isolated CLI
+            run: npm install --ignore-scripts firebase-tools@15.24.0
+      deploy:
+        permissions:
+          contents: read
+          id-token: write
+        steps:
+          - name: Download trusted handoff
+            uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+          - name: Authenticate to Google Cloud through exact-workflow OIDC
+            uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+            with:
+              workload_identity_provider: \${{ vars.FIREBASE_DEPLOY_WORKLOAD_IDENTITY_PROVIDER }}
+              service_account: \${{ vars.FIREBASE_DEPLOY_SERVICE_ACCOUNT }}
+              project_id: game-flow-c6311
+              create_credentials_file: true
+              cleanup_credentials: true
+          - name: Deploy Firebase
+            timeout-minutes: 4
+            run: node "$firebase_cli" deploy --only hosting --project game-flow-c6311
         `;
 
         expect(() => validateFirebaseDeployWorkloadIdentity(validWorkflow, 'Test deploy')).not.toThrow();
@@ -180,7 +188,7 @@ service firebase.storage {
             'Test deploy'
         )).toThrow('Test deploy OIDC token permission');
         expect(() => validateFirebaseDeployWorkloadIdentity(
-            validWorkflow.replace(/@[0-9a-f]{40}/, '@v3'),
+            validWorkflow.replace('google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093', 'google-github-actions/auth@v3'),
             'Test deploy'
         )).toThrow('Test deploy pinned Google authentication action');
         expect(() => validateFirebaseDeployWorkloadIdentity(
@@ -190,25 +198,25 @@ service firebase.storage {
         expect(() => validateFirebaseDeployWorkloadIdentity(
             validWorkflow.replace(
                 'create_credentials_file: true',
-                'create_credentials_file: true\n          credentials_json: \${{ secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311 }}'
+                'create_credentials_file: true\n              credentials_json: \${{ secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311 }}'
             ),
             'Test deploy'
         )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');
         expect(() => validateFirebaseDeployWorkloadIdentity(
             validWorkflow.replace(
-                'run: npx firebase-tools@14.25.0 deploy',
-                'env:\n          GOOGLE_APPLICATION_CREDENTIALS : \${{ secrets.RENAMED_KEY }}\n        run: npx firebase-tools@14.25.0 deploy'
+                'run: node "$firebase_cli" deploy',
+                'env:\n              GOOGLE_APPLICATION_CREDENTIALS : \${{ secrets.RENAMED_KEY }}\n            run: node "$firebase_cli" deploy'
             ),
             'Test deploy'
         )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');
         expect(() => validateFirebaseDeployWorkloadIdentity(
-            validWorkflow.replace('credentials_file: true', 'credentials_file: true\n          credentials_json : \${{ secrets.RENAMED_KEY }}'),
+            validWorkflow.replace('credentials_file: true', 'credentials_file: true\n              credentials_json : \${{ secrets.RENAMED_KEY }}'),
             'Test deploy'
         )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');
         expect(() => validateFirebaseDeployWorkloadIdentity(
             validWorkflow.replace(
-                'npx firebase-tools@14.25.0 deploy --only hosting',
-                'gcloud auth activate-service-account --key-file /tmp/key.json\n          npx firebase-tools@14.25.0 deploy --only hosting'
+                'node "$firebase_cli" deploy --only hosting',
+                'gcloud auth activate-service-account --key-file /tmp/key.json\n              node "$firebase_cli" deploy --only hosting'
             ),
             'Test deploy'
         )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');
@@ -218,15 +226,32 @@ service firebase.storage {
         )).toThrow('Test deploy credentialed deploy steps must have a four-minute timeout');
         expect(() => validateFirebaseDeployWorkloadIdentity(
             validWorkflow.replace(
-                '      - name: Deploy Firebase',
-                '      - name: Delay after authentication\n        run: sleep 1\n      - name: Deploy Firebase'
+                '          - name: Deploy Firebase',
+                '          - name: Delay after authentication\n            run: sleep 1\n          - name: Deploy Firebase'
             ),
             'Test deploy'
         )).toThrow('Test deploy must authenticate immediately before each Firebase deploy step');
         expect(() => validateFirebaseDeployWorkloadIdentity(
-            validWorkflow.replace('run: npx firebase-tools@14.25.0 --version', 'run: echo not-primed'),
+            validWorkflow.replace(
+                '          - name: Download trusted handoff',
+                '          - name: Install dependencies in credentialed job\n            run: npm install firebase-tools\n          - name: Download trusted handoff'
+            ),
             'Test deploy'
-        )).toThrow('Test deploy must resolve the exact Firebase CLI before requesting OIDC');
+        )).toThrow('Test deploy dependency, build, and raw-artifact preparation must run in a separate no-OIDC job');
+        expect(() => validateFirebaseDeployWorkloadIdentity(
+            validWorkflow.replace(
+                '          - name: Download trusted handoff',
+                '          - name: Download raw artifact\n            run: gh api repos/example/repo/actions/artifacts/42/zip\n          - name: Download trusted handoff'
+            ),
+            'Test deploy'
+        )).toThrow('Test deploy dependency, build, and raw-artifact preparation must run in a separate no-OIDC job');
+        expect(() => validateFirebaseDeployWorkloadIdentity(
+            validWorkflow.replace(
+                '          - name: Download trusted handoff',
+                '          - name: Checkout\n            uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd\n          - name: Download trusted handoff'
+            ),
+            'Test deploy'
+        )).toThrow('Test deploy credentialed deploy job contains an unapproved action');
     });
 
     it('requires preview deploy release-target outage handling', () => {
@@ -235,7 +260,7 @@ service firebase.storage {
           grep -Eiq "HTTP Error: 400, Can't release to .*resource doesn't exist or isn't a valid release target" "$log_file"
           preview_skip_reason="skip_preview_for_release_target"
           env:
-            PREVIEW_SKIP_REASON: \${{ steps.deploy_preview.outputs.preview_skip_reason }}
+            PREVIEW_SKIP_REASON: \${{ needs.deploy-preview.outputs.preview_skip_reason }}
         `;
 
         expect(() => assertPreviewDeploySkipHandling(deployPreview)).not.toThrow();
@@ -251,7 +276,7 @@ service firebase.storage {
         expect(() => assertPreviewDeploySkipHandling(deployPreview.replace('skip_preview_for_release_target', ''))).toThrow(
             'Preview deploy release target skip is missing'
         );
-        expect(() => assertPreviewDeploySkipHandling(deployPreview.replace('PREVIEW_SKIP_REASON: ${{ steps.deploy_preview.outputs.preview_skip_reason }}', ''))).toThrow(
+        expect(() => assertPreviewDeploySkipHandling(deployPreview.replace('PREVIEW_SKIP_REASON: ${{ needs.deploy-preview.outputs.preview_skip_reason }}', ''))).toThrow(
             'Preview deploy skipped reason PR comment is missing'
         );
     });

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -221,6 +221,20 @@ service firebase.storage {
             'Test deploy'
         )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');
         expect(() => validateFirebaseDeployWorkloadIdentity(
+            validWorkflow.replace(
+                'node "$firebase_cli" deploy --only hosting',
+                'node "$firebase_cli" deploy --token "$DEPLOY_TOKEN" --only hosting'
+            ),
+            'Test deploy'
+        )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');
+        expect(() => validateFirebaseDeployWorkloadIdentity(
+            validWorkflow.replace(
+                'run: node "$firebase_cli" deploy',
+                'env:\n              RENAMED_AUTH: \${{ secrets.FIREBASE_RELEASE_TOKEN }}\n            run: node "$firebase_cli" deploy'
+            ),
+            'Test deploy'
+        )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');
+        expect(() => validateFirebaseDeployWorkloadIdentity(
             validWorkflow.replace('timeout-minutes: 4', 'timeout-minutes: 6'),
             'Test deploy'
         )).toThrow('Test deploy credentialed deploy steps must have a four-minute timeout');

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
     assertPreviewDeploySkipHandling,
     extractMatchBlock,
+    validateFirebaseDeployWorkloadIdentity,
     validatePreviewDeployCommand,
     validateProductionDeployCommand,
     validateFirebaseRulesCi
@@ -111,7 +112,6 @@ service firebase.storage {
             retry_firebase_deploy "hosting,functions" "application"
           else
             retry_firebase_deploy "hosting,functions" "application"
-            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"
           fi
         `;
 
@@ -146,12 +146,46 @@ service firebase.storage {
         ))).toThrow('Production Firestore deploy must run first when its configuration changed');
         expect(() => validateProductionDeployCommand(validDeployCommand.replace(
             `else
-            retry_firebase_deploy "hosting,functions" "application"
-            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"`,
+            retry_firebase_deploy "hosting,functions" "application"`,
             `else
             retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"
             retry_firebase_deploy "hosting,functions" "application"`
-        ))).toThrow('Production application deploy must run first when Firestore configuration is unchanged');
+        ))).toThrow('Production must not redeploy unchanged Firestore configuration');
+    });
+
+    it('requires pinned keyless Google authentication for Firebase deployers', () => {
+        const validWorkflow = `
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Authenticate to Google Cloud through exact-workflow OIDC
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: \${{ vars.FIREBASE_DEPLOY_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: \${{ vars.FIREBASE_DEPLOY_SERVICE_ACCOUNT }}
+          project_id: game-flow-c6311
+          create_credentials_file: true
+          cleanup_credentials: true
+        `;
+
+        expect(() => validateFirebaseDeployWorkloadIdentity(validWorkflow, 'Test deploy')).not.toThrow();
+        expect(() => validateFirebaseDeployWorkloadIdentity(
+            validWorkflow.replace('id-token: write', 'id-token: none'),
+            'Test deploy'
+        )).toThrow('Test deploy OIDC token permission');
+        expect(() => validateFirebaseDeployWorkloadIdentity(
+            validWorkflow.replace(/@[0-9a-f]{40}/, '@v3'),
+            'Test deploy'
+        )).toThrow('Test deploy pinned Google authentication action');
+        expect(() => validateFirebaseDeployWorkloadIdentity(
+            validWorkflow.replace('workload_identity_provider:', 'provider:'),
+            'Test deploy'
+        )).toThrow('Test deploy workload identity provider variable');
+        expect(() => validateFirebaseDeployWorkloadIdentity(
+            `${validWorkflow}\ncredentials_json: \${{ secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311 }}`,
+            'Test deploy'
+        )).toThrow('Test deploy must not use a long-lived Google service-account key');
     });
 
     it('requires preview deploy release-target outage handling', () => {

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -159,6 +159,8 @@ service firebase.storage {
       contents: read
       id-token: write
     steps:
+      - name: Prime exact Firebase deploy CLI
+        run: npx firebase-tools@14.25.0 --version
       - name: Authenticate to Google Cloud through exact-workflow OIDC
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
@@ -167,6 +169,9 @@ service firebase.storage {
           project_id: game-flow-c6311
           create_credentials_file: true
           cleanup_credentials: true
+      - name: Deploy Firebase
+        timeout-minutes: 4
+        run: npx firebase-tools@14.25.0 deploy --only hosting --project game-flow-c6311
         `;
 
         expect(() => validateFirebaseDeployWorkloadIdentity(validWorkflow, 'Test deploy')).not.toThrow();
@@ -181,11 +186,47 @@ service firebase.storage {
         expect(() => validateFirebaseDeployWorkloadIdentity(
             validWorkflow.replace('workload_identity_provider:', 'provider:'),
             'Test deploy'
-        )).toThrow('Test deploy workload identity provider variable');
+        )).toThrow('Test deploy workload identity provider variable is missing or changed');
         expect(() => validateFirebaseDeployWorkloadIdentity(
-            `${validWorkflow}\ncredentials_json: \${{ secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311 }}`,
+            validWorkflow.replace(
+                'create_credentials_file: true',
+                'create_credentials_file: true\n          credentials_json: \${{ secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311 }}'
+            ),
             'Test deploy'
-        )).toThrow('Test deploy must not use a long-lived Google service-account key');
+        )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');
+        expect(() => validateFirebaseDeployWorkloadIdentity(
+            validWorkflow.replace(
+                'run: npx firebase-tools@14.25.0 deploy',
+                'env:\n          GOOGLE_APPLICATION_CREDENTIALS : \${{ secrets.RENAMED_KEY }}\n        run: npx firebase-tools@14.25.0 deploy'
+            ),
+            'Test deploy'
+        )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');
+        expect(() => validateFirebaseDeployWorkloadIdentity(
+            validWorkflow.replace('credentials_file: true', 'credentials_file: true\n          credentials_json : \${{ secrets.RENAMED_KEY }}'),
+            'Test deploy'
+        )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');
+        expect(() => validateFirebaseDeployWorkloadIdentity(
+            validWorkflow.replace(
+                'npx firebase-tools@14.25.0 deploy --only hosting',
+                'gcloud auth activate-service-account --key-file /tmp/key.json\n          npx firebase-tools@14.25.0 deploy --only hosting'
+            ),
+            'Test deploy'
+        )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');
+        expect(() => validateFirebaseDeployWorkloadIdentity(
+            validWorkflow.replace('timeout-minutes: 4', 'timeout-minutes: 6'),
+            'Test deploy'
+        )).toThrow('Test deploy credentialed deploy steps must have a four-minute timeout');
+        expect(() => validateFirebaseDeployWorkloadIdentity(
+            validWorkflow.replace(
+                '      - name: Deploy Firebase',
+                '      - name: Delay after authentication\n        run: sleep 1\n      - name: Deploy Firebase'
+            ),
+            'Test deploy'
+        )).toThrow('Test deploy must authenticate immediately before each Firebase deploy step');
+        expect(() => validateFirebaseDeployWorkloadIdentity(
+            validWorkflow.replace('run: npx firebase-tools@14.25.0 --version', 'run: echo not-primed'),
+            'Test deploy'
+        )).toThrow('Test deploy must resolve the exact Firebase CLI before requesting OIDC');
     });
 
     it('requires preview deploy release-target outage handling', () => {

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -235,6 +235,34 @@ service firebase.storage {
             'Test deploy'
         )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');
         expect(() => validateFirebaseDeployWorkloadIdentity(
+            validWorkflow.replace(
+                'run: node "$firebase_cli" deploy',
+                'env:\n              CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE: /tmp/renamed.json\n            run: node "$firebase_cli" deploy'
+            ),
+            'Test deploy'
+        )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');
+        expect(() => validateFirebaseDeployWorkloadIdentity(
+            validWorkflow.replace(
+                'run: node "$firebase_cli" deploy',
+                'env:\n              FIREBASE_DEPLOY_TOKEN: renamed-token\n            run: node "$firebase_cli" deploy'
+            ),
+            'Test deploy'
+        )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');
+        expect(() => validateFirebaseDeployWorkloadIdentity(
+            validWorkflow.replace(
+                'node "$firebase_cli" deploy --only hosting',
+                'export FIREBASE_TOKEN="$DEPLOY_AUTH"\n              node "$firebase_cli" deploy --only hosting'
+            ),
+            'Test deploy'
+        )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');
+        expect(() => validateFirebaseDeployWorkloadIdentity(
+            validWorkflow.replace(
+                'run: node "$firebase_cli" deploy',
+                'env:\n              RENAMED_AUTH: \${{ secrets.RENAMED }}\n            run: node "$firebase_cli" deploy'
+            ),
+            'Test deploy'
+        )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');
+        expect(() => validateFirebaseDeployWorkloadIdentity(
             validWorkflow.replace('timeout-minutes: 4', 'timeout-minutes: 6'),
             'Test deploy'
         )).toThrow('Test deploy credentialed deploy steps must have a four-minute timeout');

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -284,6 +284,20 @@ service firebase.storage {
             'Test deploy'
         )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');
         expect(() => validateFirebaseDeployWorkloadIdentity(
+            validWorkflow.replace(
+                'run: node "$firebase_cli" deploy --only hosting --project game-flow-c6311',
+                'run: |\n              export FIREBASE_\\\n              TOKEN="$DEPLOY_AUTH"\n              node "$firebase_cli" deploy --only hosting --project game-flow-c6311'
+            ),
+            'Test deploy'
+        )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');
+        expect(() => validateFirebaseDeployWorkloadIdentity(
+            validWorkflow.replace(
+                'run: node "$firebase_cli" deploy --only hosting --project game-flow-c6311',
+                'run: |\n              node "$firebase_cli" deploy --\\\n              token "$DEPLOY_AUTH" --only hosting --project game-flow-c6311'
+            ),
+            'Test deploy'
+        )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');
+        expect(() => validateFirebaseDeployWorkloadIdentity(
             validWorkflow.replace('timeout-minutes: 4', 'timeout-minutes: 6'),
             'Test deploy'
         )).toThrow('Test deploy credentialed deploy steps must have a four-minute timeout');

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -263,6 +263,27 @@ service firebase.storage {
             'Test deploy'
         )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');
         expect(() => validateFirebaseDeployWorkloadIdentity(
+            validWorkflow.replace(
+                'run: node "$firebase_cli" deploy',
+                'env:\n              DEPLOY_AUTH: \${{ secrets["RENAMED"] }}\n            run: node "$firebase_cli" deploy'
+            ),
+            'Test deploy'
+        )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');
+        expect(() => validateFirebaseDeployWorkloadIdentity(
+            validWorkflow.replace(
+                'run: node "$firebase_cli" deploy',
+                'env:\n              FIREBASE_RELEASE_TOKEN: renamed-token\n            run: node "$firebase_cli" deploy'
+            ),
+            'Test deploy'
+        )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');
+        expect(() => validateFirebaseDeployWorkloadIdentity(
+            validWorkflow.replace(
+                'node "$firebase_cli" deploy --only hosting',
+                'export FIREBASE_"TOKEN"="$DEPLOY_AUTH"\n              node "$firebase_cli" deploy --only hosting'
+            ),
+            'Test deploy'
+        )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');
+        expect(() => validateFirebaseDeployWorkloadIdentity(
             validWorkflow.replace('timeout-minutes: 4', 'timeout-minutes: 6'),
             'Test deploy'
         )).toThrow('Test deploy credentialed deploy steps must have a four-minute timeout');

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -210,6 +210,20 @@ service firebase.storage {
             'Test deploy'
         )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');
         expect(() => validateFirebaseDeployWorkloadIdentity(
+            validWorkflow.replace(
+                'node "$firebase_cli" deploy --only hosting',
+                'export GOOGLE_"APPLICATION"_CREDENTIALS=/tmp/key.json\n              node "$firebase_cli" deploy --only hosting'
+            ),
+            'Test deploy'
+        )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');
+        expect(() => validateFirebaseDeployWorkloadIdentity(
+            validWorkflow.replace(
+                'node "$firebase_cli" deploy --only hosting',
+                "export GOO'GLE'_''APPLICATION'_CREDENTIALS=/tmp/key.json\n              node \"$firebase_cli\" deploy --only hosting"
+            ),
+            'Test deploy'
+        )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');
+        expect(() => validateFirebaseDeployWorkloadIdentity(
             validWorkflow.replace('credentials_file: true', 'credentials_file: true\n              credentials_json : \${{ secrets.RENAMED_KEY }}'),
             'Test deploy'
         )).toThrow('Test deploy must not use a long-lived Google service-account key or static ADC input');

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -47,6 +47,8 @@ service firebase.storage {
         const validPreviewDeployStep = `
       - name: Deploy preview channel
         run: node "$firebase_cli" hosting:channel:deploy "$CURRENT_CHANNEL" --project game-flow-c6311 --config "$firebase_config"
+        preview_deploy_hit_auth_domain_sync_error() { return 1; }
+        echo "refusing to report a partially functional preview"
 `;
 
         expect(() => validatePreviewDeployCommand(validPreviewDeployStep)).not.toThrow();
@@ -55,6 +57,11 @@ service firebase.storage {
       - name: Deploy preview channel
         run: node "$firebase_cli" hosting:channel:deploy "$CURRENT_CHANNEL" --site allplays-preview --project game-flow-c6311 --config "$firebase_config"
 `)).toThrow('Preview deploy must not pass --site');
+
+        expect(() => validatePreviewDeployCommand(
+            validPreviewDeployStep.replace('$firebase_config"', '$firebase_config" --no-authorized-domains')
+        ))
+            .toThrow('Preview deploy must preserve Firebase Auth authorized-domain synchronization');
 
         expect(() => validatePreviewDeployCommand(`
       - name: Deploy preview channel


### PR DESCRIPTION
READY FOR MANUAL MERGE — exact-head CI green; automation lanes held

## Summary
- replace protected-environment Firebase JSON keys with pinned GitHub OIDC / Google Workload Identity Federation authentication
- bind production and trusted-preview workflows to environment-scoped provider/service-account variables
- keep rules-changing releases rules-first while skipping redundant unchanged Firestore writes
- explicitly remove ephemeral ADC files before preview comment writes and retain action cleanup
- document exact-workflow IAM cutover, canaries, rollback, and final JSON-key retirement
- retain the credential-free production handoff for 30 days so environment approval delays cannot expire it
- reject quoted or fragmented Google ADC environment names in the deploy-policy guard
- preserve Functions symlinks and executable modes through a bounded, validated tar handoff
- keep preview Firebase Auth domain synchronization functional with an exact two-permission custom role and fail-closed warning detection
- reject a symlinked preview verifier and verify its reviewed workflow-literal SHA-256 immediately before authenticated execution

## Exact state
- Base: `7debd46b34cb5b33b6257531399bc8005c8953b8`
- Head: `1d33086af476807ff9c90c5204c22642958d2824`
- the WIF provider is restricted to immutable repository/owner IDs, `master`, and the exact recovery, production, or trusted-preview workflow ref
- production, trusted-preview, and recovery protected-environment variables point to their workflow-specific service accounts
- the broad repository-level recovery impersonation binding has been removed
- the preview service account has only Hosting Admin, API Keys Viewer, and `allplaysPreviewAuthDomainUpdater`; the custom role contains only `firebaseauth.configs.get` and `firebaseauth.configs.update`
- recovery canary `29665005383` passed after the exact-workflow binding cutover
- the remaining JSON secrets and GCP key stay available only as rollback until production and preview OIDC canaries pass

## Validation
- full unit corpus: 648 files passed / 3 skipped; 4,563 tests passed / 78 skipped
- focused WIF/trust/deploy suite: 4 files / 34 tests passed, including quoted ADC-name bypasses, artifact mode loss, traversal/escaping links, and partial preview Auth sync
- `npm run ci:firebase-rules`: passed
- `npm run app:build`: passed; 231 production files and bundle visualizer verified
- Java-backed rules behavior remains covered in GitHub CI
- diff/YAML/syntax checks passed before push

## Remaining rollout gates
1. Merge manually; require the production WIF deploy and post-deploy smoke to pass.
2. Run a same-repository fixed-`pr-N` preview through the default-branch trusted WIF workflow.
3. Only after recovery, production, and preview canaries all pass, remove both JSON environment secrets and delete the remaining GCP service-account key.
