### PR TITLE
Unify app invite flows

### DIFF
--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getHorizontalScrollTarget, ParentTools, type ParentToolId } from './ParentTools';
 import type { AuthState } from '../lib/types';
 import { APP_BACK_DISMISS_EVENT, getNativeBackTarget } from '../lib/nativeBackButton';
-import { openPublicUrl, sharePublicUrl } from '../lib/publicActions';
+import { copyPublicText, openPublicUrl, sharePublicUrl } from '../lib/publicActions';
 
 const parentToolsServiceMocks = vi.hoisted(() => ({
     buildParentScheduleIcs: vi.fn(),
@@ -72,6 +72,7 @@ vi.mock('../lib/parentCertificatesService', () => ({
 vi.mock('../lib/parentToolsAccessService', () => parentToolsAccessServiceMocks);
 vi.mock('../lib/inviteRedemption', () => inviteRedemptionMocks);
 vi.mock('../lib/publicActions', () => ({
+    copyPublicText: vi.fn(),
     openPublicUrl: vi.fn(),
     sharePublicUrl: vi.fn()
 }));
@@ -238,6 +239,7 @@ describe('ParentTools access', () => {
             ],
             members: []
         });
+        vi.mocked(copyPublicText).mockResolvedValue('copied');
         inviteRedemptionMocks.redeemSignedInInvite.mockResolvedValue({
             code: 'AB12CD34',
             redirectPath: '/home',
@@ -748,7 +750,8 @@ describe('ParentTools access', () => {
         expect(parentToolsServiceMocks.getGoogleCalendarFeedUrl).toHaveBeenCalledWith(privateFeedUrl);
 
         fireEvent.click(screen.getByRole('button', { name: 'Copy private link' }));
-        await waitFor(() => expect(writeText).toHaveBeenCalledWith(privateFeedUrl));
+        await waitFor(() => expect(copyPublicText).toHaveBeenCalledWith(privateFeedUrl));
+        expect(writeText).not.toHaveBeenCalled();
         expect(parentToolsServiceMocks.getPrivateTeamCalendarFeedUrl).toHaveBeenCalledTimes(3);
     });
 
@@ -903,12 +906,7 @@ describe('ParentTools access', () => {
     });
 
     it('shows a created family link when clipboard copy and refresh recovery miss it', async () => {
-        Object.defineProperty(navigator, 'clipboard', {
-            configurable: true,
-            value: {
-                writeText: vi.fn().mockRejectedValue(new Error('Clipboard unavailable.'))
-            }
-        });
+        vi.mocked(copyPublicText).mockResolvedValueOnce('failed');
         parentToolsServiceMocks.loadFamilyShareModel.mockResolvedValue({
             children: [
                 {

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -88,6 +88,7 @@ vi.mock('lucide-react', () => {
         Download: Icon,
         ExternalLink: Icon,
         KeyRound: Icon,
+        Link2: Icon,
         Loader2: Icon,
         RefreshCw: Icon,
         Search: Icon,
@@ -808,7 +809,7 @@ describe('ParentTools access', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Household' }));
         await screen.findByText('No pending household invites');
         expect(parentToolsServiceMocks.loadParentHouseholdInviteModel).toHaveBeenCalledTimes(1);
-        fireEvent.change(screen.getByPlaceholderText('Household contact email'), { target: { value: 'guardian@example.com' } });
+        fireEvent.change(screen.getByPlaceholderText('Recipient email'), { target: { value: 'guardian@example.com' } });
         expect(parentToolsServiceMocks.loadParentHouseholdInviteModel).toHaveBeenCalledTimes(1);
     });
 

--- a/apps/app/src/pages/PlayerDetail.test.tsx
+++ b/apps/app/src/pages/PlayerDetail.test.tsx
@@ -280,7 +280,7 @@ describe('PlayerDetail athlete profile season selection', () => {
     await waitFor(() => {
       expect(writeText).toHaveBeenCalledWith('mom@allplays.ai');
     });
-    expect(screen.getByText('Invite Co-Parent')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Create invite' })).toBeTruthy();
   });
 
   it('lazy-loads video clips once when the Video Clips report opens', async () => {

--- a/apps/app/src/pages/PlayerDetail.tsx
+++ b/apps/app/src/pages/PlayerDetail.tsx
@@ -70,7 +70,9 @@ import {
   type RsvpResponse
 } from '../lib/scheduleLogic';
 import { sharePublicUrl } from '../lib/publicActions';
+import { buildAppAcceptInviteUrl } from '../lib/inviteUrls';
 import { completeParentCoreWorkflowTimer } from '../lib/parentWorkflowTiming';
+import { InviteResultCard } from './parent-tools/shared';
 import type { AuthState } from '../lib/types';
 import type { ProfilePhotoSource } from '../lib/profilePhotoService';
 
@@ -2697,13 +2699,14 @@ function CoParentInviteCard({ data, auth }: { data: ParentPlayerDetailData; auth
   const [email, setEmail] = useState('');
   const [sending, setSending] = useState(false);
   const [status, setStatus] = useState<{ tone: 'error' | 'success'; message: string } | null>(null);
-  const [code, setCode] = useState('');
+  const [createdInvite, setCreatedInvite] = useState<{ code: string; inviteUrl: string; email: string; emailSent: boolean } | null>(null);
 
   const submit = async (event: FormEvent) => {
     event.preventDefault();
     setSending(true);
     setStatus(null);
-    setCode('');
+    setCreatedInvite(null);
+    const normalizedEmail = email.trim().toLowerCase();
     try {
       const result = await sendParentCoParentInvite({
         user: auth.user,
@@ -2712,8 +2715,14 @@ function CoParentInviteCard({ data, auth }: { data: ParentPlayerDetailData; auth
         playerName: data.player.name || data.child.playerName,
         email
       });
-      setCode(result?.code || '');
-      setStatus({ tone: 'success', message: `Invite created for ${email.trim().toLowerCase()}.` });
+      const code = String(result?.code || '').trim().toUpperCase();
+      setCreatedInvite({
+        code,
+        inviteUrl: buildAppAcceptInviteUrl(code, 'coparent'),
+        email: normalizedEmail,
+        emailSent: false
+      });
+      setStatus({ tone: 'success', message: `Invite created for ${normalizedEmail}.` });
       setEmail('');
     } catch (error: any) {
       setStatus({ tone: 'error', message: error?.message || 'Unable to send co-parent invite.' });
@@ -2726,21 +2735,27 @@ function CoParentInviteCard({ data, auth }: { data: ParentPlayerDetailData; auth
     <section className="app-card p-4">
       <div className="flex items-center gap-2 text-sm font-black text-primary-800">
         <Users className="h-4 w-4" aria-hidden="true" />
-        Invite Co-Parent
+        Create invite
       </div>
-      <p className="mt-1 text-xs font-semibold leading-5 text-gray-500">Creates the same co-parent invite code as the parent dashboard.</p>
+      <p className="mt-1 text-xs font-semibold leading-5 text-gray-500">Invite another parent or caregiver to connect their account to this player.</p>
       <form className="mt-4 space-y-3" onSubmit={submit}>
-        <TextField label="Co-parent email" value={email} onChange={setEmail} placeholder="co-parent@example.com" type="email" />
+        <TextField label="Recipient email" value={email} onChange={setEmail} placeholder="parent@example.com" type="email" />
         {status ? <Status tone={status.tone} message={status.message} /> : null}
-        {code ? (
-          <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-3">
-            <div className="text-xs font-black uppercase tracking-[0.04em] text-emerald-700">Invite code</div>
-            <div className="mt-1 font-mono text-lg font-black text-emerald-950">{code}</div>
-          </div>
+        {createdInvite ? (
+          <InviteResultCard
+            code={createdInvite.code}
+            inviteUrl={createdInvite.inviteUrl}
+            recipientEmail={createdInvite.email}
+            emailSent={createdInvite.emailSent}
+            title="Invite code"
+            shareTitle="ALL PLAYS parent invite"
+            shareText={`Join ALL PLAYS to follow this player with invite code ${createdInvite.code}.`}
+            onStatus={(message) => setStatus({ tone: 'success', message })}
+          />
         ) : null}
         <button type="submit" className="primary-button w-full justify-center" disabled={sending}>
           {sending ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Mail className="h-4 w-4" aria-hidden="true" />}
-          {sending ? 'Creating Invite' : 'Create Invite'}
+          {sending ? 'Creating invite...' : 'Create invite'}
         </button>
       </form>
     </section>

--- a/apps/app/src/pages/Profile.test.tsx
+++ b/apps/app/src/pages/Profile.test.tsx
@@ -276,8 +276,8 @@ describe('Profile', () => {
 
     renderProfile('/profile?section=invites');
 
-    expect(await screen.findByText('Invite codes')).toBeTruthy();
-    expect(await screen.findByText('No codes generated yet.')).toBeTruthy();
+    expect((await screen.findAllByText('Create invite')).length).toBeGreaterThan(0);
+    expect(await screen.findByText('No invites created yet.')).toBeTruthy();
     expect(screen.queryByText('Unable to load invite history.')).toBeNull();
     expect(profileServiceMocks.loadProfileAccessCodesPage).toHaveBeenCalledWith('user-1', { pageSize: 3 });
   });

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -40,6 +40,7 @@ import {
 import { buildAppAcceptInviteUrl } from '../lib/inviteUrls';
 import { createLogger } from '../lib/logger';
 import { sharePublicUrl } from '../lib/publicActions';
+import { InviteResultCard } from './parent-tools/shared';
 import { startAppInitialLoadTimer } from '../lib/telemetry';
 import { useShellLayout } from '../lib/useShellLayout';
 import { useViewLoadTimer } from '../lib/viewLoadTiming';
@@ -1679,9 +1680,9 @@ export function Profile({ auth }: { auth: AuthState }) {
           <div>
             <div className="flex items-center gap-2 text-sm font-black text-primary-800">
               <Clipboard className="h-4 w-4" aria-hidden="true" />
-              Invite codes
+              Create invite
             </div>
-            <p className="mt-2 text-sm font-semibold leading-6 text-gray-600">Create one-time access codes and keep recent history handy.</p>
+            <p className="mt-2 text-sm font-semibold leading-6 text-gray-600">Create an invite, then share it by link or fallback code.</p>
           </div>
           {accessCodes.length ? (
             <span className="rounded-full border border-gray-200 bg-gray-50 px-3 py-1 text-xs font-black text-gray-600">{accessCodes.length} total</span>
@@ -1689,58 +1690,48 @@ export function Profile({ auth }: { auth: AuthState }) {
         </div>
 
         <form className="mt-4 space-y-3" onSubmit={createInviteCode}>
-          <details className="rounded-xl border border-gray-200 bg-gray-50 p-3">
-            <summary className="cursor-pointer text-sm font-black text-gray-700">Advanced: add recipient label</summary>
-            <p className="mt-2 text-xs font-semibold leading-5 text-gray-500">Add an email or phone number to label and target the invite; the app does not send it.</p>
-            <div className="mt-3 grid gap-3 sm:grid-cols-2">
-              <input className="auth-input" type="email" value={inviteEmail} onChange={(event) => setInviteEmail(event.target.value)} placeholder="coach@example.com" aria-label="Invite email label" />
-              <input className="auth-input" type="tel" value={invitePhone} onChange={(event) => setInvitePhone(event.target.value)} placeholder="(555) 123-4567" aria-label="Invite phone label" />
-            </div>
-          </details>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <label>
+              <span className="app-label">Recipient email</span>
+              <input className="auth-input mt-1" type="email" value={inviteEmail} onChange={(event) => setInviteEmail(event.target.value)} placeholder="coach@example.com" aria-label="Recipient email" />
+            </label>
+            <label>
+              <span className="app-label">Recipient phone</span>
+              <input className="auth-input mt-1" type="tel" value={invitePhone} onChange={(event) => setInvitePhone(event.target.value)} placeholder="(555) 123-4567" aria-label="Recipient phone" />
+            </label>
+          </div>
+          <p className="text-xs font-semibold leading-5 text-gray-500">Add an email or phone number to label and target the invite; this invite is shared by link or code.</p>
           <div className="flex flex-wrap items-center gap-2">
             <button type="submit" className="primary-button" disabled={busy === 'invite'}>
               {busy === 'invite' ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Link2 className="h-4 w-4" aria-hidden="true" />}
-              Generate invite link
+              {busy === 'invite' ? 'Creating invite...' : 'Create invite'}
             </button>
             <StatusMessage status={inviteStatus} />
           </div>
         </form>
 
         {generatedCode ? (
-          <div className="mt-4 rounded-xl border border-emerald-200 bg-emerald-50 p-3">
-            <div className="text-xs font-extrabold uppercase tracking-[0.04em] text-emerald-700">Generated invite link</div>
-            <div className="mt-2 flex flex-wrap items-center gap-2">
-              <button type="button" className="primary-button" onClick={() => shareInviteLink(generatedCode, generatedInviteMetadata)}>
-                <Share2 className="h-4 w-4" aria-hidden="true" />
-                Share invite link
-              </button>
-              <button type="button" className="ghost-button" onClick={() => copyText(signupLink, 'Link copied.')}>
-                <Link2 className="h-4 w-4" aria-hidden="true" />
-                Copy invite link
-              </button>
-              <span className="break-all rounded-lg bg-white px-3 py-2 text-sm font-bold text-gray-700">{signupLink}</span>
-            </div>
-            {inviteActionStatus ? <div className="mt-2 text-sm font-black text-emerald-700">{inviteActionStatus}</div> : null}
-            <div className="mt-3 flex flex-wrap items-center gap-2 text-sm font-bold text-gray-600">
-              <span>Fallback code</span>
-              <code className="rounded-lg bg-white px-3 py-1.5 text-lg font-black tracking-widest text-gray-950">{generatedCode}</code>
-              <button type="button" className="ghost-button" onClick={() => copyText(generatedCode, 'Code copied.')}>
-                <Copy className="h-4 w-4" aria-hidden="true" />
-                Copy code
-              </button>
-            </div>
-          </div>
+          <InviteResultCard
+            code={generatedCode}
+            inviteUrl={signupLink}
+            recipientLabel={generatedInviteMetadata.email || generatedInviteMetadata.phone}
+            emailSent={false}
+            title="Invite code"
+            shareTitle={`ALL PLAYS invite${generatedInviteMetadata.email ? ` for ${generatedInviteMetadata.email}` : generatedInviteMetadata.phone ? ` for ${generatedInviteMetadata.phone}` : ''}`}
+            shareText={generatedInviteMetadata.email ? `Use this ALL PLAYS invite link for ${generatedInviteMetadata.email}.` : generatedInviteMetadata.phone ? `Use this ALL PLAYS invite link for ${generatedInviteMetadata.phone}.` : `Use this ALL PLAYS invite link.`}
+            onStatus={setInviteActionStatus}
+          />
         ) : null}
 
         <div className="mt-4 space-y-2">
           {accessCodes.length ? visibleAccessCodes.map((code) => (
             <AccessCodeCard key={code.id} code={code} onCopy={copyText} onShare={shareInviteLink} />
           )) : (
-            <div className="rounded-xl border border-gray-200 bg-gray-50 p-3 text-sm font-semibold text-gray-500">No codes generated yet.</div>
+            <div className="rounded-xl border border-gray-200 bg-gray-50 p-3 text-sm font-semibold text-gray-500">No invites created yet.</div>
           )}
         </div>
 
-        {!generatedCode && inviteActionStatus ? <div className="mt-3 text-sm font-black text-emerald-700">{inviteActionStatus}</div> : null}
+        {inviteActionStatus ? <div className="mt-3 text-sm font-black text-emerald-700">{inviteActionStatus}</div> : null}
 
         {accessCodesHasMore || accessCodes.length > collapsedInviteCount ? (
           <button type="button" className="ghost-button mt-3 w-full justify-center" onClick={loadMoreInviteHistory} disabled={accessCodesLoadingMore}>

--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -84,6 +84,7 @@ vi.mock('lucide-react', () => {
     ExternalLink: Icon,
     ImageIcon: Icon,
     LinkIcon: Icon,
+    Link2: Icon,
     Loader2: Icon,
     MapPin: Icon,
     MessageCircle: Icon,
@@ -93,6 +94,7 @@ vi.mock('lucide-react', () => {
     Shield: Icon,
     Ticket: Icon,
     Trophy: Icon,
+    Share2: Icon,
     UserPlus: Icon,
     UserRound: Icon,
     Users: Icon,
@@ -1544,7 +1546,7 @@ describe('TeamDetail', () => {
     fireEvent.click(screen.getByRole('button', { name: /roster/i }));
 
     await waitFor(() => expect(teamDetailServiceMocks.loadTeamRosterParentInvites).toHaveBeenCalledTimes(1));
-    expect(await screen.findByRole('button', { name: 'Invite parent' })).toBeTruthy();
+    expect(await screen.findByRole('button', { name: 'Create invite' })).toBeTruthy();
     await waitFor(() => expect(teamDetailServiceMocks.loadTeamRosterParentInvites).toHaveBeenCalledTimes(1));
   });
 
@@ -1609,11 +1611,11 @@ describe('TeamDetail', () => {
 
     expect(await screen.findByRole('heading', { name: 'Bears' })).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: /roster/i }));
-    expect(await screen.findByRole('button', { name: 'Invite parent' })).toBeTruthy();
+    expect(await screen.findByRole('button', { name: 'Create invite' })).toBeTruthy();
 
-    fireEvent.change(screen.getByLabelText('Parent email for Pat Star'), { target: { value: 'parent@example.com' } });
+    fireEvent.change(screen.getByLabelText('Recipient email for Pat Star'), { target: { value: 'parent@example.com' } });
     fireEvent.change(screen.getByLabelText('Parent relation for Pat Star'), { target: { value: 'Guardian' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Invite parent' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create invite' }));
 
     await waitFor(() => expect(teamDetailServiceMocks.createRosterParentInviteForApp).toHaveBeenCalledWith(
       'team-1',
@@ -1622,7 +1624,7 @@ describe('TeamDetail', () => {
       { email: 'parent@example.com', relation: 'Guardian' }
     ));
     await waitFor(() => expect(teamDetailServiceMocks.loadTeamRosterParentInvites).toHaveBeenCalledTimes(2));
-    expect(await screen.findByText('Invite emailed to parent@example.com with the code and signup link.')).toBeTruthy();
+    expect(await screen.findByText('Email queued for parent@example.com.')).toBeTruthy();
   });
 
   it('keeps a created parent invite visible when its email cannot be sent', async () => {
@@ -1656,13 +1658,13 @@ describe('TeamDetail', () => {
 
     expect(await screen.findByRole('heading', { name: 'Bears' })).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: /roster/i }));
-    expect(await screen.findByRole('button', { name: 'Invite parent' })).toBeTruthy();
+    expect(await screen.findByRole('button', { name: 'Create invite' })).toBeTruthy();
 
-    fireEvent.change(screen.getByLabelText('Parent email for Pat Star'), { target: { value: 'parent@example.com' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Invite parent' }));
+    fireEvent.change(screen.getByLabelText('Recipient email for Pat Star'), { target: { value: 'parent@example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create invite' }));
 
     await waitFor(() => expect(teamDetailServiceMocks.loadTeamRosterParentInvites).toHaveBeenCalledTimes(2));
-    expect(await screen.findByText('Invite created, but the email to parent@example.com could not be sent. Copy or share the code or link.')).toBeTruthy();
+    expect(await screen.findByText('Copy and share this invite with parent@example.com.')).toBeTruthy();
     expect(screen.getByText('ABCD1234')).toBeTruthy();
   });
 
@@ -1713,7 +1715,7 @@ describe('TeamDetail', () => {
     const { sharePublicUrl } = await import('../lib/publicActions');
     expect(sharePublicUrl).toHaveBeenCalledWith({
       title: 'Bears staff invite',
-      text: 'Join Bears staff on ALL PLAYS',
+      text: 'Join Bears staff on ALL PLAYS.',
       url: 'https://allplays.ai/app#/accept-invite?code=CODE123&type=admin',
       clipboardText: 'https://allplays.ai/app#/accept-invite?code=CODE123&type=admin'
     });

--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -1724,6 +1724,51 @@ describe('TeamDetail', () => {
     await waitFor(() => expect(teamDetailServiceMocks.revokeTeamAdminAccessForApp).toHaveBeenCalledWith('team-1', 'coach@example.com', auth.user));
   });
 
+  it('shows an error when an admin fallback invite has no code or link to share', async () => {
+    const managedModel = {
+      ...model,
+      canManageTeam: true,
+      canManageAdmins: true,
+      staffPermissions: {
+        staff: [{ label: 'owner@example.com', role: 'Owner' }],
+        pendingInvites: [],
+        helperPermissions: [],
+        scorekeepingMode: 'selected',
+        scorekeeperGrantTargets: [],
+        teamMediaManagerGrantTargets: [],
+        videographerGrantTargets: [],
+        hasAnyStaff: true
+      }
+    };
+    teamDetailServiceMocks.loadParentTeamDetail.mockResolvedValue(managedModel);
+    teamDetailServiceMocks.loadTeamStaffPermissions.mockResolvedValue(managedModel.staffPermissions);
+    teamDetailServiceMocks.inviteTeamAdminForApp.mockResolvedValue({
+      email: 'newcoach@example.com',
+      status: 'fallback_code',
+      code: null,
+      teamName: 'Bears',
+      acceptInviteUrl: null
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/teams/team-1']}>
+        <Routes>
+          <Route path="/teams/:teamId" element={<TeamDetail auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Bears' })).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /more/i }));
+    fireEvent.change(screen.getByLabelText('Admin email'), { target: { value: ' NewCoach@Example.com ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send invite' }));
+
+    expect(await screen.findByText('Unable to create an admin invite code. Try again.')).toBeTruthy();
+    expect(screen.queryByText('newcoach@example.com already has an account and was added as an admin.')).toBeNull();
+    expect(screen.getByLabelText('Admin email')).toHaveValue('NewCoach@Example.com');
+    expect(teamDetailServiceMocks.loadTeamStaffPermissions).not.toHaveBeenCalled();
+  });
+
   it('shows staff permissions read-only for team managers who cannot manage admins', async () => {
     const managerAuth: AuthState = {
       ...auth,

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -41,6 +41,7 @@ import { addRosterPlayerForApp, archiveTeamTrackingItemForApp, buildPublicTeamGa
 import { buildStatTrackerConfigPayload, createBlankStatTrackerConfigColumnDraft, createEmptyStatTrackerConfigDraft, createStatTrackerConfigDraft, createStatTrackerConfigDraftFromPreset, getStatTrackerConfigPresetCatalog, validateStatTrackerConfigDraft, type StatTrackerConfigDraft } from '../lib/statTrackerConfigEditor';
 import { useViewLoadTimer } from '../lib/viewLoadTiming';
 import type { AuthState } from '../lib/types';
+import { InviteResultCard } from './parent-tools/shared';
 
 type TeamTab = 'overview' | 'schedule' | 'roster' | 'insights' | 'more';
 type RosterAiImportModule = typeof import('../lib/rosterAiImport');
@@ -2313,7 +2314,6 @@ function StaffPermissionsCard({ model, auth, onInviteSuccess }: { model: TeamDet
   const [grantingUserId, setGrantingUserId] = useState<string | null>(null);
   const [removingAdminEmail, setRemovingAdminEmail] = useState<string | null>(null);
   const [grantStatus, setGrantStatus] = useState<{ success: boolean; message: string } | null>(null);
-  const [copyStatus, setCopyStatus] = useState<{ kind: 'code' | 'link'; success: boolean } | null>(null);
   if (!summary) return null;
   const scorekeeperGrantTargets = summary.scorekeeperGrantTargets || [];
   const teamMediaManagerGrantTargets = summary.teamMediaManagerGrantTargets || [];
@@ -2325,7 +2325,6 @@ function StaffPermissionsCard({ model, auth, onInviteSuccess }: { model: TeamDet
     event.preventDefault();
     const normalizedEmail = email.trim().toLowerCase();
     setResult(null);
-    setCopyStatus(null);
     if (!normalizedEmail) {
       setError('Enter an admin email.');
       return;
@@ -2353,30 +2352,6 @@ function StaffPermissionsCard({ model, auth, onInviteSuccess }: { model: TeamDet
     }
   }
 
-  async function copyInviteValue(kind: 'code' | 'link', value: string | null) {
-    if (!value) return;
-    const copyResult = await copyPublicText(value);
-    setCopyStatus({ kind, success: copyResult === 'copied' });
-  }
-
-  async function shareInviteLink() {
-    if (!result?.acceptInviteUrl) return;
-    const shareResult = await sharePublicUrl({
-      title: `${model.team.name} staff invite`,
-      text: `Join ${model.team.name} staff on ALL PLAYS`,
-      url: result.acceptInviteUrl,
-      clipboardText: result.acceptInviteUrl
-    });
-    setGrantStatus({
-      success: shareResult === 'shared' || shareResult === 'copied',
-      message: shareResult === 'shared'
-        ? 'Share sheet opened.'
-        : shareResult === 'copied'
-          ? 'Invite link copied.'
-          : 'Unable to share the invite from this device.'
-    });
-  }
-
   async function removeAdmin(emailToRemove: string) {
     if (!emailToRemove || removingAdminEmail) return;
     const confirmed = window.confirm(`Remove ${emailToRemove} as a team admin?`);
@@ -2384,7 +2359,6 @@ function StaffPermissionsCard({ model, auth, onInviteSuccess }: { model: TeamDet
     setRemovingAdminEmail(emailToRemove);
     setGrantStatus(null);
     setResult(null);
-    setCopyStatus(null);
     try {
       await revokeTeamAdminAccessForApp(model.team.id, emailToRemove, auth.user || null);
       setGrantStatus({ success: true, message: `${emailToRemove} removed from team admins.` });
@@ -2401,7 +2375,6 @@ function StaffPermissionsCard({ model, auth, onInviteSuccess }: { model: TeamDet
     setGrantingUserId(memberUserId);
     setGrantStatus(null);
     setResult(null);
-    setCopyStatus(null);
     try {
       if (isGranted) {
         await revokeScorekeeperAccessForApp(model.team.id, memberUserId);
@@ -2422,7 +2395,6 @@ function StaffPermissionsCard({ model, auth, onInviteSuccess }: { model: TeamDet
     setGrantingUserId(memberUserId);
     setGrantStatus(null);
     setResult(null);
-    setCopyStatus(null);
     try {
       if (isGranted) {
         await revokeVideographerAccessForApp(model.team.id, memberUserId);
@@ -2443,7 +2415,6 @@ function StaffPermissionsCard({ model, auth, onInviteSuccess }: { model: TeamDet
     setGrantingUserId(memberUserId);
     setGrantStatus(null);
     setResult(null);
-    setCopyStatus(null);
     try {
       if (isGranted) {
         await revokeTeamMediaManagerAccessForApp(model.team.id, memberUserId);
@@ -2496,19 +2467,22 @@ function StaffPermissionsCard({ model, auth, onInviteSuccess }: { model: TeamDet
           </div>
           {error ? <div className="mt-2 text-xs font-black text-rose-700" role="alert">{error}</div> : null}
           {result ? (
-            <div className="mt-3 rounded-lg border border-white/80 bg-white p-3 text-xs font-semibold leading-5 text-gray-700" role="status">
-              <div className="font-black text-gray-950">
-                {result.status === 'sent' ? `Invite sent to ${result.email}.` : result.status === 'existing_user' ? `${result.email} already has an account and was added as an admin.` : `Email delivery needs a fallback for ${result.email}.`}
+            result.code || result.acceptInviteUrl ? (
+              <InviteResultCard
+                code={result.code}
+                inviteUrl={result.acceptInviteUrl}
+                recipientEmail={result.email}
+                emailSent={result.status === 'sent'}
+                title="Invite code"
+                shareTitle={`${model.team.name} staff invite`}
+                shareText={`Join ${model.team.name} staff on ALL PLAYS.`}
+                onStatus={(message) => setGrantStatus({ success: !message.startsWith('Unable'), message })}
+              />
+            ) : (
+              <div className="mt-3 rounded-lg border border-white/80 bg-white p-3 text-xs font-black text-gray-950" role="status">
+                {result.email} already has an account and was added as an admin.
               </div>
-              {result.code || result.acceptInviteUrl ? (
-                <div className="mt-2 flex flex-wrap gap-2">
-                  {result.code ? <button type="button" className="secondary-button !min-h-8 text-xs" onClick={() => copyInviteValue('code', result.code)}>Copy code</button> : null}
-                  {result.acceptInviteUrl ? <button type="button" className="secondary-button !min-h-8 text-xs" onClick={() => copyInviteValue('link', result.acceptInviteUrl)}>Copy link</button> : null}
-                  {result.acceptInviteUrl ? <button type="button" className="secondary-button !min-h-8 text-xs" onClick={shareInviteLink}>Share invite</button> : null}
-                </div>
-              ) : null}
-              {copyStatus ? <div className={`mt-2 font-black ${copyStatus.success ? 'text-emerald-700' : 'text-rose-700'}`}>{copyStatus.success ? `${copyStatus.kind === 'code' ? 'Invite code' : 'Invite link'} copied.` : `Unable to copy ${copyStatus.kind === 'code' ? 'invite code' : 'invite link'}.`}</div> : null}
-            </div>
+            )
           ) : null}
         </form>
       ) : (
@@ -2991,11 +2965,7 @@ function PlayerRow({
         success: true,
         message: result.autoLinked
           ? `Existing parent linked automatically${result.emailSent && result.email ? ` and notified at ${result.email}` : ''}.`
-          : result.emailSent && result.email
-            ? `Invite emailed to ${result.email} with the code and signup link.`
-            : result.email
-              ? `Invite created, but the email to ${result.email} could not be sent. Copy or share the code or link.`
-              : 'Parent invite is ready to copy or share.'
+          : 'Invite created.'
       });
       await onInviteCreated();
     } catch (error: any) {
@@ -3003,32 +2973,6 @@ function PlayerRow({
     } finally {
       setCreatingInvite(false);
     }
-  }
-
-  async function copyInvite(kind: 'code' | 'link') {
-    const value = kind === 'code' ? inviteResult?.code : inviteResult?.inviteUrl;
-    if (!value) return;
-    const result = await copyPublicText(value);
-    setInviteStatus({ success: result === 'copied', message: result === 'copied' ? `${kind === 'code' ? 'Invite code' : 'Invite link'} copied.` : `Unable to copy the ${kind}.` });
-  }
-
-  async function shareInvite() {
-    if (!inviteResult?.inviteUrl) return;
-    const result = await sharePublicUrl({
-      title: `${player.name} parent invite`,
-      text: `Join ${teamName} on ALL PLAYS for ${player.name}`,
-      url: inviteResult.inviteUrl,
-      clipboardText: inviteResult.inviteUrl
-    });
-    if (result === 'shared') {
-      setInviteStatus({ success: true, message: 'Share sheet opened.' });
-      return;
-    }
-    if (result === 'copied') {
-      setInviteStatus({ success: true, message: 'Invite link copied.' });
-      return;
-    }
-    setInviteStatus({ success: false, message: 'Unable to share the invite from this device.' });
   }
 
   const playerPath = `/players/${encodeURIComponent(teamId)}/${encodeURIComponent(player.id)}`;
@@ -3092,20 +3036,20 @@ function PlayerRow({
             {player.active ? (
               <button type="button" className="secondary-button !min-h-8 text-xs" disabled={creatingInvite} onClick={createInvite}>
                 {creatingInvite ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" /> : <LinkIcon className="h-3.5 w-3.5" aria-hidden="true" />}
-                {effectiveStatus === 'pending' || inviteResult ? 'Regenerate invite' : 'Invite parent'}
+                {creatingInvite ? 'Creating invite...' : 'Create invite'}
               </button>
             ) : null}
           </div>
           {player.active ? (
             <div className="mt-3 grid gap-2 sm:grid-cols-[minmax(0,1fr)_10rem]">
               <label className="text-xs font-black text-gray-700">
-                Parent email
+                Recipient email
                 <input
                   className="auth-input mt-1"
                   type="email"
                   inputMode="email"
                   autoComplete="email"
-                  aria-label={`Parent email for ${player.name}`}
+                  aria-label={`Recipient email for ${player.name}`}
                   placeholder="parent@example.com"
                   value={parentEmail}
                   onChange={(event) => setParentEmail(event.target.value)}
@@ -3122,22 +3066,23 @@ function PlayerRow({
                   <option value="Other">Other</option>
                 </select>
               </label>
-              <div className="text-[11px] font-semibold text-gray-500 sm:col-span-2">Enter an email to send the code and signup link, or leave it blank for a shareable code.</div>
+              <div className="text-[11px] font-semibold text-gray-500 sm:col-span-2">Enter an email to send the invite, or leave it blank for a shareable link and code.</div>
             </div>
           ) : null}
           {inviteSummary?.status === 'accepted' && inviteSummary.acceptedParentCount > 0 ? <div className="mt-2 text-xs font-semibold text-emerald-700">{inviteSummary.acceptedParentCount} linked parent{inviteSummary.acceptedParentCount === 1 ? '' : 's'}.</div> : null}
           {inviteSummary?.status === 'pending' && inviteSummary.pendingInviteCount > 0 && !inviteResult ? <div className="mt-2 text-xs font-semibold text-amber-700">{inviteSummary.pendingInviteCount} pending invite{inviteSummary.pendingInviteCount === 1 ? '' : 's'}.</div> : null}
           {!player.active ? <div className="mt-2 text-xs font-semibold text-gray-500">Reactivate the player to send a parent invite.</div> : null}
           {inviteResult ? (
-            <div className="mt-3 rounded-lg border border-primary-100 bg-primary-50 p-3">
-              <div className="text-[11px] font-black uppercase tracking-[0.04em] text-primary-700">Invite code</div>
-              <div className="mt-1 font-mono text-sm font-black text-gray-950">{inviteResult.code}</div>
-              <div className="mt-3 flex flex-wrap gap-2">
-                <button type="button" className="secondary-button !min-h-8 text-xs" onClick={() => copyInvite('code')}>Copy code</button>
-                <button type="button" className="secondary-button !min-h-8 text-xs" onClick={() => copyInvite('link')}>Copy link</button>
-                <button type="button" className="secondary-button !min-h-8 text-xs" onClick={shareInvite}>Share</button>
-              </div>
-            </div>
+            <InviteResultCard
+              code={inviteResult.code}
+              inviteUrl={inviteResult.inviteUrl}
+              recipientEmail={inviteResult.email}
+              emailSent={inviteResult.emailSent}
+              title="Invite code"
+              shareTitle={`${player.name} parent invite`}
+              shareText={`Join ${teamName} on ALL PLAYS for ${player.name}.`}
+              onStatus={(message) => setInviteStatus({ success: !message.startsWith('Unable'), message })}
+            />
           ) : null}
           {inviteStatus ? <div className={`mt-2 text-xs font-black ${inviteStatus.success ? 'text-emerald-700' : 'text-rose-700'}`} role="status">{inviteStatus.message}</div> : null}
         </div>

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -2342,6 +2342,10 @@ function StaffPermissionsCard({ model, auth, onInviteSuccess }: { model: TeamDet
     setError('');
     try {
       const inviteResult = await inviteTeamAdminForApp(model.team.id, normalizedEmail, auth.user || null);
+      if (inviteResult.status === 'fallback_code' && !inviteResult.code && !inviteResult.acceptInviteUrl) {
+        setError('Unable to create an admin invite code. Try again.');
+        return;
+      }
       setResult(inviteResult);
       setEmail('');
       await onInviteSuccess();

--- a/apps/app/src/pages/parent-tools/AccessTool.test.tsx
+++ b/apps/app/src/pages/parent-tools/AccessTool.test.tsx
@@ -18,7 +18,7 @@ vi.mock('../../lib/parentToolsAccessService', () => accessServiceMocks);
 vi.mock('../../lib/inviteRedemption', () => ({ redeemSignedInInvite: vi.fn() }));
 vi.mock('lucide-react', () => {
     const Icon = () => null;
-    return { AlertCircle: Icon, CheckCircle2: Icon, KeyRound: Icon, Loader2: Icon, RefreshCw: Icon, Search: Icon, Shield: Icon, Users: Icon };
+    return { AlertCircle: Icon, CheckCircle2: Icon, Copy: Icon, KeyRound: Icon, Link2: Icon, Loader2: Icon, RefreshCw: Icon, Search: Icon, Share2: Icon, Shield: Icon, Users: Icon };
 });
 
 const auth = {

--- a/apps/app/src/pages/parent-tools/CertificatesTool.test.tsx
+++ b/apps/app/src/pages/parent-tools/CertificatesTool.test.tsx
@@ -25,7 +25,9 @@ vi.mock('lucide-react', () => {
         AlertCircle: Icon,
         Award: Icon,
         CheckCircle2: Icon,
+        Copy: Icon,
         ExternalLink: Icon,
+        Link2: Icon,
         Loader2: Icon,
         RefreshCw: Icon,
         Share2: Icon

--- a/apps/app/src/pages/parent-tools/HouseholdInviteTool.tsx
+++ b/apps/app/src/pages/parent-tools/HouseholdInviteTool.tsx
@@ -3,7 +3,7 @@ import { CheckCircle2, Copy, Loader2, RefreshCw, Users } from 'lucide-react';
 import { createParentHouseholdMemberInvite, loadParentHouseholdInviteModel, type ParentHouseholdFamilyContact, type ParentHouseholdFamilyMember, type ParentHouseholdLinkedPlayer } from '../../lib/parentHouseholdService';
 import { toAppServiceError } from '../../lib/appErrors';
 import type { AuthState } from '../../lib/types';
-import { EmptyState, LoadingBlock, RetryableStatus, Status, ToolHeader, copyText, useParentToolAsyncOperation } from './shared';
+import { copyText, EmptyState, InviteResultCard, LoadingBlock, RetryableStatus, Status, ToolHeader, useParentToolAsyncOperation } from './shared';
 
 export function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: number }) {
     const [linkedPlayers, setLinkedPlayers] = useState<ParentHouseholdLinkedPlayer[]>([]);
@@ -80,9 +80,7 @@ export function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState;
             {
                 onSuccess: async (result) => {
                     setCreatedInvite(result);
-                    setMessage(result.emailSent
-                        ? `Invite emailed to ${result.email} with the code and signup link.`
-                        : 'Parent invite created. Copy the link below to share it.');
+                    setMessage('Invite created.');
                     setDisplayName('');
                     setEmail('');
                     setRelation('');
@@ -103,15 +101,20 @@ export function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState;
     return (
         <div className="space-y-3">
             <section className="app-card p-4">
-                <ToolHeader icon={Users} title="Invite another parent or caregiver" detail="Email an invite that connects their account to one of your linked players." action={<button type="button" className="ghost-button !min-h-9 text-xs" onClick={refresh} disabled={loading}><RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" />Refresh</button>} />
+                <ToolHeader icon={Users} title="Create invite" detail="Invite another parent or caregiver to connect their account to one of your linked players." action={<button type="button" className="ghost-button !min-h-9 text-xs" onClick={refresh} disabled={loading}><RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" />Refresh</button>} />
                 {error ? <RetryableStatus error={error} fallbackMessage="Unable to load household invites." onRetry={loading ? undefined : refresh} retrying={loading} /> : null}
                 {message ? <Status tone="success" message={message} /> : null}
                 {createdInvite ? (
-                    <div className="mt-3 rounded-2xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-900">
-                        <div className="font-black">Invite code: <span className="font-mono">{createdInvite.code}</span></div>
-                        <div className="mt-1 break-all text-xs font-semibold">{createdInvite.inviteUrl}</div>
-                        <button type="button" className="ghost-button mt-2 !min-h-8 text-xs" onClick={() => copyText(createdInvite.inviteUrl, setMessage)}><Copy className="h-4 w-4" aria-hidden="true" />Copy invite link</button>
-                    </div>
+                    <InviteResultCard
+                        code={createdInvite.code}
+                        inviteUrl={createdInvite.inviteUrl}
+                        recipientEmail={createdInvite.email}
+                        emailSent={createdInvite.emailSent}
+                        title="Invite code"
+                        shareTitle="ALL PLAYS parent invite"
+                        shareText={`Join ALL PLAYS to follow this player with invite code ${createdInvite.code}.`}
+                        onStatus={setMessage}
+                    />
                 ) : null}
                 {loading ? <LoadingBlock label="Loading household invites" /> : (
                     <form className="mt-3 grid gap-3" onSubmit={submit}>
@@ -125,12 +128,12 @@ export function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState;
                         </label>
                         <div className="grid gap-3 sm:grid-cols-2">
                             <input className="auth-input" value={displayName} onChange={(event) => setDisplayName(event.target.value)} placeholder="Name (optional)" autoComplete="name" enterKeyHint="next" disabled={saving || !linkedPlayers.length} />
-                            <input className="auth-input" type="email" inputMode="email" autoComplete="email" enterKeyHint="send" value={email} onChange={(event) => setEmail(event.target.value)} placeholder="Household contact email" disabled={saving || !linkedPlayers.length} />
+                            <input className="auth-input" type="email" inputMode="email" autoComplete="email" enterKeyHint="send" value={email} onChange={(event) => setEmail(event.target.value)} placeholder="Recipient email" disabled={saving || !linkedPlayers.length} />
                         </div>
                         <input className="auth-input" value={relation} onChange={(event) => setRelation(event.target.value)} placeholder="Relation, like grandparent or guardian" autoComplete="off" enterKeyHint="next" disabled={saving || !linkedPlayers.length} />
                         <button type="submit" className="primary-button" disabled={saving || loading || !linkedPlayers.length}>
                             {saving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Users className="h-4 w-4" aria-hidden="true" />}
-                            Email parent invite
+                            {saving ? 'Creating invite...' : 'Create invite'}
                         </button>
                     </form>
                 )}

--- a/apps/app/src/pages/parent-tools/shared.test.tsx
+++ b/apps/app/src/pages/parent-tools/shared.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { InviteResultCard } from './shared';
+
+const publicActionMocks = vi.hoisted(() => ({
+    sharePublicUrl: vi.fn()
+}));
+
+vi.mock('../../lib/publicActions', () => publicActionMocks);
+vi.mock('lucide-react', () => {
+    const Icon = () => null;
+    return {
+        AlertCircle: Icon,
+        CheckCircle2: Icon,
+        Copy: Icon,
+        Link2: Icon,
+        Loader2: Icon,
+        RefreshCw: Icon,
+        Share2: Icon
+    };
+});
+
+describe('InviteResultCard', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        Object.assign(navigator, {
+            clipboard: {
+                writeText: vi.fn().mockResolvedValue(undefined)
+            }
+        });
+    });
+
+    afterEach(() => cleanup());
+
+    it('prioritizes share, then copy link, with copy code available as fallback', async () => {
+        const onStatus = vi.fn();
+        publicActionMocks.sharePublicUrl.mockResolvedValue('shared');
+
+        render(
+            <InviteResultCard
+                code="home5678"
+                inviteUrl="https://allplays.ai/app#/accept-invite?code=HOME5678&type=household"
+                recipientEmail="aunt@example.com"
+                emailSent
+                shareTitle="ALL PLAYS parent invite"
+                shareText="Join this player."
+                onStatus={onStatus}
+            />
+        );
+
+        expect(screen.getByRole('button', { name: 'Share invite' }).className).toContain('primary-button');
+        expect(screen.getByRole('button', { name: 'Copy link' }).className).toContain('secondary-button');
+        expect(screen.getByRole('button', { name: 'Copy code' }).className).toContain('ghost-button');
+        expect(screen.getByText('HOME5678')).toBeTruthy();
+        expect(screen.getByText('Email queued for aunt@example.com.')).toBeTruthy();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Share invite' }));
+        await waitFor(() => expect(publicActionMocks.sharePublicUrl).toHaveBeenCalledWith({
+            title: 'ALL PLAYS parent invite',
+            text: 'Join this player.',
+            url: 'https://allplays.ai/app#/accept-invite?code=HOME5678&type=household',
+            clipboardText: 'https://allplays.ai/app#/accept-invite?code=HOME5678&type=household'
+        }));
+        await waitFor(() => expect(onStatus).toHaveBeenCalledWith('Invite shared.'));
+
+        fireEvent.click(screen.getByRole('button', { name: 'Copy link' }));
+        await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalledWith('https://allplays.ai/app#/accept-invite?code=HOME5678&type=household'));
+        await waitFor(() => expect(onStatus).toHaveBeenCalledWith('Invite link copied.'));
+
+        fireEvent.click(screen.getByRole('button', { name: 'Copy code' }));
+        await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalledWith('HOME5678'));
+        await waitFor(() => expect(onStatus).toHaveBeenCalledWith('Invite code copied.'));
+    });
+
+    it('uses the invite code as the share fallback when no link exists', async () => {
+        const onStatus = vi.fn();
+        publicActionMocks.sharePublicUrl.mockResolvedValue('copied');
+
+        render(<InviteResultCard code="CODE1234" recipientEmail="coach@example.com" emailSent={false} onStatus={onStatus} />);
+
+        expect(screen.queryByRole('button', { name: 'Copy link' })).toBeNull();
+        expect(screen.getByText('Copy and share this invite with coach@example.com.')).toBeTruthy();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Share invite' }));
+
+        await waitFor(() => expect(publicActionMocks.sharePublicUrl).toHaveBeenCalledWith({
+            title: 'ALL PLAYS invite',
+            text: 'Join ALL PLAYS with invite code CODE1234.',
+            url: undefined,
+            clipboardText: 'CODE1234'
+        }));
+        await waitFor(() => expect(onStatus).toHaveBeenCalledWith('Invite code copied.'));
+    });
+});

--- a/apps/app/src/pages/parent-tools/shared.test.tsx
+++ b/apps/app/src/pages/parent-tools/shared.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { InviteResultCard } from './shared';
 
 const publicActionMocks = vi.hoisted(() => ({
+    copyPublicText: vi.fn(),
     sharePublicUrl: vi.fn()
 }));
 
@@ -24,6 +25,7 @@ vi.mock('lucide-react', () => {
 describe('InviteResultCard', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        publicActionMocks.copyPublicText.mockResolvedValue('copied');
         Object.assign(navigator, {
             clipboard: {
                 writeText: vi.fn().mockResolvedValue(undefined)
@@ -65,11 +67,11 @@ describe('InviteResultCard', () => {
         await waitFor(() => expect(onStatus).toHaveBeenCalledWith('Invite shared.'));
 
         fireEvent.click(screen.getByRole('button', { name: 'Copy link' }));
-        await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalledWith('https://allplays.ai/app#/accept-invite?code=HOME5678&type=household'));
+        await waitFor(() => expect(publicActionMocks.copyPublicText).toHaveBeenCalledWith('https://allplays.ai/app#/accept-invite?code=HOME5678&type=household'));
         await waitFor(() => expect(onStatus).toHaveBeenCalledWith('Invite link copied.'));
 
         fireEvent.click(screen.getByRole('button', { name: 'Copy code' }));
-        await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalledWith('HOME5678'));
+        await waitFor(() => expect(publicActionMocks.copyPublicText).toHaveBeenCalledWith('HOME5678'));
         await waitFor(() => expect(onStatus).toHaveBeenCalledWith('Invite code copied.'));
     });
 
@@ -91,5 +93,17 @@ describe('InviteResultCard', () => {
             clipboardText: 'CODE1234'
         }));
         await waitFor(() => expect(onStatus).toHaveBeenCalledWith('Invite code copied.'));
+    });
+
+    it('reports copy failures after the public copy fallback fails', async () => {
+        const onStatus = vi.fn();
+        publicActionMocks.copyPublicText.mockResolvedValue('failed');
+
+        render(<InviteResultCard code="CODE1234" inviteUrl="https://allplays.ai/app#/accept-invite?code=CODE1234" onStatus={onStatus} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Copy link' }));
+
+        await waitFor(() => expect(publicActionMocks.copyPublicText).toHaveBeenCalledWith('https://allplays.ai/app#/accept-invite?code=CODE1234'));
+        await waitFor(() => expect(onStatus).toHaveBeenCalledWith('Unable to copy invite link.'));
     });
 });

--- a/apps/app/src/pages/parent-tools/shared.tsx
+++ b/apps/app/src/pages/parent-tools/shared.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState, type ReactNode } from 'react';
 import type { LucideIcon } from 'lucide-react';
 import { AlertCircle, CheckCircle2, Copy, Link2, Loader2, RefreshCw, Share2 } from 'lucide-react';
 import { toAppServiceError, type AppServiceError } from '../../lib/appErrors';
-import { sharePublicUrl } from '../../lib/publicActions';
+import { copyPublicText, sharePublicUrl } from '../../lib/publicActions';
 import { useAsyncOperation } from '../../lib/useAsyncOperation';
 
 type ParentToolAsyncOptions<T> = {
@@ -162,12 +162,8 @@ export function EmptyState({ icon: Icon, title, detail }: { icon: LucideIcon; ti
 }
 
 export async function copyText(value: string, setMessage: (message: string) => void) {
-    try {
-        await navigator.clipboard.writeText(value);
-        setMessage('Copied.');
-    } catch {
-        setMessage('Copy is not available in this browser.');
-    }
+    const result = await copyPublicText(value);
+    setMessage(result === 'copied' ? 'Copied.' : 'Copy is not available in this browser.');
 }
 
 export type InviteResultCardProps = {

--- a/apps/app/src/pages/parent-tools/shared.tsx
+++ b/apps/app/src/pages/parent-tools/shared.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useState, type ReactNode } from 'react';
 import type { LucideIcon } from 'lucide-react';
-import { AlertCircle, CheckCircle2, Loader2, RefreshCw } from 'lucide-react';
+import { AlertCircle, CheckCircle2, Copy, Link2, Loader2, RefreshCw, Share2 } from 'lucide-react';
 import { toAppServiceError, type AppServiceError } from '../../lib/appErrors';
+import { sharePublicUrl } from '../../lib/publicActions';
 import { useAsyncOperation } from '../../lib/useAsyncOperation';
 
 type ParentToolAsyncOptions<T> = {
@@ -167,6 +168,104 @@ export async function copyText(value: string, setMessage: (message: string) => v
     } catch {
         setMessage('Copy is not available in this browser.');
     }
+}
+
+export type InviteResultCardProps = {
+    code?: string | null;
+    inviteUrl?: string | null;
+    recipientEmail?: string | null;
+    recipientLabel?: string | null;
+    emailSent?: boolean;
+    title?: string;
+    shareTitle?: string;
+    shareText?: string;
+    onStatus: (message: string) => void;
+};
+
+export function InviteResultCard({
+    code,
+    inviteUrl,
+    recipientEmail,
+    recipientLabel,
+    emailSent,
+    title = 'Invite created',
+    shareTitle = 'ALL PLAYS invite',
+    shareText,
+    onStatus
+}: InviteResultCardProps) {
+    const normalizedCode = String(code || '').trim().toUpperCase();
+    const normalizedInviteUrl = String(inviteUrl || '').trim();
+    const cleanRecipient = String(recipientLabel || recipientEmail || '').trim();
+    const deliveryMessage = cleanRecipient
+        ? emailSent
+            ? `Email queued for ${cleanRecipient}.`
+            : `Copy and share this invite with ${cleanRecipient}.`
+        : 'Copy and share this invite.';
+    const defaultShareText = normalizedCode
+        ? `Join ALL PLAYS with invite code ${normalizedCode}.`
+        : 'Join ALL PLAYS with this invite.';
+
+    const copyInviteCode = () => {
+        if (!normalizedCode) return;
+        void copyText(normalizedCode, (message) => {
+            onStatus(message === 'Copied.' ? 'Invite code copied.' : 'Unable to copy invite code.');
+        });
+    };
+    const copyInviteLink = () => {
+        if (!normalizedInviteUrl) return;
+        void copyText(normalizedInviteUrl, (message) => {
+            onStatus(message === 'Copied.' ? 'Invite link copied.' : 'Unable to copy invite link.');
+        });
+    };
+    const shareInvite = async () => {
+        if (!normalizedInviteUrl && !normalizedCode) return;
+        const result = await sharePublicUrl({
+            title: shareTitle,
+            text: shareText || defaultShareText,
+            url: normalizedInviteUrl || undefined,
+            clipboardText: normalizedInviteUrl || normalizedCode
+        });
+        if (result === 'shared') {
+            onStatus('Invite shared.');
+        } else if (result === 'copied') {
+            onStatus(normalizedInviteUrl ? 'Invite link copied.' : 'Invite code copied.');
+        } else if (result === 'cancelled') {
+            onStatus('Share cancelled.');
+        } else {
+            onStatus('Unable to share invite.');
+        }
+    };
+
+    return (
+        <div className="mt-3 rounded-2xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-950">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="min-w-0">
+                    <div className="text-xs font-black uppercase tracking-[0.04em] text-emerald-700">{title}</div>
+                    {normalizedCode ? <div className="mt-1 font-mono text-2xl font-black tracking-[0.16em] text-gray-950">{normalizedCode}</div> : null}
+                    {normalizedInviteUrl ? <div className="mt-1 break-all text-xs font-semibold text-emerald-900">{normalizedInviteUrl}</div> : null}
+                    <div className="mt-2 text-xs font-semibold text-emerald-800">{deliveryMessage}</div>
+                </div>
+                <div className="grid flex-none grid-cols-1 gap-2 sm:min-w-[9rem]">
+                    <button type="button" className="primary-button !min-h-9 text-xs" onClick={shareInvite} disabled={!normalizedInviteUrl && !normalizedCode}>
+                        <Share2 className="h-4 w-4" aria-hidden="true" />
+                        Share invite
+                    </button>
+                    {normalizedInviteUrl ? (
+                        <button type="button" className="secondary-button !min-h-9 text-xs" onClick={copyInviteLink}>
+                            <Link2 className="h-4 w-4" aria-hidden="true" />
+                            Copy link
+                        </button>
+                    ) : null}
+                    {normalizedCode ? (
+                        <button type="button" className="ghost-button !min-h-8 text-xs" onClick={copyInviteCode}>
+                            <Copy className="h-4 w-4" aria-hidden="true" />
+                            Copy code
+                        </button>
+                    ) : null}
+                </div>
+            </div>
+        </div>
+    );
 }
 
 export function splitLines(value: string) {

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -699,7 +699,7 @@ test('profile exposes account, notification, invite, verification, password, upl
     await expect(page.getByText('Notification preferences saved.')).toBeVisible();
 
     await page.getByRole('button', { name: 'Invites', exact: true }).click();
-    await expect(page.getByText('Create invite')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Create invite' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Show more codes' })).toBeVisible();
     await page.getByLabel('Recipient email').fill('friend@example.com');
     await page.getByRole('button', { name: 'Create invite' }).click();

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -699,20 +699,17 @@ test('profile exposes account, notification, invite, verification, password, upl
     await expect(page.getByText('Notification preferences saved.')).toBeVisible();
 
     await page.getByRole('button', { name: 'Invites', exact: true }).click();
-    await expect(page.getByText('Invite codes')).toBeVisible();
+    await expect(page.getByText('Create invite')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Show more codes' })).toBeVisible();
-    await expect(page.getByText('Advanced: add recipient label')).toBeVisible();
-    await page.getByText('Advanced: add recipient label').click();
-    await page.getByLabel('Invite email label').fill('friend@example.com');
-    await page.getByRole('button', { name: 'Generate invite link' }).click();
-    await expect(page.getByText('Generated invite link')).toBeVisible();
-    const shareInviteLink = page.getByRole('button', { name: 'Share invite link' });
+    await page.getByLabel('Recipient email').fill('friend@example.com');
+    await page.getByRole('button', { name: 'Create invite' }).click();
+    await expect(page.getByText('Invite code')).toBeVisible();
+    const shareInviteLink = page.getByRole('button', { name: 'Share invite' });
     await expect(shareInviteLink).toBeVisible();
     await expect(shareInviteLink).toHaveClass(/primary-button/);
-    await expect(page.getByRole('button', { name: 'Copy invite link' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Copy link' })).toBeVisible();
     await shareInviteLink.click();
-    await expect(page.getByText('Share sheet opened.')).toBeVisible();
-    await expect(page.getByText('Fallback code')).toBeVisible();
+    await expect(page.getByText('Invite shared.')).toBeVisible();
     await expect(page.getByText('NEWMVP42', { exact: true }).first()).toBeVisible();
     await expect(page.getByRole('button', { name: 'Copy code' })).toBeVisible();
 

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -703,7 +703,7 @@ test('profile exposes account, notification, invite, verification, password, upl
     await expect(page.getByRole('button', { name: 'Show more codes' })).toBeVisible();
     await page.getByLabel('Recipient email').fill('friend@example.com');
     await page.getByRole('button', { name: 'Create invite' }).click();
-    await expect(page.getByText('Invite code')).toBeVisible();
+    await expect(page.getByText('Invite code', { exact: true })).toBeVisible();
     const shareInviteLink = page.getByRole('button', { name: 'Share invite' });
     await expect(shareInviteLink).toBeVisible();
     await expect(shareInviteLink).toHaveClass(/primary-button/);

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -1729,7 +1729,7 @@ test('requested app workflows emit DB-ready view load baseline timers', async ({
             ready: async (testPage) => {
                 await expect(async () => {
                     await expect(testPage.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 3000 });
-                    await expect(testPage.getByText('Create invite')).toBeVisible({ timeout: 3000 });
+                    await expect(testPage.getByRole('button', { name: 'Create invite' })).toBeVisible({ timeout: 3000 });
                     await expect(testPage.getByText('ABC12345')).toBeVisible({ timeout: 3000 });
                 }).toPass({ timeout: 45000 });
             }

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -1729,7 +1729,7 @@ test('requested app workflows emit DB-ready view load baseline timers', async ({
             ready: async (testPage) => {
                 await expect(async () => {
                     await expect(testPage.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 3000 });
-                    await expect(testPage.getByText('Invite codes')).toBeVisible({ timeout: 3000 });
+                    await expect(testPage.getByText('Create invite')).toBeVisible({ timeout: 3000 });
                     await expect(testPage.getByText('ABC12345')).toBeVisible({ timeout: 3000 });
                 }).toPass({ timeout: 45000 });
             }

--- a/tests/unit/app-auth-profile-capabilities.test.js
+++ b/tests/unit/app-auth-profile-capabilities.test.js
@@ -239,7 +239,7 @@ describe('React app auth/profile capability parity', () => {
             'Email not verified',
             'Set a password',
             'Send password reset',
-            'Generate invite link',
+            'Create invite',
             'Show fewer codes',
             'Sign out'
         ]);

--- a/tests/unit/app-home-player-integration.test.jsx
+++ b/tests/unit/app-home-player-integration.test.jsx
@@ -652,7 +652,7 @@ describe('React app Home and player drill-in integration', () => {
         expect(container.textContent).toContain('Incentives');
         expect(container.textContent).toContain('Certificates');
         await clickButton(container, 'Family');
-        expect(container.textContent).toContain('Invite Co-Parent');
+        expect(container.textContent).toContain('Create invite');
         await clickButton(container, 'Incentives');
         await waitForText(container, 'Incentive wallet');
         expect(container.textContent).toContain('Payouts need attention');

--- a/tests/unit/app-parent-tools-integration.test.jsx
+++ b/tests/unit/app-parent-tools-integration.test.jsx
@@ -30,6 +30,7 @@ const serviceMocks = vi.hoisted(() => ({
 }));
 
 const publicActionMocks = vi.hoisted(() => ({
+    copyPublicText: vi.fn(),
     exportCalendarIcsFile: vi.fn().mockResolvedValue('downloaded'),
     openPublicUrl: vi.fn(),
     sharePublicUrl: vi.fn().mockResolvedValue('shared')
@@ -215,6 +216,7 @@ beforeEach(() => {
             writeText: vi.fn().mockResolvedValue()
         }
     });
+    publicActionMocks.copyPublicText.mockResolvedValue('copied');
     URL.createObjectURL = vi.fn(() => 'blob:test');
     URL.revokeObjectURL = vi.fn();
 
@@ -356,7 +358,7 @@ describe('React app parent tools integration', () => {
         expect(publicActionMocks.exportCalendarIcsFile).toHaveBeenCalledWith('all-plays-family-schedule.ics', 'BEGIN:VCALENDAR\r\nEND:VCALENDAR');
         expect(container.textContent).toContain('Calendar file ready to share.');
         await clickButton(container, 'Copy agenda');
-        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('Bears Practice');
+        expect(publicActionMocks.copyPublicText).toHaveBeenCalledWith('Bears Practice');
         await clickButton(container, 'Apple');
         expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('webcal://feed.example.test/team-1.ics');
 

--- a/tests/unit/app-parent-tools-integration.test.jsx
+++ b/tests/unit/app-parent-tools-integration.test.jsx
@@ -325,13 +325,13 @@ describe('React app parent tools integration', () => {
         expect(accessServiceMocks.submitParentAccessRequest).toHaveBeenCalledWith('team-1', 'player-1', 'Parent');
 
         await clickButton(container, 'Household');
-        await waitForText(container, 'Invite another parent or caregiver');
+        await waitForText(container, 'Create invite');
         expect(container.textContent).toContain('Grandma');
-        const householdEmail = container.querySelector('input[placeholder="Household contact email"]');
+        const householdEmail = container.querySelector('input[placeholder="Recipient email"]');
         const householdRelation = container.querySelector('input[placeholder^="Relation"]');
         await changeValue(householdEmail, 'aunt@example.com');
         await changeValue(householdRelation, 'Aunt');
-        await submitForm(container, 'Email parent invite');
+        await submitForm(container, 'Create invite');
         expect(serviceMocks.createParentHouseholdMemberInvite).toHaveBeenCalledWith(auth.user, {
             playerKey: 'team-1::player-1',
             displayName: '',
@@ -339,7 +339,7 @@ describe('React app parent tools integration', () => {
             relation: 'Aunt'
         });
         expect(container.textContent).toContain('HOME5678');
-        expect(container.textContent).toContain('Invite emailed to aunt@example.com with the code and signup link.');
+        expect(container.textContent).toContain('Email queued for aunt@example.com.');
 
         await clickButton(container, 'Fees');
         await waitForText(container, 'Team dues');

--- a/tests/unit/app-profile-invites.test.tsx
+++ b/tests/unit/app-profile-invites.test.tsx
@@ -210,11 +210,11 @@ describe('Profile invites', () => {
     renderProfile();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Invites' }));
-    fireEvent.change(screen.getByLabelText('Invite email label'), { target: { value: 'coach@example.com' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Generate invite link' }));
+    fireEvent.change(screen.getByLabelText('Recipient email'), { target: { value: 'coach@example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create invite' }));
 
-    await screen.findByText('Generated invite link');
-    fireEvent.click(screen.getByRole('button', { name: 'Share invite link' }));
+    await screen.findByText('Invite code');
+    fireEvent.click(screen.getByRole('button', { name: 'Share invite' }));
 
     await waitFor(() => expect(publicActionsMocks.sharePublicUrl).toHaveBeenCalledWith(expect.objectContaining({
       title: 'ALL PLAYS invite for coach@example.com',
@@ -223,14 +223,14 @@ describe('Profile invites', () => {
       clipboardText: expect.stringContaining('/app#/accept-invite?code=NEWMVP42&type=friend')
     })));
     expect(screen.getByText(/\/app#\/accept-invite\?code=NEWMVP42&type=friend/)).toBeTruthy();
-    expect(await screen.findByText('Share sheet opened.')).toBeTruthy();
+    expect(await screen.findByText('Invite shared.')).toBeTruthy();
   });
 
   it('requires an email or phone before generating a friend invite', async () => {
     renderProfile();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Invites' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Generate invite link' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create invite' }));
 
     expect(await screen.findByText('Enter an email or phone number for the invite.')).toBeTruthy();
     expect(profileServiceMocks.createProfileAccessCode).not.toHaveBeenCalled();

--- a/tests/unit/app-team-detail-staff-permissions.test.jsx
+++ b/tests/unit/app-team-detail-staff-permissions.test.jsx
@@ -166,6 +166,12 @@ beforeEach(() => {
         return 0;
     };
     window.scrollTo = vi.fn();
+    Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: {
+            writeText: vi.fn().mockResolvedValue(undefined)
+        }
+    });
     publicActionMocks.copyPublicText.mockResolvedValue('copied');
     teamDetailMocks.loadTeamDetailInsights.mockResolvedValue({ leaderboards: [], trackingSummaries: [] });
     teamDetailMocks.loadTeamDetailSponsors.mockResolvedValue({ sponsors: [] });
@@ -262,11 +268,11 @@ describe('React app TeamDetail staff permissions overview', () => {
 
         expect(teamDetailMocks.inviteTeamAdminForApp).toHaveBeenCalledWith('team-1', 'newcoach@example.com', auth.user);
         expect(teamDetailMocks.loadParentTeamDetail).toHaveBeenCalledTimes(2);
-        expect(container.textContent).toContain('Email delivery needs a fallback for newcoach@example.com.');
+        expect(container.textContent).toContain('Copy and share this invite with newcoach@example.com.');
         await clickButton(container, 'Copy code');
         await clickButton(container, 'Copy link');
-        expect(publicActionMocks.copyPublicText).toHaveBeenCalledWith('CODE123');
-        expect(publicActionMocks.copyPublicText).toHaveBeenCalledWith('https://allplays.ai/accept-invite?code=CODE123&type=admin');
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('CODE123');
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('https://allplays.ai/accept-invite?code=CODE123&type=admin');
     });
 
     it('keeps the screening block message visible when a helper grant is rejected', async () => {

--- a/tests/unit/app-team-detail-staff-permissions.test.jsx
+++ b/tests/unit/app-team-detail-staff-permissions.test.jsx
@@ -271,8 +271,8 @@ describe('React app TeamDetail staff permissions overview', () => {
         expect(container.textContent).toContain('Copy and share this invite with newcoach@example.com.');
         await clickButton(container, 'Copy code');
         await clickButton(container, 'Copy link');
-        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('CODE123');
-        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('https://allplays.ai/accept-invite?code=CODE123&type=admin');
+        expect(publicActionMocks.copyPublicText).toHaveBeenCalledWith('CODE123');
+        expect(publicActionMocks.copyPublicText).toHaveBeenCalledWith('https://allplays.ai/accept-invite?code=CODE123&type=admin');
     });
 
     it('keeps the screening block message visible when a helper grant is rejected', async () => {


### PR DESCRIPTION
## Summary
- Unifies invite creation UX across profile, household, player family, coach roster parent, and staff/admin fallback flows.
- Adds a shared InviteResultCard with consistent Share invite, Copy link, and Copy code actions.
- Updates labels/status text to use the same Create invite and Recipient email language across the app.

## Validation
- npm --prefix apps/app run test -- --run src/pages/TeamDetail.test.tsx src/pages/Profile.test.tsx src/pages/parent-tools/shared.test.tsx --reporter=verbose
- npx vitest run tests/unit/app-profile-invites.test.tsx tests/unit/app-parent-tools-integration.test.jsx tests/unit/app-home-player-integration.test.jsx tests/unit/app-auth-profile-capabilities.test.js tests/unit/app-team-detail-staff-permissions.test.jsx tests/unit/app-team-detail-integration.test.jsx --reporter=verbose
- npm run app:build

## Local testing
- App verified running locally at http://localhost:5176/ before publishing.
