### PR TITLE
Stage RSVP privacy rules closure

### DIFF
--- a/docs/security/rsvp-family-projection-rollout.md
+++ b/docs/security/rsvp-family-projection-rollout.md
@@ -47,6 +47,16 @@ collections, both of which Phase B closes.
 6. Monitor permission-denied and callable error rates. Roll back the rules alone
    if projection availability regresses; do not roll back the PII-free writes.
 
+## Phase B activation record
+
+Leave every item unchecked while this PR is held:
+
+- [ ] Phase A Functions and clients are live with preview and production parity.
+- [ ] Supported iOS and Android populations use projection-first family sharing.
+- [ ] Supported iOS and Android populations use exact-document parent RSVP reads.
+- [ ] Callable/fallback and permission-denied telemetry is within approved bounds.
+- [ ] Phase B is rebased on current master with only the documented closure delta.
+
 The projection reuses the hardened calendar SSRF fetch path and its shared
 cache/in-flight coalescing, making repeated bearer requests side-effect-free and
 idempotent at the outbound-fetch boundary. Each response is bounded to 8 source

--- a/firestore.rules
+++ b/firestore.rules
@@ -3576,6 +3576,9 @@ service cloud.firestore {
           }
           function isRsvpStatusPayloadSafe(data) {
             return !data.keys().hasAny([
+              'parentEmail',
+              'email',
+              'guardianEmail',
               'note',
               'notes',
               'adminNote',
@@ -3585,13 +3588,18 @@ service cloud.firestore {
               'privateAvailabilityNote'
             ]);
           }
-          allow read: if isTeamOwnerOrAdmin(teamId) ||
-                         isParentForTeam(teamId) ||
-                         (isSignedIn() &&
-                          isOwnRsvpDoc() &&
-                          resource.data.userId == request.auth.uid &&
-                          canUseLinkedPlayerRsvp(teamId, resource.data) &&
-                          isOwnLinkedPlayerRsvpId(rsvpId, resource.data));
+          // Staff retain the roster-wide list. Parents use exact document gets
+          // for their own base/player-scoped RSVP and the game-level aggregate.
+          allow get: if isTeamOwnerOrAdmin(teamId) ||
+                        (isSignedIn() &&
+                         isOwnRsvpDoc() &&
+                         resource == null &&
+                         isParentForTeam(teamId)) ||
+                        (isSignedIn() &&
+                         resource != null &&
+                         resource.data.userId == request.auth.uid &&
+                         canWriteOwnParentRsvp(resource.data));
+          allow list: if isTeamOwnerOrAdmin(teamId);
           allow create, update: if (isTeamOwnerOrAdmin(teamId) ||
                                     canWriteOwnParentRsvp(request.resource.data)) &&
                                    isSignedIn() && isOwnRsvpDoc() &&
@@ -3654,8 +3662,7 @@ service cloud.firestore {
           }
           function canReadRsvpNote(teamId, data) {
             return isTeamOwnerOrAdmin(teamId) ||
-                   isOwnRsvpNoteDoc(data) ||
-                   (isParentForTeam(teamId) && isTeamVisibleRsvpNote(teamId, data));
+                   isOwnRsvpNoteDoc(data);
           }
           function isRsvpNotePayloadValid(teamId, data) {
             return data.keys().hasOnly([
@@ -3695,8 +3702,8 @@ service cloud.firestore {
           // child override resolves as a missing document instead of a denied
           // read. Existing documents still use the data-aware privacy check.
           allow get: if (resource == null && isOwnRsvpNoteId() && isParentForTeam(teamId)) ||
-                        canReadRsvpNote(teamId, resource.data);
-          allow list: if canReadRsvpNote(teamId, resource.data);
+                        (resource != null && canReadRsvpNote(teamId, resource.data));
+          allow list: if isTeamOwnerOrAdmin(teamId);
           allow create, update: if isVerifiedForSensitiveWrite() && canWriteRsvpNote(teamId, rsvpId, request.resource.data);
           allow delete: if (resource == null && isOwnRsvpNoteId() && isParentForTeam(teamId)) ||
                            (isVerifiedForSensitiveWrite() &&
@@ -4067,17 +4074,10 @@ service cloud.firestore {
       }
     }
 
-    // Family share tokens — parent-created read-only share links for grandparents/friends.
-    // The tokenId is a 40-char hex string that serves as a bearer credential.
+    // Family share token documents are owner/admin control-plane records. Bearer
+    // viewers receive a server-side projection and never read this source doc.
     match /familyShareTokens/{tokenId} {
-      // Anyone who has the token ID can read it (to validate and load the family page).
-      // Legacy revoked tokens may use revoked/revokedAt without active=false, so honor all revocation markers.
-      // Owner can always read their own tokens (including revoked ones).
-      allow get: if (resource.data.get('active', true) == true &&
-                     resource.data.get('revoked', false) != true &&
-                     resource.data.get('revokedAt', null) == null &&
-                     (resource.data.get('expiresAt', null) == null || resource.data.expiresAt > request.time)) ||
-                    (isSignedIn() && resource.data.ownerUserId == request.auth.uid) ||
+      allow get: if (isSignedIn() && resource.data.ownerUserId == request.auth.uid) ||
                     isGlobalAdmin();
       // Only the owner can list their own tokens (rule applied per-document).
       allow list: if isSignedIn() && resource.data.ownerUserId == request.auth.uid;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "vitest run tests/unit",
     "test:unit": "vitest run tests/unit",
     "test:unit:ci": "vitest run tests/unit --reporter=dot && npm run test:storage-rules:ci",
-    "test:storage-rules:ci": "firebase emulators:exec --only firestore,storage --project demo-allplays \"vitest run tests/unit/storage-rules-team-boundary.test.js tests/unit/player-rules-privacy.test.js tests/unit/private-ai-rules.test.js tests/unit/team-entitlement-rules.test.js tests/unit/team-email-send-rules.test.js tests/unit/app-social-rules.test.js tests/unit/rsvp-note-privacy-rules.test.js tests/unit/stored-xss-media-rules.test.js tests/unit/verified-email-policy-rules.test.js --reporter=dot --no-file-parallelism\"",
+    "test:storage-rules:ci": "firebase emulators:exec --only firestore,storage --project demo-allplays \"vitest run tests/unit/storage-rules-team-boundary.test.js tests/unit/player-rules-privacy.test.js tests/unit/private-ai-rules.test.js tests/unit/team-entitlement-rules.test.js tests/unit/team-email-send-rules.test.js tests/unit/app-social-rules.test.js tests/unit/family-share-token-rules.test.js tests/unit/rsvp-note-privacy-rules.test.js tests/unit/stored-xss-media-rules.test.js tests/unit/verified-email-policy-rules.test.js --reporter=dot --no-file-parallelism\"",
     "test:coverage-map": "node scripts/report-test-coverage-map.mjs --check",
     "test:functions:notifications": "npm run test:notifications --prefix functions",
     "test:functions:auth-email": "node --test functions/test/auth-email-*.test.cjs",

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -381,9 +381,14 @@ export function validateFirebaseRulesCi() {
     assertIncludes(firestoreRules, 'allow read, create, update, delete: if isTeamOwnerOrAdmin(teamId);', 'Firestore team fee admin billing admin-only rules');
     assertIncludes(firestoreRules, 'match /rsvpNotes/{rsvpId}', 'Firestore restricted RSVP note rules');
     assertIncludes(firestoreRules, 'function isRsvpStatusPayloadSafe(data)', 'Firestore RSVP status note exclusion helper');
+    assertIncludes(firestoreRules, "'parentEmail',", 'Firestore RSVP status direct-email exclusion');
+    assertIncludes(firestoreRules, "'guardianEmail',", 'Firestore RSVP status guardian-email exclusion');
+    assertIncludes(firestoreRules, 'allow list: if isTeamOwnerOrAdmin(teamId);', 'Firestore staff-only RSVP collection reads');
     assertIncludes(firestoreRules, 'allow get: if (resource == null && isOwnRsvpNoteId() && isParentForTeam(teamId)) ||', 'Firestore missing own RSVP note read rules');
-    assertIncludes(firestoreRules, 'canReadRsvpNote(teamId, resource.data);', 'Firestore existing RSVP note read rules');
-    assertIncludes(firestoreRules, 'allow list: if canReadRsvpNote(teamId, resource.data);', 'Firestore restricted RSVP note list rules');
+    assertIncludes(firestoreRules, '(resource != null && canReadRsvpNote(teamId, resource.data));', 'Firestore existing RSVP note read rules');
+    assertIncludes(firestoreRules, 'allow list: if isTeamOwnerOrAdmin(teamId);', 'Firestore staff-only RSVP note list rules');
+    assertIncludes(firestoreRules, 'match /familyShareTokens/{tokenId}', 'Firestore family share source document rules');
+    assertIncludes(firestoreRules, 'allow get: if (isSignedIn() && resource.data.ownerUserId == request.auth.uid) ||', 'Firestore family share owner/admin source reads');
     assertIncludes(firestoreRules, 'function isNestedChatMessageCreateValid(teamId, conversationId, conversationData, data)', 'Nested chat message payload validator');
     assertIncludes(firestoreRules, 'function isNestedChatMessageTargetValid(teamId, conversationId, conversationData, data)', 'Nested chat message target validator');
     assertIncludes(firestoreRules, 'function hasValidNestedChatAttachments(teamId, conversationId, data)', 'Nested chat attachment validator');

--- a/tests/unit/family-share-token-rules.test.js
+++ b/tests/unit/family-share-token-rules.test.js
@@ -1,26 +1,20 @@
-import { describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { assertFails, assertSucceeds, initializeTestEnvironment } from '@firebase/rules-unit-testing';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
 
 const rules = readFileSync(resolve(process.cwd(), 'firestore.rules'), 'utf8');
 const familyShareTokenMatch = rules.match(/match \/familyShareTokens\/\{tokenId\} \{[\s\S]*?\n\s*}/);
 const familyShareTokenRules = familyShareTokenMatch?.[0] || '';
 
 describe('family share token Firestore rules', () => {
-    it('allows anonymous reads for legacy tokens that omit the active field', () => {
+    it('denies anonymous source-document reads and reserves them for owner/admin control-plane access', () => {
         expect(familyShareTokenRules).toContain("match /familyShareTokens/{tokenId}");
-        expect(familyShareTokenRules).toContain("resource.data.get('active', true) == true");
         expect(familyShareTokenRules).toContain("resource.data.ownerUserId == request.auth.uid");
-        expect(familyShareTokenRules).not.toContain("resource.data.get('active', false) == true");
-    });
-
-    it('blocks anonymous reads when legacy revocation flags are present', () => {
-        expect(familyShareTokenRules).toContain("resource.data.get('revoked', false) != true");
-        expect(familyShareTokenRules).toContain("resource.data.get('revokedAt', null) == null");
-    });
-
-    it('blocks anonymous reads after token expiration while preserving legacy tokens without expiresAt', () => {
-        expect(familyShareTokenRules).toContain("resource.data.get('expiresAt', null) == null || resource.data.expiresAt > request.time");
+        expect(familyShareTokenRules).toContain('isGlobalAdmin()');
+        expect(familyShareTokenRules).not.toContain("resource.data.get('active', true) == true");
+        expect(familyShareTokenRules).not.toContain("resource.data.get('revoked', false)");
     });
 
     it('requires expiresAt on owner-created and owner-updated share tokens', () => {
@@ -32,8 +26,48 @@ describe('family share token Firestore rules', () => {
         expect(familyShareTokenRules).toContain('request.resource.data.ownerUserId == resource.data.ownerUserId');
     });
 
-    it('still reserves revoked-token access for owners and global admins', () => {
+    it('still reserves revoked-token control-plane access for owners and global admins', () => {
         expect(familyShareTokenRules).toContain("isSignedIn() && resource.data.ownerUserId == request.auth.uid");
         expect(familyShareTokenRules).toContain('isGlobalAdmin()');
+    });
+
+    describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('family token source-document actor matrix', () => {
+        let testEnv;
+        const tokenId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+        beforeAll(async () => {
+            testEnv = await initializeTestEnvironment({
+                projectId: `allplays-family-token-${Date.now()}`,
+                firestore: { rules }
+            });
+        }, 30000);
+
+        beforeEach(async () => {
+            await testEnv.clearFirestore();
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                const db = context.firestore();
+                await setDoc(doc(db, `familyShareTokens/${tokenId}`), {
+                    ownerUserId: 'parent-1',
+                    active: true,
+                    label: 'Grandma',
+                    extraCalendarUrls: ['https://calendar.example.test/feed.ics?secret=SENTINEL_SECRET']
+                });
+                await setDoc(doc(db, 'users/global-admin'), { isAdmin: true, email: 'global@example.com' });
+            });
+        });
+
+        afterAll(async () => testEnv?.cleanup());
+
+        it('denies anonymous and unrelated users while preserving owner/admin reads', async () => {
+            const anonymousDb = testEnv.unauthenticatedContext().firestore();
+            const unrelatedDb = testEnv.authenticatedContext('parent-2', { email: 'parent-2@example.com' }).firestore();
+            const ownerDb = testEnv.authenticatedContext('parent-1', { email: 'parent-1@example.com' }).firestore();
+            const adminDb = testEnv.authenticatedContext('global-admin', { email: 'global@example.com' }).firestore();
+
+            await assertFails(getDoc(doc(anonymousDb, `familyShareTokens/${tokenId}`)));
+            await assertFails(getDoc(doc(unrelatedDb, `familyShareTokens/${tokenId}`)));
+            await assertSucceeds(getDoc(doc(ownerDb, `familyShareTokens/${tokenId}`)));
+            await assertSucceeds(getDoc(doc(adminDb, `familyShareTokens/${tokenId}`)));
+        });
     });
 });

--- a/tests/unit/rsvp-note-privacy-rules.test.js
+++ b/tests/unit/rsvp-note-privacy-rules.test.js
@@ -5,7 +5,7 @@ import {
   assertSucceeds,
   initializeTestEnvironment
 } from '@firebase/rules-unit-testing';
-import { deleteDoc, doc, getDoc, setDoc, Timestamp, updateDoc, writeBatch } from 'firebase/firestore';
+import { collection, deleteDoc, doc, getDoc, getDocs, setDoc, Timestamp, updateDoc, writeBatch } from 'firebase/firestore';
 import { extractMatchBlock } from '../../scripts/validate-firebase-rules-ci.mjs';
 
 const rules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
@@ -32,6 +32,8 @@ describe('RSVP note privacy Firestore rules', () => {
 
     expect(rsvpBlock).toContain('function isRsvpStatusPayloadSafe(data)');
     expect(rsvpBlock).toContain("'note'");
+    expect(rsvpBlock).toContain("'parentEmail'");
+    expect(rsvpBlock).toContain("'guardianEmail'");
     expect(rsvpBlock).toContain("'adminOnlyNote'");
     expect(rsvpBlock).toContain("'privateAvailabilityNote'");
     expect(rsvpBlock).toContain('isRsvpStatusPayloadSafe(request.resource.data)');
@@ -50,8 +52,8 @@ describe('RSVP note privacy Firestore rules', () => {
     expect(gamesBlock).toContain('isParentForPlayer(teamId, playerId)');
     expect(gamesBlock).toContain('isParentForRsvpPlayerAt(teamId, playerIds, 9)');
     expect(gamesBlock).toContain('rsvpId == request.auth.uid + "__" + playerId');
-    expect(rsvpBlock).toContain('canUseLinkedPlayerRsvp(teamId, resource.data)');
-    expect(rsvpBlock).toContain('isOwnLinkedPlayerRsvpId(rsvpId, resource.data)');
+    expect(rsvpBlock).toContain('canWriteOwnParentRsvp(resource.data)');
+    expect(rsvpBlock).toContain('allow list: if isTeamOwnerOrAdmin(teamId);');
     expect(parentWriteFunction).toContain('isOwnBaseRsvpDoc() &&\n                    isParentForTeam(teamId) &&\n                    (!hasRsvpPlayerScope(data) ||\n                     canUseLinkedPlayerRsvp(teamId, data) ||\n                     canUseGroupedLinkedPlayerRsvp(teamId, data))');
     expect(parentWriteFunction).toContain('isOwnLinkedPlayerRsvpDoc() &&\n                    canUseLinkedPlayerRsvp(teamId, data) &&\n                    isOwnLinkedPlayerRsvpId(rsvpId, data)');
     expect(rsvpBlock).not.toContain('isParentForTeam(teamId) ||\n                                    (canUseLinkedPlayerRsvp');
@@ -74,16 +76,16 @@ describe('RSVP note privacy Firestore rules', () => {
     expect(deleteRule).not.toContain('isParentForTeam(teamId) ||');
   });
 
-  it('restricts note docs to admins, the note owner, or explicit team-visible notes', () => {
+  it('restricts note docs to admins or the note owner even when legacy notes are team-visible', () => {
     const noteBlock = extractNestedBlock(gamesBlock, 'match /rsvpNotes/{rsvpId} {');
 
     expect(noteBlock).toContain('function canReadRsvpNote(teamId, data)');
     expect(noteBlock).toContain('isTeamOwnerOrAdmin(teamId)');
     expect(noteBlock).toContain('isOwnRsvpNoteDoc(data)');
-    expect(noteBlock).toContain("data.get('visibility', 'admins') == 'team'");
     expect(noteBlock).toContain("get('noteVisibility', 'admins') == 'team'");
     expect(noteBlock).toContain('allow get: if (resource == null && isOwnRsvpNoteId() && isParentForTeam(teamId)) ||');
-    expect(noteBlock).toContain('allow list: if canReadRsvpNote(teamId, resource.data);');
+    expect(noteBlock).toContain('allow list: if isTeamOwnerOrAdmin(teamId);');
+    expect(extractNestedBlock(noteBlock, 'function canReadRsvpNote(teamId, data) {')).not.toContain('isTeamVisibleRsvpNote');
   });
 
   it('requires an explicit safe RSVP note document shape and writer-owned ID for writes', () => {
@@ -159,6 +161,16 @@ describe('RSVP note privacy Firestore rules', () => {
         await setDoc(doc(firestore, 'users/owner-1'), {
           email: 'owner@example.com',
           isAdmin: false
+        });
+        await setDoc(doc(firestore, 'users/parent-2'), {
+          email: 'other-parent@example.com',
+          isAdmin: false,
+          parentTeamIds: ['team-1'],
+          parentPlayerKeys: ['team-1::player-b']
+        });
+        await setDoc(doc(firestore, 'users/global-admin'), {
+          email: 'global@example.com',
+          isAdmin: true
         });
       });
     });
@@ -295,9 +307,12 @@ describe('RSVP note privacy Firestore rules', () => {
       await assertSucceeds(batch.commit());
     });
 
-    it('returns missing own note overrides to a parent without exposing another user path', async () => {
+    it('returns missing own RSVP and note overrides without exposing another user path', async () => {
       const parentDb = authedFirestore('parent-1', 'parent@example.com');
 
+      await assertSucceeds(getDoc(baseRsvpRef(parentDb)));
+      await assertSucceeds(getDoc(rsvpRef(parentDb, 'player-a')));
+      await assertFails(getDoc(rsvpRef(parentDb, 'player-a', 'other-parent')));
       await assertSucceeds(getDoc(baseNoteRef(parentDb)));
       await assertSucceeds(getDoc(noteRef(parentDb, 'player-a')));
       await assertFails(getDoc(noteRef(parentDb, 'player-a', 'other-parent')));
@@ -348,6 +363,41 @@ describe('RSVP note privacy Firestore rules', () => {
 
       await assertSucceeds(setDoc(ownerRsvpRef, rsvpPayload('player-b', 'owner-1')));
       await assertSucceeds(setDoc(ownerNoteRef, notePayload('player-b', 'owner-1')));
+    });
+
+    it('prevents cross-family RSVP reads while preserving own gets, staff lists, and aggregate game reads', async () => {
+      await seedRsvpDoc('teams/team-1/games/game-1/rsvps/parent-1__player-a', rsvpPayload('player-a'));
+      await seedRsvpDoc('teams/team-1/games/game-1/rsvps/parent-2__player-b', rsvpPayload('player-b', 'parent-2'));
+      await seedRsvpDoc('teams/team-1/games/game-1/rsvpNotes/parent-1__player-a', { ...notePayload('player-a'), visibility: 'team' });
+      await seedRsvpDoc('teams/team-1/games/game-1/rsvpNotes/parent-2__player-b', { ...notePayload('player-b', 'parent-2'), visibility: 'team' });
+
+      const parentDb = authedFirestore('parent-1', 'parent@example.com');
+      const ownerDb = authedFirestore('owner-1', 'owner@example.com');
+      const globalDb = authedFirestore('global-admin', 'global@example.com');
+      const rsvpCollection = collection(parentDb, 'teams/team-1/games/game-1/rsvps');
+
+      await assertSucceeds(getDoc(rsvpRef(parentDb, 'player-a')));
+      await assertFails(getDoc(rsvpRef(parentDb, 'player-b', 'parent-2')));
+      await assertFails(getDocs(rsvpCollection));
+      await assertSucceeds(getDoc(noteRef(parentDb, 'player-a')));
+      await assertFails(getDoc(noteRef(parentDb, 'player-b', 'parent-2')));
+      await assertFails(getDocs(collection(parentDb, 'teams/team-1/games/game-1/rsvpNotes')));
+      await assertSucceeds(getDocs(collection(ownerDb, 'teams/team-1/games/game-1/rsvps')));
+      await assertSucceeds(getDocs(collection(ownerDb, 'teams/team-1/games/game-1/rsvpNotes')));
+      await assertSucceeds(getDocs(collection(globalDb, 'teams/team-1/games/game-1/rsvps')));
+      await assertSucceeds(getDoc(doc(parentDb, 'teams/team-1/games/game-1')));
+    });
+
+    it('rejects new RSVP status writes containing direct parent email PII', async () => {
+      const parentDb = authedFirestore('parent-1', 'parent@example.com');
+      await assertFails(setDoc(rsvpRef(parentDb, 'player-a'), {
+        ...rsvpPayload('player-a'),
+        parentEmail: 'SENTINEL_PARENT@example.test'
+      }));
+      await assertFails(setDoc(rsvpRef(parentDb, 'player-a'), {
+        ...rsvpPayload('player-a'),
+        guardianEmail: 'SENTINEL_GUARDIAN@example.test'
+      }));
     });
   });
 });


### PR DESCRIPTION
🚫 **DO NOT MERGE — PHASE B RULES CLOSURE HOLD**

This draft is intentionally stacked on Phase A PR #4047 at exact base `9ef784e2dd198b1ede18a0730ea69598080b8a49`.

Current exact held head: `2ed2c5c2fa738f99176828701622345758f3a047`.

## Exact allocation

This PR changes only six files relative to Phase A:

- `firestore.rules` — deny anonymous family-token source reads; make RSVP/note lists staff-only; keep exact parent gets and reject direct email fields.
- `scripts/validate-firebase-rules-ci.mjs` — closure contract assertions.
- `tests/unit/family-share-token-rules.test.js` — source-token actor matrix.
- `tests/unit/rsvp-note-privacy-rules.test.js` — parent/staff RSVP and note actor matrix plus PII rejection.
- `package.json` — include family-token actor tests in emulator CI.
- `docs/security/rsvp-family-projection-rollout.md` — unchecked Phase B activation record.

The closure diff is byte-for-byte patch-equivalent to the previously verified held head; application behavior remains in Phase A.

## Hard blocker: installed native compatibility

Existing shipped iOS/Android bundles can route family-share views and directly read `familyShareTokens`. They also use parent RSVP/note collection lists that these rules deny. Hosting deployment does not update installed bundles, verified HTTPS associations are not currently published, and no enforced minimum-version retirement mechanism was found.

Do not merge Phase B until all of the following are evidenced:

- Phase A Functions and clients are live with production parity.
- Signed, versioned iOS and Android releases contain projection-first family sharing and exact-document RSVP hydration.
- Supported installed populations have adopted those builds, or older versions are enforceably retired.
- Terminated/background/foreground device canaries pass for active, revoked, and expired family links and parent RSVP hydration.
- Callable/fallback and permission-denied telemetry is within approved bounds.
- This branch is rebased onto then-current master/Phase A with the same closure-only diff.

App-store submission, approval, simulator CI, or web parity alone is insufficient.

## Verification

- Rules validator passed.
- Closure static tests: **16 passed, 11 emulator-only skipped**.
- Full Firestore/Storage emulator suite: **95/95 passed** on the patch-equivalent closure.
- Rebase patch hash matches exactly: `d8714d247ac75d225fe6bd12bdc8f517449c7df29ef89c2eb4863ff7a1754f4d`.
- Cache-bust guard and `git diff --check` passed.
- Hosted CI is green on the exact held head: 14 checks passed and the deploy job was intentionally skipped.

## Rollback

After closure, do not remove projection Functions/clients while these rules remain. A functionality rollback must roll back Phase B rules first and explicitly accept restored raw source-token exposure.

No merge, deploy, sanitizer execution, data mutation, ready-for-review transition, auto-merge, or hold removal is authorized.
