### PR TITLE
Compact Firestore rules deployment artifact

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -127,7 +127,8 @@ jobs:
           node scripts/write-firebase-hosting-config.mjs "$site_dir" "$config_file"
           jq '.hosting.public = "site"' "$config_file" > "$config_file.tmp"
           mv "$config_file.tmp" "$config_file"
-          cp firestore.rules firestore.indexes.json storage.rules "$bundle_dir/"
+          node scripts/compact-firestore-rules.mjs firestore.rules "$bundle_dir/firestore.rules"
+          cp firestore.indexes.json storage.rules "$bundle_dir/"
           echo "FIREBASE_PRODUCTION_BUNDLE=$bundle_dir" >> "$GITHUB_ENV"
 
       - name: Install Functions dependencies
@@ -380,7 +381,8 @@ jobs:
           retry_firebase_deploy() {
             local deploy_targets="$1"
             local deploy_label="$2"
-            local max_attempts=3
+            local max_attempts="${3:-3}"
+            local base_delay_seconds="${4:-15}"
             local attempt deploy_log deploy_status retry_delay_seconds
 
             for ((attempt = 1; attempt <= max_attempts; attempt += 1)); do
@@ -407,7 +409,10 @@ jobs:
                 return "$deploy_status"
               fi
 
-              retry_delay_seconds=$((15 * (2 ** (attempt - 1))))
+              retry_delay_seconds=$((base_delay_seconds * (2 ** (attempt - 1))))
+              if (( retry_delay_seconds > 120 )); then
+                retry_delay_seconds=120
+              fi
               echo "Transient Firebase ${deploy_label} deploy failure; retrying in ${retry_delay_seconds} seconds (attempt $((attempt + 1))/${max_attempts})." >&2
               sleep "$retry_delay_seconds"
             done
@@ -416,7 +421,7 @@ jobs:
           if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then
             # Keep coupled authorization/index changes fail-closed: application code
             # must not publish until its Firestore configuration is active.
-            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"
+            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30
             retry_firebase_deploy "hosting,functions" "application"
           else
             # No authorization/index drift exists relative to the last successful

--- a/scripts/compact-firestore-rules.mjs
+++ b/scripts/compact-firestore-rules.mjs
@@ -1,0 +1,25 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+export function compactFirestoreRules(rulesSource) {
+    const compactLines = rulesSource
+        .split(/\r?\n/)
+        .filter(line => !/^\s*\/\//.test(line))
+        .map(line => line.trim())
+        .filter(Boolean);
+
+    return `${compactLines.join('\n')}\n`;
+}
+
+function main() {
+    const [inputPath, outputPath] = process.argv.slice(2);
+    if (!inputPath || !outputPath) {
+        throw new Error('Usage: node scripts/compact-firestore-rules.mjs <input> <output>');
+    }
+
+    writeFileSync(outputPath, compactFirestoreRules(readFileSync(inputPath, 'utf8')));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main();
+}

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
 import { parse as parseYaml } from 'yaml';
+import { compactFirestoreRules } from './compact-firestore-rules.mjs';
 
 function readText(path) {
     return readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
@@ -24,7 +25,7 @@ function assertEquals(actual, expected, label) {
     }
 }
 
-export const FIRESTORE_RULES_DEPLOY_BUDGET_BYTES = 208 * 1024;
+export const FIRESTORE_RULES_DEPLOY_BUDGET_BYTES = 180 * 1024;
 
 export function validateFirestoreRulesDeployBudget(rulesSource) {
     const sourceBytes = Buffer.byteLength(rulesSource, 'utf8');
@@ -262,7 +263,8 @@ export function validateProductionDeployCommand(deployProd) {
     }
 
     assertIncludes(deployProd, 'retry_firebase_deploy "hosting,functions" "application"', 'Production application deploy targets');
-    assertIncludes(deployProd, 'retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"', 'Production Firestore deploy targets');
+    assertIncludes(deployProd, 'retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30', 'Production Firestore deploy targets and bounded extended retry');
+    assertIncludes(deployProd, 'if (( retry_delay_seconds > 120 )); then', 'Production Firebase retry delay cap');
     assertIncludes(deployProd, 'HTTP Error:[[:space:]]*409,[[:space:]]*Requested entity already exists', 'Production Firestore release-race retry');
     assertIncludes(deployProd, 'actions: read', 'Production workflow-run read permission');
     assertIncludes(deployProd, 'GH_TOKEN: ${{ github.token }}', 'Production workflow-run authentication');
@@ -334,7 +336,7 @@ export function validateFirebaseRulesCi() {
     const deployPreviewTrusted = readText('.github/workflows/deploy-preview-trusted.yml');
     const regressionGuards = readText('.github/workflows/regression-guards.yml');
 
-    validateFirestoreRulesDeployBudget(firestoreRules);
+    validateFirestoreRulesDeployBudget(compactFirestoreRules(firestoreRules));
 
     if (firebaseJson.firestore?.rules !== 'firestore.rules') {
         throw new Error('firebase.json must deploy firestore.rules.');
@@ -486,6 +488,11 @@ export function validateFirebaseRulesCi() {
 
     assertIncludes(regressionGuards, 'npm run ci:firebase-rules', 'Regression guard workflow');
     assertIncludes(regressionGuards, 'npm run test:smoke:team-fallback', 'Regression guard workflow');
+    assertIncludes(
+        deployProd,
+        'node scripts/compact-firestore-rules.mjs firestore.rules "$bundle_dir/firestore.rules"',
+        'Production Firestore rules compaction'
+    );
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/tests/unit/auth-email-resend-routing.test.js
+++ b/tests/unit/auth-email-resend-routing.test.js
@@ -111,7 +111,7 @@ describe('authentication email delivery routing', () => {
         }
     });
 
-    it('bounds the normal non-destructive production deploy to three attempts', () => {
+    it('bounds normal deploys to three attempts and gives Firestore an extended retry window', () => {
         const productionSource = read('.github/workflows/deploy-prod.yml');
         const firebaseDeployCommands = productionSource
             .split('\n')
@@ -126,10 +126,14 @@ describe('authentication email delivery routing', () => {
         expect(productionSource).toContain('[[ "$STORAGE_RULES_CHANGED" != "true" ]]');
         expect(productionSource).toContain('exit "$storage_status"');
         expect(productionSource.match(/--force/g) ?? []).toHaveLength(0);
-        expect(productionSource).toContain('max_attempts=3');
+        expect(productionSource).toContain('local max_attempts="${3:-3}"');
+        expect(productionSource).toContain('local base_delay_seconds="${4:-15}"');
         expect(productionSource).toContain('for ((attempt = 1; attempt <= max_attempts; attempt += 1)); do');
         expect(productionSource).toContain('if (( attempt == max_attempts )); then');
-        expect(productionSource).toContain('retry_delay_seconds=$((15 * (2 ** (attempt - 1))))');
+        expect(productionSource).toContain('retry_delay_seconds=$((base_delay_seconds * (2 ** (attempt - 1))))');
+        expect(productionSource).toContain('if (( retry_delay_seconds > 120 )); then');
+        expect(productionSource).toContain('retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30');
+        expect(productionSource).toContain('retry_firebase_deploy "hosting,functions" "application"');
         const changedBranchStart = productionSource.indexOf('if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then');
         const unchangedBranchStart = productionSource.indexOf('\n          else', changedBranchStart);
         const conditionalEnd = productionSource.indexOf('\n          fi', unchangedBranchStart);
@@ -146,7 +150,7 @@ describe('authentication email delivery routing', () => {
         const deployStep = productionSource.slice(deployStepStart);
         const transientGuard = 'if ! grep -Eiq "$transient_pattern" "$deploy_log"; then';
         const attemptLimitGuard = 'if (( attempt == max_attempts )); then';
-        const retryDelay = 'retry_delay_seconds=$((15 * (2 ** (attempt - 1))))';
+        const retryDelay = 'retry_delay_seconds=$((base_delay_seconds * (2 ** (attempt - 1))))';
         const nonTransientBranch = deployStep.slice(
             deployStep.indexOf(transientGuard),
             deployStep.indexOf(attemptLimitGuard)

--- a/tests/unit/compact-firestore-rules.test.js
+++ b/tests/unit/compact-firestore-rules.test.js
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { compactFirestoreRules } from '../../scripts/compact-firestore-rules.mjs';
+
+describe('compact Firestore rules', () => {
+    it('removes formatting without changing rule expressions or string contents', () => {
+        const source = `
+            // full-line comment
+            match /teams/{teamId} {
+                allow read: if value == "https://example.com/a//b"; // inline text stays intact
+
+                allow write: if true;
+            }
+        `;
+
+        expect(compactFirestoreRules(source)).toBe([
+            'match /teams/{teamId} {',
+            'allow read: if value == "https://example.com/a//b"; // inline text stays intact',
+            'allow write: if true;',
+            '}',
+            ''
+        ].join('\n'));
+    });
+
+    it('keeps the production artifact comfortably below the deploy budget', () => {
+        const source = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
+        const compact = compactFirestoreRules(source);
+
+        expect(Buffer.byteLength(compact, 'utf8')).toBeLessThanOrEqual(180 * 1024);
+        expect(compact).toContain('function isTeamOwnerOrAdmin(teamId)');
+        expect(compact).toContain('match /chatConversations/{conversationId}');
+    });
+});

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -125,8 +125,12 @@ service firebase.storage {
             node "$firebase_cli" deploy --only "$deploy_targets" --project game-flow-c6311 --config "$firebase_config" --non-interactive
           env:
             FIRESTORE_CONFIG_CHANGED: \${{ needs.prepare-deploy.outputs.firestore_changed }}
+          retry_delay_seconds=$((base_delay_seconds * (2 ** (attempt - 1))))
+          if (( retry_delay_seconds > 120 )); then
+            retry_delay_seconds=120
+          fi
           if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then
-            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"
+            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30
             retry_firebase_deploy "hosting,functions" "application"
           else
             retry_firebase_deploy "hosting,functions" "application"
@@ -157,16 +161,16 @@ service firebase.storage {
             '(^|[^[:alnum:]])409([^[:alnum:]]|$)'
         ))).toThrow('Production Firestore release-race retry');
         expect(() => validateProductionDeployCommand(validDeployCommand.replace(
-            `retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"
+            `retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30
             retry_firebase_deploy "hosting,functions" "application"`,
             `retry_firebase_deploy "hosting,functions" "application"
-            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"`
+            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30`
         ))).toThrow('Production Firestore deploy must run first when its configuration changed');
         expect(() => validateProductionDeployCommand(validDeployCommand.replace(
             `else
             retry_firebase_deploy "hosting,functions" "application"`,
             `else
-            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore"
+            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30
             retry_firebase_deploy "hosting,functions" "application"`
         ))).toThrow('Production must not redeploy unchanged Firestore configuration');
     });


### PR DESCRIPTION
## Summary
- generate a semantics-preserving compact Firestore rules artifact for production deploys
- reduce the deployed rules source from 203,074 bytes to 148,355 bytes
- extend only Firestore deploy retries to eight attempts with 30/60/120-second capped backoff
- enforce a 180 KiB compact artifact budget and retry contract in Firebase CI

## Why
Production deploy run 29754611497 received three Firebase Rules compiler 503 responses with the 203 KB readable source. Direct API research showed minimal rules compile reliably, but large real rulesets are intermittently accepted and rejected with 503, including an unchanged historical source. The canonical source remains readable; only the trusted production handoff receives the compact copy.

## Validation
- `npm run ci:firebase-rules`
- `npm test -- --run` (667 passed files, 4,756 passed tests; 3 files/106 tests skipped)
- focused transformer and deployment-policy tests
- direct authenticated Firebase Rules API probes
- `git diff --check`