### PR TITLE
Allow cached team chat upload paths

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2253,11 +2253,24 @@ service cloud.firestore {
              pathSegments[5].size() > 0;
     }
 
+    function isCachedLegacyNestedChatFallbackMediaPath(teamId, conversationId, value) {
+      let pathSegments = value.split('/');
+      return conversationId == 'team' &&
+             pathSegments.size() == 6 &&
+             pathSegments[0] == 'stat-sheets' &&
+             pathSegments[1] == 'team-chat' &&
+             pathSegments[2] == request.auth.uid &&
+             pathSegments[3] == 'team' &&
+             pathSegments[4] == teamId &&
+             pathSegments[5].size() > 0;
+    }
+
     function isScopedNestedChatMediaPath(teamId, conversationId, value) {
       return value is string &&
              value.size() > 0 &&
              value.size() <= 1024 &&
              (isScopedNestedChatFallbackMediaPath(teamId, conversationId, value) ||
+              isCachedLegacyNestedChatFallbackMediaPath(teamId, conversationId, value) ||
               (isSafeNestedChatRegexSegment(teamId) &&
                isSafeNestedChatRegexSegment(request.auth.uid) &&
                value.matches('team-(photos|videos)/[0-9]+_chat_' + teamId + '_[^/]+_' + request.auth.uid + '_[^/]+')));

--- a/storage.rules
+++ b/storage.rules
@@ -212,6 +212,19 @@ service firebase.storage {
       allow update: if false;
     }
 
+    match /stat-sheets/team-chat/{userId}/team/{teamId}/{fileName} {
+      allow get: if canAccessChatAttachment(teamId, 'team') &&
+        (isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId);
+      allow list: if false;
+      allow create: if isSignedIn() &&
+        canAccessChatAttachment(teamId, 'team') &&
+        request.auth.uid == userId &&
+        isAllowedChatAttachmentUpload(request.resource.contentType, request.resource.size);
+      allow delete: if (isVerifiedForSensitiveWrite() && isTeamOwnerOrAdmin(teamId)) ||
+        canDeleteOwnChatAttachment(teamId, 'team', userId);
+      allow update: if false;
+    }
+
     match /stat-sheets/team-chat/{teamId}/{userId}/{fileName} {
       allow get: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;
       allow list: if false;

--- a/tests/unit/fallback-media-storage.test.js
+++ b/tests/unit/fallback-media-storage.test.js
@@ -13,6 +13,7 @@ function extractRuleBlock(startMarker) {
 }
 
 const chatFallbackRules = extractRuleBlock('match /stat-sheets/team-chat/{teamId}/{conversationId}/{userId}/{fileName}');
+const cachedLegacyChatFallbackRules = extractRuleBlock('match /stat-sheets/team-chat/{userId}/team/{teamId}/{fileName}');
 const legacyChatFallbackRules = extractRuleBlock('match /stat-sheets/team-chat/{teamId}/{userId}/{fileName}');
 const statSheetFallbackRules = extractRuleBlock('match /stat-sheets/team-games/{teamId}/{userId}/{fileName}');
 const drillFallbackRules = extractRuleBlock('match /stat-sheets/drills/{teamId}/{drillId}/{userId}/{fileName}');
@@ -95,6 +96,10 @@ describe('fallback media paths and Storage rules', () => {
         expect(rules).toContain('function canDeleteOwnChatAttachment(teamId, conversationId, userId)');
         expect(chatFallbackRules).toContain('allow delete: if (isVerifiedForSensitiveWrite() && isTeamOwnerOrAdmin(teamId)) ||\n        canDeleteOwnChatAttachment(teamId, conversationId, userId);');
         expect(chatFallbackRules).not.toContain('allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;');
+        expect(cachedLegacyChatFallbackRules).toContain("allow create: if isSignedIn() &&\n        canAccessChatAttachment(teamId, 'team') &&");
+        expect(cachedLegacyChatFallbackRules).toContain('request.auth.uid == userId');
+        expect(cachedLegacyChatFallbackRules).toContain('isAllowedChatAttachmentUpload(request.resource.contentType, request.resource.size);');
+        expect(cachedLegacyChatFallbackRules).toContain("canDeleteOwnChatAttachment(teamId, 'team', userId);");
         expect(legacyChatFallbackRules).toContain('allow get: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;');
         expect(legacyChatFallbackRules).toContain('allow create: if false;');
         expect(legacyChatFallbackRules).toContain('allow delete: if isVerifiedForSensitiveWrite() &&\n        (isTeamOwnerOrAdmin(teamId) || canDeleteOwnTeamScopedUpload(teamId, userId));');

--- a/tests/unit/storage-rules-team-boundary.test.js
+++ b/tests/unit/storage-rules-team-boundary.test.js
@@ -158,6 +158,40 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST || !process.env.FIREBASE_ST
             );
         });
 
+        it('allows the cached legacy team chat upload path while preserving team and uploader boundaries', async () => {
+            const memberStorage = testEnv.authenticatedContext('member-a', {
+                email: 'member-a@example.com'
+            }).storage();
+            const otherMemberStorage = testEnv.authenticatedContext('other-member', {
+                email: 'other@example.com'
+            }).storage();
+
+            await assertSucceeds(
+                memberStorage.ref('stat-sheets/team-chat/member-a/team/team-a/cached-photo.jpg').put(
+                    new Uint8Array([1]),
+                    { contentType: 'image/jpeg' }
+                )
+            );
+            await assertFails(
+                memberStorage.ref('stat-sheets/team-chat/member-a/team/team-b/cross-team.jpg').put(
+                    new Uint8Array([1]),
+                    { contentType: 'image/jpeg' }
+                )
+            );
+            await assertFails(
+                otherMemberStorage.ref('stat-sheets/team-chat/member-a/team/team-a/wrong-uploader.jpg').put(
+                    new Uint8Array([1]),
+                    { contentType: 'image/jpeg' }
+                )
+            );
+            await assertFails(
+                memberStorage.ref('stat-sheets/team-chat/member-a/team/team-a/document.txt').put(
+                    new Uint8Array([1]),
+                    { contentType: 'text/plain' }
+                )
+            );
+        });
+
         it('allows team chat image upload and own delete when verified-email policy is enforced for an unverified signed-in parent', async () => {
             await testEnv.withSecurityRulesDisabled(async (context) => {
                 await context.firestore().doc('securityPolicies/verifiedEmail').set({ mode: 'enforce' });

--- a/tests/unit/team-chat-nested-message-payload-rules.test.js
+++ b/tests/unit/team-chat-nested-message-payload-rules.test.js
@@ -31,14 +31,21 @@ describe('nested team chat message payload contracts', () => {
         expect(rules).toContain('function hasValidNestedChatAttachments(teamId, conversationId, data)');
         expect(rules).toContain('function isSafeNestedChatRegexSegment(value)');
         expect(rules).toContain('function isScopedNestedChatFallbackMediaPath(teamId, conversationId, value)');
+        expect(rules).toContain('function isCachedLegacyNestedChatFallbackMediaPath(teamId, conversationId, value)');
         expect(rules).toContain("let pathSegments = value.split('/');");
         expect(rules).toContain('pathSegments[3] == conversationId');
+        expect(rules).toContain("conversationId == 'team'");
+        expect(rules).toContain("pathSegments[2] == request.auth.uid");
+        expect(rules).toContain('pathSegments[4] == teamId');
         expect(rules).toContain("value.matches('[A-Za-z0-9_%:-]+')");
         const scopedMediaPathValidator = rules.slice(
             rules.indexOf('function isScopedNestedChatMediaPath'),
             rules.indexOf('function isValidNestedChatAttachment')
         );
         expect(scopedMediaPathValidator.indexOf('isScopedNestedChatFallbackMediaPath')).toBeLessThan(
+            scopedMediaPathValidator.indexOf('isCachedLegacyNestedChatFallbackMediaPath')
+        );
+        expect(scopedMediaPathValidator.indexOf('isCachedLegacyNestedChatFallbackMediaPath')).toBeLessThan(
             scopedMediaPathValidator.indexOf("value.matches('team-(photos|videos)")
         );
         const attachmentValidator = rules.slice(
@@ -350,6 +357,15 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('nested team chat message 
 
     function fallbackAttachment(conversationId = staffConversationId, overrides = {}) {
         const path = overrides.path || `stat-sheets/team-chat/team-1/${conversationId}/coach-1/photo.jpg`;
+        return legacyAttachment({
+            path,
+            url: firebaseMediaUrl(path, 'game-flow-c6311.firebasestorage.app'),
+            ...overrides
+        });
+    }
+
+    function cachedLegacyFallbackAttachment(overrides = {}) {
+        const path = overrides.path || 'stat-sheets/team-chat/parent-1/team/team-1/photo.jpg';
         return legacyAttachment({
             path,
             url: firebaseMediaUrl(path, 'game-flow-c6311.firebasestorage.app'),
@@ -771,6 +787,7 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('nested team chat message 
     it('allows legacy full-team text and exact scoped Firebase Storage uploads', async () => {
         const parentDb = authedFirestore('parent-1', 'parent@example.com');
         const attachment = legacyAttachment();
+        const cachedAttachment = cachedLegacyFallbackAttachment();
 
         await assertSucceeds(setDoc(legacyMessageRef(parentDb, 'valid-text'), legacyPayload()));
         await assertSucceeds(setDoc(legacyMessageRef(parentDb, 'valid-canonical-photo'), legacyPayload({
@@ -783,6 +800,10 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('nested team chat message 
         await assertSucceeds(setDoc(legacyMessageRef(parentDb, 'valid-media'), legacyPayload({
             text: '',
             attachments: [attachment]
+        })));
+        await assertSucceeds(setDoc(legacyMessageRef(parentDb, 'valid-cached-fallback-media'), legacyPayload({
+            text: '',
+            attachments: [cachedAttachment]
         })));
     });
 
@@ -811,6 +832,8 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('nested team chat message 
                 imageSize: validAttachment.size
             }),
             legacyPayload({ attachments: [legacyAttachment({ path: 'team-photos/unscoped-photo.jpg' })] }),
+            legacyPayload({ attachments: [cachedLegacyFallbackAttachment({ path: 'stat-sheets/team-chat/user-2/team/team-1/photo.jpg' })] }),
+            legacyPayload({ attachments: [cachedLegacyFallbackAttachment({ path: 'stat-sheets/team-chat/parent-1/team/team-2/photo.jpg' })] }),
             legacyPayload({ attachments: [legacyAttachment({ size: 5 * 1024 * 1024 + 1 })] }),
             legacyPayload({ unexpectedField: true }),
             legacyPayload({ senderId: 'user-2' }),


### PR DESCRIPTION
## Summary
- add a compatibility Firebase Storage rule for cached team-chat upload clients still writing to `stat-sheets/team-chat/{userId}/team/{teamId}/{fileName}`
- keep the rule bounded by team-chat access, uploader UID, MIME type, file size, and existing owner/admin delete checks
- add static and emulator-style regression coverage for the cached path

## Root Cause
Some deployed/cached clients can still attempt photo uploads with the older team chat fallback path. The current production rule shape only allows the newer scoped path, so those cached uploads fail with `storage/unauthorized` even for valid team members.

## Validation
- `npx vitest run tests/unit/fallback-media-storage.test.js tests/unit/storage-rules-team-boundary.test.js --reporter=verbose`
- `npm run ci:firebase-rules`
- `git diff --check`
