### PR TITLE
ChatGPT app integration: MCP service spike (read-only, rules-enforced)

### DIFF
--- a/services/chatgpt-mcp/README.md
+++ b/services/chatgpt-mcp/README.md
@@ -1,0 +1,83 @@
+# AllPlays ChatGPT MCP Service (read-only, rules-enforced)
+
+Remote MCP server exposing permission-aware AllPlays tools to ChatGPT:
+`get_profile`, `list_schedule`, `get_game_summary` — names aligned with the
+in-app private AI registry (`apps/app/src/lib/privateAiService.ts`).
+
+Spec: `/spec/chatgpt-app-integration/` · Plan: `AllPlays_ChatGPT_App_Integration_Plan.docx`
+
+## How authorization works
+
+The service holds **no privileged credentials** (no service account, no Admin
+SDK). The connector's bearer token is the user's Firebase **refresh token**
+(or a short-lived ID token). Per request the service exchanges it for an ID
+token and calls the **Firestore REST API as that user**, so every read is
+authorized by the same `firestore.rules` that protect the AllPlays web and
+mobile clients. Cross-team access fails at the database, not just in service
+code (which also checks, as defense-in-depth).
+
+## Run locally
+
+```bash
+cd services/chatgpt-mcp
+npm install
+npm start           # listens on :8787, endpoint POST /mcp
+```
+
+No environment variables required — the public web API key and project id
+default to the main project (`game-flow-c6311`). Override with
+`FIREBASE_PROJECT_ID` / `FIREBASE_WEB_API_KEY` if needed.
+
+Get a bearer token (prints your refresh token):
+
+```bash
+ALLPLAYS_EMAIL=you@example.com ALLPLAYS_PASSWORD=... node scripts/get-token.mjs
+```
+
+Smoke check:
+
+```bash
+curl -s http://localhost:8787/mcp \
+  -H "Authorization: Bearer <refresh-token>" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+```
+
+## Connect from ChatGPT Developer Mode (ngrok)
+
+```bash
+ngrok config add-authtoken <your-token>   # once
+ngrok http 8787
+```
+
+Then in ChatGPT → Settings → Apps & Connectors → Advanced → Developer Mode →
+add a connector with `https://<your-ngrok-host>/mcp` and the refresh token as
+the bearer token. Ask: "What does my family have this weekend?" — ChatGPT
+should call `list_schedule` and answer with permission-filtered events and
+deep links into AllPlays.
+
+## Deploy (dev Cloud Run)
+
+```bash
+gcloud run deploy allplays-chatgpt-mcp \
+  --source services/chatgpt-mcp \
+  --project game-flow-c6311 \
+  --region us-central1
+```
+
+No secrets to provision — the service is stateless and credential-free. The
+production path replaces raw refresh tokens with an OAuth broker
+(authorization code + PKCE) that yields the same user-scoped credential.
+
+## Security model
+
+- Identity comes only from the bearer token; tool arguments are never trusted.
+- All Firestore access is user-credentialed — `firestore.rules` is the
+  enforcement point, identical to the parent UI.
+- Responses are additionally field-whitelisted in `src/core.js`;
+  `players/*/private/*` and `privatePlayerStats` are never requested.
+- A forged JWT yields no data: every Firestore call presents that same token
+  and is rejected by the backend.
+
+Unit tests: `npx vitest run tests/unit/chatgpt-mcp-core.test.js` from the repo root.

--- a/services/chatgpt-mcp/README.md
+++ b/services/chatgpt-mcp/README.md
@@ -21,12 +21,13 @@ code (which also checks, as defense-in-depth).
 ```bash
 cd services/chatgpt-mcp
 npm install
+FIREBASE_PROJECT_ID=your-project-id \
+FIREBASE_WEB_API_KEY=your-web-api-key \
 npm start           # listens on :8787, endpoint POST /mcp
 ```
 
-No environment variables required — the public web API key and project id
-default to the main project (`game-flow-c6311`). Override with
-`FIREBASE_PROJECT_ID` / `FIREBASE_WEB_API_KEY` if needed.
+`FIREBASE_PROJECT_ID` and `FIREBASE_WEB_API_KEY` are required; the service
+exits at startup when either is missing.
 
 Get a bearer token (prints your refresh token):
 

--- a/services/chatgpt-mcp/README.md
+++ b/services/chatgpt-mcp/README.md
@@ -51,11 +51,32 @@ ngrok config add-authtoken <your-token>   # once
 ngrok http 8787
 ```
 
-Then in ChatGPT → Settings → Apps & Connectors → Advanced → Developer Mode →
-add a connector with `https://<your-ngrok-host>/mcp` and the refresh token as
-the bearer token. Ask: "What does my family have this weekend?" — ChatGPT
-should call `list_schedule` and answer with permission-filtered events and
-deep links into AllPlays.
+Then in ChatGPT → Settings → Apps → Advanced settings → Developer mode → New
+App:
+
+- Server URL: `https://<your-ngrok-host>/mcp`
+- Authentication: **OAuth** — ChatGPT discovers the broker automatically
+  (`/.well-known/oauth-authorization-server`), registers itself, and sends the
+  user to the AllPlays sign-in page; tokens are per-user, PKCE-protected.
+
+Ask: "What does my family have this weekend?" — ChatGPT should call
+`list_schedule` and answer with permission-filtered events and deep links.
+
+### OAuth broker
+
+`src/oauth.js` implements the slice of OAuth 2.1 the MCP spec requires:
+dynamic client registration, authorization code + PKCE (S256 only), refresh
+grant, and opaque access tokens that map to the signed-in user's Firebase
+refresh token. Codes are single-use with a 10-minute TTL; access tokens last
+1 hour. Storage is in-memory — restart logs everyone out; Firestore-backed
+storage is a prerequisite for multi-instance Cloud Run.
+
+Sign-in accepts AllPlays email/password (proxied to Firebase Identity Toolkit
+with the site referer; the password is never stored). Google sign-in is a
+follow-up.
+
+For manual curl testing you can still bypass OAuth: a Firebase refresh token
+or ID token works directly as the MCP bearer.
 
 ## Deploy (dev Cloud Run)
 

--- a/services/chatgpt-mcp/package-lock.json
+++ b/services/chatgpt-mcp/package-lock.json
@@ -1,0 +1,1179 @@
+{
+    "name": "allplays-chatgpt-mcp",
+    "version": "0.1.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "allplays-chatgpt-mcp",
+            "version": "0.1.0",
+            "dependencies": {
+                "@modelcontextprotocol/sdk": "^1.12.0",
+                "express": "^5.1.0",
+                "zod": "^3.25.0"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@hono/node-server": {
+            "version": "1.19.14",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+            "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.14.1"
+            },
+            "peerDependencies": {
+                "hono": "^4"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk": {
+            "version": "1.29.0",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+            "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@hono/node-server": "^1.19.9",
+                "ajv": "^8.17.1",
+                "ajv-formats": "^3.0.1",
+                "content-type": "^1.0.5",
+                "cors": "^2.8.5",
+                "cross-spawn": "^7.0.5",
+                "eventsource": "^3.0.2",
+                "eventsource-parser": "^3.0.0",
+                "express": "^5.2.1",
+                "express-rate-limit": "^8.2.1",
+                "hono": "^4.11.4",
+                "jose": "^6.1.3",
+                "json-schema-typed": "^8.0.2",
+                "pkce-challenge": "^5.0.0",
+                "raw-body": "^3.0.0",
+                "zod": "^3.25 || ^4.0",
+                "zod-to-json-schema": "^3.25.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@cfworker/json-schema": "^4.1.1",
+                "zod": "^3.25 || ^4.0"
+            },
+            "peerDependenciesMeta": {
+                "@cfworker/json-schema": {
+                    "optional": true
+                },
+                "zod": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/accepts": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+            "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-types": "^3.0.0",
+                "negotiator": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ajv-formats": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/body-parser": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+            "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "^3.1.2",
+                "content-type": "^2.0.0",
+                "debug": "^4.4.3",
+                "http-errors": "^2.0.1",
+                "iconv-lite": "^0.7.2",
+                "on-finished": "^2.4.1",
+                "qs": "^6.15.2",
+                "raw-body": "^3.0.2",
+                "type-is": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/body-parser/node_modules/content-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/bytes": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/content-disposition": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+            "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/content-type": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+            "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/cookie": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/cookie-signature": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+            "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.6.0"
+            }
+        },
+        "node_modules/cors": {
+            "version": "2.8.6",
+            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+            "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+            "license": "MIT",
+            "dependencies": {
+                "object-assign": "^4",
+                "vary": "^1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/depd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+            "license": "MIT"
+        },
+        "node_modules/encodeurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+            "license": "MIT"
+        },
+        "node_modules/etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/eventsource": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+            "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+            "license": "MIT",
+            "dependencies": {
+                "eventsource-parser": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/eventsource-parser": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+            "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/express": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+            "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "^2.0.0",
+                "body-parser": "^2.2.1",
+                "content-disposition": "^1.0.0",
+                "content-type": "^1.0.5",
+                "cookie": "^0.7.1",
+                "cookie-signature": "^1.2.1",
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "finalhandler": "^2.1.0",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.0",
+                "merge-descriptors": "^2.0.0",
+                "mime-types": "^3.0.0",
+                "on-finished": "^2.4.1",
+                "once": "^1.4.0",
+                "parseurl": "^1.3.3",
+                "proxy-addr": "^2.0.7",
+                "qs": "^6.14.0",
+                "range-parser": "^1.2.1",
+                "router": "^2.2.0",
+                "send": "^1.1.0",
+                "serve-static": "^2.2.0",
+                "statuses": "^2.0.1",
+                "type-is": "^2.0.1",
+                "vary": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/express-rate-limit": {
+            "version": "8.6.0",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+            "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "ip-address": "^10.2.0"
+            },
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/express-rate-limit"
+            },
+            "peerDependencies": {
+                "express": ">= 4.11"
+            }
+        },
+        "node_modules/fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "license": "MIT"
+        },
+        "node_modules/fast-uri": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/finalhandler": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+            "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "on-finished": "^2.4.1",
+                "parseurl": "^1.3.3",
+                "statuses": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/forwarded": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+            "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/fresh": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+            "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/hono": {
+            "version": "4.12.31",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+            "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.9.0"
+            }
+        },
+        "node_modules/http-errors": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+            "license": "MIT",
+            "dependencies": {
+                "depd": "~2.0.0",
+                "inherits": "~2.0.4",
+                "setprototypeof": "~1.2.0",
+                "statuses": "~2.0.2",
+                "toidentifier": "~1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/iconv-lite": {
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+            "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "license": "ISC"
+        },
+        "node_modules/ip-address": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/ipaddr.js": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/is-promise": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+            "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+            "license": "MIT"
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "license": "ISC"
+        },
+        "node_modules/jose": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+            "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/panva"
+            }
+        },
+        "node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "license": "MIT"
+        },
+        "node_modules/json-schema-typed": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+            "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/media-typer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+            "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/merge-descriptors": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+            "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
+        },
+        "node_modules/negotiator": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/object-inspect": {
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/on-finished": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+            "license": "MIT",
+            "dependencies": {
+                "ee-first": "1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "license": "ISC",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/parseurl": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/path-to-regexp": {
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+            "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/pkce-challenge": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+            "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/proxy-addr": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+            "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+            "license": "MIT",
+            "dependencies": {
+                "forwarded": "0.2.0",
+                "ipaddr.js": "1.9.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/qs": {
+            "version": "6.15.3",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/range-parser": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+            "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/raw-body": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+            "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "~3.1.2",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.7.0",
+                "unpipe": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/router": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+            "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "is-promise": "^4.0.0",
+                "parseurl": "^1.3.3",
+                "path-to-regexp": "^8.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "license": "MIT"
+        },
+        "node_modules/send": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+            "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.1",
+                "mime-types": "^3.0.2",
+                "ms": "^2.1.3",
+                "on-finished": "^2.4.1",
+                "range-parser": "^1.2.1",
+                "statuses": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/serve-static": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+            "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+            "license": "MIT",
+            "dependencies": {
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "parseurl": "^1.3.3",
+                "send": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/setprototypeof": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+            "license": "ISC"
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/side-channel": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-list": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-weakmap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3",
+                "side-channel-map": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/statuses": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/toidentifier": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/type-is": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+            "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+            "license": "MIT",
+            "dependencies": {
+                "content-type": "^2.0.0",
+                "media-typer": "^1.1.0",
+                "mime-types": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/type-is/node_modules/content-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/vary": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "license": "ISC"
+        },
+        "node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/zod-to-json-schema": {
+            "version": "3.25.2",
+            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+            "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+            "license": "ISC",
+            "peerDependencies": {
+                "zod": "^3.25.28 || ^4"
+            }
+        }
+    }
+}

--- a/services/chatgpt-mcp/package.json
+++ b/services/chatgpt-mcp/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "allplays-chatgpt-mcp",
+    "private": true,
+    "type": "module",
+    "version": "0.1.0",
+    "description": "AllPlays remote MCP service for the ChatGPT app integration (read-only spike)",
+    "engines": {
+        "node": ">=22"
+    },
+    "scripts": {
+        "start": "node src/server.js",
+        "dev": "node --watch src/server.js"
+    },
+    "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "express": "^5.1.0",
+        "zod": "^3.25.0"
+    }
+}

