### PR TITLE
Allow production Firebase deploys to finish

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -364,7 +364,10 @@ jobs:
           cleanup_credentials: true
 
       - name: Deploy Firebase production
-        timeout-minutes: 4
+        # Updating the full first-generation Functions fleet routinely takes
+        # longer than four minutes. Leave enough room for one deployment plus
+        # the bounded transient retries above without allowing an unbounded job.
+        timeout-minutes: 20
         shell: bash
         env:
           FIRESTORE_CONFIG_CHANGED: ${{ needs.prepare-deploy.outputs.firestore_changed }}

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -160,8 +160,14 @@ export function validateFirebaseDeployWorkloadIdentity(workflow, label) {
                 continue;
             }
             deployStepCount += 1;
-            if (!Number.isInteger(step['timeout-minutes']) || step['timeout-minutes'] > 4) {
-                throw new Error(`${label} credentialed deploy steps must have a four-minute timeout.`);
+            const maxTimeoutMinutes = label === 'Production deploy' &&
+                step.name === 'Deploy Firebase production'
+                ? 20
+                : 4;
+            if (!Number.isInteger(step['timeout-minutes']) ||
+                step['timeout-minutes'] < 1 ||
+                step['timeout-minutes'] > maxTimeoutMinutes) {
+                throw new Error(`${label} credentialed deploy step ${step.name || '(unnamed)'} must have a timeout from one to ${maxTimeoutMinutes} minutes.`);
             }
             const authStep = object.steps[index - 1];
             if (!authStep || typeof authStep.uses !== 'string' ||

--- a/tests/unit/firebase-deploy-workload-identity.test.js
+++ b/tests/unit/firebase-deploy-workload-identity.test.js
@@ -112,7 +112,7 @@ describe('Firebase deploy Workload Identity boundary', () => {
         expect(production.slice(storageAuth, storageDeploy)).not.toContain('run:');
         expect(production.slice(productionAuth, productionDeploy)).not.toContain('run:');
         expect(production.slice(storageDeploy, storageCleanup)).toContain('timeout-minutes: 4');
-        expect(production.slice(productionDeploy)).toContain('timeout-minutes: 4');
+        expect(production.slice(productionDeploy)).toContain('timeout-minutes: 20');
         const oidcJobs = workflowJobs(production).filter((job) => job.permissions?.['id-token'] === 'write');
         expect(oidcJobs).toHaveLength(1);
         expect(JSON.stringify(oidcJobs[0])).not.toMatch(/npm (?:ci|install)|stage-pages-bundle|write-firebase-hosting-config/);

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -321,7 +321,7 @@ service firebase.storage {
         expect(() => validateFirebaseDeployWorkloadIdentity(
             validWorkflow.replace('timeout-minutes: 4', 'timeout-minutes: 6'),
             'Test deploy'
-        )).toThrow('Test deploy credentialed deploy steps must have a four-minute timeout');
+        )).toThrow('Test deploy credentialed deploy step Deploy Firebase must have a timeout from one to 4 minutes');
         expect(() => validateFirebaseDeployWorkloadIdentity(
             validWorkflow.replace(
                 '          - name: Deploy Firebase',


### PR DESCRIPTION
## What changed
- extend only the full production Hosting/Functions deploy step from 4 to 20 minutes
- keep Storage and preview credential windows capped at 4 minutes
- update the keyless-deploy guard and regression tests for the narrowly named production step

## Why
The exact #4045 production deployment updates roughly 100 first-generation Functions. GitHub killed the credentialed deploy after four minutes even though updates were still succeeding, leaving Hosting unfinished. Twenty minutes bounds the OIDC window while allowing the existing three-attempt transient retry policy to complete.

## Validation
- `npx vitest run tests/unit/firebase-deploy-workload-identity.test.js tests/unit/validate-firebase-rules-ci.test.js --reporter=verbose` (10 passed)
- `npm run ci:firebase-rules`
- `git diff --check`