### PR TITLE
Merge Home 'Do first' and 'To-do list' cards into one compact priority card

### DIFF
--- a/apps/app/src/pages/Home.test.tsx
+++ b/apps/app/src/pages/Home.test.tsx
@@ -544,13 +544,43 @@ describe('Home', () => {
 
     expect(await screen.findByText('1 open')).toBeTruthy();
     expect(screen.getByRole('heading', { name: title })).toBeTruthy();
-    const toDoSection = screen.getByText('To-do list').closest('section');
-    expect(toDoSection).toBeTruthy();
-    expect(within(toDoSection!).getByRole('heading', { name: 'Priority only' })).toBeTruthy();
-    expect(within(toDoSection!).getByText('0')).toBeTruthy();
-    expect(within(toDoSection!).getByText('Priority shown above')).toBeTruthy();
-    expect(within(toDoSection!).getByText('Your only open action is highlighted above.')).toBeTruthy();
-    expect(within(toDoSection!).queryByText('All caught up')).toBeNull();
+    expect(screen.queryByText('To-do list')).toBeNull();
+    expect(screen.queryByText('Also to do')).toBeNull();
+    expect(screen.queryByText('Priority shown above')).toBeNull();
+    expect(screen.queryByText('All caught up')).toBeNull();
+  });
+
+  it('renders remaining actions inside the priority card with an overflow count', async () => {
+    const makeAction = (index: number) => ({
+      id: `rsvp:${index}`,
+      kind: 'rsvp' as const,
+      tone: 'amber' as const,
+      title: `Respond for game ${index}`,
+      detail: 'Bears · Tomorrow',
+      to: `/schedule/team-1/event-${index}`,
+      priority: 30 + index,
+      date: new Date('2100-06-06T18:00:00Z')
+    });
+    const actionHome = {
+      ...baseHome,
+      metrics: { ...baseHome.metrics, rsvpNeeded: 5 },
+      actionItems: [1, 2, 3, 4, 5].map(makeAction)
+    };
+    homeServiceMocks.loadParentHomeSummaryBootstrap.mockResolvedValueOnce({ home: actionHome, schedule: [] });
+    homeServiceMocks.loadParentHomeWithSecondaryData.mockResolvedValueOnce(actionHome);
+
+    renderHome(signedInAuth);
+
+    expect(await screen.findByRole('heading', { name: 'Respond for game 1' })).toBeTruthy();
+    const priorityCard = screen.getByText('Do first').closest('section');
+    expect(priorityCard).toBeTruthy();
+    expect(within(priorityCard!).getByText('Also to do')).toBeTruthy();
+    expect(within(priorityCard!).getByText('4')).toBeTruthy();
+    expect(within(priorityCard!).getByText('Respond for game 2')).toBeTruthy();
+    expect(within(priorityCard!).getByText('Respond for game 4')).toBeTruthy();
+    expect(within(priorityCard!).queryByText('Respond for game 5')).toBeNull();
+    expect(within(priorityCard!).getByText('+1 more in Schedule and Messages')).toBeTruthy();
+    expect(screen.queryByText('To-do list')).toBeNull();
   });
 
   it('shows network-specific Home retry copy after an initial load failure', async () => {
@@ -738,7 +768,7 @@ describe('Home', () => {
 
     renderHome(signedInAuth);
 
-    expect(await screen.findByText('Falcons')).toBeTruthy();
+    expect(await screen.findByText('2 open assignments')).toBeTruthy();
     expect(socialServiceMocks.loadSocialHome).toHaveBeenCalledWith(signedInAuth.user, largeHome);
     expect(uxTimingMocks.recordFirstMeaningfulRender).toHaveBeenCalledWith('home');
 
@@ -1091,7 +1121,8 @@ describe('Home', () => {
     expect(screen.getByRole('link', { name: 'Open action' }).getAttribute('href')).toBe('/schedule/team-1/upcoming-1');
     expect(screen.getByRole('link', { name: /Availability.*2.*Needs a response/i }).getAttribute('href')).toBe('/schedule?bulkRsvp=1');
     expect(screen.getByRole('link', { name: 'Multi RSVP' }).getAttribute('href')).toBe('/schedule?bulkRsvp=1');
-    expect(screen.getByText('Falcons')).toBeTruthy();
+    expect(screen.getByText('2 open assignments')).toBeTruthy();
+    expect(screen.getByText('+2 more in Schedule and Messages')).toBeTruthy();
     expect(screen.getAllByText('Tournament fee').length).toBeGreaterThan(0);
 
     fireEvent.click(screen.getByRole('button', { name: 'Refresh Home' }));
@@ -1102,6 +1133,6 @@ describe('Home', () => {
     });
 
     expect(screen.getByRole('heading', { name: 'Your day' })).toBeTruthy();
-    expect(screen.getByText('1 unread message')).toBeTruthy();
+    expect(screen.getByText('Practice packet ready')).toBeTruthy();
   });
 });

--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -704,7 +704,14 @@ function TodaySection({
 
   return (
     <div className="home-section-content space-y-3">
-      <TodayPriorityCard action={topAction} nextEvent={nextEvent} loading={!hasLoadedHomeDetails} />
+      <TodayPriorityCard
+        action={topAction}
+        nextEvent={nextEvent}
+        loading={!hasLoadedHomeDetails}
+        remainingActions={remainingActions}
+        remainingActionCount={remainingActionCount}
+        multiRsvpTo={home.metrics.rsvpNeeded > 1 ? '/schedule?bulkRsvp=1' : null}
+      />
 
       <section className="home-signal-grid grid gap-2 sm:grid-cols-3">
         <SignalCard
@@ -757,42 +764,6 @@ function TodaySection({
         )}
       </section>
 
-      <section className="home-action-section app-card p-4">
-        <div className="flex items-center justify-between gap-3">
-          <div>
-            <div className="app-label">To-do list</div>
-            <h2 className="mt-1 app-section-title">{topAction ? (remainingActionCount ? 'More to do' : 'Priority only') : 'Needs Attention'}</h2>
-          </div>
-          <div className="flex items-center gap-2">
-            {home.metrics.rsvpNeeded > 1 ? <MultiRsvpLink to="/schedule?bulkRsvp=1" /> : null}
-            <span className="rounded-full border border-gray-200 bg-gray-50 px-2.5 py-1 text-xs font-black text-gray-600">{remainingActionCount}</span>
-          </div>
-        </div>
-        <div className="mt-3 space-y-2">
-          {remainingActions.length ? remainingActions.map((action) => (
-            <ActionRow key={action.id} action={action} />
-          )) : !hasLoadedHomeDetails ? (
-            <HomeDetailsLoadingState message="Checking for parent actions…" />
-          ) : topAction ? (
-            <div className="flex items-start gap-3 rounded-xl border border-gray-200 bg-gray-50 p-3">
-              <CheckCircle2 className="mt-0.5 h-5 w-5 flex-none text-gray-600" aria-hidden="true" />
-              <div>
-                <div className="text-sm font-black text-gray-900">Priority shown above</div>
-                <div className="mt-0.5 text-xs font-semibold text-gray-600">Your only open action is highlighted above.</div>
-              </div>
-            </div>
-          ) : (
-            <div className="flex items-start gap-3 rounded-xl border border-emerald-200 bg-emerald-50 p-3">
-              <CheckCircle2 className="mt-0.5 h-5 w-5 flex-none text-emerald-700" aria-hidden="true" />
-              <div>
-                <div className="text-sm font-black text-emerald-900">All caught up</div>
-                <div className="mt-0.5 text-xs font-semibold text-emerald-700">No parent actions need attention right now.</div>
-              </div>
-            </div>
-          )}
-        </div>
-      </section>
-
       {home.fees.length ? (
         <section className="app-card p-4">
           <div className="flex items-center gap-2 text-sm font-black text-rose-800">
@@ -836,7 +807,14 @@ function HomeDetailsLoadingState({ message }: { message: string }) {
   );
 }
 
-function TodayPriorityCard({ action, nextEvent, loading }: { action: ParentHomeAction | null; nextEvent: ParentScheduleEvent | null; loading: boolean }) {
+function TodayPriorityCard({ action, nextEvent, loading, remainingActions, remainingActionCount, multiRsvpTo }: {
+  action: ParentHomeAction | null;
+  nextEvent: ParentScheduleEvent | null;
+  loading: boolean;
+  remainingActions: ParentHomeAction[];
+  remainingActionCount: number;
+  multiRsvpTo: string | null;
+}) {
   if (!action) {
     if (loading) {
       return (
@@ -885,6 +863,25 @@ function TodayPriorityCard({ action, nextEvent, loading }: { action: ParentHomeA
           <p className="mt-1 line-clamp-2 text-sm font-semibold leading-5 text-gray-600">{action.detail}</p>
         </div>
       </div>
+      {remainingActions.length ? (
+        <div className="border-t border-gray-100 px-4 pb-3 pt-2">
+          <div className="flex items-center justify-between gap-3">
+            <div className="app-label">Also to do</div>
+            <div className="flex items-center gap-2">
+              {multiRsvpTo ? <MultiRsvpLink to={multiRsvpTo} /> : null}
+              <span className="rounded-full border border-gray-200 bg-gray-50 px-2.5 py-1 text-xs font-black text-gray-600">{remainingActionCount}</span>
+            </div>
+          </div>
+          <div className="mt-2 space-y-2">
+            {remainingActions.slice(0, 3).map((item) => (
+              <ActionRow key={item.id} action={item} />
+            ))}
+            {remainingActionCount > 3 ? (
+              <div className="text-xs font-semibold text-gray-500">+{remainingActionCount - 3} more in Schedule and Messages</div>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
       <PriorityFooter action={action} nextEvent={nextEvent} loading={loading} />
     </section>
   );

--- a/tests/unit/app-home-player-integration.test.jsx
+++ b/tests/unit/app-home-player-integration.test.jsx
@@ -577,9 +577,8 @@ describe('React app Home and player drill-in integration', () => {
         expect(container.textContent).toContain('Team feed');
         expect(container.textContent).toContain('Pat Star highlight');
         expect(container.textContent).toContain('Next up');
-        await waitForText(container, 'Priority only');
-        expect(container.textContent).toContain('Priority shown above');
-        expect(container.textContent).toContain('Your only open action is highlighted above.');
+        expect(container.textContent).not.toContain('To-do list');
+        expect(container.textContent).not.toContain('Priority shown above');
         expect(container.textContent).not.toContain('No parent actions need attention right now.');
         expect(homeMocks.loadParentHome).toHaveBeenCalledWith(auth.user);
         expect(socialMocks.loadSocialHome).toHaveBeenCalledWith(auth.user, expect.objectContaining({


### PR DESCRIPTION
Closes #4095

## Summary
- Fold the standalone "To-do list" section into the "Do first" priority card: remaining actions render as up to 3 compact rows under the top action with an overflow count
- Keep the multi-RSVP shortcut, count badge, analytics triggers, and the Open action / Ask AI / Next up footer unchanged
- Remove the duplicated empty states ("Priority shown above") so loading/caught-up copy exists once

## Manual test steps
1. `npm run app:dev`, sign in as a parent with open actions
2. Home shows a single "Do first" card: top action + "Also to do" rows (max 3) + `+N more` overflow
3. With exactly one action: no "Also to do" block, no second card
4. With zero actions: single "All caught up" card
5. With `rsvpNeeded > 1`: Multi RSVP link appears in the "Also to do" header

## Tests
- Updated `Home.test.tsx` lone-action test; new test for remaining actions + overflow inside the priority card; adjusted large-payload proxies. 43/43 pass, `tsc --noEmit` clean, `app:build` + bundle budget green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)