### PR TITLE
Keep player profile available on schedule timeout

### DIFF
--- a/apps/app/src/lib/playerService.ts
+++ b/apps/app/src/lib/playerService.ts
@@ -203,7 +203,8 @@ export async function loadParentPlayerDetail(user: AuthUser | null, teamId: stri
   const linkedChild = findLinkedChild(schedule.children, teamId, playerId);
   const initialTeam = await getTeam(requestedTeamId, { includeInactive: true });
   const routeAccess = buildPlayerAccess(user, requestedTeamId, requestedPlayerId, initialTeam);
-  if (!linkedChild && !routeAccess.isLinkedParent && !routeAccess.isTeamStaff) {
+  const canUseScheduleFailureFallback = !!scheduleLoadError && routeAccess.isLinkedParent;
+  if (!linkedChild && !canUseScheduleFailureFallback && !routeAccess.isTeamStaff) {
     throw new Error('This player is not linked to your account.');
   }
 

--- a/apps/app/src/lib/playerService.ts
+++ b/apps/app/src/lib/playerService.ts
@@ -61,9 +61,12 @@ import {
 import { getOpenScheduleAssignments, normalizeRsvpResponse, type ParentScheduleEvent } from './scheduleLogic';
 import { loadParentPlayerSchedule, type ParentScheduleChild } from './scheduleService';
 import { clearAppDataCache } from './appDataCache';
+import { createLogger } from './logger';
 import type { AuthUser } from './types';
 
 export type { PlayerVideoClip };
+
+const logger = createLogger('player-service');
 
 export type ParentPlayerStatRow = {
   event: ParentScheduleEvent;
@@ -124,6 +127,7 @@ export type ParentPlayerDetailData = {
   child: ParentScheduleChild;
   player: Record<string, any>;
   team: Record<string, any> | null;
+  scheduleLoadError: string | null;
   access: {
     isLinkedParent: boolean;
     isTeamStaff: boolean;
@@ -183,13 +187,23 @@ export async function loadParentPlayerDetail(user: AuthUser | null, teamId: stri
     throw new Error('Player details require a signed-in user.');
   }
 
-  const schedule = await loadParentPlayerSchedule(user, { teamId, playerId });
   const requestedTeamId = decodeURIComponent(teamId || '');
   const requestedPlayerId = decodeURIComponent(playerId || '');
+  let scheduleLoadError: string | null = null;
+  const schedule = await loadParentPlayerSchedule(user, { teamId, playerId }).catch((error) => {
+    scheduleLoadError = 'Schedule is temporarily unavailable. Refresh the player to try again.';
+    logger.warn('Continuing without player schedule data.', {
+      operation: 'player-detail-schedule-load',
+      teamId: requestedTeamId,
+      playerId: requestedPlayerId,
+      error
+    });
+    return { children: [], events: [] };
+  });
   const linkedChild = findLinkedChild(schedule.children, teamId, playerId);
   const initialTeam = await getTeam(requestedTeamId, { includeInactive: true });
   const routeAccess = buildPlayerAccess(user, requestedTeamId, requestedPlayerId, initialTeam);
-  if (!linkedChild && !routeAccess.isTeamStaff) {
+  if (!linkedChild && !routeAccess.isLinkedParent && !routeAccess.isTeamStaff) {
     throw new Error('This player is not linked to your account.');
   }
 
@@ -272,6 +286,7 @@ export async function loadParentPlayerDetail(user: AuthUser | null, teamId: stri
       number: playerDoc.number || (child as any).playerNumber || null
     },
     team,
+    scheduleLoadError,
     access,
     customRosterFields,
     events,
@@ -931,7 +946,9 @@ function assertLinkedParent(user: AuthUser | null, teamId: string, playerId: str
 }
 
 function isLinkedParent(user: AuthUser | null, teamId: string, playerId: string) {
-  return !!(user?.parentOf || []).some((entry: any) => entry?.teamId === teamId && entry?.playerId === playerId);
+  return !!(user?.parentOf || []).some((entry: any) => (
+    entry?.teamId === teamId && (entry?.playerId === playerId || entry?.childId === playerId)
+  ));
 }
 
 function isElevatedAppAdmin(user: AuthUser | null) {

--- a/apps/app/src/lib/playerService.ts
+++ b/apps/app/src/lib/playerService.ts
@@ -939,16 +939,20 @@ function assertLinkedParent(user: AuthUser | null, teamId: string, playerId: str
   if (!user?.uid) {
     throw new Error('A signed-in parent account is required.');
   }
-  const linked = (user.parentOf || []).some((entry: any) => entry?.teamId === teamId && entry?.playerId === playerId);
+  const linked = isLinkedParent(user, teamId, playerId);
   if (!linked && !user.isAdmin && !user.roles?.includes('admin') && !user.roles?.includes('platformAdmin')) {
     throw new Error('This player is not linked to your account.');
   }
 }
 
 function isLinkedParent(user: AuthUser | null, teamId: string, playerId: string) {
-  return !!(user?.parentOf || []).some((entry: any) => (
+  const linkedByParentOf = (user?.parentOf || []).some((entry: any) => (
     entry?.teamId === teamId && (entry?.playerId === playerId || entry?.childId === playerId)
   ));
+  if (linkedByParentOf) return true;
+
+  const playerKey = `${teamId}::${playerId}`;
+  return !!(user?.parentPlayerKeys || []).some((key) => String(key || '').trim() === playerKey);
 }
 
 function isElevatedAppAdmin(user: AuthUser | null) {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -4114,8 +4114,10 @@ export async function loadParentPlayerSchedule(user: AuthUser | null, options: P
       return { children, events: [] };
     }
 
-    // Single-player view: keep full history so past games still appear.
-    const events = await buildTeamSchedule(child.teamId, [child], user, { includePastGames: true });
+    // The player view only renders upcoming events plus a small recent-history
+    // window. Keep this read bounded so long-lived teams do not scan every game
+    // document before the player profile can open.
+    const events = await buildTeamSchedule(child.teamId, [child], user);
     const authoritativeEvents = hydrateDetails && events.length
       ? await hydrateEventDetails(events, user)
       : [];

--- a/apps/app/src/pages/PlayerDetail.tsx
+++ b/apps/app/src/pages/PlayerDetail.tsx
@@ -604,6 +604,7 @@ export function PlayerDetail({ auth }: { auth: AuthState }) {
       </div>
 
       {error ? <Status tone="error" message={error.message} /> : null}
+      {data.scheduleLoadError ? <ScheduleLoadNotice message={data.scheduleLoadError} /> : null}
       {activeSection === 'overview' ? <OverviewSection data={data} /> : null}
       {activeSection === 'schedule' ? <PlayerScheduleSection events={data.events} /> : null}
       {activeSection === 'performance' ? (
@@ -2648,6 +2649,20 @@ function Status({ tone, message }: { tone: 'error' | 'success'; message: string 
       aria-atomic="true"
     >
       {isError ? <AlertCircle className="mt-0.5 h-4 w-4 flex-none" aria-hidden="true" /> : <CheckCircle2 className="mt-0.5 h-4 w-4 flex-none" aria-hidden="true" />}
+      {message}
+    </div>
+  );
+}
+
+function ScheduleLoadNotice({ message }: { message: string }) {
+  return (
+    <div
+      className="flex items-start gap-2 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm font-semibold text-amber-900"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      <AlertCircle className="mt-0.5 h-4 w-4 flex-none" aria-hidden="true" />
       {message}
     </div>
   );

--- a/tests/unit/app-home-player-integration.test.jsx
+++ b/tests/unit/app-home-player-integration.test.jsx
@@ -668,6 +668,26 @@ describe('React app Home and player drill-in integration', () => {
         expect(window.scrollTo).toHaveBeenCalled();
     });
 
+    it('keeps the player profile visible when schedule data is temporarily unavailable', async () => {
+        const baselineDetail = await playerMocks.loadParentPlayerDetail();
+        playerMocks.loadParentPlayerDetail.mockClear();
+        playerMocks.loadParentPlayerDetail.mockResolvedValueOnce({
+            ...baselineDetail,
+            scheduleLoadError: 'Schedule is temporarily unavailable. Refresh the player to try again.',
+            events: [],
+            nextEvent: null,
+            actionCounts: { rsvpNeeded: 0, packetsReady: 0, openAssignments: 0 },
+            statRows: []
+        });
+
+        const { container } = await renderApp('/players/team-1/player-1');
+        await waitForText(container, 'Pat Star');
+        await waitForText(container, 'Schedule is temporarily unavailable. Refresh the player to try again.');
+
+        expect(container.textContent).not.toContain('Player unavailable');
+        expect(container.textContent).toContain('No upcoming events');
+    });
+
     it('requires media for photo quick shares and submits a compact media post payload', async () => {
         const { container } = await renderApp('/home?section=feed&social=create&type=team_media');
         await waitForText(container, 'What happened?');

--- a/tests/unit/app-player-service.test.js
+++ b/tests/unit/app-player-service.test.js
@@ -394,6 +394,20 @@ describe('React app parent player detail service', () => {
         expect(detail.scheduleLoadError).toBe('Schedule is temporarily unavailable. Refresh the player to try again.');
     });
 
+    it('rejects stale parent links when a successful schedule load omits the player', async () => {
+        scheduleMocks.loadParentPlayerSchedule.mockResolvedValue({ children: [], events: [] });
+        const keyOnlyParent = {
+            ...user(),
+            parentOf: [],
+            parentPlayerKeys: ['team-1::player-1']
+        };
+
+        await expect(loadParentPlayerDetail(user(), 'team-1', 'player-1'))
+            .rejects.toThrow('This player is not linked to your account.');
+        await expect(loadParentPlayerDetail(keyOnlyParent, 'team-1', 'player-1'))
+            .rejects.toThrow('This player is not linked to your account.');
+    });
+
     it('saves parent-editable player fields through the restricted profile helper', async () => {
         const file = new File(['avatar'], 'avatar.png', { type: 'image/png' });
 

--- a/tests/unit/app-player-service.test.js
+++ b/tests/unit/app-player-service.test.js
@@ -364,6 +364,21 @@ describe('React app parent player detail service', () => {
         expect(detail.athleteProfile.profile).toBeNull();
     });
 
+    it('keeps the player profile available when its schedule read times out', async () => {
+        scheduleMocks.loadParentPlayerSchedule.mockRejectedValueOnce(new Error('games team-1 timed out.'));
+
+        const detail = await loadParentPlayerDetail(user(), 'team-1', 'player-1');
+
+        expect(detail.player).toMatchObject({
+            id: 'player-1',
+            name: 'Pat Star',
+            teamName: 'Bears'
+        });
+        expect(detail.events).toEqual([]);
+        expect(detail.nextEvent).toBeNull();
+        expect(detail.scheduleLoadError).toBe('Schedule is temporarily unavailable. Refresh the player to try again.');
+    });
+
     it('saves parent-editable player fields through the restricted profile helper', async () => {
         const file = new File(['avatar'], 'avatar.png', { type: 'image/png' });
 

--- a/tests/unit/app-player-service.test.js
+++ b/tests/unit/app-player-service.test.js
@@ -379,6 +379,21 @@ describe('React app parent player detail service', () => {
         expect(detail.scheduleLoadError).toBe('Schedule is temporarily unavailable. Refresh the player to try again.');
     });
 
+    it('preserves key-only parent access when the player schedule times out', async () => {
+        scheduleMocks.loadParentPlayerSchedule.mockRejectedValueOnce(new Error('games team-1 timed out.'));
+        const keyOnlyParent = {
+            ...user(),
+            parentOf: [],
+            parentPlayerKeys: ['team-1::player-1']
+        };
+
+        const detail = await loadParentPlayerDetail(keyOnlyParent, 'team-1', 'player-1');
+
+        expect(detail.access.isLinkedParent).toBe(true);
+        expect(detail.player).toMatchObject({ id: 'player-1', name: 'Pat Star' });
+        expect(detail.scheduleLoadError).toBe('Schedule is temporarily unavailable. Refresh the player to try again.');
+    });
+
     it('saves parent-editable player fields through the restricted profile helper', async () => {
         const file = new File(['avatar'], 'avatar.png', { type: 'image/png' });
 

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -597,10 +597,17 @@ describe('React app schedule service contract integration', () => {
         expect(profileMocks.loadProfileDocument).toHaveBeenCalledWith('user-1');
         expect(dbMocks.getTeams).not.toHaveBeenCalled();
         expect(dbMocks.getTeam).toHaveBeenCalledWith('team-1');
-        expect(dbMocks.getGames).toHaveBeenCalledTimes(1);
-        expect(dbMocks.getGames).toHaveBeenCalledWith('team-1', {});
+        expect(dbMocks.getGames).toHaveBeenCalledTimes(2);
+        expect(dbMocks.getGames).toHaveBeenCalledWith('team-1', {
+            startDate: expect.any(Date)
+        });
+        expect(dbMocks.getGames).toHaveBeenCalledWith('team-1', {
+            tournamentGroups: [{ poolName: 'Pool A', divisionName: '10U Gold' }]
+        });
         expect(dbMocks.getPracticeSessions).toHaveBeenCalledTimes(1);
-        expect(dbMocks.getPracticeSessions).toHaveBeenCalledWith('team-1', {});
+        expect(dbMocks.getPracticeSessions).toHaveBeenCalledWith('team-1', {
+            startDate: expect.any(Date)
+        });
         expect(result.children).toEqual([
             { teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Pat', isLinkedParentChild: true },
             { teamId: 'team-1', teamName: 'Bears', playerId: 'player-2', playerName: 'Sam', isLinkedParentChild: true }


### PR DESCRIPTION
## What changed

- Bound player schedule reads to the recent-history window instead of loading every game for long-lived teams.
- Keep the player profile usable when schedule data times out.
- Show a recoverable schedule warning with refresh guidance instead of replacing the page with “Player unavailable.”
- Preserve linked-parent and team-staff access checks.
- Add service, schedule-contract, and component regression coverage.

## Root cause

The player detail bootstrap treated a full, unbounded team game-history read as mandatory. A Firestore timeout from that optional schedule slice rejected the entire player detail request.

## Impact

Parents and staff can still open the player profile when schedule data is temporarily unavailable, and large team histories no longer require an all-time game scan for this page.

## Validation

- `npx vitest run tests/unit/app-player-service.test.js tests/unit/app-schedule-service-contracts.test.js apps/app/src/lib/playerService.test.ts tests/unit/app-home-player-integration.test.jsx --reporter=dot --silent=passed-only` (92 tests passed)
- `npm --prefix apps/app run build`