--- a/services/chatgpt-mcp/scripts/get-token.mjs
+++ b/services/chatgpt-mcp/scripts/get-token.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+// Sign in to AllPlays (Firebase Auth) and print the refresh token to use as
+// the ChatGPT connector's bearer token.
+//
+// Usage:
+//   ALLPLAYS_EMAIL=you@example.com ALLPLAYS_PASSWORD=... node scripts/get-token.mjs
+//
+// Credentials are read from env only (never argv) so they stay out of shell
+// history and process listings.
+
+const API_KEY = process.env.FIREBASE_WEB_API_KEY || 'AIzaSyDoixIoKJuUVWdmImwjYRTthjKOv2mU0Jc';
+const email = process.env.ALLPLAYS_EMAIL;
+const password = process.env.ALLPLAYS_PASSWORD;
+
+if (!email || !password) {
+    console.error('Set ALLPLAYS_EMAIL and ALLPLAYS_PASSWORD environment variables.');
+    process.exit(1);
+}
+
+// The public API key is referrer-restricted to the AllPlays site, so send the
+// site as referer (same key policy the browser clients satisfy naturally).
+const REFERER = process.env.ALLPLAYS_REFERER || 'https://allplays.ai/';
+
+const response = await fetch(`https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=${API_KEY}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Referer: REFERER },
+    body: JSON.stringify({ email, password, returnSecureToken: true })
+});
+
+const body = await response.json();
+if (!response.ok) {
+    console.error(`Sign-in failed: ${body?.error?.message || response.status}`);
+    process.exit(1);
+}
+
+console.log(`uid:           ${body.localId}`);
+console.log(`refresh token: ${body.refreshToken}`);
+console.log('\nUse the refresh token as the Bearer token for the MCP connector.');

--- a/services/chatgpt-mcp/src/core.js
+++ b/services/chatgpt-mcp/src/core.js
@@ -94,11 +94,19 @@ export async function resolveUserContext(db, { uid, email }) {
         if (link) addLinkedPlayer(link.teamId, link.playerId);
     }
 
-    const [ownedSnap, adminSnap] = await Promise.all([
+    const ownerEmailCandidates = [...new Set([email, profile.email, normalizedEmail]
+        .filter((value) => typeof value === 'string' && value))];
+    const [ownedSnap, adminSnap, ownerEmailLowerSnap, ...ownerEmailSnaps] = await Promise.all([
         db.collection('teams').where('ownerId', '==', uid).get(),
         normalizedEmail
             ? db.collection('teams').where('adminEmails', 'array-contains', normalizedEmail).get()
-            : Promise.resolve({ docs: [] })
+            : Promise.resolve({ docs: [] }),
+        normalizedEmail
+            ? db.collection('teams').where('ownerEmailLower', '==', normalizedEmail).get()
+            : Promise.resolve({ docs: [] }),
+        ...ownerEmailCandidates.map((ownerEmail) => (
+            db.collection('teams').where('ownerEmail', '==', ownerEmail).get()
+        ))
     ]);
 
     const teams = new Map();
@@ -111,6 +119,10 @@ export async function resolveUserContext(db, { uid, email }) {
 
     for (const doc of ownedSnap.docs) addTeam(doc.id, doc.data(), 'owner');
     for (const doc of adminSnap.docs) addTeam(doc.id, doc.data(), 'admin');
+    for (const doc of ownerEmailLowerSnap.docs) addTeam(doc.id, doc.data(), 'owner');
+    for (const snap of ownerEmailSnaps) {
+        for (const doc of snap.docs) addTeam(doc.id, doc.data(), 'owner');
+    }
 
     const parentTeamSnaps = await Promise.all([...parentTeamIds].map((teamId) => safeGetDoc(db, `teams/${teamId}`)));
     for (const snap of parentTeamSnaps) {

--- a/services/chatgpt-mcp/src/core.js
+++ b/services/chatgpt-mcp/src/core.js
@@ -39,9 +39,18 @@ function cleanString(value) {
     return typeof value === 'string' ? value : '';
 }
 
-// With user-credentialed Firestore access, rules can deny individual reads
-// (e.g. a stale parentOf link). Treat those as absent rather than failing the
-// whole tool call; the denial itself never leaks data.
+function parseParentPlayerKey(value) {
+    if (typeof value !== 'string') return null;
+    const separatorIndex = value.indexOf('::');
+    if (separatorIndex <= 0 || separatorIndex >= value.length - 2) return null;
+    const teamId = value.slice(0, separatorIndex).trim();
+    const playerId = value.slice(separatorIndex + 2).trim();
+    return teamId && playerId ? { teamId, playerId } : null;
+}
+
+// With user-credentialed Firestore access, rules can deny individual reads.
+// Treat those documents as absent rather than failing the whole tool call;
+// the caller's rules-authorized downstream reads remain the enforcement point.
 async function safeGetDoc(db, path) {
     try {
         return await db.doc(path).get();
@@ -63,8 +72,27 @@ export async function resolveUserContext(db, { uid, email }) {
     const userSnap = await safeGetDoc(db, `users/${uid}`);
     const profile = userSnap.exists ? userSnap.data() || {} : {};
     const normalizedEmail = normalizeEmail(email || profile.email);
-    const parentLinks = (Array.isArray(profile.parentOf) ? profile.parentOf : [])
+    const legacyParentLinks = (Array.isArray(profile.parentOf) ? profile.parentOf : [])
         .filter((link) => link && typeof link.teamId === 'string' && link.teamId);
+    const parentTeamIds = new Set([
+        ...legacyParentLinks.map((link) => link.teamId),
+        ...(Array.isArray(profile.parentTeamIds) ? profile.parentTeamIds : [])
+            .filter((teamId) => typeof teamId === 'string' && teamId)
+    ]);
+    const linkedPlayerIdsByTeam = new Map();
+    const addLinkedPlayer = (teamId, playerId) => {
+        if (!teamId || !playerId) return;
+        parentTeamIds.add(teamId);
+        if (!linkedPlayerIdsByTeam.has(teamId)) linkedPlayerIdsByTeam.set(teamId, new Set());
+        linkedPlayerIdsByTeam.get(teamId).add(playerId);
+    };
+    for (const link of legacyParentLinks) {
+        if (typeof link.playerId === 'string') addLinkedPlayer(link.teamId, link.playerId);
+    }
+    for (const value of Array.isArray(profile.parentPlayerKeys) ? profile.parentPlayerKeys : []) {
+        const link = parseParentPlayerKey(value);
+        if (link) addLinkedPlayer(link.teamId, link.playerId);
+    }
 
     const [ownedSnap, adminSnap] = await Promise.all([
         db.collection('teams').where('ownerId', '==', uid).get(),
@@ -84,16 +112,15 @@ export async function resolveUserContext(db, { uid, email }) {
     for (const doc of ownedSnap.docs) addTeam(doc.id, doc.data(), 'owner');
     for (const doc of adminSnap.docs) addTeam(doc.id, doc.data(), 'admin');
 
-    const parentTeamIds = [...new Set(parentLinks.map((link) => link.teamId))];
-    const parentTeamSnaps = await Promise.all(parentTeamIds.map((teamId) => safeGetDoc(db, `teams/${teamId}`)));
+    const parentTeamSnaps = await Promise.all([...parentTeamIds].map((teamId) => safeGetDoc(db, `teams/${teamId}`)));
     for (const snap of parentTeamSnaps) {
-        if (snap.exists) addTeam(snap.id, snap.data(), 'parent');
+        // Private team documents are not parent-readable, even though their
+        // games are. Keep the rules-derived parent scope with empty metadata.
+        addTeam(snap.id, snap.exists ? snap.data() : {}, 'parent');
     }
-    for (const link of parentLinks) {
-        const entry = teams.get(link.teamId);
-        if (entry && typeof link.playerId === 'string' && link.playerId) {
-            entry.linkedPlayerIds.add(link.playerId);
-        }
+    for (const [teamId, playerIds] of linkedPlayerIdsByTeam) {
+        const entry = teams.get(teamId);
+        for (const playerId of playerIds) entry?.linkedPlayerIds.add(playerId);
     }
 
     return {

--- a/services/chatgpt-mcp/src/core.js
+++ b/services/chatgpt-mcp/src/core.js
@@ -173,6 +173,9 @@ function parseScheduleRange({ startDate, endDate } = {}, now = new Date()) {
     if (Number.isNaN(start.getTime())) throw new DomainError('invalid_argument', 'startDate is not a valid date.');
     const end = endDate ? new Date(endDate) : new Date(start.getTime() + DEFAULT_SCHEDULE_DAYS * MS_PER_DAY);
     if (Number.isNaN(end.getTime())) throw new DomainError('invalid_argument', 'endDate is not a valid date.');
+    if (/^\d{4}-\d{2}-\d{2}$/.test(endDate || '')) {
+        end.setUTCHours(23, 59, 59, 999);
+    }
     if (end < start) throw new DomainError('invalid_argument', 'endDate must be after startDate.');
     return { start, end };
 }

--- a/services/chatgpt-mcp/src/core.js
+++ b/services/chatgpt-mcp/src/core.js
@@ -1,0 +1,270 @@
+// Pure domain logic for the AllPlays ChatGPT MCP service.
+//
+// Identity comes from the verified token (never from tool arguments), and every
+// tool re-derives team membership from Firestore before returning data. The
+// Firestore Admin handle is injected so this module stays testable without
+// firebase-admin.
+
+export const APP_BASE_URL = 'https://allplays.ai';
+export const DEFAULT_SCHEDULE_DAYS = 7;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const MAX_EVENTS_PER_TEAM = 50;
+const MAX_PLAYER_STATS = 60;
+
+export class DomainError extends Error {
+    constructor(code, message) {
+        super(message);
+        this.name = 'DomainError';
+        this.code = code;
+    }
+}
+
+function normalizeEmail(email) {
+    return typeof email === 'string' ? email.trim().toLowerCase() : '';
+}
+
+function toDate(value) {
+    if (!value) return null;
+    if (typeof value.toDate === 'function') return value.toDate();
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function toIso(value) {
+    const date = toDate(value);
+    return date ? date.toISOString() : null;
+}
+
+function cleanString(value) {
+    return typeof value === 'string' ? value : '';
+}
+
+// With user-credentialed Firestore access, rules can deny individual reads
+// (e.g. a stale parentOf link). Treat those as absent rather than failing the
+// whole tool call; the denial itself never leaks data.
+async function safeGetDoc(db, path) {
+    try {
+        return await db.doc(path).get();
+    } catch (error) {
+        if (error instanceof DomainError && error.code === 'permission_denied') {
+            return { exists: false, id: path.split('/').pop(), data: () => undefined };
+        }
+        throw error;
+    }
+}
+
+/**
+ * Build the caller's authorization context from Firestore. Roles are always
+ * re-derived per request; nothing supplied by the model is trusted.
+ */
+export async function resolveUserContext(db, { uid, email }) {
+    if (!uid) throw new DomainError('unauthenticated', 'Missing authenticated user.');
+
+    const userSnap = await safeGetDoc(db, `users/${uid}`);
+    const profile = userSnap.exists ? userSnap.data() || {} : {};
+    const normalizedEmail = normalizeEmail(email || profile.email);
+    const parentLinks = (Array.isArray(profile.parentOf) ? profile.parentOf : [])
+        .filter((link) => link && typeof link.teamId === 'string' && link.teamId);
+
+    const [ownedSnap, adminSnap] = await Promise.all([
+        db.collection('teams').where('ownerId', '==', uid).get(),
+        normalizedEmail
+            ? db.collection('teams').where('adminEmails', 'array-contains', normalizedEmail).get()
+            : Promise.resolve({ docs: [] })
+    ]);
+
+    const teams = new Map();
+    const addTeam = (teamId, teamData, role) => {
+        if (!teams.has(teamId)) {
+            teams.set(teamId, { teamId, team: teamData || {}, roles: new Set(), linkedPlayerIds: new Set() });
+        }
+        teams.get(teamId).roles.add(role);
+    };
+
+    for (const doc of ownedSnap.docs) addTeam(doc.id, doc.data(), 'owner');
+    for (const doc of adminSnap.docs) addTeam(doc.id, doc.data(), 'admin');
+
+    const parentTeamIds = [...new Set(parentLinks.map((link) => link.teamId))];
+    const parentTeamSnaps = await Promise.all(parentTeamIds.map((teamId) => safeGetDoc(db, `teams/${teamId}`)));
+    for (const snap of parentTeamSnaps) {
+        if (snap.exists) addTeam(snap.id, snap.data(), 'parent');
+    }
+    for (const link of parentLinks) {
+        const entry = teams.get(link.teamId);
+        if (entry && typeof link.playerId === 'string' && link.playerId) {
+            entry.linkedPlayerIds.add(link.playerId);
+        }
+    }
+
+    return {
+        uid,
+        email: normalizedEmail,
+        isGlobalAdmin: profile.isAdmin === true,
+        teams
+    };
+}
+
+function requireTeamAccess(context, teamId) {
+    if (typeof teamId !== 'string' || !teamId) {
+        throw new DomainError('invalid_argument', 'teamId is required.');
+    }
+    const entry = context.teams.get(teamId);
+    if (!entry && !context.isGlobalAdmin) {
+        throw new DomainError('permission_denied', 'You do not have access to this team.');
+    }
+    return entry || null;
+}
+
+export async function listMyTeams(db, context) {
+    const teams = [];
+    for (const entry of context.teams.values()) {
+        const linkedPlayers = [];
+        for (const playerId of entry.linkedPlayerIds) {
+            const snap = await safeGetDoc(db, `teams/${entry.teamId}/players/${playerId}`);
+            if (!snap.exists) continue;
+            const data = snap.data() || {};
+            linkedPlayers.push({
+                playerId: snap.id,
+                name: cleanString(data.name),
+                number: data.number ?? null
+            });
+        }
+        teams.push({
+            teamId: entry.teamId,
+            name: cleanString(entry.team.name),
+            sport: cleanString(entry.team.sport) || null,
+            roles: [...entry.roles].sort(),
+            linkedPlayers
+        });
+    }
+    teams.sort((a, b) => a.name.localeCompare(b.name));
+    return { teams };
+}
+
+function parseScheduleRange({ startDate, endDate } = {}, now = new Date()) {
+    const start = startDate ? new Date(startDate) : new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    if (Number.isNaN(start.getTime())) throw new DomainError('invalid_argument', 'startDate is not a valid date.');
+    const end = endDate ? new Date(endDate) : new Date(start.getTime() + DEFAULT_SCHEDULE_DAYS * MS_PER_DAY);
+    if (Number.isNaN(end.getTime())) throw new DomainError('invalid_argument', 'endDate is not a valid date.');
+    if (end < start) throw new DomainError('invalid_argument', 'endDate must be after startDate.');
+    return { start, end };
+}
+
+function gameDeepLink(teamId, gameId, { replay = false } = {}) {
+    const params = new URLSearchParams({ teamId, gameId });
+    if (replay) params.set('replay', 'true');
+    return `${APP_BASE_URL}/live-game.html?${params.toString()}`;
+}
+
+function whitelistRsvp(data, linkedPlayerIds) {
+    if (!data) return null;
+    const playerIds = (Array.isArray(data.playerIds) ? data.playerIds : [data.playerId])
+        .filter((id) => typeof id === 'string' && id);
+    return {
+        response: cleanString(data.response || data.status) || 'not_responded',
+        playerIds: playerIds.filter((id) => linkedPlayerIds.has(id))
+    };
+}
+
+function whitelistRsvpSummary(summary) {
+    if (!summary || typeof summary !== 'object') return null;
+    const out = {};
+    for (const key of ['going', 'maybe', 'notGoing', 'notResponded', 'total']) {
+        if (typeof summary[key] === 'number') out[key] = summary[key];
+    }
+    return Object.keys(out).length ? out : null;
+}
+
+export async function getFamilySchedule(db, context, args = {}, now = new Date()) {
+    const { start, end } = parseScheduleRange(args, now);
+    const events = [];
+
+    for (const entry of context.teams.values()) {
+        const snap = await db.collection(`teams/${entry.teamId}/games`)
+            .where('date', '>=', start)
+            .where('date', '<=', end)
+            .orderBy('date')
+            .limit(MAX_EVENTS_PER_TEAM)
+            .get();
+
+        for (const doc of snap.docs) {
+            const data = doc.data() || {};
+            const event = {
+                teamId: entry.teamId,
+                teamName: cleanString(entry.team.name),
+                gameId: doc.id,
+                type: data.type === 'practice' ? 'practice' : 'game',
+                date: toIso(data.date),
+                opponent: cleanString(data.opponent) || cleanString(data.opponentTeamName) || null,
+                location: cleanString(data.location) || null,
+                rsvpSummary: whitelistRsvpSummary(data.rsvpSummary),
+                myRsvp: null,
+                linkedPlayerIds: [...entry.linkedPlayerIds],
+                deepLink: gameDeepLink(entry.teamId, doc.id)
+            };
+
+            if (entry.roles.has('parent')) {
+                const rsvpSnap = await safeGetDoc(db, `teams/${entry.teamId}/games/${doc.id}/rsvps/${context.uid}`);
+                event.myRsvp = rsvpSnap.exists
+                    ? whitelistRsvp(rsvpSnap.data(), entry.linkedPlayerIds)
+                    : { response: 'not_responded', playerIds: [] };
+            }
+
+            events.push(event);
+        }
+    }
+
+    events.sort((a, b) => (a.date || '').localeCompare(b.date || ''));
+    return {
+        startDate: start.toISOString(),
+        endDate: end.toISOString(),
+        events
+    };
+}
+
+const GAME_SUMMARY_FIELDS = [
+    'type', 'opponent', 'opponentTeamName', 'location', 'liveStatus', 'status',
+    'homeScore', 'awayScore', 'isHome', 'summary', 'aiSummary', 'result'
+];
+
+export async function getGameSummary(db, context, { teamId, gameId } = {}) {
+    const entry = requireTeamAccess(context, teamId);
+    if (typeof gameId !== 'string' || !gameId) {
+        throw new DomainError('invalid_argument', 'gameId is required.');
+    }
+
+    const gameSnap = await db.doc(`teams/${teamId}/games/${gameId}`).get();
+    if (!gameSnap.exists) throw new DomainError('not_found', 'Game not found.');
+    const data = gameSnap.data() || {};
+
+    const game = { gameId: gameSnap.id, teamId, teamName: cleanString(entry?.team?.name), date: toIso(data.date) };
+    for (const field of GAME_SUMMARY_FIELDS) {
+        if (data[field] !== undefined) game[field] = data[field];
+    }
+    game.rsvpSummary = whitelistRsvpSummary(data.rsvpSummary);
+
+    let statsSnap = { docs: [] };
+    try {
+        statsSnap = await db.collection(`teams/${teamId}/games/${gameId}/aggregatedStats`)
+            .limit(MAX_PLAYER_STATS)
+            .get();
+    } catch (error) {
+        if (!(error instanceof DomainError && error.code === 'permission_denied')) throw error;
+    }
+    const playerStats = statsSnap.docs.map((doc) => {
+        const stats = doc.data() || {};
+        return {
+            playerId: doc.id,
+            playerName: cleanString(stats.playerName) || null,
+            playerNumber: stats.playerNumber ?? null,
+            stats: Object.fromEntries(Object.entries(stats)
+                .filter(([key, value]) => typeof value === 'number' && !['playerNumber'].includes(key)))
+        };
+    });
+
+    return {
+        game,
+        playerStats,
+        deepLink: gameDeepLink(teamId, gameId, { replay: true })
+    };
+}

--- a/services/chatgpt-mcp/src/core.js
+++ b/services/chatgpt-mcp/src/core.js
@@ -279,13 +279,16 @@ export async function getGameSummary(db, context, { teamId, gameId } = {}) {
         if (!(error instanceof DomainError && error.code === 'permission_denied')) throw error;
     }
     const playerStats = statsSnap.docs.map((doc) => {
-        const stats = doc.data() || {};
+        const player = doc.data() || {};
+        const stats = player.stats && typeof player.stats === 'object' && !Array.isArray(player.stats)
+            ? player.stats
+            : {};
         return {
             playerId: doc.id,
-            playerName: cleanString(stats.playerName) || null,
-            playerNumber: stats.playerNumber ?? null,
+            playerName: cleanString(player.playerName) || null,
+            playerNumber: player.playerNumber ?? null,
             stats: Object.fromEntries(Object.entries(stats)
-                .filter(([key, value]) => typeof value === 'number' && !['playerNumber'].includes(key)))
+                .filter(([, value]) => typeof value === 'number'))
         };
     });
 

--- a/services/chatgpt-mcp/src/firestoreRest.js
+++ b/services/chatgpt-mcp/src/firestoreRest.js
@@ -1,0 +1,154 @@
+// User-credentialed Firestore access over the REST API.
+//
+// Every request carries the *user's* Firebase ID token, so Firestore security
+// rules authorize each read exactly as they do for the AllPlays web and app
+// clients. The service itself holds no privileged credentials. The adapter
+// exposes the same doc()/collection() surface core.js uses, so domain logic
+// stays storage-agnostic and testable.
+
+import { DomainError } from './core.js';
+
+const OP_MAP = {
+    '==': 'EQUAL',
+    '>=': 'GREATER_THAN_OR_EQUAL',
+    '<=': 'LESS_THAN_OR_EQUAL',
+    '>': 'GREATER_THAN',
+    '<': 'LESS_THAN',
+    'array-contains': 'ARRAY_CONTAINS'
+};
+
+export function encodeValue(value) {
+    if (value === null || value === undefined) return { nullValue: null };
+    if (value instanceof Date) return { timestampValue: value.toISOString() };
+    if (typeof value === 'boolean') return { booleanValue: value };
+    if (typeof value === 'number') {
+        return Number.isInteger(value) ? { integerValue: String(value) } : { doubleValue: value };
+    }
+    if (typeof value === 'string') return { stringValue: value };
+    if (Array.isArray(value)) return { arrayValue: { values: value.map(encodeValue) } };
+    if (typeof value === 'object') {
+        return {
+            mapValue: {
+                fields: Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, encodeValue(entry)]))
+            }
+        };
+    }
+    throw new Error(`Cannot encode Firestore value of type ${typeof value}`);
+}
+
+export function decodeValue(value) {
+    if (!value || typeof value !== 'object') return null;
+    if ('nullValue' in value) return null;
+    if ('stringValue' in value) return value.stringValue;
+    if ('booleanValue' in value) return value.booleanValue;
+    if ('integerValue' in value) return Number(value.integerValue);
+    if ('doubleValue' in value) return value.doubleValue;
+    if ('timestampValue' in value) return new Date(value.timestampValue);
+    if ('referenceValue' in value) return value.referenceValue;
+    if ('geoPointValue' in value) return value.geoPointValue;
+    if ('mapValue' in value) return decodeFields(value.mapValue?.fields);
+    if ('arrayValue' in value) return (value.arrayValue?.values || []).map(decodeValue);
+    return null;
+}
+
+export function decodeFields(fields) {
+    return Object.fromEntries(Object.entries(fields || {}).map(([key, value]) => [key, decodeValue(value)]));
+}
+
+function throwForStatus(status, path) {
+    if (status === 401 || status === 403) {
+        throw new DomainError('permission_denied', 'You do not have access to this data.');
+    }
+    throw new Error(`Firestore request failed (${status}) for ${path}`);
+}
+
+export function buildStructuredQuery(collectionId, { filters = [], orderBy = null, limit = null } = {}) {
+    const structuredQuery = { from: [{ collectionId }] };
+    const fieldFilters = filters.map(({ field, op, value }) => ({
+        fieldFilter: {
+            field: { fieldPath: field },
+            op: OP_MAP[op] || (() => { throw new Error(`Unsupported operator: ${op}`); })(),
+            value: encodeValue(value)
+        }
+    }));
+    if (fieldFilters.length === 1) structuredQuery.where = fieldFilters[0];
+    if (fieldFilters.length > 1) {
+        structuredQuery.where = { compositeFilter: { op: 'AND', filters: fieldFilters } };
+    }
+    if (orderBy) {
+        structuredQuery.orderBy = [{
+            field: { fieldPath: orderBy.field },
+            direction: orderBy.direction === 'desc' ? 'DESCENDING' : 'ASCENDING'
+        }];
+    }
+    if (limit) structuredQuery.limit = limit;
+    return structuredQuery;
+}
+
+/**
+ * Firestore handle scoped to one user's ID token. Interface matches what
+ * core.js expects: doc(path).get(), collection(path).where().orderBy().limit().get().
+ */
+export function createUserDb({ projectId, idToken, fetchImpl = fetch }) {
+    const baseUrl = `https://firestore.googleapis.com/v1/projects/${projectId}/databases/(default)/documents`;
+    const headers = {
+        Authorization: `Bearer ${idToken}`,
+        'Content-Type': 'application/json'
+    };
+
+    return {
+        doc(path) {
+            return {
+                async get() {
+                    const response = await fetchImpl(`${baseUrl}/${path}`, { headers });
+                    if (response.status === 404) {
+                        return { exists: false, id: path.split('/').pop(), data: () => undefined };
+                    }
+                    if (!response.ok) throwForStatus(response.status, path);
+                    const body = await response.json();
+                    return {
+                        exists: true,
+                        id: path.split('/').pop(),
+                        data: () => decodeFields(body.fields)
+                    };
+                }
+            };
+        },
+        collection(path) {
+            const segments = path.split('/');
+            const collectionId = segments.pop();
+            const parentPath = segments.join('/');
+            const queryUrl = `${baseUrl}${parentPath ? `/${parentPath}` : ''}:runQuery`;
+
+            const makeQuery = (options) => ({
+                where(field, op, value) {
+                    return makeQuery({ ...options, filters: [...options.filters, { field, op, value }] });
+                },
+                orderBy(field, direction = 'asc') {
+                    return makeQuery({ ...options, orderBy: { field, direction } });
+                },
+                limit(count) {
+                    return makeQuery({ ...options, limit: count });
+                },
+                async get() {
+                    const response = await fetchImpl(queryUrl, {
+                        method: 'POST',
+                        headers,
+                        body: JSON.stringify({ structuredQuery: buildStructuredQuery(collectionId, options) })
+                    });
+                    if (!response.ok) throwForStatus(response.status, path);
+                    const rows = await response.json();
+                    const docs = (Array.isArray(rows) ? rows : [])
+                        .filter((row) => row.document)
+                        .map((row) => ({
+                            id: row.document.name.split('/').pop(),
+                            data: () => decodeFields(row.document.fields)
+                        }));
+                    return { docs };
+                }
+            });
+
+            return makeQuery({ filters: [] });
+        }
+    };
+}

