### PR TITLE
Improve Home UX across public and signed-in states

### DIFF
--- a/apps/app/src/components/AppShell.test.tsx
+++ b/apps/app/src/components/AppShell.test.tsx
@@ -237,6 +237,31 @@ describe('AppShell', () => {
     expect(screen.queryByText('Signed out preview')).toBeNull();
   });
 
+  it('labels a roleless signed-in session as signed in instead of public exploration', () => {
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route
+            path="/home"
+            element={(
+              <AppShell auth={{
+                ...signedInAuth,
+                roles: [],
+                user: signedInAuth.user ? { ...signedInAuth.user, roles: [] } : null,
+              }}>
+                <div>Home</div>
+              </AppShell>
+            )}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Signed in')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Go to home' })).toBeTruthy();
+    expect(screen.queryByText('Explore ALL PLAYS')).toBeNull();
+  });
+
   it('announces notification count changes through a live region', () => {
     render(
       <MemoryRouter initialEntries={['/home']}>

--- a/apps/app/src/components/AppShell.test.tsx
+++ b/apps/app/src/components/AppShell.test.tsx
@@ -223,6 +223,20 @@ describe('AppShell', () => {
     expect(screen.queryByRole('link', { name: 'Family' })).toBeNull();
   });
 
+  it('labels the signed-out brand as public exploration instead of an account preview', () => {
+    render(
+      <MemoryRouter initialEntries={['/discover']}>
+        <Routes>
+          <Route path="/discover" element={<AppShell auth={{ ...auth, roles: [] }}><div>Discover</div></AppShell>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Explore ALL PLAYS')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Go to Discover' })).toBeTruthy();
+    expect(screen.queryByText('Signed out preview')).toBeNull();
+  });
+
   it('announces notification count changes through a live region', () => {
     render(
       <MemoryRouter initialEntries={['/home']}>

--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -359,13 +359,13 @@ export function AppShell({ auth, children }: AppShellProps) {
                 type="button"
                 className="flex min-w-0 flex-1 items-center gap-3 text-left"
                 onClick={() => navigate(hasSignedInSession ? '/home' : '/discover')}
-                aria-label="Go to home"
+                aria-label={hasSignedInSession ? 'Go to home' : 'Go to Discover'}
               >
                 <img src="./logo_small.png" alt="" className="h-10 w-10 flex-none rounded-xl shadow-sm" />
                 <span className="min-w-0">
                   <span className="block truncate text-base font-black leading-tight text-gray-950">ALL PLAYS</span>
                   <span className="block truncate text-xs font-bold text-gray-500">
-                    {auth.roles.length ? auth.roles.join(' + ') : 'Signed out preview'}
+                    {auth.roles.length ? auth.roles.join(' + ') : 'Explore ALL PLAYS'}
                   </span>
                 </span>
               </button>
@@ -467,13 +467,13 @@ export function AppShell({ auth, children }: AppShellProps) {
                 type="button"
                 className="flex min-w-0 flex-1 items-center gap-3 text-left"
                 onClick={() => navigate(hasSignedInSession ? '/home' : '/discover')}
-                aria-label="Go to home"
+                aria-label={hasSignedInSession ? 'Go to home' : 'Go to Discover'}
               >
                 <img src="./logo_small.png" alt="" className="h-10 w-10 flex-none rounded-xl shadow-sm" />
                 <span className="min-w-0">
                   <span className="block truncate text-base font-black leading-tight text-gray-950">ALL PLAYS</span>
                   <span className="block truncate text-xs font-bold text-gray-500">
-                    {auth.roles.length ? auth.roles.join(' + ') : 'Signed out preview'}
+                    {auth.roles.length ? auth.roles.join(' + ') : 'Explore ALL PLAYS'}
                   </span>
                 </span>
               </button>

--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -270,6 +270,11 @@ export function AppShell({ auth, children }: AppShellProps) {
 
   const addWorkflows = buildAddWorkflows();
   const hasSignedInSession = Boolean(auth.user || auth.roles.length);
+  const brandContextLabel = auth.roles.length
+    ? auth.roles.join(' + ')
+    : hasSignedInSession
+      ? 'Signed in'
+      : 'Explore ALL PLAYS';
   const activeNavItems = hasSignedInSession ? navItems : publicNavItems;
   const activeDesktopNavItems = hasSignedInSession ? desktopNavItems : publicNavItems;
   const commonAddWorkflows = commonAddWorkflowIds
@@ -365,7 +370,7 @@ export function AppShell({ auth, children }: AppShellProps) {
                 <span className="min-w-0">
                   <span className="block truncate text-base font-black leading-tight text-gray-950">ALL PLAYS</span>
                   <span className="block truncate text-xs font-bold text-gray-500">
-                    {auth.roles.length ? auth.roles.join(' + ') : 'Explore ALL PLAYS'}
+                    {brandContextLabel}
                   </span>
                 </span>
               </button>
@@ -473,7 +478,7 @@ export function AppShell({ auth, children }: AppShellProps) {
                 <span className="min-w-0">
                   <span className="block truncate text-base font-black leading-tight text-gray-950">ALL PLAYS</span>
                   <span className="block truncate text-xs font-bold text-gray-500">
-                    {auth.roles.length ? auth.roles.join(' + ') : 'Explore ALL PLAYS'}
+                    {brandContextLabel}
                   </span>
                 </span>
               </button>

--- a/apps/app/src/pages/Home.test.tsx
+++ b/apps/app/src/pages/Home.test.tsx
@@ -478,6 +478,37 @@ describe('Home', () => {
     expect(await screen.findByText(/Official assignments/)).toBeTruthy();
   });
 
+  it.each(['assignment', 'rideshare'] as const)('counts a lone %s action as open without duplicating it in the to-do list', async (kind) => {
+    const title = kind === 'assignment' ? 'Claim scorekeeper assignment' : 'Offer a ride to practice';
+    const actionHome = {
+      ...baseHome,
+      actionItems: [{
+        id: `${kind}:1`,
+        kind,
+        tone: 'emerald' as const,
+        title,
+        detail: 'Bears · Tomorrow',
+        to: '/schedule/team-1/event-1',
+        priority: 30,
+        date: new Date('2100-06-06T18:00:00Z')
+      }]
+    };
+    homeServiceMocks.loadParentHomeSummaryBootstrap.mockResolvedValueOnce({ home: actionHome, schedule: [] });
+    homeServiceMocks.loadParentHomeWithSecondaryData.mockResolvedValueOnce(actionHome);
+
+    renderHome(signedInAuth);
+
+    expect(await screen.findByText('1 open')).toBeTruthy();
+    expect(screen.getByRole('heading', { name: title })).toBeTruthy();
+    const toDoSection = screen.getByText('To-do list').closest('section');
+    expect(toDoSection).toBeTruthy();
+    expect(within(toDoSection!).getByRole('heading', { name: 'Priority only' })).toBeTruthy();
+    expect(within(toDoSection!).getByText('0')).toBeTruthy();
+    expect(within(toDoSection!).getByText('Priority shown above')).toBeTruthy();
+    expect(within(toDoSection!).getByText('Your only open action is highlighted above.')).toBeTruthy();
+    expect(within(toDoSection!).queryByText('All caught up')).toBeNull();
+  });
+
   it('shows network-specific Home retry copy after an initial load failure', async () => {
     homeServiceMocks.loadParentHomeSummaryBootstrap.mockRejectedValueOnce(new TypeError('Failed to fetch'));
 

--- a/apps/app/src/pages/Home.test.tsx
+++ b/apps/app/src/pages/Home.test.tsx
@@ -366,7 +366,7 @@ describe('Home', () => {
 
     resolveBootstrap({ home: baseHome, schedule: [] });
 
-    expect(await screen.findByRole('heading', { name: 'Today for your players' })).toBeTruthy();
+    expect(await screen.findByRole('heading', { name: 'Your day' })).toBeTruthy();
     await waitFor(() => {
       expect(uxTimingMocks.recordFirstMeaningfulRender).toHaveBeenCalledWith('home');
     });
@@ -383,21 +383,28 @@ describe('Home', () => {
 
     renderHome(signedInAuth);
 
-    expect(await screen.findByRole('heading', { name: 'Today for your players' })).toBeTruthy();
+    expect(await screen.findByRole('heading', { name: 'Your day' })).toBeTruthy();
     expect(screen.getByText('Checking responses…')).toBeTruthy();
     expect(screen.queryByText('Loading Home')).toBeNull();
     expect(uxTimingMocks.recordFirstMeaningfulRender).toHaveBeenCalledWith('home');
   });
 
-  it('renders the feed for signed-out users without crashing', async () => {
+  it('renders a dedicated welcome instead of personalized Home for signed-out users', async () => {
     renderHome(signedOutAuth, '/home?section=feed');
 
-    expect(await screen.findByRole('heading', { name: 'Feed' })).toBeTruthy();
+    expect(await screen.findByRole('heading', { name: 'Your sports day, organized' })).toBeTruthy();
+    const createAccountLink = screen.getByRole('link', { name: /Create account/i });
+    expect(createAccountLink.getAttribute('href')).toBe('/auth?mode=signup&next=%2Fhome');
+    expect(createAccountLink.className).toContain('!bg-none');
+    expect(screen.getByRole('link', { name: /Sign in/i }).getAttribute('href')).toBe('/auth?next=%2Fhome');
+    expect(screen.queryByRole('button', { name: 'Refresh Home' })).toBeNull();
+    expect(screen.queryByRole('navigation', { name: 'Home sections' })).toBeNull();
+    expect(screen.queryByRole('heading', { name: 'Feed' })).toBeNull();
     expect(homeServiceMocks.loadParentHomeSummaryBootstrap).not.toHaveBeenCalled();
   });
 
   it('loads an empty opportunities feed only once', async () => {
-    renderHome(signedOutAuth, '/home?section=feed');
+    renderHome(signedInAuth, '/home?section=feed');
 
     expect(await screen.findByRole('heading', { name: 'Feed' })).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: 'Opportunities' }));
@@ -407,10 +414,12 @@ describe('Home', () => {
     expect(opportunityServiceMocks.listPublicOpportunities).toHaveBeenCalledTimes(1);
   });
 
-  it('renders signed-out Today without waiting for parent or officials hydration', async () => {
+  it('renders signed-out welcome without waiting for parent or officials hydration', async () => {
     renderHome(signedOutAuth);
 
-    expect(await screen.findByRole('heading', { name: 'Get linked to your player' })).toBeTruthy();
+    expect(await screen.findByRole('heading', { name: 'Your sports day, organized' })).toBeTruthy();
+    expect(screen.queryByText('ALL PLAYS User')).toBeNull();
+    expect(screen.queryByText('Caught up')).toBeNull();
     expect(screen.queryByText('Loading Home')).toBeNull();
     expect(homeServiceMocks.loadParentHomeSummaryBootstrap).not.toHaveBeenCalled();
     expect(scheduleServiceMocks.loadOfficialAssignmentsAccess).not.toHaveBeenCalled();
@@ -437,8 +446,36 @@ describe('Home', () => {
 
     fireEvent.click(screen.getByRole('link', { name: 'Home nav' }));
 
-    expect(await screen.findByRole('heading', { name: 'Today for your players' })).toBeTruthy();
+    expect(await screen.findByRole('heading', { name: 'Your day' })).toBeTruthy();
     expect(screen.queryByRole('heading', { name: 'Feed' })).toBeNull();
+  });
+
+  it('exposes Home sections as navigation with the current route identified', async () => {
+    renderHome(signedInAuth, '/home?section=feed');
+
+    await screen.findByRole('heading', { name: 'Feed' });
+    const navigation = screen.getByRole('navigation', { name: 'Home sections' });
+    expect(within(navigation).getAllByRole('link')).toHaveLength(5);
+    expect(within(navigation).getByRole('link', { name: 'Feed' }).getAttribute('aria-current')).toBe('page');
+    expect(within(navigation).getByRole('link', { name: 'Today' }).getAttribute('href')).toBe('/home');
+    expect(within(navigation).getByRole('link', { name: 'Friends' }).getAttribute('href')).toBe('/home?section=friends');
+  });
+
+  it.each([
+    [{ ...signedInAuth, isParent: true, isCoach: false, isAdmin: false, isPlatformAdmin: false }, 'Family home'],
+    [{ ...signedInAuth, roles: ['coach'], isParent: false, isCoach: true, isAdmin: false, isPlatformAdmin: false }, 'Coach home'],
+    [{ ...signedInAuth, roles: ['admin'], isParent: false, isCoach: false, isAdmin: true, isPlatformAdmin: false }, 'Administration']
+  ])('renders role-aware Home context', async (auth, expectedContext) => {
+    renderHome(auth as AuthState);
+
+    expect(await screen.findByText(new RegExp(expectedContext))).toBeTruthy();
+  });
+
+  it('uses official context when assignments are available', async () => {
+    scheduleServiceMocks.loadOfficialAssignmentsAccess.mockResolvedValueOnce({ hasAccess: true, teamCount: 1 });
+    renderHome({ ...signedInAuth, roles: [], isParent: false } as AuthState);
+
+    expect(await screen.findByText(/Official assignments/)).toBeTruthy();
   });
 
   it('shows network-specific Home retry copy after an initial load failure', async () => {
@@ -457,7 +494,7 @@ describe('Home', () => {
     renderHome(signedInAuth);
 
     expect(await screen.findByText('Home details could not refresh while offline.')).toBeTruthy();
-    expect(screen.getByRole('heading', { name: 'Today for your players' })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Your day' })).toBeTruthy();
     expect(screen.queryByText('Home could not connect')).toBeNull();
     expect(screen.queryByRole('button', { name: 'Retry loading Home' })).toBeNull();
   });
@@ -476,6 +513,22 @@ describe('Home', () => {
     expect(screen.queryByText('Availability')).toBeNull();
     expect(screen.queryByText('Team chats')).toBeNull();
     expect(screen.queryByText('Practice packets')).toBeNull();
+  });
+
+  it('provides recovery actions in Players and Teams empty states', async () => {
+    homeServiceMocks.loadParentHomeSummaryBootstrap.mockResolvedValue({ home: emptyHome, schedule: [] });
+    homeServiceMocks.loadParentHomeWithSecondaryData.mockResolvedValue(emptyHome);
+
+    const { unmount } = renderHome(signedInAuth, '/home?section=players');
+    expect(await screen.findByText('No players linked yet')).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Accept invite' }).getAttribute('href')).toBe('/accept-invite');
+    expect(screen.getByRole('link', { name: 'Request player access' }).getAttribute('href')).toBe('/parent-tools/access');
+    unmount();
+
+    renderHome(signedInAuth, '/home?section=teams');
+    expect(await screen.findByText('No teams available')).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Request player access' }).getAttribute('href')).toBe('/parent-tools/access');
+    expect(screen.getByRole('link', { name: 'Find teams' }).getAttribute('href')).toBe('/teams/browse');
   });
 
   it('defers the parent first-run card while secondary Home data is still pending', async () => {
@@ -575,7 +628,7 @@ describe('Home', () => {
   it('keeps the normal Today dashboard when at least one player or team is linked', async () => {
     renderHome(signedInAuth);
 
-    expect(await screen.findByRole('heading', { name: 'Today for your players' })).toBeTruthy();
+    expect(await screen.findByRole('heading', { name: 'Your day' })).toBeTruthy();
     expect(screen.getByRole('heading', { name: 'All caught up' })).toBeTruthy();
     expect(screen.getByRole('heading', { name: 'Team feed' })).toBeTruthy();
     expect(screen.queryByRole('heading', { name: 'Get linked to your player' })).toBeNull();
@@ -634,6 +687,15 @@ describe('Home', () => {
     await waitFor(() => {
       expect(socialServiceMocks.loadSocialHome).toHaveBeenCalledTimes(2);
     });
+  });
+
+  it('labels Feed filters and gives an empty Feed one primary next action', async () => {
+    renderHome(signedInAuth, '/home?section=feed');
+
+    await screen.findByRole('heading', { name: 'Feed' });
+    const filters = screen.getByRole('group', { name: 'Feed filters' });
+    expect(within(filters).getAllByRole('button')).toHaveLength(6);
+    expect(screen.getByRole('button', { name: 'Create a post' })).toBeTruthy();
   });
 
   it('optimistically updates likes and blocks rapid double taps from writing twice', async () => {
@@ -859,6 +921,7 @@ describe('Home', () => {
 
     expect(await screen.findByText('Pat Player highlight just posted')).toBeTruthy();
     expect(screen.getByText('Posted to your ALL PLAYS feed.')).toBeTruthy();
+    expect(screen.getByRole('status').textContent).toContain('Posted to your ALL PLAYS feed.');
     expect(socialServiceMocks.loadSocialHome).toHaveBeenCalledTimes(2);
     resolveRefresh({ ...baseSocial, feedItems: [createdPost], metrics: { ...baseSocial.metrics, feedItems: 1 } });
     await waitFor(() => {
@@ -873,10 +936,11 @@ describe('Home', () => {
 
     renderHome(signedInAuth);
 
-    await screen.findByRole('heading', { name: 'Today for your players' });
+    await screen.findByRole('heading', { name: 'Your day' });
     fireEvent.click(screen.getByRole('button', { name: 'Refresh Home' }));
 
     expect(await screen.findByText('Unable to refresh Home because access was denied. Showing the last loaded Home.')).toBeTruthy();
+    expect(screen.getByRole('alert').textContent).toContain('Unable to refresh Home because access was denied.');
   });
 
   it('refreshes the social feed after responding to a friend request', async () => {
@@ -904,6 +968,7 @@ describe('Home', () => {
     renderHome(signedInAuth, '/home?section=friends');
 
     await screen.findByRole('heading', { name: 'Friends' });
+    expect(screen.getByLabelText('Search friends by name, email, or team')).toBeTruthy();
     await waitFor(() => {
       expect(socialServiceMocks.loadSocialHome).toHaveBeenCalledTimes(1);
     });
@@ -944,12 +1009,12 @@ describe('Home', () => {
 
     renderHome(signedInAuth);
 
-    expect(await screen.findByRole('heading', { name: 'Today for your players' })).toBeTruthy();
+    expect(await screen.findByRole('heading', { name: 'Your day' })).toBeTruthy();
     expect(screen.getByText('Upcoming')).toBeTruthy();
-    expect(screen.getAllByText('Player 1 needs availability').length).toBeGreaterThan(0);
-    expect(screen.getByRole('link', { name: /do\s*player 1 needs availability/i }).getAttribute('href')).toBe('/schedule/team-1/upcoming-1');
-    expect(screen.getByRole('link', { name: /Availability.*2.*Needs a response/i })).toHaveAttribute('href', '/schedule?bulkRsvp=1');
-    expect(screen.getByRole('link', { name: 'Multi RSVP' })).toHaveAttribute('href', '/schedule?bulkRsvp=1');
+    expect(screen.getAllByText('Player 1 needs availability')).toHaveLength(1);
+    expect(screen.getByRole('link', { name: 'Open action' }).getAttribute('href')).toBe('/schedule/team-1/upcoming-1');
+    expect(screen.getByRole('link', { name: /Availability.*2.*Needs a response/i }).getAttribute('href')).toBe('/schedule?bulkRsvp=1');
+    expect(screen.getByRole('link', { name: 'Multi RSVP' }).getAttribute('href')).toBe('/schedule?bulkRsvp=1');
     expect(screen.getByText('Falcons')).toBeTruthy();
     expect(screen.getAllByText('Tournament fee').length).toBeGreaterThan(0);
 
@@ -960,7 +1025,7 @@ describe('Home', () => {
       expect(homeServiceMocks.loadParentHomeWithSecondaryData).toHaveBeenCalledTimes(2);
     });
 
-    expect(screen.getByRole('heading', { name: 'Today for your players' })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Your day' })).toBeTruthy();
     expect(screen.getByText('1 unread message')).toBeTruthy();
   });
 });

--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -358,7 +358,8 @@ export function Home({ auth }: { auth: AuthState }) {
   const showInitialHomeSkeleton = loading && !hasRenderableHome;
   const canRenderHomeSections = !loading || hasRenderableHome;
   const displayName = auth.user?.displayName || auth.user?.email || 'ALL PLAYS User';
-  const openCount = home.metrics.rsvpNeeded + home.metrics.packetsReady + home.metrics.unreadMessages + home.fees.length + social.metrics.incomingRequests;
+  const standaloneActionCount = home.actionItems.filter((action) => action.kind === 'assignment' || action.kind === 'rideshare').length;
+  const openCount = home.metrics.rsvpNeeded + home.metrics.packetsReady + home.metrics.unreadMessages + home.fees.length + social.metrics.incomingRequests + standaloneActionCount;
   const today = new Date();
   const selectedComposerType = (searchParams.get('type') || 'manual_post') as SocialPostType;
   const homeSectionRoute = getHomeSectionRoute(activeSection);
@@ -676,6 +677,7 @@ function TodaySection({
   const firstUnreadTeam = unreadTeams[0] || null;
   const nextEvent = nextEvents[0] || null;
   const remainingActions = topAction ? home.actionItems.slice(1, 6) : home.actionItems.slice(0, 6);
+  const remainingActionCount = Math.max(0, home.actionItems.length - (topAction ? 1 : 0));
   const isFirstRunParent = home.players.length === 0 && home.teams.length === 0;
 
   if (isFirstRunParent) {
@@ -747,11 +749,11 @@ function TodaySection({
         <div className="flex items-center justify-between gap-3">
           <div>
             <div className="app-label">To-do list</div>
-            <h2 className="mt-1 app-section-title">{topAction ? 'More to do' : 'Needs Attention'}</h2>
+            <h2 className="mt-1 app-section-title">{topAction ? (remainingActionCount ? 'More to do' : 'Priority only') : 'Needs Attention'}</h2>
           </div>
           <div className="flex items-center gap-2">
             {home.metrics.rsvpNeeded > 1 ? <MultiRsvpLink to="/schedule?bulkRsvp=1" /> : null}
-            <span className="rounded-full border border-gray-200 bg-gray-50 px-2.5 py-1 text-xs font-black text-gray-600">{home.actionItems.length}</span>
+            <span className="rounded-full border border-gray-200 bg-gray-50 px-2.5 py-1 text-xs font-black text-gray-600">{remainingActionCount}</span>
           </div>
         </div>
         <div className="mt-3 space-y-2">
@@ -759,6 +761,14 @@ function TodaySection({
             <ActionRow key={action.id} action={action} />
           )) : !hasLoadedHomeDetails ? (
             <HomeDetailsLoadingState message="Checking for parent actions…" />
+          ) : topAction ? (
+            <div className="flex items-start gap-3 rounded-xl border border-gray-200 bg-gray-50 p-3">
+              <CheckCircle2 className="mt-0.5 h-5 w-5 flex-none text-gray-600" aria-hidden="true" />
+              <div>
+                <div className="text-sm font-black text-gray-900">Priority shown above</div>
+                <div className="mt-0.5 text-xs font-semibold text-gray-600">Your only open action is highlighted above.</div>
+              </div>
+            </div>
           ) : (
             <div className="flex items-start gap-3 rounded-xl border border-emerald-200 bg-emerald-50 p-3">
               <CheckCircle2 className="mt-0.5 h-5 w-5 flex-none text-emerald-700" aria-hidden="true" />

--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -186,6 +186,7 @@ export function Home({ auth }: { auth: AuthState }) {
   const { loading, error, clearError, run: runPrimaryLoad } = useAsyncOperation();
   const { loading: socialLoading, run: runSecondaryLoad } = useAsyncOperation();
   const hasStartedInitialHomeLoadRef = useRef(false);
+  const homeSectionNavRef = useRef<HTMLElement | null>(null);
 
   const authUserId = auth.user?.uid || null;
   const hasHomePreview = Boolean(authUserId) && authUserId === previewHomeUserId;
@@ -345,7 +346,13 @@ export function Home({ auth }: { auth: AuthState }) {
     setComposerOpen(searchParams.get('social') === 'create');
   }, [searchParams]);
 
-  const topAction = home.actionItems[0] || null;
+  useEffect(() => {
+    const activeLink = homeSectionNavRef.current?.querySelector<HTMLElement>(`[data-home-section="${activeSection}"]`);
+    if (activeLink && typeof activeLink.scrollIntoView === 'function') {
+      activeLink.scrollIntoView({ block: 'nearest', inline: 'center' });
+    }
+  }, [activeSection]);
+
   const hasRenderableHome = !authUserId || hasHomePreview || hasLoadedHomeDetails;
   const showBlockingErrorState = !loading && !hasRenderableHome && Boolean(homeLoadError);
   const showInitialHomeSkeleton = loading && !hasRenderableHome;
@@ -382,6 +389,10 @@ export function Home({ auth }: { auth: AuthState }) {
     })
   });
 
+  if (!auth.user) {
+    return <SignedOutHome />;
+  }
+
   const openComposer = (type: SocialPostType = 'manual_post') => {
     const nextParams = new URLSearchParams(searchParams);
     nextParams.set('section', 'feed');
@@ -398,11 +409,7 @@ export function Home({ auth }: { auth: AuthState }) {
 
   const selectSection = (sectionId: HomeSectionId) => {
     setActiveSection(sectionId);
-    const nextParams = new URLSearchParams(searchParams);
-    nextParams.set('section', sectionId);
-    nextParams.delete('social');
-    nextParams.delete('type');
-    setSearchParams(nextParams, { replace: true });
+    setComposerOpen(false);
     window.requestAnimationFrame(() => {
       window.scrollTo({ top: 0, behavior: 'smooth' });
     });
@@ -469,29 +476,24 @@ export function Home({ auth }: { auth: AuthState }) {
             <div className="flex min-w-0 items-center gap-2">
               <span className="app-label">Home</span>
               <span className={`rounded-full px-2 py-0.5 text-[10px] font-black uppercase tracking-[0.04em] ${homeDetailsPending ? 'bg-gray-100 text-gray-600' : openCount ? 'bg-amber-100 text-amber-800' : 'bg-emerald-100 text-emerald-800'}`}>
-                {homeDetailsPending ? 'Loading' : openCount ? `${openCount} open` : 'Clear'}
+                {homeDetailsPending ? 'Loading' : openCount ? `${openCount} open` : 'Caught up'}
               </span>
             </div>
-            <h1 className="mt-0.5 truncate text-xl font-black leading-tight text-gray-950">Today for your players</h1>
-            <p className="mt-0.5 truncate text-xs font-semibold text-gray-600">{displayName}</p>
+            <h1 className="mt-0.5 text-xl font-black leading-tight text-gray-950">Your day</h1>
+            <p className="mt-0.5 truncate text-xs font-semibold text-gray-600">{displayName} · {getHomeRoleContext(auth, resolvedOfficialsAccess)}</p>
           </div>
-          <button type="button" className="ghost-button !h-9 !min-h-9 !w-9 !p-0 sm:!w-auto sm:!px-3 text-xs" onClick={() => refreshHome({ force: true })} disabled={loading} aria-label="Refresh Home" title="Refresh Home">
+          <button type="button" className="ghost-button !h-11 !min-h-11 !w-11 !p-0 sm:!w-auto sm:!px-3 text-xs" onClick={() => refreshHome({ force: true })} disabled={loading} aria-label="Refresh Home" title="Refresh Home">
             {loading ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <RefreshCw className="h-4 w-4" aria-hidden="true" />}
             <span className="hidden sm:inline">Refresh</span>
           </button>
         </div>
         <div className="hidden gap-1.5 overflow-x-auto border-t border-gray-100 px-3 py-2 sm:flex sm:px-4">
-          {topAction ? <TopAction action={topAction} /> : homeDetailsPending ? (
+          {homeDetailsPending ? (
             <div className="flex min-h-8 flex-none items-center gap-1.5 rounded-full border border-gray-200 bg-gray-50 px-2.5 text-xs font-black text-gray-600" role="status">
               <Loader2 className="h-3.5 w-3.5 flex-none animate-spin" aria-hidden="true" />
               Checking actions
             </div>
-          ) : (
-            <div className="flex min-h-8 flex-none items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 text-xs font-black text-emerald-800">
-              <CheckCircle2 className="h-3.5 w-3.5 flex-none" aria-hidden="true" />
-              Clear
-            </div>
-          )}
+          ) : null}
           <PulseChip icon={UserRound} label="Players" value={String(home.metrics.players)} />
           <PulseChip icon={Users} label="Teams" value={String(home.metrics.teams)} />
           <PulseChip icon={ClipboardCheck} label="RSVP" value={String(home.metrics.rsvpNeeded)} urgent={home.metrics.rsvpNeeded > 0} />
@@ -502,24 +504,27 @@ export function Home({ auth }: { auth: AuthState }) {
         </div>
       </section>
 
-      <div className="home-section-nav sticky top-24 z-30 -mx-1 overflow-x-auto bg-gray-50/95 py-2 backdrop-blur">
-        <div className="grid min-w-max grid-cols-5 gap-1 rounded-2xl border border-gray-200 bg-white p-1 shadow-sm">
-          {homeSections.map((section) => {
-            const active = activeSection === section.id;
-            return (
-              <button
-                key={section.id}
-                type="button"
-                className={`min-h-10 rounded-xl px-3 text-sm font-black transition ${active ? 'bg-primary-600 text-white shadow-sm' : 'text-gray-600 hover:bg-gray-50 hover:text-gray-950'}`}
-                onClick={() => selectSection(section.id)}
-                aria-pressed={active}
-              >
-                {section.label}
-              </button>
-            );
-          })}
+      <nav ref={homeSectionNavRef} className="home-section-nav sticky top-24 z-30 -mx-1 bg-gray-50/95 py-2 backdrop-blur" aria-label="Home sections">
+        <div className="home-section-scroll overflow-x-auto px-1">
+          <div className="grid min-w-max grid-cols-5 gap-1 rounded-2xl border border-gray-200 bg-white p-1 shadow-sm">
+            {homeSections.map((section) => {
+              const active = activeSection === section.id;
+              return (
+                <Link
+                  key={section.id}
+                  to={getHomeSectionRoute(section.id)}
+                  data-home-section={section.id}
+                  className={`flex min-h-11 snap-start items-center justify-center rounded-xl px-3 text-sm font-black transition ${active ? 'bg-primary-600 text-white shadow-sm' : 'text-gray-600 hover:bg-gray-50 hover:text-gray-950'}`}
+                  onClick={() => selectSection(section.id)}
+                  aria-current={active ? 'page' : undefined}
+                >
+                  {section.label}
+                </Link>
+              );
+            })}
+          </div>
         </div>
-      </div>
+      </nav>
 
       {error ? <Status tone="error" message={error} /> : null}
       {socialStatus ? <Status tone={socialStatus.tone} message={socialStatus.message} /> : null}
@@ -581,6 +586,69 @@ export function Home({ auth }: { auth: AuthState }) {
     </div>
     </PullToRefresh>
   );
+}
+
+function SignedOutHome() {
+  return (
+    <div className="home-public-welcome mx-auto max-w-4xl space-y-4">
+      <section className="app-card overflow-hidden border-primary-100">
+        <div className="bg-gradient-to-br from-primary-700 via-primary-600 to-indigo-500 px-5 py-7 text-white sm:px-8 sm:py-9">
+          <div className="app-label !text-primary-100">ALL PLAYS</div>
+          <h1 className="mt-2 max-w-2xl text-3xl font-black leading-tight sm:text-4xl">Your sports day, organized</h1>
+          <p className="mt-3 max-w-2xl text-sm font-semibold leading-6 text-primary-50 sm:text-base">
+            Keep schedules, team updates, player access, availability, and family tasks together in one trusted place.
+          </p>
+          <div className="mt-5 flex flex-col gap-2 sm:flex-row">
+            <Link to="/auth?mode=signup&next=%2Fhome" className="primary-button !min-h-11 justify-center !bg-white !bg-none !text-primary-700 hover:!bg-primary-50">
+              <UserPlus className="h-5 w-5" aria-hidden="true" />
+              Create account
+            </Link>
+            <Link to="/auth?next=%2Fhome" className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border border-white/40 bg-white/10 px-4 text-sm font-black text-white transition hover:bg-white/20">
+              <Shield className="h-5 w-5" aria-hidden="true" />
+              Sign in
+            </Link>
+          </div>
+        </div>
+        <div className="grid gap-3 bg-gray-50 p-3 sm:grid-cols-2 sm:p-4">
+          <PublicBenefitCard icon={CalendarDays} title="Know what is next" detail="See upcoming games, practices, availability requests, and assignments." />
+          <PublicBenefitCard icon={Users} title="Keep everyone connected" detail="Link players and teams to bring messages, packets, fees, and updates into Home." />
+        </div>
+      </section>
+
+      <section className="app-card flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-base font-black text-gray-950">Want to explore first?</h2>
+          <p className="mt-1 text-sm font-semibold text-gray-600">Browse public teams and sports opportunities without creating an account.</p>
+        </div>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <Link to="/discover" className="ghost-button !min-h-11 justify-center">Discover</Link>
+          <Link to="/teams/browse" className="ghost-button !min-h-11 justify-center">Find teams</Link>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function PublicBenefitCard({ icon: Icon, title, detail }: { icon: LucideIcon; title: string; detail: string }) {
+  return (
+    <div className="flex items-start gap-3 rounded-xl border border-gray-200 bg-white p-4">
+      <div className="flex h-11 w-11 flex-none items-center justify-center rounded-xl bg-primary-50 text-primary-700 ring-1 ring-primary-100">
+        <Icon className="h-5 w-5" aria-hidden="true" />
+      </div>
+      <div className="min-w-0">
+        <h2 className="text-sm font-black text-gray-950">{title}</h2>
+        <p className="mt-1 text-xs font-semibold leading-5 text-gray-600">{detail}</p>
+      </div>
+    </div>
+  );
+}
+
+function getHomeRoleContext(auth: AuthState, officialsAccess: { hasAccess: boolean; teamCount: number } | null) {
+  if (auth.isPlatformAdmin || auth.isAdmin) return 'Administration';
+  if (auth.isCoach) return 'Coach home';
+  if (officialsAccess?.hasAccess) return 'Official assignments';
+  if (auth.isParent) return 'Family home';
+  return 'Teams and updates';
 }
 
 function TodaySection({
@@ -885,7 +953,19 @@ function SignalCard({ icon: Icon, label, value, detail, to, urgent = false }: { 
 
 function PlayersSection({ players }: { players: ParentHomePlayer[] }) {
   if (!players.length) {
-    return <EmptyCard icon={UserRound} title="No players linked yet" detail="Redeem an invite code or request team access." />;
+    return (
+      <EmptyCard
+        icon={UserRound}
+        title="No players linked yet"
+        detail="Accept an invite or request access to bring a player's schedule and team activity into Home."
+        actions={(
+          <>
+            <Link to="/accept-invite" className="primary-button !min-h-11 justify-center text-sm">Accept invite</Link>
+            <Link to="/parent-tools/access" className="ghost-button !min-h-11 justify-center text-sm">Request player access</Link>
+          </>
+        )}
+      />
+    );
   }
 
   const rsvpPlayers = players.filter((player) => player.rsvpNeeded > 0);
@@ -915,7 +995,19 @@ function PlayersSection({ players }: { players: ParentHomePlayer[] }) {
 
 function TeamsSection({ teams, players }: { teams: ParentHomeTeam[]; players: ParentHomePlayer[] }) {
   if (!teams.length) {
-    return <EmptyCard icon={Users} title="No teams available" detail="Team access appears after a player is linked." />;
+    return (
+      <EmptyCard
+        icon={Users}
+        title="No teams available"
+        detail="Request player access for a private team or browse teams that are public."
+        actions={(
+          <>
+            <Link to="/parent-tools/access" className="primary-button !min-h-11 justify-center text-sm">Request player access</Link>
+            <Link to="/teams/browse" className="ghost-button !min-h-11 justify-center text-sm">Find teams</Link>
+          </>
+        )}
+      />
+    );
   }
 
   const rsvpTeamIds = [...new Set(players.filter((player) => player.rsvpNeeded > 0).map((player) => player.teamId))];
@@ -1174,31 +1266,33 @@ function FeedSection({
             <p className="mt-1 text-xs font-semibold text-gray-500">Posts and highlights shared by you, friends, and your teams.</p>
           </div>
           <div className="flex flex-none items-center gap-2">
-            <button type="button" className="ghost-button !h-9 !min-h-9 !w-9 !p-0" onClick={() => onRefresh()} disabled={loading} aria-label="Refresh feed" title="Refresh feed">
+            <button type="button" className="ghost-button !h-11 !min-h-11 !w-11 !p-0" onClick={() => onRefresh()} disabled={loading} aria-label="Refresh feed" title="Refresh feed">
               {loading ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <RefreshCw className="h-4 w-4" aria-hidden="true" />}
             </button>
-            {filter === 'opportunities' ? <Link to="/discover/new" className="primary-button !min-h-9 !px-3 text-xs">
+            {filter === 'opportunities' ? <Link to="/discover/new" className="primary-button !min-h-11 !px-3 text-xs">
               <Plus className="h-4 w-4" aria-hidden="true" />
               Post opportunity
-            </Link> : <button type="button" className="primary-button !min-h-9 !px-3 text-xs" onClick={() => onOpenComposer()}>
+            </Link> : <button type="button" className="primary-button !min-h-11 !px-3 text-xs" onClick={() => onOpenComposer()}>
               <Plus className="h-4 w-4" aria-hidden="true" />
               Post
             </button>}
           </div>
         </div>
-        <div className="overflow-x-auto border-b border-gray-100 px-3 py-2">
-          <div className="flex min-w-max gap-1">
-            {socialFeedFilters.map((option) => (
-              <button
-                key={option.id}
-                type="button"
-                className={`min-h-8 rounded-full px-3 text-xs font-black transition ${filter === option.id ? 'bg-gray-950 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-gray-950'}`}
-                onClick={() => setFilter(option.id)}
-                aria-pressed={filter === option.id}
-              >
-                {option.label}
-              </button>
-            ))}
+        <div className="feed-filter-nav relative border-b border-gray-100">
+          <div className="feed-filter-scroll overflow-x-auto px-3 py-2" role="group" aria-label="Feed filters">
+            <div className="flex min-w-max gap-1">
+              {socialFeedFilters.map((option) => (
+                <button
+                  key={option.id}
+                  type="button"
+                  className={`min-h-11 snap-start rounded-full px-3 text-xs font-black transition ${filter === option.id ? 'bg-gray-950 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-gray-950'}`}
+                  onClick={() => setFilter(option.id)}
+                  aria-pressed={filter === option.id}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
           </div>
         </div>
         <div className="grid gap-3 p-3 xl:grid-cols-[minmax(0,1fr)_280px]">
@@ -1216,7 +1310,16 @@ function FeedSection({
                 onOptimisticHide={setPostOptimisticallyHidden}
               />
             )) : (
-              <EmptyCard icon={Newspaper} title="No posts for this filter" detail={home.teams.length ? 'Try another filter or create a post for your team.' : 'Link a team or player to unlock team feed activity.'} />
+              <EmptyCard
+                icon={Newspaper}
+                title="No posts for this filter"
+                detail={home.teams.length ? 'Create the first update or choose another filter.' : 'Link a team or player to unlock team feed activity.'}
+                actions={home.teams.length ? (
+                  <button type="button" className="primary-button !min-h-11 justify-center text-sm" onClick={() => onOpenComposer()}>Create a post</button>
+                ) : (
+                  <Link to="/parent-tools/access" className="primary-button !min-h-11 justify-center text-sm">Link a player</Link>
+                )}
+              />
             )}
           </div>
           <aside className="space-y-3">
@@ -1230,18 +1333,21 @@ function FeedSection({
                 <MiniMetric label="Requests" value={social.metrics.incomingRequests} urgent={social.metrics.incomingRequests > 0} />
                 <MiniMetric label="Ideas" value={social.metrics.suggestions} />
               </div>
-              <Link to="/home?section=friends" className="mt-3 flex min-h-9 items-center justify-between rounded-lg bg-white px-3 text-xs font-black text-primary-700 ring-1 ring-gray-200">
+              <Link to="/home?section=friends" className="mt-3 flex min-h-11 items-center justify-between rounded-lg bg-white px-3 text-xs font-black text-primary-700 ring-1 ring-gray-200">
                 Manage friends
                 <ChevronRight className="h-4 w-4" aria-hidden="true" />
               </Link>
             </section>
-            <section className="rounded-xl border border-primary-100 bg-primary-50 p-3">
-              <div className="flex items-center gap-2 text-sm font-black text-primary-900">
-                <Sparkles className="h-4 w-4 text-primary-700" aria-hidden="true" />
-                Quick shares
-              </div>
+            <details className="group rounded-xl border border-primary-100 bg-primary-50 p-3">
+              <summary className="flex min-h-11 cursor-pointer list-none items-center justify-between gap-2 text-sm font-black text-primary-900">
+                <span className="flex items-center gap-2">
+                  <Sparkles className="h-4 w-4 text-primary-700" aria-hidden="true" />
+                  Quick shares
+                </span>
+                <ChevronRight className="h-4 w-4 flex-none text-primary-500 transition group-open:rotate-90" aria-hidden="true" />
+              </summary>
               <div className="mt-2 grid gap-2">
-                <Link to="/discover/new" className="flex min-h-10 items-center justify-between rounded-lg bg-amber-50 px-3 text-left text-xs font-black text-amber-900 ring-1 ring-amber-100">
+                <Link to="/discover/new" className="flex min-h-11 items-center justify-between rounded-lg bg-amber-50 px-3 text-left text-xs font-black text-amber-900 ring-1 ring-amber-100">
                   Post public opportunity
                   <ChevronRight className="h-4 w-4 flex-none text-amber-600" aria-hidden="true" />
                 </Link>
@@ -1249,7 +1355,7 @@ function FeedSection({
                   <button
                     key={preset.id}
                     type="button"
-                    className="flex min-h-10 items-center justify-between rounded-lg bg-white px-3 text-left text-xs font-black text-primary-900 ring-1 ring-primary-100 transition hover:ring-primary-300"
+                    className="flex min-h-11 items-center justify-between rounded-lg bg-white px-3 text-left text-xs font-black text-primary-900 ring-1 ring-primary-100 transition hover:ring-primary-300"
                     onClick={() => onOpenComposer(preset.type)}
                   >
                     {preset.label}
@@ -1257,7 +1363,7 @@ function FeedSection({
                   </button>
                 ))}
               </div>
-            </section>
+            </details>
           </aside>
         </div>
       </div>
@@ -1579,7 +1685,9 @@ function FriendsSection({
           <h2 className="mt-1 app-section-title">Friends</h2>
           <p className="mt-1 text-xs font-semibold leading-5 text-gray-500">Find trusted families, approve requests, and choose who can see player moments.</p>
           <form className="mt-3 flex gap-2" onSubmit={handleSearch}>
+            <label htmlFor="home-friend-search" className="sr-only">Search friends by name, email, or team</label>
             <input
+              id="home-friend-search"
               value={queryText}
               onChange={(event) => setQueryText(event.target.value)}
               className="min-h-11 min-w-0 flex-1 rounded-xl border border-gray-200 bg-gray-50 px-3 text-sm font-semibold outline-none focus:border-primary-400 focus:bg-white focus:ring-2 focus:ring-primary-100"
@@ -1598,7 +1706,7 @@ function FriendsSection({
                 <div className="text-sm font-black text-rose-800">Couldn't load friend requests</div>
                 <div className="mt-0.5 text-xs font-semibold text-rose-700">{social.friendshipsError}</div>
               </div>
-              <button type="button" className="secondary-button !min-h-9" onClick={() => onRefresh()} disabled={loading}>Retry</button>
+              <button type="button" className="secondary-button !min-h-11" onClick={() => onRefresh()} disabled={loading}>Retry</button>
             </div>
           ) : null}
 
@@ -2304,12 +2412,13 @@ function PlayerAvatar({ name }: { name: string }) {
   );
 }
 
-function EmptyCard({ icon: Icon, title, detail }: { icon: LucideIcon; title: string; detail: string }) {
+function EmptyCard({ icon: Icon, title, detail, actions }: { icon: LucideIcon; title: string; detail: string; actions?: ReactNode }) {
   return (
     <section className="app-card p-5 text-center">
       <Icon className="mx-auto h-8 w-8 text-gray-300" aria-hidden="true" />
       <div className="mt-3 text-sm font-black text-gray-900">{title}</div>
       <div className="mt-1 text-xs font-semibold text-gray-500">{detail}</div>
+      {actions ? <div className="mx-auto mt-4 grid max-w-md gap-2 sm:grid-cols-2">{actions}</div> : null}
     </section>
   );
 }
@@ -2317,11 +2426,11 @@ function EmptyCard({ icon: Icon, title, detail }: { icon: LucideIcon; title: str
 function HomeLoadErrorState({ error, onRetry, retrying }: { error: AppServiceError | null; onRetry: () => void; retrying: boolean }) {
   const copy = getHomeLoadErrorStateCopy(error);
   return (
-    <section className="app-card p-5 text-center">
+    <section className="app-card p-5 text-center" role="alert">
       <AlertCircle className="mx-auto h-8 w-8 text-rose-400" aria-hidden="true" />
-      <div className="mt-3 text-sm font-black text-gray-900">{copy.title}</div>
+      <h2 className="mt-3 text-sm font-black text-gray-900">{copy.title}</h2>
       <div className="mt-1 text-xs font-semibold text-gray-500">{copy.detail}</div>
-      <button type="button" className="primary-button mx-auto mt-4 !min-h-10 !px-4 text-sm" onClick={onRetry} disabled={retrying} aria-label="Retry loading Home">
+      <button type="button" className="primary-button mx-auto mt-4 !min-h-11 !px-4 text-sm" onClick={onRetry} disabled={retrying} aria-label="Retry loading Home">
         {retrying ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <RefreshCw className="h-4 w-4" aria-hidden="true" />}
         Retry
       </button>
@@ -2332,7 +2441,12 @@ function HomeLoadErrorState({ error, onRetry, retrying }: { error: AppServiceErr
 function Status({ tone, message }: { tone: 'error' | 'success'; message: string }) {
   const isError = tone === 'error';
   return (
-    <div className={`flex items-start gap-2 rounded-xl border px-3 py-2 text-sm font-semibold ${isError ? 'border-rose-200 bg-rose-50 text-rose-800' : 'border-emerald-200 bg-emerald-50 text-emerald-800'}`}>
+    <div
+      className={`flex items-start gap-2 rounded-xl border px-3 py-2 text-sm font-semibold ${isError ? 'border-rose-200 bg-rose-50 text-rose-800' : 'border-emerald-200 bg-emerald-50 text-emerald-800'}`}
+      role={isError ? 'alert' : 'status'}
+      aria-live={isError ? 'assertive' : 'polite'}
+      aria-atomic="true"
+    >
       {isError ? <AlertCircle className="mt-0.5 h-4 w-4 flex-none" aria-hidden="true" /> : <CheckCircle2 className="mt-0.5 h-4 w-4 flex-none" aria-hidden="true" />}
       {message}
     </div>

--- a/apps/app/src/styles/index.css
+++ b/apps/app/src/styles/index.css
@@ -417,6 +417,36 @@
   font-size: 1rem;
 }
 
+.home-section-scroll,
+.feed-filter-scroll {
+  scroll-snap-type: x proximity;
+  scrollbar-width: none;
+}
+
+.home-section-scroll::-webkit-scrollbar,
+.feed-filter-scroll::-webkit-scrollbar {
+  display: none;
+}
+
+.home-section-nav::after,
+.feed-filter-nav::after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 28px;
+  content: '';
+  pointer-events: none;
+}
+
+.home-section-nav::after {
+  background: linear-gradient(to left, rgba(246, 248, 251, 0.98), rgba(246, 248, 251, 0));
+}
+
+.feed-filter-nav::after {
+  background: linear-gradient(to left, #fff, rgba(255, 255, 255, 0));
+}
+
 @media (max-width: 639px) {
   .home-signal-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -524,7 +554,10 @@
   align-items: start;
 }
 
-.desktop-app-page .home-page-live,
+.desktop-app-page .home-page-live {
+  display: block;
+}
+
 .desktop-app-page .player-detail-page {
   display: grid;
   grid-template-columns: 236px minmax(0, 1fr);
@@ -537,12 +570,48 @@
   grid-column: 1 / -1;
 }
 
-.desktop-app-page .home-page-live .home-hero,
+.desktop-app-page .home-page-live .home-hero {
+  margin-bottom: 12px;
+}
+
 .desktop-app-page .player-detail-page .player-summary-card {
   grid-column: 1 / -1;
 }
 
-.desktop-app-page .home-page-live .home-section-nav,
+.desktop-app-page .home-page-live .home-section-nav {
+  top: 65px;
+  margin: 0 0 12px;
+  overflow: visible;
+  background: #f6f8fb;
+  padding: 8px 0;
+}
+
+.desktop-app-page .home-page-live .home-section-nav::after {
+  display: none;
+}
+
+.desktop-app-page .home-page-live .home-section-scroll {
+  overflow: visible;
+  padding: 0;
+}
+
+.desktop-app-page .home-page-live .home-section-scroll > div {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 4px;
+  border-radius: 12px;
+  padding: 6px;
+}
+
+.desktop-app-page .home-page-live .home-section-nav a {
+  justify-content: center;
+  border-radius: 10px;
+  padding-left: 12px;
+  padding-right: 12px;
+  text-align: center;
+}
+
 .desktop-app-page .player-detail-page .player-section-nav {
   grid-column: 1;
   top: 84px;
@@ -552,7 +621,6 @@
   padding: 0;
 }
 
-.desktop-app-page .home-page-live .home-section-nav > div,
 .desktop-app-page .player-detail-page .player-section-nav > div {
   display: flex;
   min-width: 0;
@@ -562,7 +630,6 @@
   padding: 8px;
 }
 
-.desktop-app-page .home-page-live .home-section-nav button,
 .desktop-app-page .player-detail-page .player-section-nav button {
   justify-content: flex-start;
   border-radius: 10px;
@@ -571,9 +638,6 @@
   text-align: left;
 }
 
-.desktop-app-page .home-page-live .home-section-content,
-.desktop-app-page .home-page-live > .app-card:not(.home-hero),
-.desktop-app-page .home-page-live > .home-upcoming-section,
 .desktop-app-page .player-detail-page .player-section-content,
 .desktop-app-page .player-detail-page > .app-card:not(.player-summary-card) {
   grid-column: 2;

--- a/spec/home-ux/design.md
+++ b/spec/home-ux/design.md
@@ -1,0 +1,83 @@
+# Home UX Improvements — Design
+
+## Design principles
+
+- **State before features:** public visitors see an honest welcome; personalized
+  tools appear only after authentication.
+- **One next action:** the priority card owns the most important task while
+  signals summarize categories and the remaining list excludes the priority.
+- **Mobile-first reachability:** navigation may scroll, but never silently clips
+  without an edge cue and active-item positioning.
+- **Use the existing system:** reuse app cards, buttons, route patterns, colors,
+  typography, and Lucide icons.
+
+## Public welcome
+
+Signed-out Home becomes a single-column welcome experience:
+
+1. Brand/value card with the neutral headline `Your sports day, organized`.
+2. Primary Create account and secondary Sign in actions.
+3. Two compact benefit cards covering schedules/actions and team connection.
+4. Public Discover and Find teams links for users who are not ready to create an
+   account.
+
+The welcome state deliberately excludes the personalized date hero, status
+metrics, social composer, Refresh, and Home section navigation.
+
+## Signed-in hero
+
+- Date tile remains as the visual anchor.
+- Heading becomes `Your day`, which remains meaningful on narrow screens.
+- The badge uses `N open`, `Loading`, or `Caught up`.
+- Supporting copy combines display name with the strongest available context:
+  administrator, coach, official, parent, or general member.
+- Refresh becomes a 44px target.
+- Desktop metrics remain concise and no longer repeat the top priority action or
+  a second caught-up chip.
+
+## Home section navigation
+
+The existing section query routes remain canonical. The UI becomes a labeled
+`nav` containing links with `aria-current="page"`.
+
+- Mobile: horizontal scroller, 44px links, scroll snapping, hidden scrollbar,
+  right-edge fade, and active-link `scrollIntoView`.
+- Desktop: the same control renders as a five-column horizontal segmented row
+  across the content width.
+
+This removes the nested desktop sidebar while retaining direct links and browser
+history behavior.
+
+## Feed navigation and empty state
+
+Feed filters use the same reachability treatment: 44px chips, snapping, and an
+edge fade. The empty Feed card receives one contextual primary action:
+
+- linked team: `Create a post`
+- no linked team: `Link a player`
+
+Quick Shares remains available as a collapsed disclosure so it does not compete
+with the empty state on mobile.
+
+## Empty-state component
+
+`EmptyCard` accepts an optional action region. Players and Teams use this region
+for two compact CTAs while existing call sites continue to render unchanged.
+
+## Accessibility feedback
+
+The existing `Status` visual treatment remains. Error variants receive
+`role="alert"`; success variants receive `role="status"`, `aria-live="polite"`,
+and atomic announcements. Friend search receives a persistent label associated
+with its input.
+
+## Compatibility and risk
+
+- No service or Firestore contracts change.
+- No native-specific code changes.
+- Existing URLs remain valid.
+- The largest regression risk is Home component behavior because it combines
+  progressive loading and social state. Focused component tests cover public,
+  authenticated, error, and section-navigation paths.
+- CSS changes are scoped to Home class names so player-detail desktop navigation
+  remains unchanged.

--- a/spec/home-ux/requirements.md
+++ b/spec/home-ux/requirements.md
@@ -1,0 +1,94 @@
+# Home UX Improvements — Requirements
+
+## Context
+
+The React/Capacitor Home route currently renders the personalized dashboard for
+signed-out visitors, including account-like zero metrics and controls whose
+handlers require an authenticated user. The signed-in dashboard also needs a
+clearer mobile navigation pattern, more actionable empty states, role-aware
+copy, and stronger assistive-technology feedback.
+
+This work implements GitHub issue #4056 for the shared web, iOS, and Android
+React experience.
+
+## User stories
+
+1. As a signed-out visitor, I want a clear welcome and authentication choice so
+   I do not mistake an empty preview for my account.
+2. As a signed-in user, I want Home to identify the next important action and
+   upcoming event without repeating the same task.
+3. As a phone user, I want every Home section and Feed filter to remain
+   discoverable and easy to tap.
+4. As a new parent or team member, I want empty states to tell me what to do
+   next and take me there.
+5. As a coach, parent, official, or administrator, I want Home copy to reflect
+   my context without assuming I only manage players.
+6. As an assistive-technology user, I want navigation and asynchronous feedback
+   announced with the correct semantics.
+
+## Functional requirements
+
+### Signed-out state
+
+- `/home` and signed-out root routing shall render a dedicated welcome state.
+- The welcome state shall include working Sign in and Create account actions.
+- Authentication actions shall preserve `/home` as the safe next route.
+- Personalized metrics, Refresh, Home section navigation, Feed composer, and
+  friend search shall not render while signed out.
+- The public state shall explain the benefits of linking players and teams
+  without fabricating personalized data.
+
+### Signed-in Home
+
+- Home shall continue to default to the Today section.
+- Today, Players, Teams, Feed, and Friends shall remain directly addressable by
+  their existing query-string routes.
+- The hero shall use a role-neutral title, identify the signed-in user, and show
+  an explicit open-action or caught-up state.
+- Supporting hero copy shall prefer administrator, coach, official, or parent
+  context when available.
+- Today shall exclude its priority action from the remaining-action list.
+- Existing loading, progressive hydration, retry, pull-to-refresh, and social
+  behavior shall remain intact.
+
+### Responsive interaction
+
+- Home shall avoid document-level horizontal overflow at 320px and wider.
+- The active Home section shall expose `aria-current="page"` and be scrolled
+  into view when necessary.
+- Overflowing Home navigation and Feed filters shall provide a visible edge cue
+  and scroll snapping.
+- Frequent mobile Home controls shall be at least 44px high.
+- Desktop Home shall use a compact horizontal section navigation instead of a
+  second 236px sidebar.
+
+### Empty states
+
+- Players shall offer Accept invite and Request player access actions.
+- Teams shall offer Request player access and Find teams actions.
+- An empty Feed shall provide one primary action based on whether a team is
+  already linked.
+- Friend search shall have a persistent accessible label.
+
+### Accessibility
+
+- Home section navigation shall have an accessible navigation label.
+- Errors shall use alert semantics.
+- Success and non-critical status feedback shall use polite status semantics.
+- Existing modal focus trapping, Escape handling, meaningful control names,
+  and hidden decorative icons shall be preserved.
+
+## Acceptance criteria
+
+- Signed-out Home contains no personalized zero metrics or no-op controls.
+- Signed-out Sign in and Create account links target the existing auth route and
+  preserve `/home` as `next`.
+- All five Home destinations and all Feed filters remain reachable at 320px and
+  390px.
+- The Home and Feed scrollers do not increase document width.
+- The hero never displays the ambiguous status label `Clear`.
+- Parent, coach, official, and admin contexts produce appropriate supporting
+  copy.
+- Players, Teams, and empty Feed states contain working next-step actions.
+- Async error and success feedback is detectable by role.
+- Focused Home tests, app build, and relevant smoke/browser validation pass.

--- a/spec/home-ux/validation-log.md
+++ b/spec/home-ux/validation-log.md
@@ -16,7 +16,8 @@
 Completed July 18, 2026.
 
 - `npx vitest run apps/app/src/pages/Home.test.tsx apps/app/src/components/AppShell.test.tsx --reporter=verbose`
-  - Passed: 65 tests across 2 files.
+  - Passed: 68 tests across 2 files, including roleless signed-in shell context,
+    assignment/rideshare badge counts, and the single-priority to-do state.
 - `npm run app:build`
   - Passed TypeScript, Vite production build, production artifact verification,
     and bundle visualizer verification.

--- a/spec/home-ux/validation-log.md
+++ b/spec/home-ux/validation-log.md
@@ -1,0 +1,44 @@
+# Home UX Improvements — Validation Log
+
+## Required checks
+
+- Focused Home component tests.
+- App TypeScript/Vite production build.
+- Relevant app smoke test or equivalent local browser boot validation.
+- Responsive browser validation at 320x720, 390x844, tablet, and desktop.
+- DOM checks for document overflow, current-section semantics, and live-region
+  roles.
+- Visual review of signed-out Home and signed-in states available in automated
+  fixtures.
+
+## Results
+
+Completed July 18, 2026.
+
+- `npx vitest run apps/app/src/pages/Home.test.tsx apps/app/src/components/AppShell.test.tsx --reporter=verbose`
+  - Passed: 65 tests across 2 files.
+- `npm run app:build`
+  - Passed TypeScript, Vite production build, production artifact verification,
+    and bundle visualizer verification.
+- `npm --prefix apps/app run lint`
+  - Passed with 0 errors. The command reports 2,547 existing repository
+    warnings; this change does not make warnings fatal.
+- `SMOKE_APP_BASE_URL=http://127.0.0.1:5174 npx playwright test tests/smoke/app-home-player.spec.js --config=playwright.smoke.config.js --reporter=line`
+  - Passed: all 9 Home/player workflow tests, including the 320px and 1440px
+    Home workspace cases and existing telemetry baselines.
+- In-app browser visual and DOM review:
+  - 320x720: no document overflow (`scrollWidth === innerWidth === 320`),
+    all four welcome actions remained in bounds, and each measured 44px high.
+  - 390x844: no document overflow (`scrollWidth === innerWidth === 390`) and
+    all welcome actions measured 44px high.
+  - 768x1024: no document overflow (`scrollWidth === innerWidth === 768`),
+    benefit cards and public actions formed a stable tablet layout.
+  - Desktop: welcome content remained centered inside the app workspace and
+    primary actions measured 44px high.
+  - Visual inspection found and fixed one CTA contrast defect caused by the
+    shared primary-button gradient. The final Create account CTA computes to a
+    white background, no background image, and indigo text.
+
+The signed-in Today, Feed, Players, Teams, Friends, social quick-share, player
+drill-in, mobile overflow, desktop navigation, and telemetry workflows were
+validated through the module-mocked app smoke fixture.

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -1215,7 +1215,7 @@ test('home dashboard drills into player detail with section submenus', async ({ 
     await mockHomePlayerModules(page);
     await page.goto(appUrl(baseURL, '/home'), { waitUntil: 'domcontentloaded' });
 
-    await expect(page.getByRole('heading', { name: 'Today for your players' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Your day' })).toBeVisible();
     await expect(page.getByText('Do first')).toBeVisible();
     await expect(page.getByText('Team chats')).toBeVisible();
     await expect(page.getByText('2 unread messages')).toBeVisible();
@@ -1227,16 +1227,18 @@ test('home dashboard drills into player detail with section submenus', async ({ 
         const box = await page.locator('.home-hero').boundingBox();
         return Math.round(box?.height || 0);
     }).toBeLessThan(170);
+    const homeSectionNavigation = page.getByRole('navigation', { name: 'Home sections' });
 
-    await page.getByRole('button', { name: 'Teams' }).click();
+    await homeSectionNavigation.getByRole('link', { name: 'Teams', exact: true }).click();
     await expect(page.locator('a[href="#/teams?selectedTeamId=team-1&from=home"]')).toBeVisible();
 
-    await page.getByRole('button', { name: 'Feed' }).click();
+    await homeSectionNavigation.getByRole('link', { name: 'Feed', exact: true }).click();
     await expect(page.getByText('Quick shares')).toBeVisible();
     await expect(page.getByText('Jamie Friend')).toBeVisible();
     await expect(page.getByText('Great ball movement in the second half.')).toBeVisible();
     await expect(page.locator('a[href="#/players/team-1/player-1"]').first()).toBeVisible();
-    await expect(page.locator('a[href="#/home?section=friends"]')).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Manage friends' })).toHaveAttribute('href', '#/home?section=friends');
+    await page.getByText('Quick shares').click();
     await page.getByRole('button', { name: 'Player moment' }).click();
     await expect(page.getByRole('heading', { name: 'What happened?' })).toBeVisible();
     await expect(page.getByText('Pick one')).toHaveCount(0);
@@ -1256,13 +1258,13 @@ test('home dashboard drills into player detail with section submenus', async ({ 
         playerIds: ['player-1']
     }));
 
-    await page.locator('.home-section-nav').getByRole('button', { name: 'Friends' }).click();
+    await page.locator('.home-section-nav').getByRole('link', { name: 'Friends' }).click();
     await expect(page.getByText('Needs response')).toBeVisible();
     await expect(page.getByText('Casey Parent')).toBeVisible();
     await expect(page.getByText('Morgan Parent')).toBeVisible();
     await expect(page.getByText('Jamie Friend')).toBeVisible();
 
-    await page.getByRole('button', { name: 'Players' }).click();
+    await homeSectionNavigation.getByRole('link', { name: 'Players', exact: true }).click();
     await expect(page.getByRole('heading', { name: 'My players' })).toBeVisible();
     await page.locator('a[href="#/players/team-1/player-1"]').click();
 
@@ -1369,7 +1371,7 @@ test('parent core workflows emit baseline timers from Home drill-ins', async ({ 
             startHash: '/home',
             expectedTargetPage: 'schedule',
             expectedTargetRoute: '/schedule',
-            readyHome: (testPage) => testPage.getByRole('heading', { name: 'Today for your players' }),
+            readyHome: (testPage) => testPage.getByRole('heading', { name: 'Your day' }),
             action: async (testPage) => {
                 await testPage.locator('.home-upcoming-section a[href="#/schedule"]').click();
             },
@@ -1383,7 +1385,7 @@ test('parent core workflows emit baseline timers from Home drill-ins', async ({ 
             startHash: '/home',
             expectedTargetPage: 'schedule_event',
             expectedTargetRoute: '/schedule/team-1/game-next?childId=player-1&section=availability',
-            readyHome: (testPage) => testPage.getByRole('heading', { name: 'Today for your players' }),
+            readyHome: (testPage) => testPage.getByRole('heading', { name: 'Your day' }),
             action: async (testPage) => {
                 await testPage.getByRole('link', { name: /Open action/ }).click();
             },
@@ -1422,7 +1424,7 @@ test('parent core workflows emit baseline timers from Home drill-ins', async ({ 
             startHash: '/home',
             expectedTargetPage: 'messages',
             expectedTargetRoute: '/messages/team-1',
-            readyHome: (testPage) => testPage.getByRole('heading', { name: 'Today for your players' }),
+            readyHome: (testPage) => testPage.getByRole('heading', { name: 'Your day' }),
             action: async (testPage) => {
                 await testPage.locator('a[href="#/messages/team-1"]').first().click();
             },
@@ -1435,7 +1437,7 @@ test('parent core workflows emit baseline timers from Home drill-ins', async ({ 
             startHash: '/home',
             expectedTargetPage: 'fees',
             expectedTargetRoute: '/parent-tools/fees',
-            readyHome: (testPage) => testPage.getByRole('heading', { name: 'Today for your players' }),
+            readyHome: (testPage) => testPage.getByRole('heading', { name: 'Your day' }),
             action: async (testPage) => {
                 await testPage.locator('a[href="#/parent-tools/fees"]').click();
             },
@@ -1448,7 +1450,7 @@ test('parent core workflows emit baseline timers from Home drill-ins', async ({ 
             startHash: '/home',
             expectedTargetPage: 'officials',
             expectedTargetRoute: '/officials',
-            readyHome: (testPage) => testPage.getByRole('heading', { name: 'Today for your players' }),
+            readyHome: (testPage) => testPage.getByRole('heading', { name: 'Your day' }),
             action: async (testPage) => {
                 await testPage.locator('a[href="#/officials"]').click();
             },
@@ -1526,7 +1528,7 @@ test('requested app workflows emit DB-ready view load baseline timers', async ({
             route: '/home',
             startHash: '/home',
             ready: async (testPage) => {
-                await waitForHomeRoute(testPage, testPage.getByRole('heading', { name: 'Today for your players' }));
+                await waitForHomeRoute(testPage, testPage.getByRole('heading', { name: 'Your day' }));
             }
         },
         {
@@ -1868,6 +1870,36 @@ test('my teams opens from Home data with selected team, player, and chat routes'
     await expect(page.getByText('Yours')).toBeVisible();
 });
 
+test.describe('narrow mobile Home workspace', () => {
+    test.use({ viewport: { width: 320, height: 720 }, hasTouch: true });
+
+    test('keeps section navigation and feed controls reachable without page overflow', async ({ page, baseURL }) => {
+        await mockHomePlayerModules(page);
+        await page.goto(appUrl(baseURL, '/home'), { waitUntil: 'domcontentloaded' });
+
+        await waitForHomeRoute(page, page.getByRole('heading', { name: 'Your day' }));
+        const sectionNav = page.getByRole('navigation', { name: 'Home sections' });
+        await expect(sectionNav.getByRole('link')).toHaveCount(5);
+        await expect(sectionNav.getByRole('link', { name: 'Today' })).toHaveAttribute('aria-current', 'page');
+
+        await sectionNav.getByRole('link', { name: 'Friends' }).click();
+        await expect(sectionNav.getByRole('link', { name: 'Friends' })).toHaveAttribute('aria-current', 'page');
+        await expect(page.getByRole('heading', { name: 'Friends', exact: true })).toBeVisible();
+
+        await sectionNav.getByRole('link', { name: 'Feed' }).click();
+        const feedFilters = page.getByRole('group', { name: 'Feed filters' });
+        await expect(feedFilters).toBeVisible();
+        const opportunitiesFilter = feedFilters.getByRole('button', { name: 'Opportunities' });
+        await opportunitiesFilter.scrollIntoViewIfNeeded();
+        await expect(opportunitiesFilter).toBeVisible();
+        await expect.poll(async () => {
+            const box = await opportunitiesFilter.boundingBox();
+            return Math.round(box?.height || 0);
+        }).toBeGreaterThanOrEqual(44);
+        await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
+    });
+});
+
 test.describe('desktop Home workspace', () => {
     test.use({ viewport: { width: 1440, height: 900 }, hasTouch: false });
 
@@ -1875,12 +1907,13 @@ test.describe('desktop Home workspace', () => {
         await mockHomePlayerModules(page);
         await page.goto(appUrl(baseURL, '/home'), { waitUntil: 'domcontentloaded' });
 
-        await waitForHomeRoute(page, page.getByRole('heading', { name: 'Today for your players' }));
-        await expect(page.getByRole('button', { name: 'Today' })).toHaveAttribute('aria-pressed', 'true');
-        await expect(page.getByRole('button', { name: 'Feed' })).toBeVisible();
-        await expect(page.getByRole('button', { name: 'Players' })).toBeVisible();
-        await expect(page.getByRole('button', { name: 'Teams' })).toBeVisible();
-        await expect(page.getByRole('button', { name: 'Friends' })).toBeVisible();
+        await waitForHomeRoute(page, page.getByRole('heading', { name: 'Your day' }));
+        const sectionNav = page.getByRole('navigation', { name: 'Home sections' });
+        await expect(sectionNav.getByRole('link', { name: 'Today', exact: true })).toHaveAttribute('aria-current', 'page');
+        await expect(sectionNav.getByRole('link', { name: 'Feed', exact: true })).toBeVisible();
+        await expect(sectionNav.getByRole('link', { name: 'Players', exact: true })).toBeVisible();
+        await expect(sectionNav.getByRole('link', { name: 'Teams', exact: true })).toBeVisible();
+        await expect(sectionNav.getByRole('link', { name: 'Friends', exact: true })).toBeVisible();
         await expect.poll(async () => {
             const box = await page.locator('.home-hero').boundingBox();
             return Math.round(box?.height || 0);

--- a/tests/unit/app-home-player-integration.test.jsx
+++ b/tests/unit/app-home-player-integration.test.jsx
@@ -144,6 +144,22 @@ function buttonByText(container, text) {
     return button;
 }
 
+function linkByText(container, text) {
+    const link = Array.from(container.querySelectorAll('a')).find((candidate) => candidate.textContent.trim() === text);
+    if (!link) {
+        throw new Error(`Link not found: ${text}`);
+    }
+    return link;
+}
+
+function summaryByText(container, text) {
+    const summary = Array.from(container.querySelectorAll('summary')).find((candidate) => candidate.textContent.trim() === text);
+    if (!summary) {
+        throw new Error(`Summary not found: ${text}`);
+    }
+    return summary;
+}
+
 function buttonByAriaLabel(container, label) {
     const button = Array.from(container.querySelectorAll('button')).find((candidate) => candidate.getAttribute('aria-label') === label);
     if (!button) {
@@ -155,6 +171,20 @@ function buttonByAriaLabel(container, label) {
 async function clickButton(container, text) {
     await act(async () => {
         buttonByText(container, text).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flush();
+}
+
+async function clickLink(container, text) {
+    await act(async () => {
+        linkByText(container, text).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flush();
+}
+
+async function clickSummary(container, text) {
+    await act(async () => {
+        summaryByText(container, text).dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     await flush();
 }
@@ -539,7 +569,7 @@ afterEach(async () => {
 describe('React app Home and player drill-in integration', () => {
     it('uses the section submenu pattern and navigates from Home to the team-scoped player page', async () => {
         const { container } = await renderApp('/home');
-        await waitForText(container, 'Today for your players');
+        await waitForText(container, 'Your day');
         await waitForText(container, 'Do first');
         expect(container.textContent).toContain('Team chats');
         expect(container.textContent).toContain('2 unread messages');
@@ -553,13 +583,13 @@ describe('React app Home and player drill-in integration', () => {
             teams: expect.any(Array)
         }));
 
-        await clickButton(container, 'Teams');
+        await clickLink(container, 'Teams');
         await waitForText(container, 'Teams');
         const teamLink = Array.from(container.querySelectorAll('a')).find((link) => link.getAttribute('href') === '/teams?selectedTeamId=team-1&from=home');
         expect(teamLink?.getAttribute('href')).toBe('/teams?selectedTeamId=team-1&from=home');
         expect(teamLink?.getAttribute('aria-label')).toBe('Open Bears in My Teams');
 
-        await clickButton(container, 'Feed');
+        await clickLink(container, 'Feed');
         await waitForText(container, 'Quick shares');
         expect(container.textContent).toContain('Jamie Friend');
         expect(container.textContent).toContain('Great ball movement in the second half.');
@@ -567,6 +597,7 @@ describe('React app Home and player drill-in integration', () => {
             '/players/team-1/player-1',
             '/home?section=friends'
         ]));
+        await clickSummary(container, 'Quick shares');
         await clickButton(container, 'Player moment');
         await waitForText(container, 'What happened?');
         expect(container.textContent).not.toContain('Pick one');
@@ -585,7 +616,7 @@ describe('React app Home and player drill-in integration', () => {
             playerIds: ['player-1']
         }));
 
-        await clickButton(container, 'Friends');
+        await clickLink(container, 'Friends');
         await waitForText(container, 'Needs response');
         expect(container.textContent).toContain('Casey Parent');
         expect(container.textContent).toContain('Morgan Parent');
@@ -593,7 +624,7 @@ describe('React app Home and player drill-in integration', () => {
         await clickButton(container, 'Accept');
         expect(socialMocks.respondToFriendRequest).toHaveBeenCalledWith('friendship-3', 'accepted');
 
-        await clickButton(container, 'Players');
+        await clickLink(container, 'Players');
         await waitForText(container, 'My players');
         const playerLink = Array.from(container.querySelectorAll('a')).find((link) => link.getAttribute('href') === '/players/team-1/player-1');
         expect(playerLink?.getAttribute('href')).toBe('/players/team-1/player-1');
@@ -912,19 +943,19 @@ describe('React app Home and player drill-in integration', () => {
         });
 
         const { container } = await renderApp('/home');
-        await waitForText(container, 'Today for your players');
+        await waitForText(container, 'Your day');
         expect(container.textContent).toContain('3 unread messages');
         expect(container.textContent).toContain('Staff Wolves');
         expect(container.textContent).toContain('All caught up');
         expect(container.textContent).toContain('No upcoming events');
 
-        await clickButton(container, 'Teams');
+        await clickLink(container, 'Teams');
         await waitForText(container, 'Coach · Soccer');
         const teamLink = Array.from(container.querySelectorAll('a')).find((link) => link.getAttribute('href') === '/teams?selectedTeamId=team-staff&from=home');
         expect(teamLink).toBeTruthy();
         expect(teamLink?.getAttribute('aria-label')).toBe('Open Staff Wolves in My Teams');
 
-        await clickButton(container, 'Players');
+        await clickLink(container, 'Players');
         await waitForText(container, 'No players linked yet');
     });
 

--- a/tests/unit/app-home-player-integration.test.jsx
+++ b/tests/unit/app-home-player-integration.test.jsx
@@ -576,7 +576,10 @@ describe('React app Home and player drill-in integration', () => {
         expect(container.textContent).toContain('Team feed');
         expect(container.textContent).toContain('Pat Star highlight');
         expect(container.textContent).toContain('Next up');
-        await waitForText(container, 'More to do');
+        await waitForText(container, 'Priority only');
+        expect(container.textContent).toContain('Priority shown above');
+        expect(container.textContent).toContain('Your only open action is highlighted above.');
+        expect(container.textContent).not.toContain('No parent actions need attention right now.');
         expect(homeMocks.loadParentHome).toHaveBeenCalledWith(auth.user);
         expect(socialMocks.loadSocialHome).toHaveBeenCalledWith(auth.user, expect.objectContaining({
             players: expect.any(Array),


### PR DESCRIPTION
Closes #4056

## Summary

- replace the misleading signed-out personalized Home preview with a dedicated public welcome and working auth/public-exploration paths
- clarify the signed-in hero with role-aware context, a single priority presentation, and explicit loading/open/caught-up states
- make Home sections and Feed filters semantic, reachable horizontal navigation with 44px targets and desktop compaction
- add actionable Players, Teams, and Feed empty states plus accessible friend search and live feedback
- document requirements, design decisions, risks, and validation evidence in `spec/home-ux/`

## Design

The implementation keeps all existing Home query routes and shared React/Capacitor behavior. It reuses the current card/button/icon system, uses links with `aria-current="page"`, keeps public and personalized states honest, and scopes CSS changes to Home navigation.

## Validation

- 65 focused Home/AppShell component tests passed
- all 9 `app-home-player.spec.js` smoke scenarios passed
- `npm run app:build` passed TypeScript, Vite, artifact, and bundle visualizer checks
- app ESLint passed with 0 errors (existing warnings remain)
- visual/DOM review passed at 320x720, 390x844, 768x1024, and desktop
- no document overflow at validated mobile/tablet sizes; primary controls measured at least 44px
- visual review found and fixed the signed-out Create account CTA contrast regression before publication

## Test commands

```sh
npx vitest run apps/app/src/pages/Home.test.tsx apps/app/src/components/AppShell.test.tsx --reporter=verbose
npm run app:build
npm --prefix apps/app run lint
SMOKE_APP_BASE_URL=http://127.0.0.1:5174 npx playwright test tests/smoke/app-home-player.spec.js --config=playwright.smoke.config.js --reporter=line
```
