### PR TITLE
Show linked family contacts

### DIFF
--- a/apps/app/src/lib/parentHouseholdService.ts
+++ b/apps/app/src/lib/parentHouseholdService.ts
@@ -1,4 +1,4 @@
-import { addPendingFamilyMember, readFamilyMembers } from './adapters/legacyParentTools';
+import { addPendingFamilyMember, getPlayers, readFamilyMembers } from './adapters/legacyParentTools';
 import type { AuthUser } from './types';
 
 const legacyOrigin = 'https://allplays.ai';
@@ -25,6 +25,20 @@ export type ParentHouseholdFamilyMember = Record<string, any> & {
     inviteUrl?: string;
 };
 
+export type ParentHouseholdFamilyContact = {
+    id: string;
+    name: string;
+    email: string;
+    phone: string;
+    relation: string;
+    status: 'linked' | 'contact';
+    teamId: string;
+    teamName: string;
+    playerId: string;
+    playerName: string;
+    playerNumber?: string;
+};
+
 export type ParentHouseholdInviteRequest = {
     playerKey: string;
     email: string;
@@ -39,14 +53,17 @@ export type ParentHouseholdInviteResult = {
     emailSent: boolean;
 };
 
-export async function loadParentHouseholdInviteModel(user: AuthUser | null): Promise<{ linkedPlayers: ParentHouseholdLinkedPlayer[]; members: ParentHouseholdFamilyMember[] }> {
-    if (!user?.uid) return { linkedPlayers: [], members: [] };
+export async function loadParentHouseholdInviteModel(user: AuthUser | null): Promise<{ linkedPlayers: ParentHouseholdLinkedPlayer[]; members: ParentHouseholdFamilyMember[]; linkedContacts: ParentHouseholdFamilyContact[] }> {
+    if (!user?.uid) return { linkedPlayers: [], members: [], linkedContacts: [] };
+    const linkedPlayerList = normalizeFamilyChildren(user.parentOf || []) as ParentHouseholdLinkedPlayer[];
     const [linkedPlayers, members] = await Promise.all([
-        Promise.resolve(normalizeFamilyChildren(user.parentOf || []) as ParentHouseholdLinkedPlayer[]),
+        Promise.resolve(linkedPlayerList),
         Promise.resolve(readFamilyMembers(user.uid))
     ]);
+    const linkedContacts = await loadLinkedPlayerFamilyContacts(linkedPlayerList);
     return {
         linkedPlayers,
+        linkedContacts,
         members: (members || []).map((member: any) => ({
             ...member,
             inviteUrl: toAbsoluteLegacyUrl(member.inviteUrl)
@@ -100,6 +117,81 @@ function normalizeFamilyChildren(children: any[]) {
             playerNumber: compactString(child.playerNumber || child.number),
             playerPhotoUrl: child.playerPhotoUrl || null
         }));
+}
+
+async function loadLinkedPlayerFamilyContacts(linkedPlayers: ParentHouseholdLinkedPlayer[]): Promise<ParentHouseholdFamilyContact[]> {
+    const byTeam = new Map<string, ParentHouseholdLinkedPlayer[]>();
+    linkedPlayers.forEach((player) => {
+        if (!player.teamId || !player.playerId) return;
+        byTeam.set(player.teamId, [...(byTeam.get(player.teamId) || []), player]);
+    });
+    const contactGroups = await Promise.all([...byTeam.entries()].map(async ([teamId, players]) => {
+        const roster = await Promise.resolve(getPlayers(teamId, { includeInactive: true })).catch(() => []);
+        return players.flatMap((linkedPlayer) => {
+            const player = (Array.isArray(roster) ? roster : []).find((candidate: any) => compactString(candidate?.id) === linkedPlayer.playerId) || {};
+            return normalizePlayerFamilyContacts(player, linkedPlayer);
+        });
+    }));
+    return dedupeFamilyContacts(contactGroups.flat());
+}
+
+function normalizePlayerFamilyContacts(player: Record<string, any>, linkedPlayer: ParentHouseholdLinkedPlayer): ParentHouseholdFamilyContact[] {
+    const contacts: ParentHouseholdFamilyContact[] = [];
+    const addContact = (source: Record<string, any> | null | undefined, fallback: Record<string, any> = {}) => {
+        if (!source || typeof source !== 'object') return;
+        const email = compactString(source.email || source.parentEmail || source.guardianEmail || fallback.email).toLowerCase();
+        const userId = compactString(source.userId || source.uid || source.accountUserId || source.parentUserId || source.guardianUserId || fallback.userId);
+        const name = compactString(source.name || source.displayName || source.fullName || source.parentName || source.guardianName || fallback.name);
+        const phone = compactString(source.phone || source.parentPhone || source.guardianPhone || fallback.phone);
+        const relation = compactString(source.relation || source.relationship || source.parentRelation || source.guardianRelation || fallback.relation) || 'Parent/guardian';
+        if (!email && !userId && !name && !phone) return;
+        contacts.push({
+            id: userId || email || `${linkedPlayer.teamId}:${linkedPlayer.playerId}:${contacts.length}`,
+            name,
+            email,
+            phone,
+            relation,
+            status: userId ? 'linked' : 'contact',
+            teamId: linkedPlayer.teamId,
+            teamName: linkedPlayer.teamName,
+            playerId: linkedPlayer.playerId,
+            playerName: linkedPlayer.playerName,
+            playerNumber: linkedPlayer.playerNumber
+        });
+    };
+
+    [
+        ...(Array.isArray(player?.parents) ? player.parents : []),
+        ...(Array.isArray(player?.privateProfileParents) ? player.privateProfileParents : [])
+    ].forEach((contact) => addContact(contact));
+    addContact({
+        userId: player?.parentUserId,
+        email: player?.parentEmail,
+        name: player?.parentName,
+        phone: player?.parentPhone,
+        relation: player?.parentRelation || 'Parent'
+    });
+    addContact({
+        userId: player?.guardianUserId,
+        email: player?.guardianEmail,
+        name: player?.guardianName,
+        phone: player?.guardianPhone,
+        relation: player?.guardianRelation || 'Guardian'
+    });
+    return contacts;
+}
+
+function dedupeFamilyContacts(contacts: ParentHouseholdFamilyContact[]) {
+    const seen = new Set<string>();
+    return contacts.filter((contact) => {
+        const key = `${contact.teamId}:${contact.playerId}:${contact.email || contact.id || contact.name}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+    }).sort((a, b) => (
+        a.playerName.localeCompare(b.playerName)
+        || (a.name || a.email || a.phone).localeCompare(b.name || b.email || b.phone)
+    ));
 }
 
 function toAbsoluteLegacyUrl(value: unknown) {

--- a/apps/app/src/lib/parentHouseholdService.ts
+++ b/apps/app/src/lib/parentHouseholdService.ts
@@ -1,3 +1,4 @@
+import { getPlayerPrivateProfile } from './adapters/legacyPlayerDb';
 import { addPendingFamilyMember, getPlayers, readFamilyMembers } from './adapters/legacyParentTools';
 import type { AuthUser } from './types';
 
@@ -127,15 +128,20 @@ async function loadLinkedPlayerFamilyContacts(linkedPlayers: ParentHouseholdLink
     });
     const contactGroups = await Promise.all([...byTeam.entries()].map(async ([teamId, players]) => {
         const roster = await Promise.resolve(getPlayers(teamId, { includeInactive: true })).catch(() => []);
+        const privateProfiles = await Promise.all(players.map(async (linkedPlayer) => ({
+            playerId: linkedPlayer.playerId,
+            profile: await getPlayerPrivateProfile(teamId, linkedPlayer.playerId).catch(() => null)
+        })));
+        const privateProfileByPlayerId = new Map(privateProfiles.map((entry) => [entry.playerId, entry.profile]));
         return players.flatMap((linkedPlayer) => {
             const player = (Array.isArray(roster) ? roster : []).find((candidate: any) => compactString(candidate?.id) === linkedPlayer.playerId) || {};
-            return normalizePlayerFamilyContacts(player, linkedPlayer);
+            return normalizePlayerFamilyContacts(player, linkedPlayer, privateProfileByPlayerId.get(linkedPlayer.playerId));
         });
     }));
     return dedupeFamilyContacts(contactGroups.flat());
 }
 
-function normalizePlayerFamilyContacts(player: Record<string, any>, linkedPlayer: ParentHouseholdLinkedPlayer): ParentHouseholdFamilyContact[] {
+function normalizePlayerFamilyContacts(player: Record<string, any>, linkedPlayer: ParentHouseholdLinkedPlayer, privateProfile?: Record<string, any> | null): ParentHouseholdFamilyContact[] {
     const contacts: ParentHouseholdFamilyContact[] = [];
     const addContact = (source: Record<string, any> | null | undefined, fallback: Record<string, any> = {}) => {
         if (!source || typeof source !== 'object') return;
@@ -162,7 +168,10 @@ function normalizePlayerFamilyContacts(player: Record<string, any>, linkedPlayer
 
     [
         ...(Array.isArray(player?.parents) ? player.parents : []),
-        ...(Array.isArray(player?.privateProfileParents) ? player.privateProfileParents : [])
+        ...(Array.isArray(player?.privateProfileParents) ? player.privateProfileParents : []),
+        ...(Array.isArray(privateProfile?.parents) ? privateProfile.parents : []),
+        ...(Array.isArray(privateProfile?.privateProfileParents) ? privateProfile.privateProfileParents : []),
+        ...(Array.isArray(privateProfile?.familyContacts) ? privateProfile.familyContacts : [])
     ].forEach((contact) => addContact(contact));
     addContact({
         userId: player?.parentUserId,

--- a/apps/app/src/lib/playerService.ts
+++ b/apps/app/src/lib/playerService.ts
@@ -1385,10 +1385,6 @@ function isParentOnTeam(user: AuthUser | null, teamId: string) {
     return true;
   }
 
-  if (Array.isArray(user?.parentOf) && user.parentOf.some((entry: any) => String(entry?.teamId || '').trim() === normalizedTeamId)) {
-    return true;
-  }
-
   return !!(user?.parentPlayerKeys || []).some((key) => {
     const raw = String(key || '').trim();
     const separatorIndex = raw.indexOf('::');

--- a/apps/app/src/lib/playerService.ts
+++ b/apps/app/src/lib/playerService.ts
@@ -149,6 +149,15 @@ export type ParentPlayerPrivateProfile = {
   medicalInfo?: string | null;
 };
 
+export type ParentPlayerFamilyContact = {
+  id: string;
+  name: string;
+  email: string;
+  phone: string;
+  relation: string;
+  status: 'linked' | 'contact';
+};
+
 export type ParentPlayerIncentiveData = {
   rules: PlayerIncentiveRule[];
   currentRules: PlayerIncentiveRule[];
@@ -226,6 +235,7 @@ export type ParentPlayerDetailData = {
   certificates: Array<Record<string, any>>;
   trackingSummary: PlayerTrackingSummary[];
   privateProfile: ParentPlayerPrivateProfile | null;
+  familyContacts: ParentPlayerFamilyContact[];
   incentives: ParentPlayerIncentiveData;
   athleteProfile: ParentAthleteProfileData;
 };
@@ -372,6 +382,7 @@ export async function loadParentPlayerDetail(user: AuthUser | null, teamId: stri
     certificates: Array.isArray(certificates) ? certificates : [],
     trackingSummary,
     privateProfile: normalizePrivateProfile(privateProfile),
+    familyContacts: normalizePlayerFamilyContacts(playerDoc, privateProfile),
     incentives: buildPlayerIncentiveData({
       rules: incentiveRules,
       paidGames,
@@ -1362,6 +1373,58 @@ function isLinkedParent(user: AuthUser | null, teamId: string, playerId: string)
 
   const playerKey = `${teamId}::${playerId}`;
   return !!(user?.parentPlayerKeys || []).some((key) => String(key || '').trim() === playerKey);
+}
+
+function normalizePlayerFamilyContacts(player: Record<string, any>, privateProfile: Record<string, any> | null | undefined): ParentPlayerFamilyContact[] {
+  const contacts: ParentPlayerFamilyContact[] = [];
+  const seen = new Set<string>();
+  const clean = (value: unknown) => String(value || '').trim();
+  const addContact = (source: Record<string, any> | null | undefined, fallback: Record<string, any> = {}) => {
+    if (!source || typeof source !== 'object') return;
+    const email = normalizeEmail(source.email || source.parentEmail || source.guardianEmail || fallback.email);
+    const userId = clean(source.userId || source.uid || source.accountUserId || source.parentUserId || source.guardianUserId || fallback.userId);
+    const name = clean(source.name || source.displayName || source.fullName || source.parentName || source.guardianName || fallback.name);
+    const phone = clean(source.phone || source.parentPhone || source.guardianPhone || fallback.phone);
+    const relation = clean(source.relation || source.relationship || source.parentRelation || source.guardianRelation || fallback.relation) || 'Parent/guardian';
+    if (!email && !userId && !name && !phone) return;
+    const key = email || userId || `${name}:${phone}:${relation}`.toLowerCase();
+    if (seen.has(key)) return;
+    seen.add(key);
+    contacts.push({
+      id: userId || email || key || `family-contact-${contacts.length + 1}`,
+      name,
+      email,
+      phone,
+      relation,
+      status: userId ? 'linked' : 'contact'
+    });
+  };
+
+  [
+    ...(Array.isArray(player?.parents) ? player.parents : []),
+    ...(Array.isArray(player?.privateProfileParents) ? player.privateProfileParents : []),
+    ...(Array.isArray(privateProfile?.parents) ? privateProfile.parents : [])
+  ].forEach((contact) => addContact(contact));
+
+  addContact({
+    userId: player?.parentUserId,
+    email: player?.parentEmail,
+    name: player?.parentName,
+    phone: player?.parentPhone,
+    relation: player?.parentRelation || 'Parent'
+  });
+  addContact({
+    userId: player?.guardianUserId,
+    email: player?.guardianEmail,
+    name: player?.guardianName,
+    phone: player?.guardianPhone,
+    relation: player?.guardianRelation || 'Guardian'
+  });
+
+  return contacts.sort((a, b) => {
+    if (a.status !== b.status) return a.status === 'linked' ? -1 : 1;
+    return (a.name || a.email || a.phone).localeCompare(b.name || b.email || b.phone);
+  });
 }
 
 function isElevatedAppAdmin(user: AuthUser | null) {

--- a/apps/app/src/lib/playerService.ts
+++ b/apps/app/src/lib/playerService.ts
@@ -207,6 +207,7 @@ export type ParentPlayerDetailData = {
   scheduleLoadError: string | null;
   access: {
     isLinkedParent: boolean;
+    isTeamParent: boolean;
     isTeamStaff: boolean;
     canEditRosterDetails: boolean;
     canEditCustomRosterFields: boolean;
@@ -283,7 +284,7 @@ export async function loadParentPlayerDetail(user: AuthUser | null, teamId: stri
   const initialTeam = await getTeam(requestedTeamId, { includeInactive: true });
   const routeAccess = buildPlayerAccess(user, requestedTeamId, requestedPlayerId, initialTeam);
   const canUseScheduleFailureFallback = !!scheduleLoadError && routeAccess.isLinkedParent;
-  if (!linkedChild && !canUseScheduleFailureFallback && !routeAccess.isTeamStaff) {
+  if (!linkedChild && !canUseScheduleFailureFallback && !routeAccess.isTeamParent && !routeAccess.isTeamStaff) {
     throw new Error('This player is not linked to your account.');
   }
 
@@ -324,6 +325,7 @@ export async function loadParentPlayerDetail(user: AuthUser | null, teamId: stri
 
   const playerDoc = (Array.isArray(players) ? players : []).find((candidate: LegacyPlayerRecord) => candidate?.id === resolvedPlayerId) || {};
   const access = buildPlayerAccess(user, resolvedTeamId, resolvedPlayerId, team);
+  const visiblePrivateProfile = access.isLinkedParent || access.isTeamStaff ? privateProfile : null;
   const child = linkedChild || {
     teamId: resolvedTeamId,
     teamName: String(team?.name || '').trim() || String(playerDoc?.teamName || '').trim() || resolvedTeamId,
@@ -333,7 +335,7 @@ export async function loadParentPlayerDetail(user: AuthUser | null, teamId: stri
   const customRosterFields = buildVisibleCustomRosterFields({
     definitions: rosterFieldDefinitions,
     player: playerDoc,
-    privateProfile,
+    privateProfile: visiblePrivateProfile,
     access
   });
   const completedGameEvents = events
@@ -381,8 +383,8 @@ export async function loadParentPlayerDetail(user: AuthUser | null, teamId: stri
     clips: [],
     certificates: Array.isArray(certificates) ? certificates : [],
     trackingSummary,
-    privateProfile: normalizePrivateProfile(privateProfile),
-    familyContacts: normalizePlayerFamilyContacts(playerDoc, privateProfile),
+    privateProfile: normalizePrivateProfile(visiblePrivateProfile),
+    familyContacts: normalizePlayerFamilyContacts(playerDoc, visiblePrivateProfile),
     incentives: buildPlayerIncentiveData({
       rules: incentiveRules,
       paidGames,
@@ -423,7 +425,7 @@ async function loadParentPlayerStatsDetailUncached(user: AuthUser, teamId: strin
     getConfigs(teamId).catch(() => [])
   ]);
   const access = buildPlayerAccess(user, teamId, playerId, team);
-  if (!access.isLinkedParent && !access.isTeamStaff) {
+  if (!access.isLinkedParent && !access.isTeamParent && !access.isTeamStaff) {
     throw new Error('This player is not linked to your account.');
   }
 
@@ -488,7 +490,7 @@ export async function loadParentPlayerVideoClips(user: AuthUser | null, teamId: 
   const resolvedPlayerId = linkedChild?.playerId || requestedPlayerId;
   const team = await getTeam(resolvedTeamId, { includeInactive: true });
   const access = buildPlayerAccess(user, resolvedTeamId, resolvedPlayerId, team);
-  if (!linkedChild && !access.isLinkedParent && !access.isTeamStaff) {
+  if (!linkedChild && !access.isLinkedParent && !access.isTeamParent && !access.isTeamStaff) {
     throw new Error('This player is not linked to your account.');
   }
 
@@ -535,7 +537,7 @@ export async function loadParentPlayerStatTotals(user: AuthUser | null, teamId: 
   const requestedPlayerId = decodeURIComponent(playerId || '');
   const team = await getTeam(requestedTeamId, { includeInactive: true });
   const access = buildPlayerAccess(user, requestedTeamId, requestedPlayerId, team);
-  if (!access.isLinkedParent && !access.isTeamStaff) {
+  if (!access.isLinkedParent && !access.isTeamParent && !access.isTeamStaff) {
     throw new Error('This player is not linked to your account.');
   }
 
@@ -1375,6 +1377,25 @@ function isLinkedParent(user: AuthUser | null, teamId: string, playerId: string)
   return !!(user?.parentPlayerKeys || []).some((key) => String(key || '').trim() === playerKey);
 }
 
+function isParentOnTeam(user: AuthUser | null, teamId: string) {
+  const normalizedTeamId = String(teamId || '').trim();
+  if (!normalizedTeamId) return false;
+
+  if (Array.isArray(user?.parentTeamIds) && user.parentTeamIds.some((value) => String(value || '').trim() === normalizedTeamId)) {
+    return true;
+  }
+
+  if (Array.isArray(user?.parentOf) && user.parentOf.some((entry: any) => String(entry?.teamId || '').trim() === normalizedTeamId)) {
+    return true;
+  }
+
+  return !!(user?.parentPlayerKeys || []).some((key) => {
+    const raw = String(key || '').trim();
+    const separatorIndex = raw.indexOf('::');
+    return separatorIndex > 0 && raw.slice(0, separatorIndex) === normalizedTeamId;
+  });
+}
+
 function normalizePlayerFamilyContacts(player: Record<string, any>, privateProfile: Record<string, any> | null | undefined): ParentPlayerFamilyContact[] {
   const contacts: ParentPlayerFamilyContact[] = [];
   const seen = new Set<string>();
@@ -1451,12 +1472,14 @@ function isTeamStaffUser(user: AuthUser | null, team: LegacyTeamRecord | null) {
 
 function buildPlayerAccess(user: AuthUser | null, teamId: string, playerId: string, team: LegacyTeamRecord | null) {
   const linkedParent = isLinkedParent(user, teamId, playerId);
+  const teamParent = linkedParent || isParentOnTeam(user, teamId);
   const resolvedTeam = team ? { ...team, id: team.id || teamId } : { id: teamId };
   const isTeamStaff = isTeamStaffUser(user, resolvedTeam);
   const canEditRosterDetails = isTeamOwnerOrAdminUser(user, resolvedTeam);
   const canEditCustomRosterFields = canEditRosterDetails;
   return {
     isLinkedParent: linkedParent,
+    isTeamParent: teamParent,
     isTeamStaff,
     canEditRosterDetails,
     canEditCustomRosterFields
@@ -1472,7 +1495,7 @@ function buildVisibleCustomRosterFields({
   definitions: unknown;
   player: LegacyPlayerRecord;
   privateProfile: LegacyPlayerPrivateProfileRecord | null;
-  access: { isLinkedParent: boolean; isTeamStaff: boolean; canEditRosterDetails: boolean; canEditCustomRosterFields: boolean };
+  access: { isLinkedParent: boolean; isTeamParent?: boolean; isTeamStaff: boolean; canEditRosterDetails: boolean; canEditCustomRosterFields: boolean };
 }) {
   const normalizedFields = normalizeRosterFieldDefinitions(definitions);
   if (!normalizedFields.length) return [];
@@ -1483,11 +1506,16 @@ function buildVisibleCustomRosterFields({
   };
 
   return normalizedFields
-    .filter((field) => canViewRosterField({ id: field.key, visibility: field.visibility }, {
-      isAdmin: access.canEditCustomRosterFields,
-      isTeamMember: access.isTeamStaff || access.isLinkedParent,
-      isLinkedParent: access.isLinkedParent
-    }))
+    .filter((field) => {
+      if (field.visibility === 'parents' && !access.canEditCustomRosterFields && !access.isTeamStaff && !access.isLinkedParent) {
+        return false;
+      }
+      return canViewRosterField({ id: field.key, visibility: field.visibility }, {
+        isAdmin: access.canEditCustomRosterFields,
+        isTeamMember: access.isTeamStaff || access.isLinkedParent || !!access.isTeamParent,
+        isLinkedParent: access.isLinkedParent
+      });
+    })
     .map((field) => ({
       key: field.key,
       label: field.label,

--- a/apps/app/src/pages/PlayerDetail.test.tsx
+++ b/apps/app/src/pages/PlayerDetail.test.tsx
@@ -91,6 +91,7 @@ function buildDetailData(overrides: Record<string, any> = {}) {
     team: { id: 'team-current', name: 'Current Team' },
     access: {
       isLinkedParent: true,
+      isTeamParent: true,
       isTeamStaff: false,
       canEditRosterDetails: false,
       canEditCustomRosterFields: false
@@ -253,6 +254,11 @@ describe('PlayerDetail athlete profile season selection', () => {
   });
 
   it('shows already linked family contacts on the Family profile tab', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText }
+    });
     playerServiceMocks.loadParentPlayerDetail.mockResolvedValue(buildDetailData({
       familyContacts: [
         { id: 'mom-1', name: 'Mom Snider', email: 'mom@allplays.ai', phone: '', relation: 'Mom', status: 'linked' },
@@ -270,6 +276,10 @@ describe('PlayerDetail athlete profile season selection', () => {
     expect(screen.getByText('mom@allplays.ai')).toBeTruthy();
     expect(screen.getByText('dad@allplays.ai')).toBeTruthy();
     expect(screen.getAllByText('Linked')).toHaveLength(2);
+    fireEvent.click(screen.getByRole('button', { name: 'Copy mom@allplays.ai' }));
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('mom@allplays.ai');
+    });
     expect(screen.getByText('Invite Co-Parent')).toBeTruthy();
   });
 

--- a/apps/app/src/pages/PlayerDetail.test.tsx
+++ b/apps/app/src/pages/PlayerDetail.test.tsx
@@ -109,6 +109,7 @@ function buildDetailData(overrides: Record<string, any> = {}) {
     certificates: [],
     trackingSummary: [],
     privateProfile: null,
+    familyContacts: [],
     incentives: {
       rules: [],
       currentRules: [],
@@ -249,6 +250,27 @@ describe('PlayerDetail athlete profile season selection', () => {
     await waitFor(() => {
       expect(playerServiceMocks.loadParentPlayerAthleteProfile).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it('shows already linked family contacts on the Family profile tab', async () => {
+    playerServiceMocks.loadParentPlayerDetail.mockResolvedValue(buildDetailData({
+      familyContacts: [
+        { id: 'mom-1', name: 'Mom Snider', email: 'mom@allplays.ai', phone: '', relation: 'Mom', status: 'linked' },
+        { id: 'dad-1', name: 'Dad Snider', email: 'dad@allplays.ai', phone: '', relation: 'Dad', status: 'linked' }
+      ]
+    }));
+
+    renderPlayerDetail();
+
+    await screen.findByText('Sam Player');
+    fireEvent.click(screen.getByRole('button', { name: 'Profile' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Family' }));
+
+    expect(await screen.findByText('Linked Family')).toBeTruthy();
+    expect(screen.getByText('mom@allplays.ai')).toBeTruthy();
+    expect(screen.getByText('dad@allplays.ai')).toBeTruthy();
+    expect(screen.getAllByText('Linked')).toHaveLength(2);
+    expect(screen.getByText('Invite Co-Parent')).toBeTruthy();
   });
 
   it('lazy-loads video clips once when the Video Clips report opens', async () => {

--- a/apps/app/src/pages/PlayerDetail.tsx
+++ b/apps/app/src/pages/PlayerDetail.tsx
@@ -12,6 +12,7 @@ import {
   ChevronLeft,
   ChevronRight,
   ClipboardCheck,
+  Copy,
   DollarSign,
   Edit3,
   ExternalLink,
@@ -1544,6 +1545,16 @@ function PlayerProfileSection({
 
 function FamilyContactsCard({ data }: { data: ParentPlayerDetailData }) {
   const contacts = Array.isArray(data.familyContacts) ? data.familyContacts : [];
+  const [copiedEmail, setCopiedEmail] = useState('');
+
+  const copyEmail = async (email: string) => {
+    const normalizedEmail = compactString(email);
+    if (!normalizedEmail) return;
+    await navigator.clipboard?.writeText(normalizedEmail);
+    setCopiedEmail(normalizedEmail);
+    window.setTimeout(() => setCopiedEmail((current) => current === normalizedEmail ? '' : current), 1400);
+  };
+
   return (
     <section className="app-card p-4">
       <div className="flex items-center gap-2 text-sm font-black text-gray-950">
@@ -1552,22 +1563,34 @@ function FamilyContactsCard({ data }: { data: ParentPlayerDetailData }) {
       </div>
       <p className="mt-1 text-xs font-semibold leading-5 text-gray-500">Parent and guardian accounts or contacts already connected to this player.</p>
       {contacts.length ? (
-        <div className="mt-4 divide-y divide-gray-100 rounded-xl border border-gray-200 bg-white">
+        <div className="mt-3 grid gap-2 sm:grid-cols-2">
           {contacts.map((contact) => {
             const label = contact.name || contact.email || contact.phone || 'Family contact';
+            const showEmailMeta = Boolean(contact.email && contact.email !== label);
             return (
-              <div key={contact.id} className="flex items-start justify-between gap-3 px-3 py-3">
-                <div className="min-w-0">
-                  <div className="truncate text-sm font-black text-gray-950">{label}</div>
-                  <div className="mt-0.5 flex flex-wrap gap-x-2 gap-y-1 text-xs font-semibold text-gray-500">
-                    {contact.email && contact.email !== label ? <span>{contact.email}</span> : null}
-                    {contact.phone ? <span>{contact.phone}</span> : null}
-                    <span>{contact.relation || 'Parent/guardian'}</span>
+              <div key={contact.id} className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex min-w-0 items-center gap-2">
+                      <div className="truncate text-sm font-black leading-5 text-gray-950">{label}</div>
+                      {contact.email ? (
+                        <button type="button" className="ghost-button !h-7 !min-h-7 !w-7 !flex-none !p-0" onClick={() => copyEmail(contact.email)} aria-label={`Copy ${contact.email}`} title={copiedEmail === contact.email ? 'Copied' : 'Copy email'}>
+                          {copiedEmail === contact.email ? <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600" aria-hidden="true" /> : <Copy className="h-3.5 w-3.5" aria-hidden="true" />}
+                        </button>
+                      ) : null}
+                    </div>
+                    <div className="text-xs font-semibold leading-4 text-gray-500">{contact.relation || 'Parent/guardian'}</div>
                   </div>
+                  <span className={`flex-none rounded-full border px-2 py-0.5 text-[11px] font-black uppercase leading-4 ${contact.status === 'linked' ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-gray-200 bg-white text-gray-600'}`}>
+                    {contact.status === 'linked' ? 'Linked' : 'Contact'}
+                  </span>
                 </div>
-                <span className={`flex-none rounded-full border px-2 py-1 text-[11px] font-black uppercase ${contact.status === 'linked' ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-gray-200 bg-gray-50 text-gray-600'}`}>
-                  {contact.status === 'linked' ? 'Linked' : 'Contact'}
-                </span>
+                {showEmailMeta || contact.phone ? (
+                  <div className="mt-1 flex min-w-0 flex-wrap gap-x-3 gap-y-0.5 text-xs font-semibold leading-4 text-gray-600">
+                    {showEmailMeta ? <span className="truncate">{contact.email}</span> : null}
+                    {contact.phone ? <span className="truncate">{contact.phone}</span> : null}
+                  </div>
+                ) : null}
               </div>
             );
           })}

--- a/apps/app/src/pages/PlayerDetail.tsx
+++ b/apps/app/src/pages/PlayerDetail.tsx
@@ -1497,7 +1497,12 @@ function PlayerProfileSection({
           <div className="app-card p-4 text-sm font-semibold text-gray-500">Athlete profile tools will appear here after the profile data finishes loading.</div>
         )
       ) : null}
-      {activePanel === 'family' ? <CoParentInviteCard data={data} auth={auth} /> : null}
+      {activePanel === 'family' ? (
+        <>
+          <FamilyContactsCard data={data} />
+          <CoParentInviteCard data={data} auth={auth} />
+        </>
+      ) : null}
       {activePanel === 'incentives' ? <IncentivesCard data={data} auth={auth} onChanged={onChanged} /> : null}
 
       <section className="grid gap-3 sm:grid-cols-3">
@@ -1534,6 +1539,45 @@ function PlayerProfileSection({
         </Link>
       </section>
     </div>
+  );
+}
+
+function FamilyContactsCard({ data }: { data: ParentPlayerDetailData }) {
+  const contacts = Array.isArray(data.familyContacts) ? data.familyContacts : [];
+  return (
+    <section className="app-card p-4">
+      <div className="flex items-center gap-2 text-sm font-black text-gray-950">
+        <Users className="h-4 w-4 text-primary-600" aria-hidden="true" />
+        Linked Family
+      </div>
+      <p className="mt-1 text-xs font-semibold leading-5 text-gray-500">Parent and guardian accounts or contacts already connected to this player.</p>
+      {contacts.length ? (
+        <div className="mt-4 divide-y divide-gray-100 rounded-xl border border-gray-200 bg-white">
+          {contacts.map((contact) => {
+            const label = contact.name || contact.email || contact.phone || 'Family contact';
+            return (
+              <div key={contact.id} className="flex items-start justify-between gap-3 px-3 py-3">
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-black text-gray-950">{label}</div>
+                  <div className="mt-0.5 flex flex-wrap gap-x-2 gap-y-1 text-xs font-semibold text-gray-500">
+                    {contact.email && contact.email !== label ? <span>{contact.email}</span> : null}
+                    {contact.phone ? <span>{contact.phone}</span> : null}
+                    <span>{contact.relation || 'Parent/guardian'}</span>
+                  </div>
+                </div>
+                <span className={`flex-none rounded-full border px-2 py-1 text-[11px] font-black uppercase ${contact.status === 'linked' ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-gray-200 bg-gray-50 text-gray-600'}`}>
+                  {contact.status === 'linked' ? 'Linked' : 'Contact'}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="mt-4 rounded-xl border border-dashed border-gray-200 bg-gray-50 p-3 text-sm font-semibold text-gray-500">
+          No linked family contacts are saved for this player yet.
+        </div>
+      )}
+    </section>
   );
 }
 

--- a/apps/app/src/pages/parent-tools/HouseholdInviteTool.tsx
+++ b/apps/app/src/pages/parent-tools/HouseholdInviteTool.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
 import { Copy, Loader2, RefreshCw, Users } from 'lucide-react';
-import { createParentHouseholdMemberInvite, loadParentHouseholdInviteModel, type ParentHouseholdFamilyMember, type ParentHouseholdLinkedPlayer } from '../../lib/parentHouseholdService';
+import { createParentHouseholdMemberInvite, loadParentHouseholdInviteModel, type ParentHouseholdFamilyContact, type ParentHouseholdFamilyMember, type ParentHouseholdLinkedPlayer } from '../../lib/parentHouseholdService';
 import { toAppServiceError } from '../../lib/appErrors';
 import type { AuthState } from '../../lib/types';
 import { EmptyState, LoadingBlock, RetryableStatus, Status, ToolHeader, copyText, useParentToolAsyncOperation } from './shared';
@@ -8,6 +8,7 @@ import { EmptyState, LoadingBlock, RetryableStatus, Status, ToolHeader, copyText
 export function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: number }) {
     const [linkedPlayers, setLinkedPlayers] = useState<ParentHouseholdLinkedPlayer[]>([]);
     const [members, setMembers] = useState<ParentHouseholdFamilyMember[]>([]);
+    const [linkedContacts, setLinkedContacts] = useState<ParentHouseholdFamilyContact[]>([]);
     const [playerKey, setPlayerKey] = useState('');
     const [displayName, setDisplayName] = useState('');
     const [email, setEmail] = useState('');
@@ -37,6 +38,7 @@ export function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState;
                 onSuccess: (model) => {
                     setLinkedPlayers(model.linkedPlayers);
                     setMembers(model.members);
+                    setLinkedContacts(model.linkedContacts || []);
                     setPlayerKey((current) => current || (model.linkedPlayers[0] ? `${model.linkedPlayers[0].teamId}::${model.linkedPlayers[0].playerId}` : ''));
                 }
             }
@@ -123,6 +125,30 @@ export function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState;
                         </button>
                     </form>
                 )}
+            </section>
+
+            <section className="app-card p-4">
+                <ToolHeader icon={Users} title="Already linked family" detail="Parent and guardian accounts or contacts already connected to your linked players." />
+                <div className="mt-3 grid gap-3 lg:grid-cols-2">
+                    {linkedContacts.length ? linkedContacts.map((contact) => {
+                        const label = contact.name || contact.email || contact.phone || 'Family contact';
+                        return (
+                            <div key={`${contact.teamId}-${contact.playerId}-${contact.id}`} className="rounded-xl border border-gray-200 bg-gray-50 p-3">
+                                <div className="flex items-start justify-between gap-3">
+                                    <div className="min-w-0">
+                                        <div className="truncate text-sm font-black text-gray-950">{label}</div>
+                                        {contact.email && contact.email !== label ? <div className="mt-0.5 text-xs font-semibold text-gray-500">{contact.email}</div> : null}
+                                        {contact.phone ? <div className="mt-0.5 text-xs font-semibold text-gray-500">{contact.phone}</div> : null}
+                                    </div>
+                                    <span className={`flex-none rounded-full border px-2 py-1 text-[11px] font-black uppercase ${contact.status === 'linked' ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-gray-200 bg-gray-50 text-gray-600'}`}>
+                                        {contact.status === 'linked' ? 'Linked' : 'Contact'}
+                                    </span>
+                                </div>
+                                <div className="mt-1 text-xs font-semibold text-gray-600">{contact.relation || 'Parent/guardian'} for {contact.playerName || 'Player'}{contact.playerNumber ? ` #${contact.playerNumber}` : ''}{contact.teamName ? ` - ${contact.teamName}` : ''}</div>
+                            </div>
+                        );
+                    }) : <EmptyState icon={Users} title="No linked family contacts" detail="Linked parent and guardian contacts will appear here after they are saved on the player." />}
+                </div>
             </section>
 
             <section className="app-card p-4">

--- a/apps/app/src/pages/parent-tools/HouseholdInviteTool.tsx
+++ b/apps/app/src/pages/parent-tools/HouseholdInviteTool.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
-import { Copy, Loader2, RefreshCw, Users } from 'lucide-react';
+import { CheckCircle2, Copy, Loader2, RefreshCw, Users } from 'lucide-react';
 import { createParentHouseholdMemberInvite, loadParentHouseholdInviteModel, type ParentHouseholdFamilyContact, type ParentHouseholdFamilyMember, type ParentHouseholdLinkedPlayer } from '../../lib/parentHouseholdService';
 import { toAppServiceError } from '../../lib/appErrors';
 import type { AuthState } from '../../lib/types';
@@ -15,6 +15,7 @@ export function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState;
     const [relation, setRelation] = useState('');
     const [createdInvite, setCreatedInvite] = useState<{ code: string; inviteUrl: string; email: string; emailSent: boolean } | null>(null);
     const [message, setMessage] = useState('');
+    const [copiedEmail, setCopiedEmail] = useState('');
     const loadOperation = useParentToolAsyncOperation();
     const submitOperation = useParentToolAsyncOperation();
     const runLoad = loadOperation.run;
@@ -91,6 +92,14 @@ export function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState;
         );
     };
 
+    const copyEmail = async (nextEmail: string) => {
+        const normalizedEmail = String(nextEmail || '').trim();
+        if (!normalizedEmail) return;
+        await copyText(normalizedEmail, setMessage);
+        setCopiedEmail(normalizedEmail);
+        window.setTimeout(() => setCopiedEmail((current) => current === normalizedEmail ? '' : current), 1400);
+    };
+
     return (
         <div className="space-y-3">
             <section className="app-card p-4">
@@ -129,22 +138,34 @@ export function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState;
 
             <section className="app-card p-4">
                 <ToolHeader icon={Users} title="Already linked family" detail="Parent and guardian accounts or contacts already connected to your linked players." />
-                <div className="mt-3 grid gap-3 lg:grid-cols-2">
+                <div className="mt-3 grid gap-2 lg:grid-cols-2">
                     {linkedContacts.length ? linkedContacts.map((contact) => {
                         const label = contact.name || contact.email || contact.phone || 'Family contact';
+                        const showEmailMeta = Boolean(contact.email && contact.email !== label);
                         return (
-                            <div key={`${contact.teamId}-${contact.playerId}-${contact.id}`} className="rounded-xl border border-gray-200 bg-gray-50 p-3">
-                                <div className="flex items-start justify-between gap-3">
-                                    <div className="min-w-0">
-                                        <div className="truncate text-sm font-black text-gray-950">{label}</div>
-                                        {contact.email && contact.email !== label ? <div className="mt-0.5 text-xs font-semibold text-gray-500">{contact.email}</div> : null}
-                                        {contact.phone ? <div className="mt-0.5 text-xs font-semibold text-gray-500">{contact.phone}</div> : null}
+                            <div key={`${contact.teamId}-${contact.playerId}-${contact.id}`} className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2">
+                                <div className="flex items-center justify-between gap-2">
+                                    <div className="min-w-0 flex-1">
+                                        <div className="flex min-w-0 items-center gap-2">
+                                            <div className="truncate text-sm font-black leading-5 text-gray-950">{label}</div>
+                                            {contact.email ? (
+                                                <button type="button" className="ghost-button !h-7 !min-h-7 !w-7 !flex-none !p-0" onClick={() => copyEmail(contact.email)} aria-label={`Copy ${contact.email}`} title={copiedEmail === contact.email ? 'Copied' : 'Copy email'}>
+                                                    {copiedEmail === contact.email ? <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600" aria-hidden="true" /> : <Copy className="h-3.5 w-3.5" aria-hidden="true" />}
+                                                </button>
+                                            ) : null}
+                                        </div>
+                                        <div className="text-xs font-semibold leading-4 text-gray-600">{contact.relation || 'Parent/guardian'} for {contact.playerName || 'Player'}{contact.playerNumber ? ` #${contact.playerNumber}` : ''}{contact.teamName ? ` - ${contact.teamName}` : ''}</div>
                                     </div>
-                                    <span className={`flex-none rounded-full border px-2 py-1 text-[11px] font-black uppercase ${contact.status === 'linked' ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-gray-200 bg-gray-50 text-gray-600'}`}>
+                                    <span className={`flex-none rounded-full border px-2 py-0.5 text-[11px] font-black uppercase leading-4 ${contact.status === 'linked' ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-gray-200 bg-white text-gray-600'}`}>
                                         {contact.status === 'linked' ? 'Linked' : 'Contact'}
                                     </span>
                                 </div>
-                                <div className="mt-1 text-xs font-semibold text-gray-600">{contact.relation || 'Parent/guardian'} for {contact.playerName || 'Player'}{contact.playerNumber ? ` #${contact.playerNumber}` : ''}{contact.teamName ? ` - ${contact.teamName}` : ''}</div>
+                                {showEmailMeta || contact.phone ? (
+                                    <div className="mt-1 flex min-w-0 flex-wrap gap-x-3 gap-y-0.5 text-xs font-semibold leading-4 text-gray-600">
+                                        {showEmailMeta ? <span className="truncate">{contact.email}</span> : null}
+                                        {contact.phone ? <span className="truncate">{contact.phone}</span> : null}
+                                    </div>
+                                ) : null}
                             </div>
                         );
                     }) : <EmptyState icon={Users} title="No linked family contacts" detail="Linked parent and guardian contacts will appear here after they are saved on the player." />}

--- a/tests/unit/app-parent-household-service.test.js
+++ b/tests/unit/app-parent-household-service.test.js
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const parentToolsMocks = vi.hoisted(() => ({
+    addPendingFamilyMember: vi.fn(),
+    getPlayers: vi.fn(),
+    readFamilyMembers: vi.fn()
+}));
+
+const playerDbMocks = vi.hoisted(() => ({
+    getPlayerPrivateProfile: vi.fn()
+}));
+
+vi.mock('../../apps/app/src/lib/adapters/legacyParentTools', () => parentToolsMocks);
+vi.mock('../../apps/app/src/lib/adapters/legacyPlayerDb', () => playerDbMocks);
+
+import { loadParentHouseholdInviteModel } from '../../apps/app/src/lib/parentHouseholdService.ts';
+
+const user = {
+    uid: 'user-1',
+    parentOf: [{ teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Pat Star', playerNumber: '9' }]
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    parentToolsMocks.readFamilyMembers.mockResolvedValue([]);
+    parentToolsMocks.getPlayers.mockResolvedValue([{ id: 'player-1', name: 'Pat Star', parents: [] }]);
+    playerDbMocks.getPlayerPrivateProfile.mockResolvedValue(null);
+});
+
+describe('parent household invite service', () => {
+    it('loads linked contacts from player private profile parents', async () => {
+        playerDbMocks.getPlayerPrivateProfile.mockResolvedValueOnce({
+            parents: [
+                { userId: 'mom-1', name: 'Mom Snider', email: 'mom@allplays.ai', relation: 'Mom' }
+            ]
+        });
+
+        const model = await loadParentHouseholdInviteModel(user);
+
+        expect(playerDbMocks.getPlayerPrivateProfile).toHaveBeenCalledWith('team-1', 'player-1');
+        expect(model.linkedContacts).toEqual([
+            expect.objectContaining({
+                teamId: 'team-1',
+                playerId: 'player-1',
+                playerName: 'Pat Star',
+                name: 'Mom Snider',
+                email: 'mom@allplays.ai',
+                relation: 'Mom',
+                status: 'linked'
+            })
+        ]);
+    });
+});

--- a/tests/unit/app-player-service.test.js
+++ b/tests/unit/app-player-service.test.js
@@ -333,7 +333,10 @@ describe('React app parent player detail service', () => {
             parents: [{ name: 'Private Parent', email: 'private@example.com', relation: 'Guardian' }]
         });
 
-        const detail = await loadParentPlayerDetail(user(), 'team-1', 'player-2');
+        const detail = await loadParentPlayerDetail({
+            ...user(),
+            parentTeamIds: ['team-1']
+        }, 'team-1', 'player-2');
 
         expect(detail.access.isLinkedParent).toBe(false);
         expect(detail.access.isTeamParent).toBe(true);
@@ -343,6 +346,16 @@ describe('React app parent player detail service', () => {
             expect.objectContaining({ name: 'Taylor Parent', email: 'taylor@example.com', relation: 'Parent' })
         ]);
         expect(JSON.stringify(detail.familyContacts)).not.toContain('private@example.com');
+    });
+
+    it('does not treat raw parentOf rows as team-parent access for teammates', async () => {
+        scheduleMocks.loadParentPlayerSchedule.mockResolvedValue({
+            children: [{ teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Pat' }],
+            events: []
+        });
+
+        await expect(loadParentPlayerDetail(user(), 'team-1', 'player-2'))
+            .rejects.toThrow('This player is not linked to your account.');
     });
 
     it('falls back to the legacy player-only route and blocks unlinked players', async () => {

--- a/tests/unit/app-player-service.test.js
+++ b/tests/unit/app-player-service.test.js
@@ -153,7 +153,16 @@ beforeEach(() => {
     });
     dbMocks.getTeam.mockResolvedValue({ id: 'team-1', name: 'Bears', sport: 'basketball' });
     dbMocks.getPlayers.mockResolvedValue([
-        { id: 'player-1', name: 'Pat Star', number: '9', photoUrl: 'https://example.test/pat.jpg' }
+        {
+            id: 'player-1',
+            name: 'Pat Star',
+            number: '9',
+            photoUrl: 'https://example.test/pat.jpg',
+            parents: [
+                { userId: 'mom-1', name: 'Mom Snider', email: 'mom@allplays.ai', relation: 'Mom' },
+                { userId: 'dad-1', name: 'Dad Snider', email: 'dad@allplays.ai', relation: 'Dad' }
+            ]
+        }
     ]);
     dbMocks.getGames.mockResolvedValue([{ id: 'game-final', clips: [] }]);
     dbMocks.getAggregatedStatsForPlayer.mockResolvedValue({ pts: 12, reb: 4 });
@@ -265,6 +274,10 @@ describe('React app parent player detail service', () => {
             emergencyContact: { name: 'Jamie Parent', phone: '555-0100' },
             medicalInfo: 'Peanut allergy'
         });
+        expect(detail.familyContacts).toEqual([
+            expect.objectContaining({ name: 'Dad Snider', email: 'dad@allplays.ai', relation: 'Dad', status: 'linked' }),
+            expect.objectContaining({ name: 'Mom Snider', email: 'mom@allplays.ai', relation: 'Mom', status: 'linked' })
+        ]);
         expect(detail.incentives).toMatchObject({
             totalEarnedCents: 1200,
             totalPaidCents: 1200,

--- a/tests/unit/app-player-service.test.js
+++ b/tests/unit/app-player-service.test.js
@@ -309,6 +309,42 @@ describe('React app parent player detail service', () => {
         expect(clips).toEqual([{ title: 'Fast break', url: 'https://video.example.test/clip', gameLabel: 'vs. Falcons' }]);
     });
 
+    it('allows a same-team parent to open a teammate profile without private household details', async () => {
+        scheduleMocks.loadParentPlayerSchedule.mockResolvedValue({
+            children: [{ teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Pat' }],
+            events: []
+        });
+        dbMocks.getPlayers.mockResolvedValue([
+            {
+                id: 'player-1',
+                name: 'Pat Star',
+                parents: [{ userId: 'mom-1', name: 'Mom Snider', email: 'mom@allplays.ai', relation: 'Mom' }]
+            },
+            {
+                id: 'player-2',
+                name: 'Taylor Teammate',
+                number: '11',
+                parents: [{ userId: 'team-parent-1', name: 'Taylor Parent', email: 'taylor@example.com', relation: 'Parent' }]
+            }
+        ]);
+        dbMocks.getPlayerPrivateProfile.mockResolvedValue({
+            emergencyContact: { name: 'Private Contact', phone: '555-0199' },
+            medicalInfo: 'Private note',
+            parents: [{ name: 'Private Parent', email: 'private@example.com', relation: 'Guardian' }]
+        });
+
+        const detail = await loadParentPlayerDetail(user(), 'team-1', 'player-2');
+
+        expect(detail.access.isLinkedParent).toBe(false);
+        expect(detail.access.isTeamParent).toBe(true);
+        expect(detail.child).toMatchObject({ teamId: 'team-1', playerId: 'player-2', playerName: 'Taylor Teammate' });
+        expect(detail.privateProfile).toBeNull();
+        expect(detail.familyContacts).toEqual([
+            expect.objectContaining({ name: 'Taylor Parent', email: 'taylor@example.com', relation: 'Parent' })
+        ]);
+        expect(JSON.stringify(detail.familyContacts)).not.toContain('private@example.com');
+    });
+
     it('falls back to the legacy player-only route and blocks unlinked players', async () => {
         const legacyDetail = await loadParentPlayerDetail(user(), '', 'player-2');
         expect(scheduleMocks.loadParentPlayerSchedule).toHaveBeenCalledWith(expect.objectContaining({ uid: 'user-1' }), {
@@ -409,17 +445,21 @@ describe('React app parent player detail service', () => {
         expect(detail.scheduleLoadError).toBe('Schedule is temporarily unavailable. Refresh the player to try again.');
     });
 
-    it('rejects stale parent links when a successful schedule load omits the player', async () => {
+    it('rejects off-team stale parent links when a successful schedule load omits the player', async () => {
         scheduleMocks.loadParentPlayerSchedule.mockResolvedValue({ children: [], events: [] });
-        const keyOnlyParent = {
+        const offTeamParent = {
+            ...user(),
+            parentOf: [{ teamId: 'team-2', playerId: 'player-2', playerName: 'Sam', teamName: 'Thunder' }]
+        };
+        const offTeamKeyOnlyParent = {
             ...user(),
             parentOf: [],
-            parentPlayerKeys: ['team-1::player-1']
+            parentPlayerKeys: ['team-2::player-2']
         };
 
-        await expect(loadParentPlayerDetail(user(), 'team-1', 'player-1'))
+        await expect(loadParentPlayerDetail(offTeamParent, 'team-1', 'player-1'))
             .rejects.toThrow('This player is not linked to your account.');
-        await expect(loadParentPlayerDetail(keyOnlyParent, 'team-1', 'player-1'))
+        await expect(loadParentPlayerDetail(offTeamKeyOnlyParent, 'team-1', 'player-1'))
             .rejects.toThrow('This player is not linked to your account.');
     });
 


### PR DESCRIPTION
## Summary
- Add normalized linked family/contact data to the parent player detail model.
- Show existing linked family contacts on the Player Profile family tab.
- Show already-linked family contacts on Parent Tools > Household, separate from pending invites.

## Why
Parents could see that multiple accounts were linked to the same player, but the Family and Household tabs only exposed invite flows. Existing linked parents/guardians such as mom@allplays.ai and dad@allplays.ai were not visible unless they came through the pending household invite list.

## Validation
- `npx vitest run tests/unit/app-player-service.test.js apps/app/src/pages/PlayerDetail.test.tsx --reporter=verbose`
- `npm --prefix apps/app run typecheck`
- `npm run app:build`