### PR TITLE
Stabilize workflow mobile TOC smoke timeout

### DIFF
--- a/tests/smoke/help-workflow-pages.spec.js
+++ b/tests/smoke/help-workflow-pages.spec.js
@@ -127,6 +127,8 @@ test.describe('help topic and workflow pages', () => {
     }
 
     test('workflow pages expose mobile table-of-contents links', async ({ page, baseURL }) => {
+        // This aggregate check makes 18 sequential production navigations.
+        test.setTimeout(60_000);
         await page.setViewportSize({ width: 390, height: 844 });
 
         for (const file of workflowPages) {


### PR DESCRIPTION
## What changed
- give only the 18-page mobile workflow TOC aggregate smoke a 60-second budget
- document why this one test needs more than the global 30-second budget
- leave application code and the global Playwright configuration unchanged

## Why
Production post-deploy run 29673711704 timed out at exactly 30 seconds on both attempts while sequentially loading all 18 workflow pages. Every per-page workflow boot test and the later mobile TOC interaction tests passed, so the failure was Playwright closing a still-running aggregate test, not a product regression.

## Verification
- npx vitest run tests/unit/help-workflow-pages.test.js --reporter=verbose (8 passed)
- targeted production smoke, repeat-each=4, workers=2 (4 passed in 44.5s)
- targeted production smoke before the change (1 passed in 24.4s, leaving only 5.6s margin)
- git diff --check