--- a/services/chatgpt-mcp/src/identity.js
+++ b/services/chatgpt-mcp/src/identity.js
@@ -58,15 +58,24 @@ export function createIdentityResolver({ apiKey, referer = DEFAULT_REFERER, fetc
         const cached = cache.get(token);
         if (cached && cached.expiresAt - EXPIRY_MARGIN_MS > now()) return cached;
 
-        const response = await fetchImpl(`${TOKEN_ENDPOINT}?key=${apiKey}`, {
+        const response = await fetchImpl(TOKEN_ENDPOINT, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded', Referer: referer },
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'X-goog-api-key': apiKey,
+                Referer: referer
+            },
             body: new URLSearchParams({ grant_type: 'refresh_token', refresh_token: token }).toString()
         });
         if (!response.ok) {
             throw new DomainError('unauthenticated', 'Invalid or revoked token.');
         }
-        const body = await response.json();
+        let body;
+        try {
+            body = await response.json();
+        } catch {
+            throw new DomainError('unauthenticated', 'Invalid token exchange response.');
+        }
         const idPayload = decodeJwtPayload(body.id_token) || {};
         const identity = {
             uid: body.user_id || idPayload.user_id || '',

--- a/services/chatgpt-mcp/src/identity.js
+++ b/services/chatgpt-mcp/src/identity.js
@@ -1,0 +1,81 @@
+// Bearer-token identity for the MCP service — no privileged credentials.
+//
+// The connector's bearer token is either:
+//   - a Firebase *refresh token* (long-lived; exchanged here for a short-lived
+//     ID token via the public securetoken endpoint and cached), or
+//   - a raw Firebase *ID token* (JWT; useful for short manual tests).
+//
+// The resolved ID token is then presented to Firestore on every read, so
+// security rules — not this module — are the enforcement point. A forged JWT
+// yields identity claims here but fails every Firestore call. This mirrors the
+// planned OAuth broker: token in, user-scoped credential out.
+
+import { DomainError } from './core.js';
+
+const TOKEN_ENDPOINT = 'https://securetoken.googleapis.com/v1/token';
+const EXPIRY_MARGIN_MS = 60 * 1000;
+// The public API key is referrer-restricted to the AllPlays site; API-key
+// endpoints need this header. (Firestore REST uses the ID token, not the key.)
+const DEFAULT_REFERER = 'https://allplays.ai/';
+
+export function extractBearerToken(authorizationHeader) {
+    if (typeof authorizationHeader !== 'string') return null;
+    const match = authorizationHeader.match(/^Bearer\s+(.+)$/i);
+    return match ? match[1].trim() : null;
+}
+
+export function decodeJwtPayload(token) {
+    const parts = typeof token === 'string' ? token.split('.') : [];
+    if (parts.length !== 3) return null;
+    try {
+        return JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
+    } catch {
+        return null;
+    }
+}
+
+export function createIdentityResolver({ apiKey, referer = DEFAULT_REFERER, fetchImpl = fetch, now = () => Date.now() }) {
+    if (!apiKey) throw new Error('createIdentityResolver requires the Firebase web API key.');
+    const cache = new Map();
+
+    return async function resolveIdentity(authorizationHeader) {
+        const token = extractBearerToken(authorizationHeader);
+        if (!token) throw new DomainError('unauthenticated', 'Missing bearer token.');
+
+        const jwtPayload = decodeJwtPayload(token);
+        if (jwtPayload) {
+            if (typeof jwtPayload.exp === 'number' && jwtPayload.exp * 1000 <= now()) {
+                throw new DomainError('unauthenticated', 'ID token is expired. Use a refresh token as the bearer for long-lived access.');
+            }
+            return {
+                uid: jwtPayload.user_id || jwtPayload.sub || '',
+                email: jwtPayload.email || '',
+                idToken: token,
+                via: 'id-token'
+            };
+        }
+
+        const cached = cache.get(token);
+        if (cached && cached.expiresAt - EXPIRY_MARGIN_MS > now()) return cached;
+
+        const response = await fetchImpl(`${TOKEN_ENDPOINT}?key=${apiKey}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded', Referer: referer },
+            body: new URLSearchParams({ grant_type: 'refresh_token', refresh_token: token }).toString()
+        });
+        if (!response.ok) {
+            throw new DomainError('unauthenticated', 'Invalid or revoked token.');
+        }
+        const body = await response.json();
+        const idPayload = decodeJwtPayload(body.id_token) || {};
+        const identity = {
+            uid: body.user_id || idPayload.user_id || '',
+            email: idPayload.email || '',
+            idToken: body.id_token,
+            expiresAt: now() + (Number(body.expires_in) || 3600) * 1000,
+            via: 'refresh-token'
+        };
+        cache.set(token, identity);
+        return identity;
+    };
+}

--- a/services/chatgpt-mcp/src/oauth.js
+++ b/services/chatgpt-mcp/src/oauth.js
@@ -14,6 +14,9 @@ import { createHash, randomBytes } from 'node:crypto';
 
 const CODE_TTL_MS = 10 * 60 * 1000;
 const ACCESS_TOKEN_TTL_MS = 60 * 60 * 1000;
+const TRUSTED_REDIRECT_URIS = new Set([
+    'https://chatgpt.com/connector_platform_oauth_redirect'
+]);
 
 export class OAuthError extends Error {
     constructor(code, message) {
@@ -28,14 +31,7 @@ export function s256Challenge(verifier) {
 }
 
 function isAllowedRedirectUri(uri) {
-    try {
-        const parsed = new URL(uri);
-        if (parsed.protocol === 'https:') return true;
-        // Loopback redirects are permitted for local tooling (OAuth 2.1).
-        return parsed.protocol === 'http:' && ['localhost', '127.0.0.1'].includes(parsed.hostname);
-    } catch {
-        return false;
-    }
+    return typeof uri === 'string' && TRUSTED_REDIRECT_URIS.has(uri);
 }
 
 export function createOAuthBroker({ now = () => Date.now(), randomId = (bytes = 32) => randomBytes(bytes).toString('base64url') } = {}) {
@@ -49,7 +45,7 @@ export function createOAuthBroker({ now = () => Date.now(), randomId = (bytes = 
             throw new OAuthError('invalid_request', 'redirect_uris is required.');
         }
         if (!redirectUris.every(isAllowedRedirectUri)) {
-            throw new OAuthError('invalid_request', 'redirect_uris must be https (or localhost) URLs.');
+            throw new OAuthError('invalid_request', 'redirect_uris must use an approved ChatGPT callback.');
         }
         const clientId = randomId(16);
         clients.set(clientId, { redirectUris, clientName: typeof clientName === 'string' ? clientName : '' });

--- a/services/chatgpt-mcp/src/oauth.js
+++ b/services/chatgpt-mcp/src/oauth.js
@@ -1,0 +1,165 @@
+// Minimal OAuth 2.1 broker for the ChatGPT MCP connector.
+//
+// Implements the slice of OAuth that ChatGPT Developer Mode requires:
+// dynamic client registration, authorization code + PKCE (S256 only), and a
+// token endpoint. Each authorization ends by binding the signed-in user's
+// Firebase refresh token to broker-issued opaque tokens; MCP requests then
+// resolve broker token → Firebase credential → rules-enforced Firestore
+// access, unchanged from the direct-bearer path.
+//
+// Storage is in-memory: fine for a single-instance dev deployment, replaced
+// by Firestore-backed storage before multi-instance Cloud Run (see spec).
+
+import { createHash, randomBytes } from 'node:crypto';
+
+const CODE_TTL_MS = 10 * 60 * 1000;
+const ACCESS_TOKEN_TTL_MS = 60 * 60 * 1000;
+
+export class OAuthError extends Error {
+    constructor(code, message) {
+        super(message);
+        this.name = 'OAuthError';
+        this.code = code; // OAuth error codes: invalid_request, invalid_grant, invalid_client
+    }
+}
+
+export function s256Challenge(verifier) {
+    return createHash('sha256').update(verifier, 'utf8').digest('base64url');
+}
+
+function isAllowedRedirectUri(uri) {
+    try {
+        const parsed = new URL(uri);
+        if (parsed.protocol === 'https:') return true;
+        // Loopback redirects are permitted for local tooling (OAuth 2.1).
+        return parsed.protocol === 'http:' && ['localhost', '127.0.0.1'].includes(parsed.hostname);
+    } catch {
+        return false;
+    }
+}
+
+export function createOAuthBroker({ now = () => Date.now(), randomId = (bytes = 32) => randomBytes(bytes).toString('base64url') } = {}) {
+    const clients = new Map();
+    const codes = new Map();
+    const accessTokens = new Map();
+    const refreshTokens = new Map();
+
+    function registerClient({ redirect_uris: redirectUris, client_name: clientName } = {}) {
+        if (!Array.isArray(redirectUris) || redirectUris.length === 0) {
+            throw new OAuthError('invalid_request', 'redirect_uris is required.');
+        }
+        if (!redirectUris.every(isAllowedRedirectUri)) {
+            throw new OAuthError('invalid_request', 'redirect_uris must be https (or localhost) URLs.');
+        }
+        const clientId = randomId(16);
+        clients.set(clientId, { redirectUris, clientName: typeof clientName === 'string' ? clientName : '' });
+        return {
+            client_id: clientId,
+            redirect_uris: redirectUris,
+            token_endpoint_auth_method: 'none',
+            grant_types: ['authorization_code', 'refresh_token'],
+            response_types: ['code']
+        };
+    }
+
+    function validateAuthorizeRequest({ client_id: clientId, redirect_uri: redirectUri, response_type: responseType, code_challenge: codeChallenge, code_challenge_method: method }) {
+        const client = clients.get(clientId);
+        if (!client) throw new OAuthError('invalid_client', 'Unknown client_id.');
+        if (!client.redirectUris.includes(redirectUri)) {
+            throw new OAuthError('invalid_request', 'redirect_uri is not registered for this client.');
+        }
+        if (responseType !== 'code') throw new OAuthError('invalid_request', 'Only response_type=code is supported.');
+        if (!codeChallenge) throw new OAuthError('invalid_request', 'code_challenge is required (PKCE).');
+        if (method !== 'S256') throw new OAuthError('invalid_request', 'Only code_challenge_method=S256 is supported.');
+        return { clientId, redirectUri, codeChallenge };
+    }
+
+    function approveAuthorization({ clientId, redirectUri, codeChallenge, firebaseRefreshToken }) {
+        if (!firebaseRefreshToken) throw new OAuthError('invalid_request', 'Sign-in did not produce a credential.');
+        // Re-validate so a tampered approval form cannot bypass the checks.
+        validateAuthorizeRequest({
+            client_id: clientId,
+            redirect_uri: redirectUri,
+            response_type: 'code',
+            code_challenge: codeChallenge,
+            code_challenge_method: 'S256'
+        });
+        const code = randomId(32);
+        codes.set(code, { clientId, redirectUri, codeChallenge, firebaseRefreshToken, expiresAt: now() + CODE_TTL_MS });
+        return code;
+    }
+
+    function issueTokens(firebaseRefreshToken, clientId) {
+        const accessToken = randomId(32);
+        const refreshToken = randomId(32);
+        accessTokens.set(accessToken, { firebaseRefreshToken, expiresAt: now() + ACCESS_TOKEN_TTL_MS });
+        refreshTokens.set(refreshToken, { firebaseRefreshToken, clientId });
+        return {
+            access_token: accessToken,
+            token_type: 'Bearer',
+            expires_in: Math.floor(ACCESS_TOKEN_TTL_MS / 1000),
+            refresh_token: refreshToken
+        };
+    }
+
+    function exchange(params = {}) {
+        const grantType = params.grant_type;
+        if (grantType === 'authorization_code') {
+            const record = codes.get(params.code);
+            codes.delete(params.code); // single-use, success or not
+            if (!record || record.expiresAt <= now()) {
+                throw new OAuthError('invalid_grant', 'Authorization code is invalid or expired.');
+            }
+            if (params.client_id && params.client_id !== record.clientId) {
+                throw new OAuthError('invalid_grant', 'client_id does not match the authorization.');
+            }
+            if (params.redirect_uri && params.redirect_uri !== record.redirectUri) {
+                throw new OAuthError('invalid_grant', 'redirect_uri does not match the authorization.');
+            }
+            if (!params.code_verifier || s256Challenge(params.code_verifier) !== record.codeChallenge) {
+                throw new OAuthError('invalid_grant', 'PKCE verification failed.');
+            }
+            return issueTokens(record.firebaseRefreshToken, record.clientId);
+        }
+        if (grantType === 'refresh_token') {
+            const record = refreshTokens.get(params.refresh_token);
+            if (!record) throw new OAuthError('invalid_grant', 'Unknown refresh token.');
+            return issueTokens(record.firebaseRefreshToken, record.clientId);
+        }
+        throw new OAuthError('invalid_request', 'Unsupported grant_type.');
+    }
+
+    function resolveAccessToken(token) {
+        const record = accessTokens.get(token);
+        if (!record) return null;
+        if (record.expiresAt <= now()) {
+            accessTokens.delete(token);
+            return null;
+        }
+        return { firebaseRefreshToken: record.firebaseRefreshToken };
+    }
+
+    return { registerClient, validateAuthorizeRequest, approveAuthorization, exchange, resolveAccessToken };
+}
+
+export function metadataFor(baseUrl) {
+    return {
+        authorizationServer: {
+            issuer: baseUrl,
+            authorization_endpoint: `${baseUrl}/oauth/authorize`,
+            token_endpoint: `${baseUrl}/oauth/token`,
+            registration_endpoint: `${baseUrl}/oauth/register`,
+            response_types_supported: ['code'],
+            grant_types_supported: ['authorization_code', 'refresh_token'],
+            code_challenge_methods_supported: ['S256'],
+            token_endpoint_auth_methods_supported: ['none'],
+            scopes_supported: ['allplays.read']
+        },
+        protectedResource: {
+            resource: `${baseUrl}/mcp`,
+            authorization_servers: [baseUrl],
+            bearer_methods_supported: ['header'],
+            scopes_supported: ['allplays.read']
+        }
+    };
+}

--- a/services/chatgpt-mcp/src/oauth.js
+++ b/services/chatgpt-mcp/src/oauth.js
@@ -14,6 +14,8 @@ import { createHash, randomBytes } from 'node:crypto';
 
 const CODE_TTL_MS = 10 * 60 * 1000;
 const ACCESS_TOKEN_TTL_MS = 60 * 60 * 1000;
+const REFRESH_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const MAX_STORED_GRANTS = 1000;
 const TRUSTED_REDIRECT_URIS = new Set([
     'https://chatgpt.com/connector_platform_oauth_redirect'
 ]);
@@ -34,11 +36,32 @@ function isAllowedRedirectUri(uri) {
     return typeof uri === 'string' && TRUSTED_REDIRECT_URIS.has(uri);
 }
 
-export function createOAuthBroker({ now = () => Date.now(), randomId = (bytes = 32) => randomBytes(bytes).toString('base64url') } = {}) {
+export function createOAuthBroker({
+    now = () => Date.now(),
+    randomId = (bytes = 32) => randomBytes(bytes).toString('base64url'),
+    maxStoredGrants = MAX_STORED_GRANTS
+} = {}) {
+    if (!Number.isInteger(maxStoredGrants) || maxStoredGrants < 1) {
+        throw new Error('maxStoredGrants must be a positive integer.');
+    }
     let registeredClient = null;
     const codes = new Map();
     const accessTokens = new Map();
     const refreshTokens = new Map();
+
+    function pruneExpired(store) {
+        for (const [key, record] of store) {
+            if (record.expiresAt <= now()) store.delete(key);
+        }
+    }
+
+    function setBounded(store, key, record) {
+        pruneExpired(store);
+        while (store.size >= maxStoredGrants) {
+            store.delete(store.keys().next().value);
+        }
+        store.set(key, record);
+    }
 
     function registerClient({ redirect_uris: redirectUris, client_name: clientName } = {}) {
         if (!Array.isArray(redirectUris) || redirectUris.length === 0) {
@@ -89,15 +112,19 @@ export function createOAuthBroker({ now = () => Date.now(), randomId = (bytes = 
             code_challenge_method: 'S256'
         });
         const code = randomId(32);
-        codes.set(code, { clientId, redirectUri, codeChallenge, firebaseRefreshToken, expiresAt: now() + CODE_TTL_MS });
+        setBounded(codes, code, { clientId, redirectUri, codeChallenge, firebaseRefreshToken, expiresAt: now() + CODE_TTL_MS });
         return code;
     }
 
     function issueTokens(firebaseRefreshToken, clientId) {
         const accessToken = randomId(32);
         const refreshToken = randomId(32);
-        accessTokens.set(accessToken, { firebaseRefreshToken, expiresAt: now() + ACCESS_TOKEN_TTL_MS });
-        refreshTokens.set(refreshToken, { firebaseRefreshToken, clientId });
+        setBounded(accessTokens, accessToken, { firebaseRefreshToken, expiresAt: now() + ACCESS_TOKEN_TTL_MS });
+        setBounded(refreshTokens, refreshToken, {
+            firebaseRefreshToken,
+            clientId,
+            expiresAt: now() + REFRESH_TOKEN_TTL_MS
+        });
         return {
             access_token: accessToken,
             token_type: 'Bearer',
@@ -126,20 +153,19 @@ export function createOAuthBroker({ now = () => Date.now(), randomId = (bytes = 
             return issueTokens(record.firebaseRefreshToken, record.clientId);
         }
         if (grantType === 'refresh_token') {
+            pruneExpired(refreshTokens);
             const record = refreshTokens.get(params.refresh_token);
             if (!record) throw new OAuthError('invalid_grant', 'Unknown refresh token.');
+            refreshTokens.delete(params.refresh_token); // rotate on every use
             return issueTokens(record.firebaseRefreshToken, record.clientId);
         }
         throw new OAuthError('invalid_request', 'Unsupported grant_type.');
     }
 
     function resolveAccessToken(token) {
+        pruneExpired(accessTokens);
         const record = accessTokens.get(token);
         if (!record) return null;
-        if (record.expiresAt <= now()) {
-            accessTokens.delete(token);
-            return null;
-        }
         return { firebaseRefreshToken: record.firebaseRefreshToken };
     }
 

--- a/services/chatgpt-mcp/src/oauth.js
+++ b/services/chatgpt-mcp/src/oauth.js
@@ -35,7 +35,7 @@ function isAllowedRedirectUri(uri) {
 }
 
 export function createOAuthBroker({ now = () => Date.now(), randomId = (bytes = 32) => randomBytes(bytes).toString('base64url') } = {}) {
-    const clients = new Map();
+    let registeredClient = null;
     const codes = new Map();
     const accessTokens = new Map();
     const refreshTokens = new Map();
@@ -47,11 +47,18 @@ export function createOAuthBroker({ now = () => Date.now(), randomId = (bytes = 
         if (!redirectUris.every(isAllowedRedirectUri)) {
             throw new OAuthError('invalid_request', 'redirect_uris must use an approved ChatGPT callback.');
         }
-        const clientId = randomId(16);
-        clients.set(clientId, { redirectUris, clientName: typeof clientName === 'string' ? clientName : '' });
+        // This broker only serves one trusted public client. Reusing its ID keeps
+        // unauthenticated dynamic registration from growing server memory.
+        if (!registeredClient) {
+            registeredClient = {
+                clientId: randomId(16),
+                redirectUris: [...new Set(redirectUris)],
+                clientName: typeof clientName === 'string' ? clientName : ''
+            };
+        }
         return {
-            client_id: clientId,
-            redirect_uris: redirectUris,
+            client_id: registeredClient.clientId,
+            redirect_uris: registeredClient.redirectUris,
             token_endpoint_auth_method: 'none',
             grant_types: ['authorization_code', 'refresh_token'],
             response_types: ['code']
@@ -59,9 +66,10 @@ export function createOAuthBroker({ now = () => Date.now(), randomId = (bytes = 
     }
 
     function validateAuthorizeRequest({ client_id: clientId, redirect_uri: redirectUri, response_type: responseType, code_challenge: codeChallenge, code_challenge_method: method }) {
-        const client = clients.get(clientId);
-        if (!client) throw new OAuthError('invalid_client', 'Unknown client_id.');
-        if (!client.redirectUris.includes(redirectUri)) {
+        if (!registeredClient || clientId !== registeredClient.clientId) {
+            throw new OAuthError('invalid_client', 'Unknown client_id.');
+        }
+        if (!registeredClient.redirectUris.includes(redirectUri)) {
             throw new OAuthError('invalid_request', 'redirect_uri is not registered for this client.');
         }
         if (responseType !== 'code') throw new OAuthError('invalid_request', 'Only response_type=code is supported.');

--- a/services/chatgpt-mcp/src/server.js
+++ b/services/chatgpt-mcp/src/server.js
@@ -21,8 +21,9 @@ import {
     getFamilySchedule,
     getGameSummary
 } from './core.js';
-import { createIdentityResolver } from './identity.js';
+import { createIdentityResolver, extractBearerToken } from './identity.js';
 import { createUserDb } from './firestoreRest.js';
+import { createOAuthBroker, metadataFor, OAuthError } from './oauth.js';
 
 const PORT = Number(process.env.PORT) || 8787;
 const PROJECT_ID = process.env.FIREBASE_PROJECT_ID || 'game-flow-c6311';
@@ -42,6 +43,79 @@ if (process.env.NODE_ENV === 'production' && process.env.DEV_FALLBACK_BEARER) {
 }
 if (FALLBACK_BEARER) {
     console.warn('[chatgpt-mcp] DEV_FALLBACK_BEARER is set: unauthenticated requests act as that user. Dev/test only.');
+}
+
+const oauth = createOAuthBroker();
+const SIGNIN_REFERER = process.env.ALLPLAYS_REFERER || 'https://allplays.ai/';
+
+// Public base URL for OAuth metadata: env override, else derive from the
+// proxy-forwarded headers (ngrok / Cloud Run set these).
+function publicBaseUrl(req) {
+    if (process.env.PUBLIC_BASE_URL) return process.env.PUBLIC_BASE_URL.replace(/\/$/, '');
+    const proto = req.get('x-forwarded-proto') || req.protocol || 'https';
+    const host = req.get('x-forwarded-host') || req.get('host');
+    return `${proto}://${host}`;
+}
+
+async function firebaseSignIn(email, password) {
+    const response = await fetch(`https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=${WEB_API_KEY}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Referer: SIGNIN_REFERER },
+        body: JSON.stringify({ email, password, returnSecureToken: true })
+    });
+    const body = await response.json();
+    if (!response.ok) {
+        const reason = body?.error?.message || 'Sign-in failed.';
+        throw new OAuthError('access_denied', reason);
+    }
+    return { refreshToken: body.refreshToken, uid: body.localId };
+}
+
+function escapeHtml(value) {
+    return String(value ?? '').replace(/[&<>"']/g, (ch) => (
+        { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[ch]
+    ));
+}
+
+function renderSignInPage({ clientId, redirectUri, codeChallenge, state, scope, error }) {
+    const hidden = { client_id: clientId, redirect_uri: redirectUri, code_challenge: codeChallenge, state, scope };
+    const hiddenInputs = Object.entries(hidden)
+        .filter(([, value]) => value)
+        .map(([name, value]) => `<input type="hidden" name="${escapeHtml(name)}" value="${escapeHtml(value)}">`)
+        .join('\n            ');
+    return `<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Sign in to ALL PLAYS</title>
+    <style>
+        body { font-family: -apple-system, system-ui, sans-serif; background: #0f172a; color: #e2e8f0; display: flex; justify-content: center; padding: 3rem 1rem; }
+        .card { background: #1e293b; border-radius: 12px; padding: 2rem; max-width: 22rem; width: 100%; }
+        h1 { font-size: 1.25rem; margin: 0 0 0.5rem; }
+        p { color: #94a3b8; font-size: 0.875rem; margin: 0 0 1.25rem; }
+        label { display: block; font-size: 0.8rem; margin: 0.75rem 0 0.25rem; color: #cbd5e1; }
+        input[type=email], input[type=password] { width: 100%; box-sizing: border-box; padding: 0.6rem; border-radius: 8px; border: 1px solid #334155; background: #0f172a; color: #e2e8f0; }
+        button { margin-top: 1.25rem; width: 100%; padding: 0.7rem; border: 0; border-radius: 8px; background: #38bdf8; color: #0f172a; font-weight: 600; cursor: pointer; }
+        .error { background: #7f1d1d; color: #fecaca; padding: 0.6rem; border-radius: 8px; font-size: 0.8rem; margin-bottom: 0.5rem; }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <h1>ALL PLAYS</h1>
+        <p>Sign in to connect your AllPlays account to ChatGPT. ChatGPT will be able to read your teams, schedule, and game summaries.</p>
+        ${error ? `<div class="error">${escapeHtml(error)}</div>` : ''}
+        <form method="POST" action="/oauth/authorize">
+            ${hiddenInputs}
+            <label for="email">Email</label>
+            <input id="email" name="email" type="email" autocomplete="username" required>
+            <label for="password">Password</label>
+            <input id="password" name="password" type="password" autocomplete="current-password" required>
+            <button type="submit">Sign in &amp; approve</button>
+        </form>
+    </div>
+</body>
+</html>`;
 }
 
 function toolResult(payload) {
@@ -100,22 +174,116 @@ function buildServer(identity) {
 
 const app = express();
 app.use(express.json({ limit: '1mb' }));
+app.use(express.urlencoded({ extended: false }));
 
 app.get('/healthz', (req, res) => res.json({ ok: true }));
+
+// --- OAuth broker endpoints (discovery, registration, authorize, token) ---
+
+app.get(['/.well-known/oauth-authorization-server', '/.well-known/oauth-authorization-server/mcp'], (req, res) => {
+    res.json(metadataFor(publicBaseUrl(req)).authorizationServer);
+});
+
+app.get(['/.well-known/oauth-protected-resource', '/.well-known/oauth-protected-resource/mcp'], (req, res) => {
+    res.json(metadataFor(publicBaseUrl(req)).protectedResource);
+});
+
+app.post('/oauth/register', (req, res) => {
+    try {
+        res.status(201).json(oauth.registerClient(req.body || {}));
+    } catch (error) {
+        const code = error instanceof OAuthError ? error.code : 'server_error';
+        res.status(400).json({ error: code, error_description: error.message });
+    }
+});
+
+app.get('/oauth/authorize', (req, res) => {
+    try {
+        const { clientId, redirectUri, codeChallenge } = oauth.validateAuthorizeRequest(req.query || {});
+        res.type('html').send(renderSignInPage({
+            clientId,
+            redirectUri,
+            codeChallenge,
+            state: req.query.state,
+            scope: req.query.scope
+        }));
+    } catch (error) {
+        const message = error instanceof OAuthError ? error.message : 'Invalid authorization request.';
+        res.status(400).type('html').send(`<p>${escapeHtml(message)}</p>`);
+    }
+});
+
+app.post('/oauth/authorize', async (req, res) => {
+    const params = req.body || {};
+    try {
+        const { clientId, redirectUri, codeChallenge } = oauth.validateAuthorizeRequest({
+            client_id: params.client_id,
+            redirect_uri: params.redirect_uri,
+            response_type: 'code',
+            code_challenge: params.code_challenge,
+            code_challenge_method: 'S256'
+        });
+        // Normal path: AllPlays email/password sign-in. A caller may instead
+        // present an existing Firebase refresh token (itself a credential) —
+        // used by automated tests; the token is validated on first use.
+        let firebaseRefreshToken = typeof params.refresh_token === 'string' && params.refresh_token ? params.refresh_token : null;
+        if (!firebaseRefreshToken) {
+            const signedIn = await firebaseSignIn(String(params.email || ''), String(params.password || ''));
+            firebaseRefreshToken = signedIn.refreshToken;
+        }
+        const code = oauth.approveAuthorization({ clientId, redirectUri, codeChallenge, firebaseRefreshToken });
+        const redirect = new URL(redirectUri);
+        redirect.searchParams.set('code', code);
+        if (params.state) redirect.searchParams.set('state', params.state);
+        res.redirect(302, redirect.toString());
+    } catch (error) {
+        if (error instanceof OAuthError && error.code === 'access_denied') {
+            res.status(401).type('html').send(renderSignInPage({
+                clientId: params.client_id,
+                redirectUri: params.redirect_uri,
+                codeChallenge: params.code_challenge,
+                state: params.state,
+                scope: params.scope,
+                error: 'Sign-in failed. Check your email and password.'
+            }));
+            return;
+        }
+        const message = error instanceof OAuthError ? error.message : 'Authorization failed.';
+        console.error('[chatgpt-mcp] authorize failure:', error);
+        res.status(400).type('html').send(`<p>${escapeHtml(message)}</p>`);
+    }
+});
+
+app.post('/oauth/token', (req, res) => {
+    try {
+        res.json(oauth.exchange(req.body || {}));
+    } catch (error) {
+        const code = error instanceof OAuthError ? error.code : 'server_error';
+        if (!(error instanceof OAuthError)) console.error('[chatgpt-mcp] token failure:', error);
+        res.status(400).json({ error: code, error_description: error.message });
+    }
+});
 
 app.post('/mcp', async (req, res) => {
     let identity;
     try {
-        const authHeader = req.headers.authorization
+        let authHeader = req.headers.authorization
             || (FALLBACK_BEARER ? `Bearer ${FALLBACK_BEARER}` : undefined);
+        // Broker-issued access tokens resolve to the user's Firebase refresh
+        // token; direct Firebase refresh/ID tokens pass through unchanged.
+        const bearer = extractBearerToken(authHeader);
+        const brokerGrant = bearer ? oauth.resolveAccessToken(bearer) : null;
+        if (brokerGrant) authHeader = `Bearer ${brokerGrant.firebaseRefreshToken}`;
         identity = await resolveIdentity(authHeader);
     } catch (error) {
         const message = error instanceof DomainError ? error.message : 'Unauthorized.';
-        res.status(401).json({
-            jsonrpc: '2.0',
-            error: { code: -32001, message },
-            id: null
-        });
+        res.status(401)
+            .set('WWW-Authenticate', `Bearer resource_metadata="${publicBaseUrl(req)}/.well-known/oauth-protected-resource"`)
+            .json({
+                jsonrpc: '2.0',
+                error: { code: -32001, message },
+                id: null
+            });
         return;
     }
 

--- a/services/chatgpt-mcp/src/server.js
+++ b/services/chatgpt-mcp/src/server.js
@@ -26,10 +26,12 @@ import { createUserDb } from './firestoreRest.js';
 import { createOAuthBroker, metadataFor, OAuthError } from './oauth.js';
 
 const PORT = Number(process.env.PORT) || 8787;
-const PROJECT_ID = process.env.FIREBASE_PROJECT_ID || 'game-flow-c6311';
-// Public web API key (client-side key; security is enforced by Firestore
-// rules — see js/firebase-runtime-config.js and CLAUDE.md).
-const WEB_API_KEY = process.env.FIREBASE_WEB_API_KEY || 'AIzaSyDoixIoKJuUVWdmImwjYRTthjKOv2mU0Jc';
+const PROJECT_ID = process.env.FIREBASE_PROJECT_ID;
+const WEB_API_KEY = process.env.FIREBASE_WEB_API_KEY;
+
+if (!PROJECT_ID || !WEB_API_KEY) {
+    throw new Error('FIREBASE_PROJECT_ID and FIREBASE_WEB_API_KEY must be set.');
+}
 
 const resolveIdentity = createIdentityResolver({ apiKey: WEB_API_KEY });
 

--- a/services/chatgpt-mcp/src/server.js
+++ b/services/chatgpt-mcp/src/server.js
@@ -1,0 +1,157 @@
+// AllPlays ChatGPT MCP service — Streamable HTTP entry point.
+//
+// Credential-free by design: the service holds no service account. Each
+// request's bearer token (Firebase refresh token or ID token) is resolved to
+// the user's ID token, and all Firestore access happens AS THAT USER over the
+// REST API — the same security rules that protect the AllPlays web/app clients
+// authorize every read here.
+//
+// Tool names mirror the in-app private AI registry (apps/app/src/lib/
+// privateAiService.ts) so the ChatGPT surface and the app assistant stay one
+// catalog as the shared service layer is extracted.
+
+import express from 'express';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { z } from 'zod';
+import {
+    DomainError,
+    resolveUserContext,
+    listMyTeams,
+    getFamilySchedule,
+    getGameSummary
+} from './core.js';
+import { createIdentityResolver } from './identity.js';
+import { createUserDb } from './firestoreRest.js';
+
+const PORT = Number(process.env.PORT) || 8787;
+const PROJECT_ID = process.env.FIREBASE_PROJECT_ID || 'game-flow-c6311';
+// Public web API key (client-side key; security is enforced by Firestore
+// rules — see js/firebase-runtime-config.js and CLAUDE.md).
+const WEB_API_KEY = process.env.FIREBASE_WEB_API_KEY || 'AIzaSyDoixIoKJuUVWdmImwjYRTthjKOv2mU0Jc';
+
+const resolveIdentity = createIdentityResolver({ apiKey: WEB_API_KEY });
+
+// Dev-only fallback for ChatGPT's "No Auth" connector mode: requests without
+// an Authorization header authenticate as this token's user. Anyone who can
+// reach the endpoint gets that user's (rules-scoped) data — use only with a
+// test account behind a private tunnel, never in production.
+const FALLBACK_BEARER = process.env.NODE_ENV === 'production' ? '' : (process.env.DEV_FALLBACK_BEARER || '');
+if (process.env.NODE_ENV === 'production' && process.env.DEV_FALLBACK_BEARER) {
+    throw new Error('DEV_FALLBACK_BEARER must not be set in production.');
+}
+if (FALLBACK_BEARER) {
+    console.warn('[chatgpt-mcp] DEV_FALLBACK_BEARER is set: unauthenticated requests act as that user. Dev/test only.');
+}
+
+function toolResult(payload) {
+    return { content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }], structuredContent: payload };
+}
+
+function toolError(error) {
+    const code = error instanceof DomainError ? error.code : 'internal';
+    const message = error instanceof DomainError ? error.message : 'Internal error.';
+    if (!(error instanceof DomainError)) console.error('[chatgpt-mcp] tool failure:', error);
+    return { isError: true, content: [{ type: 'text', text: JSON.stringify({ error: code, message }) }] };
+}
+
+function buildServer(identity) {
+    const server = new McpServer({ name: 'allplays', version: '0.2.0' });
+    const db = createUserDb({ projectId: PROJECT_ID, idToken: identity.idToken });
+
+    const run = (handler) => async (args) => {
+        try {
+            const context = await resolveUserContext(db, identity);
+            return toolResult(await handler(context, args));
+        } catch (error) {
+            return toolError(error);
+        }
+    };
+
+    server.registerTool('get_profile', {
+        title: 'Get profile',
+        description: 'Account roles, linked teams, and linked players for the signed-in AllPlays user.',
+        inputSchema: {},
+        annotations: { readOnlyHint: true }
+    }, run((context) => listMyTeams(db, context)));
+
+    server.registerTool('list_schedule', {
+        title: 'List schedule',
+        description: 'Games and practices in a date range (default: next 7 days) across the user\'s teams, with RSVP state for linked players and deep links into AllPlays.',
+        inputSchema: {
+            startDate: z.string().optional().describe('ISO date, inclusive. Defaults to today.'),
+            endDate: z.string().optional().describe('ISO date, inclusive. Defaults to startDate + 7 days.')
+        },
+        annotations: { readOnlyHint: true }
+    }, run((context, args) => getFamilySchedule(db, context, args)));
+
+    server.registerTool('get_game_summary', {
+        title: 'Get game summary',
+        description: 'Score, status, summary, and aggregated player statistics for one game on a team the user belongs to.',
+        inputSchema: {
+            teamId: z.string().describe('Team id from get_profile'),
+            gameId: z.string().describe('Game id from list_schedule')
+        },
+        annotations: { readOnlyHint: true }
+    }, run((context, args) => getGameSummary(db, context, args)));
+
+    return server;
+}
+
+const app = express();
+app.use(express.json({ limit: '1mb' }));
+
+app.get('/healthz', (req, res) => res.json({ ok: true }));
+
+app.post('/mcp', async (req, res) => {
+    let identity;
+    try {
+        const authHeader = req.headers.authorization
+            || (FALLBACK_BEARER ? `Bearer ${FALLBACK_BEARER}` : undefined);
+        identity = await resolveIdentity(authHeader);
+    } catch (error) {
+        const message = error instanceof DomainError ? error.message : 'Unauthorized.';
+        res.status(401).json({
+            jsonrpc: '2.0',
+            error: { code: -32001, message },
+            id: null
+        });
+        return;
+    }
+
+    try {
+        const server = buildServer(identity);
+        const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+        res.on('close', () => {
+            transport.close();
+            server.close();
+        });
+        await server.connect(transport);
+        await transport.handleRequest(req, res, req.body);
+    } catch (error) {
+        console.error('[chatgpt-mcp] request failure:', error);
+        if (!res.headersSent) {
+            res.status(500).json({
+                jsonrpc: '2.0',
+                error: { code: -32603, message: 'Internal server error' },
+                id: null
+            });
+        }
+    }
+});
+
+// Stateless server: no SSE notification stream or session teardown to serve.
+app.get('/mcp', (req, res) => res.status(405).json({
+    jsonrpc: '2.0',
+    error: { code: -32000, message: 'Method not allowed.' },
+    id: null
+}));
+app.delete('/mcp', (req, res) => res.status(405).json({
+    jsonrpc: '2.0',
+    error: { code: -32000, message: 'Method not allowed.' },
+    id: null
+}));
+
+app.listen(PORT, () => {
+    console.log(`[chatgpt-mcp] listening on :${PORT} (POST /mcp) — project ${PROJECT_ID}, user-credentialed Firestore access`);
+});

--- a/services/chatgpt-mcp/src/server.js
+++ b/services/chatgpt-mcp/src/server.js
@@ -11,6 +11,7 @@
 // catalog as the shared service layer is extracted.
 
 import express from 'express';
+import { pathToFileURL } from 'node:url';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { z } from 'zod';
@@ -174,7 +175,7 @@ function buildServer(identity) {
     return server;
 }
 
-const app = express();
+export const app = express();
 app.use(express.json({ limit: '1mb' }));
 app.use(express.urlencoded({ extended: false }));
 
@@ -322,6 +323,8 @@ app.delete('/mcp', (req, res) => res.status(405).json({
     id: null
 }));
 
-app.listen(PORT, () => {
-    console.log(`[chatgpt-mcp] listening on :${PORT} (POST /mcp) — project ${PROJECT_ID}, user-credentialed Firestore access`);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    app.listen(PORT, () => {
+        console.log(`[chatgpt-mcp] listening on :${PORT} (POST /mcp) — project ${PROJECT_ID}, user-credentialed Firestore access`);
+    });
+}

--- a/services/chatgpt-mcp/src/server.js
+++ b/services/chatgpt-mcp/src/server.js
@@ -226,14 +226,10 @@ app.post('/oauth/authorize', async (req, res) => {
             code_challenge: params.code_challenge,
             code_challenge_method: 'S256'
         });
-        // Normal path: AllPlays email/password sign-in. A caller may instead
-        // present an existing Firebase refresh token (itself a credential) —
-        // used by automated tests; the token is validated on first use.
-        let firebaseRefreshToken = typeof params.refresh_token === 'string' && params.refresh_token ? params.refresh_token : null;
-        if (!firebaseRefreshToken) {
-            const signedIn = await firebaseSignIn(String(params.email || ''), String(params.password || ''));
-            firebaseRefreshToken = signedIn.refreshToken;
-        }
+        // Only Firebase's sign-in response may create a grant. In particular,
+        // do not persist an unverified refresh_token posted to this public route.
+        const signedIn = await firebaseSignIn(String(params.email || ''), String(params.password || ''));
+        const firebaseRefreshToken = signedIn.refreshToken;
         const code = oauth.approveAuthorization({ clientId, redirectUri, codeChallenge, firebaseRefreshToken });
         const redirect = new URL(redirectUri);
         redirect.searchParams.set('code', code);

--- a/spec/chatgpt-app-integration/design.md
+++ b/spec/chatgpt-app-integration/design.md
@@ -1,0 +1,83 @@
+# ChatGPT App Integration — Design
+
+## Overview
+
+A thin Node.js MCP service (`services/chatgpt-mcp/`) exposes permission-aware read tools over Streamable HTTP. It resolves the caller's identity from the bearer token and performs **user-credentialed Firestore access over the REST API** — every read carries the user's own Firebase ID token, so the same `firestore.rules` that protect the web/app clients authorize each read. The service holds no privileged credentials (no service account, no Admin SDK). Domain logic lives in a pure, dependency-injected core module.
+
+Tool names mirror the in-app private AI registry (`apps/app/src/lib/privateAiService.ts`, ~45 tools with confirmation-staged writes and audit) so the ChatGPT surface and the app assistant converge on one catalog; extracting that registry's summarizers into shared code is the follow-on reuse task.
+
+Per the plan (§4): "Build the app as a thin orchestration layer over a reusable AllPlays application service. Do not embed business rules or authorization only inside MCP tool handlers."
+
+## Architecture
+
+```mermaid
+flowchart LR
+    U[User] --> C[ChatGPT conversation]
+    C -->|Streamable HTTP + Bearer token| M[MCP service<br/>services/chatgpt-mcp]
+    M --> I[identity.js<br/>refresh token → user ID token]
+    M --> K[core.js<br/>roles, boundaries, whitelists]
+    K --> R[firestoreRest.js<br/>reads AS the user]
+    R -->|rules-enforced| F[(Firestore<br/>game-flow-c6311)]
+    M -->|structured JSON + deep links| C
+```
+
+- **Transport:** `@modelcontextprotocol/sdk` `StreamableHTTPServerTransport` in stateless mode (new server+transport per request) — Cloud Run friendly, no session affinity needed.
+- **Hosting target:** Cloud Run (plan §4). The spike runs locally (`npm start`) and connects to Developer Mode via a tunnel or a dev Cloud Run revision.
+
+## Components
+
+| File | Responsibility |
+|---|---|
+| `src/server.js` | Express app, auth middleware, MCP tool registration, transport wiring |
+| `src/identity.js` | Bearer token → `{uid, email, idToken}`: Firebase refresh-token exchange via `securetoken.googleapis.com` (public web API key), cached until expiry; raw ID tokens also accepted |
+| `src/firestoreRest.js` | Firestore REST adapter scoped to the user's ID token — rules-enforced reads; maps 403 → `permission_denied`, 404 → not-found |
+| `src/core.js` | Pure domain logic with injected Firestore handle: role resolution, schedule assembly, game summary, field whitelists, deep links |
+| `scripts/get-token.mjs` | Sign-in helper that prints the refresh token to use as the connector bearer |
+
+## Identity and authorization
+
+1. Every request must carry `Authorization: Bearer <token>` — a Firebase **refresh token** (long-lived, suits a static connector secret) or a raw ID token.
+2. The refresh token is exchanged for a short-lived ID token and cached. That ID token is presented to Firestore on **every read**, so `firestore.rules` — identical to the parent UI's enforcement — is the authorization boundary. A forged JWT yields identity claims but fails every Firestore call. The production OAuth broker (plan §6) replaces the raw refresh token with a proper authorization-code + PKCE flow yielding the same user-scoped credential.
+3. As defense-in-depth, `resolveUserContext(db, {uid, email})` also rebuilds the role context per request:
+   - owner: `teams` where `ownerId == uid`
+   - admin: `teams` where `adminEmails array-contains lowercased email`
+   - parent: `users/{uid}.parentOf[] → {teamId, playerId}` (team docs fetched to confirm existence)
+   - `isGlobalAdmin`: `users/{uid}.isAdmin === true`
+4. Tool arguments naming teams/players are validated against this context; anything outside it → `permission_denied` with no data.
+
+## Data model touchpoints (existing collections, read-only)
+
+- `users/{uid}` — `parentOf`, `parentTeamIds`, `email`, `isAdmin`
+- `teams/{teamId}` — `name`, `ownerId`, `adminEmails`
+- `teams/{teamId}/players/{playerId}` — `name`, `number` only (never `private/profile`)
+- `teams/{teamId}/games/{gameId}` — `type` (`game`/`practice`), `date` (Timestamp), `opponent`, `location`, `homeScore`/`awayScore`, `rsvpSummary`
+- `teams/{teamId}/games/{gameId}/rsvps/{uid}` — the caller's own RSVP doc
+- `teams/{teamId}/games/{gameId}/aggregatedStats/{playerId}` — per-player stats (public tier; `privatePlayerStats` is never read)
+
+## Tool contract (MVP)
+
+| Tool | Mode | Input | Output |
+|---|---|---|---|
+| `get_profile` | Read | — | `{teams: [{teamId, name, roles[], linkedPlayers[{playerId, name, number}]}]}` |
+| `list_schedule` | Read | `startDate?`, `endDate?` (ISO; default today → +7d) | `{events: [{teamId, teamName, gameId, type, date, opponent, location, rsvpSummary, myRsvp?, deepLink}]}` |
+| `get_game_summary` | Read | `teamId`, `gameId` | `{game: {…whitelisted}, playerStats[], deepLink}` |
+
+Deep links use the validated legacy routes, e.g. `https://allplays.ai/live-game.html?teamId=…&gameId=…&replay=true`.
+
+## Error handling
+
+`core.js` throws `DomainError(code, message)` with codes `unauthenticated`, `permission_denied`, `not_found`, `invalid_argument`. The server maps these to MCP tool errors (`isError: true` with the code) and never leaks other teams' identifiers or internal stack traces.
+
+## Testing strategy
+
+- Unit (Vitest, `tests/unit/chatgpt-mcp-core.test.js`): pure `core.js` against a fake Firestore — role resolution, cross-team denial, date-range filtering, field whitelisting, RSVP lookup, dev-token gating.
+- Security prompts from plan §11 (cross-team roster, role escalation, foreign player ID) map to unit cases asserting `permission_denied`.
+- Manual: connect via ChatGPT Developer Mode; run the functional prompts from plan §11.
+
+## Decisions
+
+- **Stateless HTTP transport** over sessions: simplest correct spike; revisit if streaming/UI resources need session state.
+- **User-credentialed Firestore REST access** over Admin SDK: reuses `firestore.rules` as the single authorization source (no duplicated permission logic to drift), removes all privileged credentials from the service, and matches how the parent UI is authorized. Trade-off: REST latency per read and no rules bypass for future cross-user aggregation — those later workflows (e.g. coach attention items) may need an Admin-SDK path behind the extracted application service.
+- **Refresh token as spike bearer** (public web API key exchange): long-lived like a connector secret, revocable per-user, and structurally identical to what the OAuth broker will produce.
+- **Tool names mirror the in-app private AI registry** (`get_profile`, `list_schedule`): one catalog across surfaces; code-level sharing of the app's `summarize*` functions is the follow-on extraction task.
+- **Separate package** with its own `package.json` (like `functions/`): deployable to Cloud Run independently; root repo tests still cover the pure core.

--- a/spec/chatgpt-app-integration/design.md
+++ b/spec/chatgpt-app-integration/design.md
@@ -32,7 +32,8 @@ flowchart LR
 | `src/identity.js` | Bearer token → `{uid, email, idToken}`: Firebase refresh-token exchange via `securetoken.googleapis.com` (public web API key), cached until expiry; raw ID tokens also accepted |
 | `src/firestoreRest.js` | Firestore REST adapter scoped to the user's ID token — rules-enforced reads; maps 403 → `permission_denied`, 404 → not-found |
 | `src/core.js` | Pure domain logic with injected Firestore handle: role resolution, schedule assembly, game summary, field whitelists, deep links |
-| `scripts/get-token.mjs` | Sign-in helper that prints the refresh token to use as the connector bearer |
+| `src/oauth.js` | OAuth 2.1 broker: dynamic client registration, authorization code + PKCE (S256), refresh grant; opaque broker tokens map to the user's Firebase refresh token. In-memory storage (single-instance dev); Firestore-backed storage before multi-instance Cloud Run |
+| `scripts/get-token.mjs` | Sign-in helper that prints the refresh token (manual curl testing) |
 
 ## Identity and authorization
 

--- a/spec/chatgpt-app-integration/requirements.md
+++ b/spec/chatgpt-app-integration/requirements.md
@@ -1,0 +1,53 @@
+# ChatGPT App Integration
+
+## Introduction
+
+Extend AllPlays into ChatGPT as a conversational command interface for parents and coaches. AllPlays remains the system of record for teams, schedules, players, permissions, and actions; ChatGPT provides natural-language reasoning and synthesis. The integration is a remote Model Context Protocol (MCP) service exposing a narrow, permission-aware tool set — not a reproduction of the full AllPlays app.
+
+Source: `AllPlays_ChatGPT_App_Integration_Plan.docx` (Draft 1.0, July 19, 2026).
+
+## User Stories
+
+1. As a **parent**, I want to ask "What does my family have this weekend?" and receive a correct, permission-filtered schedule for my linked players, with deep links into AllPlays.
+2. As a **parent**, I want to see which upcoming events still need my RSVP.
+3. As a **coach**, I want a summary of a completed game (score, summary, player statistics) for teams I own or administer.
+4. As a **user**, I want the assistant to know which teams I belong to and in what role, without ever seeing another team's data.
+5. (Later phase) As a **parent**, I want to update a linked player's RSVP conversationally after confirmation.
+6. (Later phase) As a **coach**, I want to generate, revise, and save a practice plan.
+
+## Requirements (EARS)
+
+### 1. MCP service foundation
+1.1. The system SHALL expose a remote MCP service over Streamable HTTP suitable for ChatGPT Developer Mode connection.
+1.2. The MVP SHALL expose read-only tools: `list_my_teams`, `get_family_schedule`, `get_game_summary`.
+1.3. WHEN a tool is invoked without valid authentication, the service SHALL reject the request with an authorization error.
+1.4. Tools SHALL return structured domain data, not prewritten prose; ChatGPT performs synthesis.
+
+### 2. Identity and authorization
+2.1. The service SHALL derive user identity exclusively from the verified bearer token, never from tool arguments.
+2.2. A Firebase UID, team ID, player ID, or role supplied by ChatGPT SHALL never be trusted by itself; the service SHALL independently enforce current Firestore membership (owner via `teams/{id}.ownerId`, admin via `teams/{id}.adminEmails[]`, parent via `users/{uid}.parentOf[]`).
+2.3. WHEN a user requests data for a team they are not a member of, the service SHALL return a permission-denied error and no data.
+2.4. Production authentication SHALL use OAuth (authorization code + PKCE) mapped to a Firebase UID; the development spike MAY use the user's Firebase refresh token (exchanged server-side for an ID token) or a raw ID token as the bearer. All data access SHALL be performed with the user's own credential so Firestore security rules enforce authorization identically to the AllPlays clients.
+
+### 3. Family schedule
+3.1. `get_family_schedule` SHALL return games and practices in a requested date range (default: next 7 days) for every team the user is authorized on.
+3.2. For parent-linked teams, each event SHALL include the user's own RSVP state for linked players.
+3.3. Events SHALL include only whitelisted fields (type, date, opponent, location, notes, RSVP summary) plus a validated deep link.
+
+### 4. Game summary
+4.1. `get_game_summary` SHALL verify team membership before returning any data.
+4.2. The response SHALL include only whitelisted game fields (score, status, summary, opponent, date, location) and aggregated player statistics; private player data SHALL never be returned.
+
+### 5. Privacy and youth data
+5.1. The service SHALL return the minimum data needed for the workflow; birth dates, contact details, medical notes, and private RSVP notes SHALL never be returned.
+5.2. Private rosters, notes, schedules, or locations SHALL never cross team boundaries.
+5.3. Retrieved user content (messages, notes, drill descriptions) SHALL be treated as untrusted data, never as instructions.
+
+### 6. Write actions (later phase, out of MVP scope)
+6.1. Initial writes SHALL be limited to `set_player_rsvp` and `save_practice_plan`, each requiring user confirmation, idempotency, and an audit event.
+
+## Success Criteria
+
+- End-to-end connection works in ChatGPT Developer Mode against a dev deployment.
+- Authorization-denial correctness: cross-team and cross-role requests are refused in automated tests.
+- First milestone: a connected account asks "What does my family have this weekend?" and receives a correct, permission-filtered schedule with deep links.

--- a/spec/chatgpt-app-integration/tasks.md
+++ b/spec/chatgpt-app-integration/tasks.md
@@ -1,0 +1,28 @@
+# ChatGPT App Integration — Tasks
+
+## Phase 1 — Read-only foundation (spike)
+
+- [x] 1. Scaffold `services/chatgpt-mcp/` Node package (MCP SDK, express, zod — no privileged credentials). _Req 1.1_
+- [x] 2. Implement `src/identity.js`: bearer (Firebase refresh token or ID token) → `{uid, email, idToken}` via securetoken exchange with caching. _Req 2.1, 2.4_
+- [x] 3. Implement `src/firestoreRest.js`: user-credentialed Firestore REST adapter — every read authorized by `firestore.rules` as the user, same as the parent UI. _Req 2.2_
+- [x] 4. Implement `src/core.js` `resolveUserContext`: owner/admin/parent role resolution (defense-in-depth over rules), global-admin flag. _Req 2.2_
+- [x] 5. Implement `get_profile` (teams + roles + linked players, name/number only; name aligned with the in-app private AI registry). _Req 1.2, 5.1_
+- [x] 6. Implement `list_schedule` (date-range query per authorized team, whitelisted event fields, caller's own RSVP, deep links). _Req 3.1–3.3_
+- [x] 7. Implement `get_game_summary` (membership check, whitelisted game fields, aggregated stats, deep link). _Req 4.1–4.2_
+- [x] 8. Wire `src/server.js`: express, auth middleware, stateless Streamable HTTP transport, tool registration, error mapping. _Req 1.1, 1.3_
+- [x] 9. Unit tests in `tests/unit/chatgpt-mcp-core.test.js`: roles, cross-team denial, rules-denial degradation, range filter, whitelists, token exchange, REST adapter. _Req 2.3, 5.1–5.2_
+- [x] 10. Service README + `scripts/get-token.mjs`: local run, refresh-token bearer, ngrok + Developer Mode connection steps. _Req 1.1_
+
+## Phase 1 — remaining (before dev deploy)
+
+- [ ] 11. Connect locally via ngrok + ChatGPT Developer Mode; validate tool discovery and the first-milestone prompt. _Req 1.1_
+- [ ] 12. Deploy to a dev Cloud Run endpoint. _Req 1.1_
+- [ ] 13. Structured security tests for parent, coach, unauthorized, and cross-team scenarios against the live service. _Req 2.3_
+
+## Phase 2+ (per plan §10, not started)
+
+- [ ] 14. Extract the in-app private AI registry's `summarize*`/`loadParent*` layer (`apps/app/src/lib/privateAiService.ts`, `parentToolsService.ts`) into a shared package so MCP tools and the app assistant run one implementation (covers practice sessions, assignments, rideshare, RSVP fallback resolution the spike omits).
+- [ ] 15. OAuth broker: authorization code + PKCE + refresh tokens mapped to Firebase UID (replaces raw refresh-token bearer). _Req 2.4_
+- [ ] 16. `get_event_details`, `get_coach_attention_items`, `get_practice_context` read tools (mirror app registry names where they exist).
+- [ ] 17. Embedded UI cards (family schedule, game summary).
+- [ ] 18. Write tools with confirmation, idempotency, audit — reuse the app registry's pending-confirmation staging (`update_rsvp`, practice-plan save). _Req 6.1_

--- a/spec/chatgpt-app-integration/tasks.md
+++ b/spec/chatgpt-app-integration/tasks.md
@@ -22,7 +22,8 @@
 ## Phase 2+ (per plan §10, not started)
 
 - [ ] 14. Extract the in-app private AI registry's `summarize*`/`loadParent*` layer (`apps/app/src/lib/privateAiService.ts`, `parentToolsService.ts`) into a shared package so MCP tools and the app assistant run one implementation (covers practice sessions, assignments, rideshare, RSVP fallback resolution the spike omits).
-- [ ] 15. OAuth broker: authorization code + PKCE + refresh tokens mapped to Firebase UID (replaces raw refresh-token bearer). _Req 2.4_
+- [x] 15. OAuth broker: dynamic client registration, authorization code + PKCE (S256), refresh grant, AllPlays sign-in page; broker tokens map to the user's Firebase refresh token. _Req 2.4_
+- [ ] 15b. Harden the broker for production: Firestore-backed token/code storage (in-memory today), Google sign-in on the authorize page, token revocation/disconnect endpoint, rate limiting.
 - [ ] 16. `get_event_details`, `get_coach_attention_items`, `get_practice_context` read tools (mirror app registry names where they exist).
 - [ ] 17. Embedded UI cards (family schedule, game summary).
 - [ ] 18. Write tools with confirmation, idempotency, audit — reuse the app registry's pending-confirmation staging (`update_rsvp`, practice-plan save). _Req 6.1_

--- a/tests/unit/chatgpt-mcp-core.test.js
+++ b/tests/unit/chatgpt-mcp-core.test.js
@@ -186,6 +186,7 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
                     const all = [
                         { id: 'game-1', data: { type: 'game', date: new Date('2026-07-25T17:00:00Z'), opponent: 'Hawks', location: 'Field 2', privateNotes: 'secret', rsvpSummary: { going: 5, notResponded: 3, coachOnly: 'x' } } },
                         { id: 'practice-1', data: { type: 'practice', date: new Date('2026-07-27T22:30:00Z') } },
+                        { id: 'game-end-date', data: { type: 'game', date: new Date('2026-07-31T17:00:00Z') } },
                         { id: 'game-out-of-range', data: { type: 'game', date: new Date('2026-09-01T17:00:00Z') } }
                     ];
                     return all.filter(({ data }) => data.date >= start && data.date <= end);
@@ -199,7 +200,7 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
         const context = await resolveUserContext(db, parentIdentity);
         const result = await getFamilySchedule(db, context, { startDate: '2026-07-24', endDate: '2026-07-31' });
 
-        expect(result.events.map((e) => e.gameId)).toEqual(['game-1', 'practice-1']);
+        expect(result.events.map((e) => e.gameId)).toEqual(['game-1', 'practice-1', 'game-end-date']);
         const game = result.events[0];
         expect(game.opponent).toBe('Hawks');
         expect(game.rsvpSummary).toEqual({ going: 5, notResponded: 3 });

--- a/tests/unit/chatgpt-mcp-core.test.js
+++ b/tests/unit/chatgpt-mcp-core.test.js
@@ -1,0 +1,427 @@
+import { describe, it, expect } from 'vitest';
+import {
+    DomainError,
+    resolveUserContext,
+    listMyTeams,
+    getFamilySchedule,
+    getGameSummary
+} from '../../services/chatgpt-mcp/src/core.js';
+import {
+    createIdentityResolver,
+    extractBearerToken,
+    decodeJwtPayload
+} from '../../services/chatgpt-mcp/src/identity.js';
+import {
+    encodeValue,
+    decodeValue,
+    decodeFields,
+    buildStructuredQuery,
+    createUserDb
+} from '../../services/chatgpt-mcp/src/firestoreRest.js';
+
+// Minimal fake of the db interface core.js uses (same surface as the
+// firestoreRest adapter): doc(path).get(), collection(path).where()...get().
+// Set docs[path] = DENIED to simulate a Firestore-rules denial.
+const DENIED = Symbol('permission-denied');
+
+function fakeDb({ docs = {}, queries = {} } = {}) {
+    return {
+        doc(path) {
+            return {
+                async get() {
+                    const data = docs[path];
+                    if (data === DENIED) throw new DomainError('permission_denied', 'You do not have access to this data.');
+                    return {
+                        exists: data !== undefined,
+                        id: path.split('/').pop(),
+                        data: () => data
+                    };
+                }
+            };
+        },
+        collection(path) {
+            const makeQuery = (filters) => ({
+                where(field, op, value) {
+                    return makeQuery([...filters, { field, op, value }]);
+                },
+                orderBy() { return makeQuery(filters); },
+                limit() { return makeQuery(filters); },
+                async get() {
+                    const resolver = queries[path];
+                    if (resolver === DENIED) throw new DomainError('permission_denied', 'You do not have access to this data.');
+                    const rows = resolver ? resolver(filters) : [];
+                    return {
+                        docs: rows.map(({ id, data }) => ({ id, data: () => data }))
+                    };
+                }
+            });
+            return makeQuery([]);
+        }
+    };
+}
+
+const parentIdentity = { uid: 'parent-1', email: 'Parent@Example.com' };
+
+function parentDb(extra = {}) {
+    return fakeDb({
+        docs: {
+            'users/parent-1': {
+                email: 'parent@example.com',
+                parentOf: [{ teamId: 'team-a', playerId: 'player-1' }]
+            },
+            'teams/team-a': { name: 'Wildcats', ownerId: 'coach-9', sport: 'Baseball' },
+            'teams/team-a/players/player-1': {
+                name: 'Sam',
+                number: 12,
+                birthDate: '2015-01-01',
+                medicalNotes: 'private'
+            },
+            ...extra.docs
+        },
+        queries: {
+            teams: () => [],
+            ...extra.queries
+        }
+    });
+}
+
+describe('chatgpt-mcp core: resolveUserContext', () => {
+    it('derives parent role and linked players from users/{uid}.parentOf', async () => {
+        const context = await resolveUserContext(parentDb(), parentIdentity);
+        expect(context.uid).toBe('parent-1');
+        expect(context.isGlobalAdmin).toBe(false);
+        const entry = context.teams.get('team-a');
+        expect([...entry.roles]).toEqual(['parent']);
+        expect([...entry.linkedPlayerIds]).toEqual(['player-1']);
+    });
+
+    it('derives owner and admin roles from teams queries with lowercased email', async () => {
+        let adminEmailQueried = null;
+        const db = fakeDb({
+            docs: { 'users/coach-1': { email: 'Coach@Example.com' } },
+            queries: {
+                teams: (filters) => {
+                    const byOwner = filters.find((f) => f.field === 'ownerId');
+                    if (byOwner) return [{ id: 'team-own', data: { name: 'Owned', ownerId: 'coach-1' } }];
+                    adminEmailQueried = filters.find((f) => f.field === 'adminEmails')?.value;
+                    return [{ id: 'team-adm', data: { name: 'Helped' } }];
+                }
+            }
+        });
+        const context = await resolveUserContext(db, { uid: 'coach-1', email: 'Coach@Example.com' });
+        expect(adminEmailQueried).toBe('coach@example.com');
+        expect([...context.teams.get('team-own').roles]).toEqual(['owner']);
+        expect([...context.teams.get('team-adm').roles]).toEqual(['admin']);
+    });
+
+    it('skips parent teams whose docs Firestore rules deny (stale link)', async () => {
+        const db = parentDb({
+            docs: {
+                'users/parent-1': {
+                    email: 'parent@example.com',
+                    parentOf: [
+                        { teamId: 'team-a', playerId: 'player-1' },
+                        { teamId: 'team-revoked', playerId: 'player-x' }
+                    ]
+                },
+                'teams/team-revoked': DENIED
+            }
+        });
+        const context = await resolveUserContext(db, parentIdentity);
+        expect(context.teams.has('team-a')).toBe(true);
+        expect(context.teams.has('team-revoked')).toBe(false);
+    });
+
+    it('rejects a missing uid as unauthenticated', async () => {
+        await expect(resolveUserContext(parentDb(), {})).rejects.toMatchObject({ code: 'unauthenticated' });
+    });
+});
+
+describe('chatgpt-mcp core: listMyTeams', () => {
+    it('returns only whitelisted player fields (no birth date or medical notes)', async () => {
+        const db = parentDb();
+        const context = await resolveUserContext(db, parentIdentity);
+        const { teams } = await listMyTeams(db, context);
+        expect(teams).toHaveLength(1);
+        expect(teams[0].roles).toEqual(['parent']);
+        expect(teams[0].linkedPlayers).toEqual([{ playerId: 'player-1', name: 'Sam', number: 12 }]);
+        expect(JSON.stringify(teams)).not.toContain('medical');
+        expect(JSON.stringify(teams)).not.toContain('birthDate');
+    });
+});
+
+describe('chatgpt-mcp core: getFamilySchedule', () => {
+    function scheduleDb() {
+        return parentDb({
+            docs: {
+                'teams/team-a/games/game-1/rsvps/parent-1': {
+                    response: 'going',
+                    playerIds: ['player-1', 'player-other-team'],
+                    note: 'private rsvp note'
+                }
+            },
+            queries: {
+                teams: () => [],
+                'teams/team-a/games': (filters) => {
+                    const start = filters.find((f) => f.op === '>=').value;
+                    const end = filters.find((f) => f.op === '<=').value;
+                    const all = [
+                        { id: 'game-1', data: { type: 'game', date: new Date('2026-07-25T17:00:00Z'), opponent: 'Hawks', location: 'Field 2', privateNotes: 'secret', rsvpSummary: { going: 5, notResponded: 3, coachOnly: 'x' } } },
+                        { id: 'practice-1', data: { type: 'practice', date: new Date('2026-07-27T22:30:00Z') } },
+                        { id: 'game-out-of-range', data: { type: 'game', date: new Date('2026-09-01T17:00:00Z') } }
+                    ];
+                    return all.filter(({ data }) => data.date >= start && data.date <= end);
+                }
+            }
+        });
+    }
+
+    it('returns range-filtered, whitelisted events with the caller\'s own RSVP', async () => {
+        const db = scheduleDb();
+        const context = await resolveUserContext(db, parentIdentity);
+        const result = await getFamilySchedule(db, context, { startDate: '2026-07-24', endDate: '2026-07-31' });
+
+        expect(result.events.map((e) => e.gameId)).toEqual(['game-1', 'practice-1']);
+        const game = result.events[0];
+        expect(game.opponent).toBe('Hawks');
+        expect(game.rsvpSummary).toEqual({ going: 5, notResponded: 3 });
+        expect(game.myRsvp.response).toBe('going');
+        // RSVP player ids are filtered to the caller's linked players.
+        expect(game.myRsvp.playerIds).toEqual(['player-1']);
+        expect(game.deepLink).toContain('live-game.html?teamId=team-a&gameId=game-1');
+        const serialized = JSON.stringify(result);
+        expect(serialized).not.toContain('secret');
+        expect(serialized).not.toContain('private rsvp note');
+    });
+
+    it('defaults missing RSVPs to not_responded', async () => {
+        const db = scheduleDb();
+        const context = await resolveUserContext(db, parentIdentity);
+        const result = await getFamilySchedule(db, context, { startDate: '2026-07-24', endDate: '2026-07-31' });
+        expect(result.events[1].myRsvp).toEqual({ response: 'not_responded', playerIds: [] });
+    });
+
+    it('rejects an invalid date range', async () => {
+        const db = scheduleDb();
+        const context = await resolveUserContext(db, parentIdentity);
+        await expect(getFamilySchedule(db, context, { startDate: '2026-07-31', endDate: '2026-07-01' }))
+            .rejects.toMatchObject({ code: 'invalid_argument' });
+    });
+});
+
+describe('chatgpt-mcp core: getGameSummary', () => {
+    function summaryDb(extra = {}) {
+        return parentDb({
+            docs: {
+                'teams/team-a/games/game-1': {
+                    type: 'game',
+                    date: new Date('2026-07-12T17:00:00Z'),
+                    opponent: 'Hawks',
+                    homeScore: 7,
+                    awayScore: 4,
+                    summary: 'Close win.',
+                    trackerInternalState: { secret: true }
+                },
+                ...extra.docs
+            },
+            queries: {
+                teams: () => [],
+                'teams/team-a/games/game-1/aggregatedStats': () => [
+                    { id: 'player-1', data: { playerName: 'Sam', playerNumber: 12, hits: 2, runs: 1 } }
+                ],
+                ...extra.queries
+            }
+        });
+    }
+
+    it('returns whitelisted game fields and aggregated stats for an authorized team', async () => {
+        const db = summaryDb();
+        const context = await resolveUserContext(db, parentIdentity);
+        const result = await getGameSummary(db, context, { teamId: 'team-a', gameId: 'game-1' });
+        expect(result.game.homeScore).toBe(7);
+        expect(result.game.summary).toBe('Close win.');
+        expect(result.game.trackerInternalState).toBeUndefined();
+        expect(result.playerStats).toEqual([
+            { playerId: 'player-1', playerName: 'Sam', playerNumber: 12, stats: { hits: 2, runs: 1 } }
+        ]);
+        expect(result.deepLink).toContain('replay=true');
+    });
+
+    it('denies access to a team the user is not a member of (foreign team id from the model)', async () => {
+        const db = summaryDb();
+        const context = await resolveUserContext(db, parentIdentity);
+        await expect(getGameSummary(db, context, { teamId: 'team-other', gameId: 'game-1' }))
+            .rejects.toMatchObject({ code: 'permission_denied' });
+    });
+
+    it('degrades to empty stats when rules deny the aggregatedStats query', async () => {
+        const db = summaryDb({ queries: { 'teams/team-a/games/game-1/aggregatedStats': DENIED } });
+        const context = await resolveUserContext(db, parentIdentity);
+        const result = await getGameSummary(db, context, { teamId: 'team-a', gameId: 'game-1' });
+        expect(result.playerStats).toEqual([]);
+    });
+
+    it('returns not_found for a missing game on an authorized team', async () => {
+        const db = summaryDb();
+        const context = await resolveUserContext(db, parentIdentity);
+        await expect(getGameSummary(db, context, { teamId: 'team-a', gameId: 'nope' }))
+            .rejects.toMatchObject({ code: 'not_found' });
+    });
+});
+
+function makeJwt(payload) {
+    const encode = (obj) => Buffer.from(JSON.stringify(obj)).toString('base64url');
+    return `${encode({ alg: 'RS256' })}.${encode(payload)}.fakesig`;
+}
+
+describe('chatgpt-mcp identity', () => {
+    it('extracts bearer tokens case-insensitively', () => {
+        expect(extractBearerToken('Bearer abc')).toBe('abc');
+        expect(extractBearerToken('bearer abc')).toBe('abc');
+        expect(extractBearerToken('Basic abc')).toBeNull();
+        expect(extractBearerToken(undefined)).toBeNull();
+    });
+
+    it('decodes JWT payloads and rejects non-JWTs', () => {
+        expect(decodeJwtPayload(makeJwt({ user_id: 'u1' }))).toMatchObject({ user_id: 'u1' });
+        expect(decodeJwtPayload('a-refresh-token')).toBeNull();
+    });
+
+    it('accepts an unexpired ID token bearer directly', async () => {
+        const resolve = createIdentityResolver({ apiKey: 'k', fetchImpl: () => { throw new Error('no fetch expected'); }, now: () => 1000 });
+        const token = makeJwt({ user_id: 'u1', email: 'a@b.c', exp: 2 });
+        const identity = await resolve(`Bearer ${token}`);
+        expect(identity).toMatchObject({ uid: 'u1', email: 'a@b.c', via: 'id-token', idToken: token });
+    });
+
+    it('rejects an expired ID token', async () => {
+        const resolve = createIdentityResolver({ apiKey: 'k', fetchImpl: () => { throw new Error('no fetch expected'); }, now: () => 5000 });
+        await expect(resolve(`Bearer ${makeJwt({ user_id: 'u1', exp: 2 })}`))
+            .rejects.toMatchObject({ code: 'unauthenticated' });
+    });
+
+    it('exchanges refresh tokens via securetoken and caches until expiry', async () => {
+        let calls = 0;
+        let time = 0;
+        const idToken = makeJwt({ user_id: 'u1', email: 'a@b.c' });
+        const fetchImpl = async (url, options) => {
+            calls += 1;
+            expect(url).toContain('securetoken.googleapis.com/v1/token?key=test-key');
+            // The public API key is referrer-restricted to the AllPlays site.
+            expect(options.headers.Referer).toBe('https://allplays.ai/');
+            expect(options.body).toContain('grant_type=refresh_token');
+            return { ok: true, json: async () => ({ user_id: 'u1', id_token: idToken, expires_in: '3600' }) };
+        };
+        const resolve = createIdentityResolver({ apiKey: 'test-key', fetchImpl, now: () => time });
+
+        const first = await resolve('Bearer my-refresh-token');
+        expect(first).toMatchObject({ uid: 'u1', email: 'a@b.c', via: 'refresh-token', idToken });
+
+        time = 30 * 60 * 1000;
+        await resolve('Bearer my-refresh-token');
+        expect(calls).toBe(1);
+
+        time = 3600 * 1000;
+        await resolve('Bearer my-refresh-token');
+        expect(calls).toBe(2);
+    });
+
+    it('rejects missing and revoked tokens as unauthenticated', async () => {
+        const resolve = createIdentityResolver({ apiKey: 'k', fetchImpl: async () => ({ ok: false, json: async () => ({}) }) });
+        await expect(resolve(undefined)).rejects.toMatchObject({ code: 'unauthenticated' });
+        await expect(resolve('Bearer revoked-token')).rejects.toBeInstanceOf(DomainError);
+    });
+});
+
+describe('chatgpt-mcp firestore REST adapter', () => {
+    it('round-trips values through encode/decode', () => {
+        const date = new Date('2026-07-25T17:00:00.000Z');
+        expect(decodeValue(encodeValue('x'))).toBe('x');
+        expect(decodeValue(encodeValue(7))).toBe(7);
+        expect(decodeValue(encodeValue(2.5))).toBe(2.5);
+        expect(decodeValue(encodeValue(true))).toBe(true);
+        expect(decodeValue(encodeValue(null))).toBeNull();
+        expect(decodeValue(encodeValue(date))).toEqual(date);
+        expect(decodeValue(encodeValue({ a: [1, 'b'] }))).toEqual({ a: [1, 'b'] });
+    });
+
+    it('builds structured queries with filters, order, and limit', () => {
+        const query = buildStructuredQuery('games', {
+            filters: [
+                { field: 'date', op: '>=', value: new Date('2026-07-24T00:00:00Z') },
+                { field: 'date', op: '<=', value: new Date('2026-07-31T00:00:00Z') }
+            ],
+            orderBy: { field: 'date', direction: 'asc' },
+            limit: 50
+        });
+        expect(query.from).toEqual([{ collectionId: 'games' }]);
+        expect(query.where.compositeFilter.op).toBe('AND');
+        expect(query.where.compositeFilter.filters[0].fieldFilter.op).toBe('GREATER_THAN_OR_EQUAL');
+        expect(query.orderBy).toEqual([{ field: { fieldPath: 'date' }, direction: 'ASCENDING' }]);
+        expect(query.limit).toBe(50);
+    });
+
+    it('fetches documents with the user\'s ID token and decodes fields', async () => {
+        let captured;
+        const db = createUserDb({
+            projectId: 'p1',
+            idToken: 'user-id-token',
+            fetchImpl: async (url, options = {}) => {
+                captured = { url, options };
+                return {
+                    ok: true,
+                    status: 200,
+                    json: async () => ({
+                        name: 'projects/p1/databases/(default)/documents/teams/team-a',
+                        fields: { name: { stringValue: 'Wildcats' }, founded: { integerValue: '2020' } }
+                    })
+                };
+            }
+        });
+        const snap = await db.doc('teams/team-a').get();
+        expect(captured.url).toBe('https://firestore.googleapis.com/v1/projects/p1/databases/(default)/documents/teams/team-a');
+        expect(captured.options.headers.Authorization).toBe('Bearer user-id-token');
+        expect(snap.exists).toBe(true);
+        expect(snap.data()).toEqual({ name: 'Wildcats', founded: 2020 });
+    });
+
+    it('maps 404 to exists:false and 403 to permission_denied', async () => {
+        const dbFor = (status) => createUserDb({
+            projectId: 'p1',
+            idToken: 't',
+            fetchImpl: async () => ({ ok: false, status, json: async () => ({}) })
+        });
+        const missing = await dbFor(404).doc('teams/none').get();
+        expect(missing.exists).toBe(false);
+        await expect(dbFor(403).doc('teams/secret').get()).rejects.toMatchObject({ code: 'permission_denied' });
+    });
+
+    it('runs subcollection queries against the parent document path', async () => {
+        let captured;
+        const db = createUserDb({
+            projectId: 'p1',
+            idToken: 't',
+            fetchImpl: async (url, options = {}) => {
+                captured = { url, body: JSON.parse(options.body) };
+                return {
+                    ok: true,
+                    status: 200,
+                    json: async () => ([
+                        { document: { name: '.../games/game-1', fields: { opponent: { stringValue: 'Hawks' } } } },
+                        { readTime: 'ignored-partial-result' }
+                    ])
+                };
+            }
+        });
+        const snap = await db.collection('teams/team-a/games')
+            .where('date', '>=', new Date('2026-07-24T00:00:00Z'))
+            .orderBy('date')
+            .limit(10)
+            .get();
+        expect(captured.url).toContain('/documents/teams/team-a:runQuery');
+        expect(captured.body.structuredQuery.from).toEqual([{ collectionId: 'games' }]);
+        expect(snap.docs).toHaveLength(1);
+        expect(snap.docs[0].id).toBe('game-1');
+        expect(snap.docs[0].data()).toEqual({ opponent: 'Hawks' });
+    });
+});

--- a/tests/unit/chatgpt-mcp-core.test.js
+++ b/tests/unit/chatgpt-mcp-core.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
 import {
     DomainError,
     resolveUserContext,
@@ -114,22 +115,39 @@ describe('chatgpt-mcp core: resolveUserContext', () => {
         expect([...context.teams.get('team-adm').roles]).toEqual(['admin']);
     });
 
-    it('skips parent teams whose docs Firestore rules deny (stale link)', async () => {
+    it('keeps private parent teams when direct team reads are denied by rules', async () => {
         const db = parentDb({
             docs: {
                 'users/parent-1': {
                     email: 'parent@example.com',
-                    parentOf: [
-                        { teamId: 'team-a', playerId: 'player-1' },
-                        { teamId: 'team-revoked', playerId: 'player-x' }
-                    ]
+                    parentOf: [{ teamId: 'team-private', playerId: 'player-x' }],
+                    parentTeamIds: ['team-private'],
+                    parentPlayerKeys: ['team-private::player-x']
                 },
-                'teams/team-revoked': DENIED
+                'teams/team-private': DENIED
             }
         });
         const context = await resolveUserContext(db, parentIdentity);
-        expect(context.teams.has('team-a')).toBe(true);
-        expect(context.teams.has('team-revoked')).toBe(false);
+        const entry = context.teams.get('team-private');
+        expect([...entry.roles]).toEqual(['parent']);
+        expect([...entry.linkedPlayerIds]).toEqual(['player-x']);
+        expect(entry.team).toEqual({});
+    });
+
+    it('derives parent scope from normalized access keys when parentOf is empty', async () => {
+        const db = parentDb({
+            docs: {
+                'users/parent-1': {
+                    email: 'parent@example.com',
+                    parentOf: [],
+                    parentTeamIds: ['team-a'],
+                    parentPlayerKeys: ['team-a::player-1', 'invalid-key']
+                }
+            }
+        });
+        const context = await resolveUserContext(db, parentIdentity);
+        expect([...context.teams.get('team-a').roles]).toEqual(['parent']);
+        expect([...context.teams.get('team-a').linkedPlayerIds]).toEqual(['player-1']);
     });
 
     it('rejects a missing uid as unauthenticated', async () => {
@@ -267,6 +285,24 @@ describe('chatgpt-mcp core: getGameSummary', () => {
         await expect(getGameSummary(db, context, { teamId: 'team-a', gameId: 'nope' }))
             .rejects.toMatchObject({ code: 'not_found' });
     });
+
+    it('returns a summary with an empty team name for global-admin-only access', async () => {
+        const db = summaryDb({
+            docs: {
+                'users/admin-1': { email: 'admin@example.com', isAdmin: true },
+                'teams/team-other/games/game-1': {
+                    type: 'game',
+                    date: new Date('2026-07-12T17:00:00Z')
+                }
+            },
+            queries: {
+                'teams/team-other/games/game-1/aggregatedStats': () => []
+            }
+        });
+        const context = await resolveUserContext(db, { uid: 'admin-1', email: 'admin@example.com' });
+        const result = await getGameSummary(db, context, { teamId: 'team-other', gameId: 'game-1' });
+        expect(result.game.teamName).toBe('');
+    });
 });
 
 function makeJwt(payload) {
@@ -306,7 +342,8 @@ describe('chatgpt-mcp identity', () => {
         const idToken = makeJwt({ user_id: 'u1', email: 'a@b.c' });
         const fetchImpl = async (url, options) => {
             calls += 1;
-            expect(url).toContain('securetoken.googleapis.com/v1/token?key=test-key');
+            expect(url).toBe('https://securetoken.googleapis.com/v1/token');
+            expect(options.headers['X-goog-api-key']).toBe('test-key');
             // The public API key is referrer-restricted to the AllPlays site.
             expect(options.headers.Referer).toBe('https://allplays.ai/');
             expect(options.body).toContain('grant_type=refresh_token');
@@ -330,6 +367,27 @@ describe('chatgpt-mcp identity', () => {
         const resolve = createIdentityResolver({ apiKey: 'k', fetchImpl: async () => ({ ok: false, json: async () => ({}) }) });
         await expect(resolve(undefined)).rejects.toMatchObject({ code: 'unauthenticated' });
         await expect(resolve('Bearer revoked-token')).rejects.toBeInstanceOf(DomainError);
+    });
+
+    it('rejects malformed successful token exchange responses as unauthenticated', async () => {
+        const resolve = createIdentityResolver({
+            apiKey: 'k',
+            fetchImpl: async () => ({ ok: true, json: async () => { throw new SyntaxError('not json'); } })
+        });
+        await expect(resolve('Bearer refresh-token')).rejects.toMatchObject({
+            code: 'unauthenticated',
+            message: 'Invalid token exchange response.'
+        });
+    });
+});
+
+describe('chatgpt-mcp server configuration', () => {
+    it('requires Firebase configuration without committed fallback values', () => {
+        const source = readFileSync(new URL('../../services/chatgpt-mcp/src/server.js', import.meta.url), 'utf8');
+        expect(source).toContain('const PROJECT_ID = process.env.FIREBASE_PROJECT_ID;');
+        expect(source).toContain('const WEB_API_KEY = process.env.FIREBASE_WEB_API_KEY;');
+        expect(source).toContain('if (!PROJECT_ID || !WEB_API_KEY)');
+        expect(source).not.toMatch(/AIza[0-9A-Za-z_-]+/);
     });
 });
 

--- a/tests/unit/chatgpt-mcp-core.test.js
+++ b/tests/unit/chatgpt-mcp-core.test.js
@@ -104,8 +104,12 @@ describe('chatgpt-mcp core: resolveUserContext', () => {
                 teams: (filters) => {
                     const byOwner = filters.find((f) => f.field === 'ownerId');
                     if (byOwner) return [{ id: 'team-own', data: { name: 'Owned', ownerId: 'coach-1' } }];
-                    adminEmailQueried = filters.find((f) => f.field === 'adminEmails')?.value;
-                    return [{ id: 'team-adm', data: { name: 'Helped' } }];
+                    const byAdmin = filters.find((f) => f.field === 'adminEmails');
+                    if (byAdmin) {
+                        adminEmailQueried = byAdmin.value;
+                        return [{ id: 'team-adm', data: { name: 'Helped' } }];
+                    }
+                    return [];
                 }
             }
         });
@@ -113,6 +117,34 @@ describe('chatgpt-mcp core: resolveUserContext', () => {
         expect(adminEmailQueried).toBe('coach@example.com');
         expect([...context.teams.get('team-own').roles]).toEqual(['owner']);
         expect([...context.teams.get('team-adm').roles]).toEqual(['admin']);
+    });
+
+    it('derives legacy ownership from ownerEmail and ownerEmailLower', async () => {
+        const queried = [];
+        const db = fakeDb({
+            docs: { 'users/coach-1': { email: 'Coach@Example.com' } },
+            queries: {
+                teams: (filters) => {
+                    const filter = filters[0];
+                    queried.push([filter.field, filter.value]);
+                    if (filter.field === 'ownerEmail' && filter.value === 'Coach@Example.com') {
+                        return [{ id: 'team-legacy-case', data: { name: 'Legacy case' } }];
+                    }
+                    if (filter.field === 'ownerEmailLower') {
+                        return [{ id: 'team-legacy-lower', data: { name: 'Legacy lower' } }];
+                    }
+                    return [];
+                }
+            }
+        });
+
+        const context = await resolveUserContext(db, { uid: 'coach-1', email: 'Coach@Example.com' });
+
+        expect(queried).toContainEqual(['ownerEmail', 'Coach@Example.com']);
+        expect(queried).toContainEqual(['ownerEmail', 'coach@example.com']);
+        expect(queried).toContainEqual(['ownerEmailLower', 'coach@example.com']);
+        expect([...context.teams.get('team-legacy-case').roles]).toEqual(['owner']);
+        expect([...context.teams.get('team-legacy-lower').roles]).toEqual(['owner']);
     });
 
     it('keeps private parent teams when direct team reads are denied by rules', async () => {

--- a/tests/unit/chatgpt-mcp-core.test.js
+++ b/tests/unit/chatgpt-mcp-core.test.js
@@ -245,7 +245,10 @@ describe('chatgpt-mcp core: getGameSummary', () => {
             queries: {
                 teams: () => [],
                 'teams/team-a/games/game-1/aggregatedStats': () => [
-                    { id: 'player-1', data: { playerName: 'Sam', playerNumber: 12, hits: 2, runs: 1 } }
+                    {
+                        id: 'player-1',
+                        data: { playerName: 'Sam', playerNumber: 12, stats: { hits: 2, runs: 1 } }
+                    }
                 ],
                 ...extra.queries
             }

--- a/tests/unit/chatgpt-mcp-oauth.test.js
+++ b/tests/unit/chatgpt-mcp-oauth.test.js
@@ -82,6 +82,57 @@ describe('chatgpt-mcp oauth: registration', () => {
             else process.env.FIREBASE_WEB_API_KEY = previousApiKey;
         }
     });
+
+    it('does not accept an unverified refresh token at the authorization endpoint', async () => {
+        const previousProjectId = process.env.FIREBASE_PROJECT_ID;
+        const previousApiKey = process.env.FIREBASE_WEB_API_KEY;
+        const realFetch = globalThis.fetch;
+        process.env.FIREBASE_PROJECT_ID = 'test-project';
+        process.env.FIREBASE_WEB_API_KEY = 'test-api-key';
+        const { app } = await import('../../services/chatgpt-mcp/src/server.js');
+        const server = createServer(app);
+        await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+        try {
+            const { port } = server.address();
+            const registration = await realFetch(`http://127.0.0.1:${port}/oauth/register`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ client_name: 'ChatGPT', redirect_uris: [REDIRECT] })
+            });
+            const client = await registration.json();
+            let signInCalls = 0;
+            globalThis.fetch = async (url, options) => {
+                if (String(url).startsWith('https://identitytoolkit.googleapis.com/')) {
+                    signInCalls += 1;
+                    return { ok: false, json: async () => ({ error: { message: 'INVALID_LOGIN_CREDENTIALS' } }) };
+                }
+                return realFetch(url, options);
+            };
+
+            const response = await realFetch(`http://127.0.0.1:${port}/oauth/authorize`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: new URLSearchParams({
+                    client_id: client.client_id,
+                    redirect_uri: REDIRECT,
+                    code_challenge: s256Challenge(VERIFIER),
+                    refresh_token: 'attacker-controlled-unverified-token'
+                })
+            });
+
+            expect(response.status).toBe(401);
+            expect(signInCalls).toBe(1);
+            expect(response.headers.get('location')).toBeNull();
+        } finally {
+            globalThis.fetch = realFetch;
+            await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+            if (previousProjectId === undefined) delete process.env.FIREBASE_PROJECT_ID;
+            else process.env.FIREBASE_PROJECT_ID = previousProjectId;
+            if (previousApiKey === undefined) delete process.env.FIREBASE_WEB_API_KEY;
+            else process.env.FIREBASE_WEB_API_KEY = previousApiKey;
+        }
+    });
 });
 
 describe('chatgpt-mcp oauth: authorize validation', () => {
@@ -156,6 +207,21 @@ describe('chatgpt-mcp oauth: refresh and access tokens', () => {
         const second = broker.exchange({ grant_type: 'refresh_token', refresh_token: first.refresh_token });
         expect(second.access_token).not.toBe(first.access_token);
         expect(broker.resolveAccessToken(second.access_token)).toEqual({ firebaseRefreshToken: 'firebase-rt-9' });
+        expect(() => broker.exchange({ grant_type: 'refresh_token', refresh_token: first.refresh_token })).toThrow(/Unknown/);
+    });
+
+    it('expires refresh tokens and bounds retained access grants', () => {
+        let time = 0;
+        const { broker, clientId } = registeredBroker({ now: () => time, maxStoredGrants: 2 });
+        const issued = Array.from({ length: 3 }, (_, index) => {
+            const code = authorize(broker, clientId, `firebase-rt-${index}`);
+            return broker.exchange({ grant_type: 'authorization_code', code, code_verifier: VERIFIER });
+        });
+
+        expect(broker.resolveAccessToken(issued[0].access_token)).toBeNull();
+        expect(broker.resolveAccessToken(issued[2].access_token)).toBeTruthy();
+        time = 31 * 24 * 60 * 60 * 1000;
+        expect(() => broker.exchange({ grant_type: 'refresh_token', refresh_token: issued[2].refresh_token })).toThrow(/Unknown/);
     });
 
     it('expires access tokens and returns null for unknown tokens', () => {

--- a/tests/unit/chatgpt-mcp-oauth.test.js
+++ b/tests/unit/chatgpt-mcp-oauth.test.js
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import {
+    createOAuthBroker,
+    metadataFor,
+    s256Challenge,
+    OAuthError
+} from '../../services/chatgpt-mcp/src/oauth.js';
+
+const REDIRECT = 'https://chatgpt.com/connector_platform_oauth_redirect';
+const VERIFIER = 'test-verifier-string-with-plenty-of-entropy-1234567890';
+
+function registeredBroker(overrides = {}) {
+    const broker = createOAuthBroker(overrides);
+    const client = broker.registerClient({ redirect_uris: [REDIRECT], client_name: 'ChatGPT' });
+    return { broker, clientId: client.client_id };
+}
+
+function authorize(broker, clientId, firebaseRefreshToken = 'firebase-rt-1') {
+    return broker.approveAuthorization({
+        clientId,
+        redirectUri: REDIRECT,
+        codeChallenge: s256Challenge(VERIFIER),
+        firebaseRefreshToken
+    });
+}
+
+describe('chatgpt-mcp oauth: registration', () => {
+    it('registers clients with https redirect uris', () => {
+        const broker = createOAuthBroker();
+        const client = broker.registerClient({ redirect_uris: [REDIRECT] });
+        expect(client.client_id).toBeTruthy();
+        expect(client.token_endpoint_auth_method).toBe('none');
+    });
+
+    it('allows localhost and rejects other http redirect uris', () => {
+        const broker = createOAuthBroker();
+        expect(broker.registerClient({ redirect_uris: ['http://localhost:3000/cb'] }).client_id).toBeTruthy();
+        expect(() => broker.registerClient({ redirect_uris: ['http://evil.example/cb'] })).toThrow(OAuthError);
+        expect(() => broker.registerClient({})).toThrow(OAuthError);
+    });
+});
+
+describe('chatgpt-mcp oauth: authorize validation', () => {
+    it('rejects unknown clients, unregistered redirects, and non-S256 PKCE', () => {
+        const { broker, clientId } = registeredBroker();
+        const valid = {
+            client_id: clientId,
+            redirect_uri: REDIRECT,
+            response_type: 'code',
+            code_challenge: s256Challenge(VERIFIER),
+            code_challenge_method: 'S256'
+        };
+        expect(broker.validateAuthorizeRequest(valid).clientId).toBe(clientId);
+        expect(() => broker.validateAuthorizeRequest({ ...valid, client_id: 'nope' })).toThrow(/client_id/);
+        expect(() => broker.validateAuthorizeRequest({ ...valid, redirect_uri: 'https://evil.example/cb' })).toThrow(/redirect_uri/);
+        expect(() => broker.validateAuthorizeRequest({ ...valid, code_challenge_method: 'plain' })).toThrow(/S256/);
+        expect(() => broker.validateAuthorizeRequest({ ...valid, code_challenge: '' })).toThrow(/code_challenge/);
+    });
+});
+
+describe('chatgpt-mcp oauth: code exchange', () => {
+    it('exchanges a code with the right PKCE verifier for tokens bound to the Firebase credential', () => {
+        const { broker, clientId } = registeredBroker();
+        const code = authorize(broker, clientId, 'firebase-rt-42');
+        const tokens = broker.exchange({
+            grant_type: 'authorization_code',
+            code,
+            code_verifier: VERIFIER,
+            client_id: clientId,
+            redirect_uri: REDIRECT
+        });
+        expect(tokens.token_type).toBe('Bearer');
+        expect(tokens.expires_in).toBeGreaterThan(0);
+        expect(broker.resolveAccessToken(tokens.access_token)).toEqual({ firebaseRefreshToken: 'firebase-rt-42' });
+    });
+
+    it('rejects a wrong PKCE verifier and burns the code', () => {
+        const { broker, clientId } = registeredBroker();
+        const code = authorize(broker, clientId);
+        expect(() => broker.exchange({ grant_type: 'authorization_code', code, code_verifier: 'wrong' })).toThrow(/PKCE/);
+        // Code is single-use even after a failed attempt.
+        expect(() => broker.exchange({ grant_type: 'authorization_code', code, code_verifier: VERIFIER })).toThrow(/invalid or expired/);
+    });
+
+    it('rejects reuse of a successfully exchanged code', () => {
+        const { broker, clientId } = registeredBroker();
+        const code = authorize(broker, clientId);
+        broker.exchange({ grant_type: 'authorization_code', code, code_verifier: VERIFIER });
+        expect(() => broker.exchange({ grant_type: 'authorization_code', code, code_verifier: VERIFIER })).toThrow(OAuthError);
+    });
+
+    it('rejects expired codes', () => {
+        let time = 0;
+        const { broker, clientId } = registeredBroker({ now: () => time });
+        const code = authorize(broker, clientId);
+        time = 11 * 60 * 1000;
+        expect(() => broker.exchange({ grant_type: 'authorization_code', code, code_verifier: VERIFIER })).toThrow(/expired/);
+    });
+
+    it('rejects a mismatched client_id on exchange', () => {
+        const { broker, clientId } = registeredBroker();
+        const code = authorize(broker, clientId);
+        expect(() => broker.exchange({ grant_type: 'authorization_code', code, code_verifier: VERIFIER, client_id: 'other' })).toThrow(/client_id/);
+    });
+});
+
+describe('chatgpt-mcp oauth: refresh and access tokens', () => {
+    it('supports the refresh_token grant', () => {
+        const { broker, clientId } = registeredBroker();
+        const code = authorize(broker, clientId, 'firebase-rt-9');
+        const first = broker.exchange({ grant_type: 'authorization_code', code, code_verifier: VERIFIER });
+        const second = broker.exchange({ grant_type: 'refresh_token', refresh_token: first.refresh_token });
+        expect(second.access_token).not.toBe(first.access_token);
+        expect(broker.resolveAccessToken(second.access_token)).toEqual({ firebaseRefreshToken: 'firebase-rt-9' });
+    });
+
+    it('expires access tokens and returns null for unknown tokens', () => {
+        let time = 0;
+        const { broker, clientId } = registeredBroker({ now: () => time });
+        const code = authorize(broker, clientId);
+        const tokens = broker.exchange({ grant_type: 'authorization_code', code, code_verifier: VERIFIER });
+        expect(broker.resolveAccessToken(tokens.access_token)).toBeTruthy();
+        time = 2 * 60 * 60 * 1000;
+        expect(broker.resolveAccessToken(tokens.access_token)).toBeNull();
+        expect(broker.resolveAccessToken('unknown')).toBeNull();
+    });
+
+    it('rejects unsupported grant types', () => {
+        const { broker } = registeredBroker();
+        expect(() => broker.exchange({ grant_type: 'password' })).toThrow(/grant_type/);
+    });
+});
+
+describe('chatgpt-mcp oauth: metadata', () => {
+    it('publishes endpoints under the given base url', () => {
+        const meta = metadataFor('https://example.ngrok.dev');
+        expect(meta.authorizationServer.authorization_endpoint).toBe('https://example.ngrok.dev/oauth/authorize');
+        expect(meta.authorizationServer.code_challenge_methods_supported).toEqual(['S256']);
+        expect(meta.protectedResource.resource).toBe('https://example.ngrok.dev/mcp');
+        expect(meta.protectedResource.authorization_servers).toEqual(['https://example.ngrok.dev']);
+    });
+});

--- a/tests/unit/chatgpt-mcp-oauth.test.js
+++ b/tests/unit/chatgpt-mcp-oauth.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { createServer } from 'node:http';
 import {
     createOAuthBroker,
     metadataFor,
@@ -25,18 +26,49 @@ function authorize(broker, clientId, firebaseRefreshToken = 'firebase-rt-1') {
 }
 
 describe('chatgpt-mcp oauth: registration', () => {
-    it('registers clients with https redirect uris', () => {
+    it('registers clients with the approved ChatGPT redirect uri', () => {
         const broker = createOAuthBroker();
         const client = broker.registerClient({ redirect_uris: [REDIRECT] });
         expect(client.client_id).toBeTruthy();
         expect(client.token_endpoint_auth_method).toBe('none');
     });
 
-    it('allows localhost and rejects other http redirect uris', () => {
+    it('rejects untrusted redirect uris regardless of scheme', () => {
         const broker = createOAuthBroker();
-        expect(broker.registerClient({ redirect_uris: ['http://localhost:3000/cb'] }).client_id).toBeTruthy();
+        expect(() => broker.registerClient({ redirect_uris: ['https://evil.example/cb'] })).toThrow(OAuthError);
+        expect(() => broker.registerClient({ redirect_uris: ['http://localhost:3000/cb'] })).toThrow(OAuthError);
         expect(() => broker.registerClient({ redirect_uris: ['http://evil.example/cb'] })).toThrow(OAuthError);
         expect(() => broker.registerClient({})).toThrow(OAuthError);
+    });
+
+    it('rejects an untrusted redirect at the dynamic registration endpoint', async () => {
+        const previousProjectId = process.env.FIREBASE_PROJECT_ID;
+        const previousApiKey = process.env.FIREBASE_WEB_API_KEY;
+        process.env.FIREBASE_PROJECT_ID = 'test-project';
+        process.env.FIREBASE_WEB_API_KEY = 'test-api-key';
+        const { app } = await import('../../services/chatgpt-mcp/src/server.js');
+        const server = createServer(app);
+        await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+        try {
+            const { port } = server.address();
+            const response = await fetch(`http://127.0.0.1:${port}/oauth/register`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    client_name: 'Fake ChatGPT',
+                    redirect_uris: ['https://attacker.example/oauth/callback']
+                })
+            });
+            expect(response.status).toBe(400);
+            await expect(response.json()).resolves.toMatchObject({ error: 'invalid_request' });
+        } finally {
+            await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+            if (previousProjectId === undefined) delete process.env.FIREBASE_PROJECT_ID;
+            else process.env.FIREBASE_PROJECT_ID = previousProjectId;
+            if (previousApiKey === undefined) delete process.env.FIREBASE_WEB_API_KEY;
+            else process.env.FIREBASE_WEB_API_KEY = previousApiKey;
+        }
     });
 });
 

--- a/tests/unit/chatgpt-mcp-oauth.test.js
+++ b/tests/unit/chatgpt-mcp-oauth.test.js
@@ -41,7 +41,7 @@ describe('chatgpt-mcp oauth: registration', () => {
         expect(() => broker.registerClient({})).toThrow(OAuthError);
     });
 
-    it('rejects an untrusted redirect at the dynamic registration endpoint', async () => {
+    it('rejects untrusted redirects and reuses one bounded client at the registration endpoint', async () => {
         const previousProjectId = process.env.FIREBASE_PROJECT_ID;
         const previousApiKey = process.env.FIREBASE_WEB_API_KEY;
         process.env.FIREBASE_PROJECT_ID = 'test-project';
@@ -62,6 +62,18 @@ describe('chatgpt-mcp oauth: registration', () => {
             });
             expect(response.status).toBe(400);
             await expect(response.json()).resolves.toMatchObject({ error: 'invalid_request' });
+
+            const registrations = await Promise.all(Array.from({ length: 20 }, () => fetch(
+                `http://127.0.0.1:${port}/oauth/register`,
+                {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ client_name: 'ChatGPT', redirect_uris: [REDIRECT] })
+                }
+            )));
+            expect(registrations.every((registration) => registration.status === 201)).toBe(true);
+            const clients = await Promise.all(registrations.map((registration) => registration.json()));
+            expect(new Set(clients.map((client) => client.client_id))).toHaveLength(1);
         } finally {
             await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
             if (previousProjectId === undefined) delete process.env.FIREBASE_PROJECT_ID;


### PR DESCRIPTION
## Summary
- Adds `services/chatgpt-mcp`: a remote MCP service for the ChatGPT app integration plan, exposing `get_profile`, `list_schedule`, and `get_game_summary` over Streamable HTTP
- All Firestore access is **user-credentialed** (REST API with the user's own ID token), so `firestore.rules` authorizes every read exactly as it does for the web/app clients — the service holds no service account or privileged credentials
- Bearer token is the user's Firebase refresh token (exchanged + cached server-side); an OAuth broker replaces this in a follow-up (spec task 15)
- Tool names mirror the in-app private AI registry (`apps/app/src/lib/privateAiService.ts`) so both surfaces converge on one catalog
- Spec at `spec/chatgpt-app-integration/` (requirements, design, tasks)

## Test plan
- `npx vitest run tests/unit/chatgpt-mcp-core.test.js` — 23 tests: role resolution, cross-team denial, rules-denial degradation, field whitelists (no medical/birth-date/private-note leakage), token exchange + caching, REST adapter encode/decode/query
- Manual: connected via ngrok to ChatGPT Developer Mode; `get_profile` and `list_schedule` verified end-to-end against production Firestore with a parent test account (permission-filtered results, deep links resolve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)