### PR TITLE
Restore team game date indexes

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -559,6 +559,8 @@
       "collectionGroup": "games",
       "fieldPath": "date",
       "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION" },
+        { "order": "DESCENDING", "queryScope": "COLLECTION" },
         { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" },
         { "order": "DESCENDING", "queryScope": "COLLECTION_GROUP" }
       ]

--- a/tests/unit/db-homepage-shared-games.test.js
+++ b/tests/unit/db-homepage-shared-games.test.js
@@ -48,7 +48,7 @@ describe('homepage shared game discovery queries', () => {
         expect(replaySource).toContain('return games.slice(0, limitCount)');
     });
 
-    it('declares homepage collection group indexes for shared and team game date queries', () => {
+    it('declares collection and collection group indexes for shared and team game date queries', () => {
         const indexConfig = readFirestoreIndexes();
         const sharedGameIndexes = indexConfig.indexes
             .filter((index) => index.collectionGroup === 'sharedGames')
@@ -76,7 +76,12 @@ describe('homepage shared game discovery queries', () => {
         expect(sharedGameIndexes).toContain('teamIds:CONTAINS,date:ASCENDING');
         expect(dateFieldOverrides).toContainEqual({
             collectionGroup: 'games',
-            indexes: ['ASCENDING:COLLECTION_GROUP', 'DESCENDING:COLLECTION_GROUP']
+            indexes: [
+                'ASCENDING:COLLECTION',
+                'DESCENDING:COLLECTION',
+                'ASCENDING:COLLECTION_GROUP',
+                'DESCENDING:COLLECTION_GROUP'
+            ]
         });
         expect(dateFieldOverrides).toContainEqual({
             collectionGroup: 'sharedGames',


### PR DESCRIPTION
## What changed
- restore ascending and descending collection-scope single-field indexes for `teams/{teamId}/games.date`
- retain the existing collection-group date indexes
- strengthen the index contract regression test to require both scopes

## Why
The public team ICS production canary returned `500 Calendar unavailable`. Cloud Function logs showed `FAILED_PRECONDITION: The query requires a COLLECTION_ASC index for collection games and field date`. The prior field override declared only collection-group indexes, which replaced the inherited collection-scope index used by direct team game queries.

## Validation
- production failure reproduced against a public test team and tied to execution `z04udl5kp1jk`
- `npx vitest run tests/unit/db-homepage-shared-games.test.js tests/unit/public-calendar-core.test.js --reporter=verbose` (8 passed)
- `npm run ci:firebase-rules`
- `git diff --check`

## Production verification
After deploy, wait for both collection-scope indexes to report `READY`, then require a public team ICS request to return `200`, `text/calendar`, and `BEGIN:VCALENDAR`.