### PR TITLE
Recover Private AI saved chat history

### DIFF
--- a/apps/app/src/lib/adapters/legacyPrivateAi.ts
+++ b/apps/app/src/lib/adapters/legacyPrivateAi.ts
@@ -10,6 +10,7 @@ import {
   orderBy as legacyOrderBy,
   query as legacyQuery,
   serverTimestamp as legacyServerTimestamp,
+  startAfter as legacyStartAfter,
   setDoc as legacySetDoc
 } from '@legacy/firebase.js';
 import { getApp as legacyGetApp } from '@legacy/vendor/firebase-app.js';
@@ -31,6 +32,7 @@ export const limit = legacyLimit as (...args: any[]) => any;
 export const orderBy = legacyOrderBy as (...args: any[]) => any;
 export const query = legacyQuery as (...args: any[]) => any;
 export const serverTimestamp = legacyServerTimestamp as (...args: any[]) => any;
+export const startAfter = legacyStartAfter as (...args: any[]) => any;
 export const setDoc = legacySetDoc as (...args: any[]) => Promise<any>;
 export const getApp = legacyGetApp as (name?: string) => unknown;
 export const getAI = legacyGetAI as (app: unknown, options?: Record<string, unknown>) => unknown;

--- a/apps/app/src/lib/privateAiService.ts
+++ b/apps/app/src/lib/privateAiService.ts
@@ -14,6 +14,7 @@ import {
   orderBy,
   query,
   serverTimestamp,
+  startAfter,
   setDoc
 } from './adapters/legacyPrivateAi';
 import {
@@ -127,6 +128,7 @@ const logger = createLogger('private-ai');
 export const DEFAULT_PRIVATE_AI_CONVERSATION_ID = 'default';
 export const DRAFT_PRIVATE_AI_CONVERSATION_ID = '__draft__';
 const maxLoadedMessages = 80;
+const maxConversationRecoveryPages = 30;
 const maxHistoryMessages = 12;
 const maxToolRounds = 2;
 const maxToolCallsPerRound = 3;
@@ -177,7 +179,7 @@ export async function loadPrivateAiConversations(user: AuthUser | null, conversa
       orderBy('updatedAt', 'desc'),
       limit(conversationLimit)
     )),
-    loadPrivateAiMessageRecords(user, maxLoadedMessages).catch(() => [])
+    loadPrivateAiConversationRecoveryMessages(user, conversationLimit).catch(() => [])
   ]);
 
   const storedConversations = (conversationSnapshot.docs || [])
@@ -243,6 +245,36 @@ async function loadPrivateAiMessageRecords(user: AuthUser, messageLimit: number)
   return (snapshot.docs || [])
     .map((document: any) => normalizePrivateAiMessage(document.id, document.data?.() || {}))
     .filter((message: PrivateAiMessage | null): message is PrivateAiMessage => Boolean(message));
+}
+
+async function loadPrivateAiConversationRecoveryMessages(
+  user: AuthUser,
+  conversationLimit: number
+): Promise<PrivateAiMessage[]> {
+  const recoveredMessages: PrivateAiMessage[] = [];
+  const recoveredConversationIds = new Set<string>();
+  let cursor: any = null;
+
+  for (let page = 0; page < maxConversationRecoveryPages; page += 1) {
+    const snapshot = await getDocs(query(
+      collection(db, 'users', user.uid, privateAiCollectionName),
+      orderBy('createdAt', 'desc'),
+      ...(cursor ? [startAfter(cursor)] : []),
+      limit(maxLoadedMessages)
+    ));
+    const documents = snapshot.docs || [];
+    const pageMessages = documents
+      .map((document: any) => normalizePrivateAiMessage(document.id, document.data?.() || {}))
+      .filter((message: PrivateAiMessage | null): message is PrivateAiMessage => Boolean(message));
+
+    recoveredMessages.push(...pageMessages);
+    pageMessages.forEach((message: PrivateAiMessage) => recoveredConversationIds.add(normalizeConversationId(message.conversationId)));
+    if (documents.length < maxLoadedMessages || recoveredConversationIds.size >= conversationLimit) break;
+    cursor = documents[documents.length - 1];
+    if (!cursor) break;
+  }
+
+  return recoveredMessages;
 }
 
 export async function sendPrivateAiMessage(

--- a/apps/app/src/lib/privateAiService.ts
+++ b/apps/app/src/lib/privateAiService.ts
@@ -179,7 +179,7 @@ export async function loadPrivateAiConversations(user: AuthUser | null, conversa
       orderBy('updatedAt', 'desc'),
       limit(conversationLimit)
     )),
-    loadPrivateAiConversationRecoveryMessages(user, conversationLimit).catch(() => [])
+    loadPrivateAiConversationRecoveryMessages(user).catch(() => [])
   ]);
 
   const storedConversations = (conversationSnapshot.docs || [])
@@ -228,31 +228,17 @@ export async function loadPrivateAiMessages(
   if (!user?.uid) return [];
 
   const activeConversationId = normalizeConversationId(conversationId);
-  const messages = await loadPrivateAiMessageRecords(user, Math.max(messageLimit, maxLoadedMessages));
+  const messages = await loadPrivateAiMessagesForConversation(
+    user,
+    activeConversationId,
+    Math.max(messageLimit, maxLoadedMessages)
+  );
 
-  return messages
-    .filter((message: PrivateAiMessage) => messageBelongsToConversation(message, activeConversationId))
-    .reverse();
+  return messages.reverse();
 }
 
-async function loadPrivateAiMessageRecords(user: AuthUser, messageLimit: number): Promise<PrivateAiMessage[]> {
-  const snapshot = await getDocs(query(
-    collection(db, 'users', user.uid, privateAiCollectionName),
-    orderBy('createdAt', 'desc'),
-    limit(messageLimit)
-  ));
-
-  return (snapshot.docs || [])
-    .map((document: any) => normalizePrivateAiMessage(document.id, document.data?.() || {}))
-    .filter((message: PrivateAiMessage | null): message is PrivateAiMessage => Boolean(message));
-}
-
-async function loadPrivateAiConversationRecoveryMessages(
-  user: AuthUser,
-  conversationLimit: number
-): Promise<PrivateAiMessage[]> {
+async function loadPrivateAiConversationRecoveryMessages(user: AuthUser): Promise<PrivateAiMessage[]> {
   const recoveredMessages: PrivateAiMessage[] = [];
-  const recoveredConversationIds = new Set<string>();
   let cursor: any = null;
 
   for (let page = 0; page < maxConversationRecoveryPages; page += 1) {
@@ -268,13 +254,42 @@ async function loadPrivateAiConversationRecoveryMessages(
       .filter((message: PrivateAiMessage | null): message is PrivateAiMessage => Boolean(message));
 
     recoveredMessages.push(...pageMessages);
-    pageMessages.forEach((message: PrivateAiMessage) => recoveredConversationIds.add(normalizeConversationId(message.conversationId)));
-    if (documents.length < maxLoadedMessages || recoveredConversationIds.size >= conversationLimit) break;
+    if (documents.length < maxLoadedMessages) break;
     cursor = documents[documents.length - 1];
     if (!cursor) break;
   }
 
   return recoveredMessages;
+}
+
+async function loadPrivateAiMessagesForConversation(
+  user: AuthUser,
+  conversationId: string,
+  messageLimit: number
+): Promise<PrivateAiMessage[]> {
+  const conversationMessages: PrivateAiMessage[] = [];
+  let cursor: any = null;
+
+  for (let page = 0; page < maxConversationRecoveryPages; page += 1) {
+    const snapshot = await getDocs(query(
+      collection(db, 'users', user.uid, privateAiCollectionName),
+      orderBy('createdAt', 'desc'),
+      ...(cursor ? [startAfter(cursor)] : []),
+      limit(maxLoadedMessages)
+    ));
+    const documents = snapshot.docs || [];
+    const pageMessages: PrivateAiMessage[] = documents
+      .map((document: any) => normalizePrivateAiMessage(document.id, document.data?.() || {}))
+      .filter((message: PrivateAiMessage | null): message is PrivateAiMessage => Boolean(message))
+      .filter((message: PrivateAiMessage) => messageBelongsToConversation(message, conversationId));
+
+    conversationMessages.push(...pageMessages);
+    if (conversationMessages.length >= messageLimit || documents.length < maxLoadedMessages) break;
+    cursor = documents[documents.length - 1];
+    if (!cursor) break;
+  }
+
+  return conversationMessages.slice(0, messageLimit);
 }
 
 export async function sendPrivateAiMessage(

--- a/apps/app/src/lib/privateAiService.ts
+++ b/apps/app/src/lib/privateAiService.ts
@@ -171,22 +171,25 @@ export function resetPrivateAiModel() {
 export async function loadPrivateAiConversations(user: AuthUser | null, conversationLimit = 30): Promise<PrivateAiConversation[]> {
   if (!user?.uid) return [];
 
-  const snapshot = await getDocs(query(
-    collection(db, 'users', user.uid, privateAiConversationCollectionName),
-    orderBy('updatedAt', 'desc'),
-    limit(conversationLimit)
-  ));
+  const [conversationSnapshot, messages] = await Promise.all([
+    getDocs(query(
+      collection(db, 'users', user.uid, privateAiConversationCollectionName),
+      orderBy('updatedAt', 'desc'),
+      limit(conversationLimit)
+    )),
+    loadPrivateAiMessageRecords(user, maxLoadedMessages).catch(() => [])
+  ]);
 
-  const conversations = (snapshot.docs || [])
+  const storedConversations = (conversationSnapshot.docs || [])
     .map((document: any) => normalizePrivateAiConversation(document.id, document.data?.() || {}))
     .filter((conversation: PrivateAiConversation | null): conversation is PrivateAiConversation => Boolean(conversation));
+  const conversationsById = new Map(
+    recoverPrivateAiConversations(messages).map((conversation) => [conversation.id, conversation])
+  );
 
-  if (conversations.length) {
-    return conversations;
-  }
-
-  const legacyMessages = await loadPrivateAiMessages(user, maxHistoryMessages, DEFAULT_PRIVATE_AI_CONVERSATION_ID).catch(() => []);
-  return legacyMessages.length ? [buildDefaultConversation(legacyMessages)] : [];
+  storedConversations.forEach((conversation: PrivateAiConversation) => conversationsById.set(conversation.id, conversation));
+  return Array.from(conversationsById.values())
+    .sort((left, right) => right.updatedAt.getTime() - left.updatedAt.getTime());
 }
 
 export async function createPrivateAiConversation(user: AuthUser | null, title = 'New chat'): Promise<PrivateAiConversation> {
@@ -222,17 +225,23 @@ export async function loadPrivateAiMessages(
   if (!user?.uid) return [];
 
   const activeConversationId = normalizeConversationId(conversationId);
+  const messages = await loadPrivateAiMessageRecords(user, Math.max(messageLimit, maxLoadedMessages));
+
+  return messages
+    .filter((message: PrivateAiMessage) => messageBelongsToConversation(message, activeConversationId))
+    .reverse();
+}
+
+async function loadPrivateAiMessageRecords(user: AuthUser, messageLimit: number): Promise<PrivateAiMessage[]> {
   const snapshot = await getDocs(query(
     collection(db, 'users', user.uid, privateAiCollectionName),
     orderBy('createdAt', 'desc'),
-    limit(Math.max(messageLimit, maxLoadedMessages))
+    limit(messageLimit)
   ));
 
   return (snapshot.docs || [])
     .map((document: any) => normalizePrivateAiMessage(document.id, document.data?.() || {}))
-    .filter((message: PrivateAiMessage | null): message is PrivateAiMessage => Boolean(message))
-    .filter((message: PrivateAiMessage) => messageBelongsToConversation(message, activeConversationId))
-    .reverse();
+    .filter((message: PrivateAiMessage | null): message is PrivateAiMessage => Boolean(message));
 }
 
 export async function sendPrivateAiMessage(
@@ -1409,16 +1418,30 @@ function normalizePrivateAiMessage(id: string, data: Record<string, any>): Priva
   };
 }
 
-function buildDefaultConversation(messages: PrivateAiMessage[]): PrivateAiConversation {
-  const latest = messages[messages.length - 1];
-  const now = latest?.createdAt || new Date(0);
-  return {
-    id: DEFAULT_PRIVATE_AI_CONVERSATION_ID,
-    title: 'Recent chat',
-    createdAt: messages[0]?.createdAt || now,
-    updatedAt: now,
-    lastMessagePreview: latest?.text || ''
-  };
+function recoverPrivateAiConversations(messages: PrivateAiMessage[]): PrivateAiConversation[] {
+  const messagesByConversationId = new Map<string, PrivateAiMessage[]>();
+  messages.forEach((message) => {
+    const conversationId = normalizeConversationId(message.conversationId);
+    const conversationMessages = messagesByConversationId.get(conversationId) || [];
+    conversationMessages.push(message);
+    messagesByConversationId.set(conversationId, conversationMessages);
+  });
+
+  return Array.from(messagesByConversationId, ([id, conversationMessages]) => {
+    const orderedMessages = [...conversationMessages]
+      .sort((left, right) => left.createdAt.getTime() - right.createdAt.getTime());
+    const first = orderedMessages[0];
+    const latest = orderedMessages[orderedMessages.length - 1] || first;
+    const firstUserMessage = orderedMessages.find((message) => message.role === 'user');
+    const timestamp = latest?.createdAt || new Date(0);
+    return {
+      id,
+      title: firstUserMessage ? buildConversationTitle(firstUserMessage.text) : 'Recent chat',
+      createdAt: first?.createdAt || timestamp,
+      updatedAt: timestamp,
+      lastMessagePreview: latest?.text || ''
+    };
+  });
 }
 
 async function getPrivateAiModel() {

--- a/apps/app/src/lib/privateAiService.ts
+++ b/apps/app/src/lib/privateAiService.ts
@@ -183,8 +183,10 @@ export async function loadPrivateAiConversations(user: AuthUser | null, conversa
   const storedConversations = (conversationSnapshot.docs || [])
     .map((document: any) => normalizePrivateAiConversation(document.id, document.data?.() || {}))
     .filter((conversation: PrivateAiConversation | null): conversation is PrivateAiConversation => Boolean(conversation));
+  const recoveredConversations = recoverPrivateAiConversations(messages)
+    .filter((conversation) => conversation.id !== DEFAULT_PRIVATE_AI_CONVERSATION_ID || storedConversations.length === 0);
   const conversationsById = new Map(
-    recoverPrivateAiConversations(messages).map((conversation) => [conversation.id, conversation])
+    recoveredConversations.map((conversation) => [conversation.id, conversation])
   );
 
   storedConversations.forEach((conversation: PrivateAiConversation) => conversationsById.set(conversation.id, conversation));

--- a/apps/app/src/lib/privateAiService.ts
+++ b/apps/app/src/lib/privateAiService.ts
@@ -183,8 +183,7 @@ export async function loadPrivateAiConversations(user: AuthUser | null, conversa
   const storedConversations = (conversationSnapshot.docs || [])
     .map((document: any) => normalizePrivateAiConversation(document.id, document.data?.() || {}))
     .filter((conversation: PrivateAiConversation | null): conversation is PrivateAiConversation => Boolean(conversation));
-  const recoveredConversations = recoverPrivateAiConversations(messages)
-    .filter((conversation) => conversation.id !== DEFAULT_PRIVATE_AI_CONVERSATION_ID || storedConversations.length === 0);
+  const recoveredConversations = recoverPrivateAiConversations(messages);
   const conversationsById = new Map(
     recoveredConversations.map((conversation) => [conversation.id, conversation])
   );

--- a/apps/app/src/pages/PrivateAiChat.test.tsx
+++ b/apps/app/src/pages/PrivateAiChat.test.tsx
@@ -215,4 +215,31 @@ describe('PrivateAiChat', () => {
         expect(screen.getByText('Here is your summary.')).toBeTruthy();
         expect(privateAiServiceMocks.loadPrivateAiMessages).not.toHaveBeenCalledWith(auth.user, undefined, 'conversation-1');
     });
+
+    it('shows persisted conversation history as saved chats after reload', async () => {
+        privateAiServiceMocks.loadPrivateAiConversations.mockResolvedValue([
+            {
+                id: 'conversation-2',
+                title: 'Practice plan',
+                createdAt: new Date('2026-06-28T13:18:00Z'),
+                updatedAt: new Date('2026-06-28T13:19:00Z'),
+                lastMessagePreview: 'Here is the practice plan.'
+            },
+            {
+                id: 'conversation-1',
+                title: 'RSVP help',
+                createdAt: new Date('2026-06-27T13:18:00Z'),
+                updatedAt: new Date('2026-06-27T13:19:00Z'),
+                lastMessagePreview: 'Your RSVP was updated.'
+            }
+        ]);
+
+        renderChat();
+
+        const conversationList = await screen.findByLabelText('AI conversations');
+        expect(within(conversationList).getByRole('button', { name: /Practice plan/ })).toBeTruthy();
+        expect(within(conversationList).getByRole('button', { name: /RSVP help/ })).toBeTruthy();
+        expect(screen.getByText('Saved chats')).toBeTruthy();
+        expect(screen.queryByText('Chats')).toBeNull();
+    });
 });

--- a/apps/app/src/pages/PrivateAiChat.test.tsx
+++ b/apps/app/src/pages/PrivateAiChat.test.tsx
@@ -239,6 +239,10 @@ describe('PrivateAiChat', () => {
         const conversationList = await screen.findByLabelText('AI conversations');
         expect(within(conversationList).getByRole('button', { name: /Practice plan/ })).toBeTruthy();
         expect(within(conversationList).getByRole('button', { name: /RSVP help/ })).toBeTruthy();
+        expect(within(conversationList).getByRole('button', { name: /Practice plan/ }).getAttribute('aria-pressed')).toBe('true');
+        await waitFor(() => {
+            expect(privateAiServiceMocks.loadPrivateAiMessages).toHaveBeenCalledWith(auth.user, undefined, 'conversation-2');
+        });
         expect(screen.getByText('Saved chats')).toBeTruthy();
         expect(screen.queryByText('Chats')).toBeNull();
     });

--- a/apps/app/src/pages/PrivateAiChat.tsx
+++ b/apps/app/src/pages/PrivateAiChat.tsx
@@ -151,7 +151,7 @@ export function PrivateAiChat({ auth }: { auth: AuthState }) {
   useEffect(() => {
     preserveMessagesForConversationRef.current = null;
     setActiveConversationId(DEFAULT_PRIVATE_AI_CONVERSATION_ID);
-    void refreshConversations();
+    void refreshConversations(true, '');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [auth.user?.uid]);
 

--- a/apps/app/src/pages/PrivateAiChat.tsx
+++ b/apps/app/src/pages/PrivateAiChat.tsx
@@ -391,7 +391,7 @@ export function PrivateAiChat({ auth }: { auth: AuthState }) {
                   </div>
                 </div>
                 <div className="mt-3 grid grid-cols-3 gap-2">
-                  <StatPill label="Chats" value={String(stats.conversations)} />
+                  <StatPill label="Saved chats" value={String(stats.conversations)} />
                   <StatPill label="Messages" value={String(stats.messages)} />
                   <StatPill label="Lookups" value={String(stats.lookups)} />
                 </div>

--- a/tests/smoke/app-private-ai.spec.js
+++ b/tests/smoke/app-private-ai.spec.js
@@ -225,6 +225,7 @@ test.describe('private AI chat', () => {
         await page.getByTitle('Private AI').first().click();
         await expect(page).toHaveURL(/#\/ai$/);
         await expect(page.getByRole('heading', { name: 'Ask ALL PLAYS' })).toBeVisible();
+        await expect(page.getByText('Saved chats', { exact: true })).toBeVisible();
         await expect(page.locator('.private-ai-card')).toContainText(/I can look up your ALL PLAYS schedule and messages\.|Ask about your teams, schedule, messages, fees, player development, coaching ideas, registrations, and profile\./);
         await expect.poll(() => page.locator('.private-ai-rail').evaluate((element) => window.getComputedStyle(element).overflowY)).toBe('auto');
         await expect.poll(() => page.locator('.private-ai-composer').evaluate((element) => window.getComputedStyle(element).paddingBottom)).toBe('6px');

--- a/tests/unit/app-private-ai-service.test.js
+++ b/tests/unit/app-private-ai-service.test.js
@@ -349,7 +349,7 @@ describe('private AI service', () => {
         );
     });
 
-    it('recovers message-backed conversations without letting legacy default replace a stored initial chat', async () => {
+    it('recovers legacy default history alongside stored and message-backed conversations', async () => {
         firebaseMocks.getDocs
             .mockResolvedValueOnce({
                 docs: [
@@ -417,6 +417,11 @@ describe('private AI service', () => {
 
         expect(conversations).toEqual([
             expect.objectContaining({
+                id: 'default',
+                title: 'What did I miss?',
+                lastMessagePreview: 'Legacy answer'
+            }),
+            expect.objectContaining({
                 id: 'conversation-2',
                 title: 'Build a practice plan',
                 lastMessagePreview: 'Here is the practice plan.'
@@ -427,7 +432,6 @@ describe('private AI service', () => {
                 lastMessagePreview: 'Metadata wins for this thread.'
             })
         ]);
-        expect(conversations.some((conversation) => conversation.id === 'default')).toBe(false);
         expect(conversations.filter((conversation) => conversation.id === 'conversation-1')).toHaveLength(1);
     });
 

--- a/tests/unit/app-private-ai-service.test.js
+++ b/tests/unit/app-private-ai-service.test.js
@@ -16,6 +16,7 @@ const firebaseMocks = vi.hoisted(() => ({
     orderBy: vi.fn((field, direction) => ({ type: 'orderBy', field, direction })),
     query: vi.fn((...parts) => ({ parts })),
     serverTimestamp: vi.fn(() => ({ __serverTimestamp: true })),
+    startAfter: vi.fn((cursor) => ({ type: 'startAfter', cursor })),
     setDoc: vi.fn()
 }));
 
@@ -433,6 +434,38 @@ describe('private AI service', () => {
             })
         ]);
         expect(conversations.filter((conversation) => conversation.id === 'conversation-1')).toHaveLength(1);
+    });
+
+    it('paginates recovery when the newest 80 messages all belong to one conversation', async () => {
+        const newestConversationDocuments = Array.from({ length: 80 }, (_, index) => ({
+            id: `newest-${index}`,
+            data: () => ({
+                role: index % 2 ? 'assistant' : 'user',
+                text: `Newest message ${index}`,
+                conversationId: 'conversation-newest',
+                clientCreatedAt: new Date(Date.UTC(2026, 5, 30, 12, 0, 80 - index)).toISOString()
+            })
+        }));
+        const legacyCursorDocument = {
+            id: 'legacy-question',
+            data: () => ({
+                role: 'user',
+                text: 'Older legacy question',
+                clientCreatedAt: '2026-05-20T12:00:00Z'
+            })
+        };
+        firebaseMocks.getDocs
+            .mockResolvedValueOnce({ docs: [] })
+            .mockResolvedValueOnce({ docs: newestConversationDocuments })
+            .mockResolvedValueOnce({ docs: [legacyCursorDocument] });
+
+        const { loadPrivateAiConversations } = await import('../../apps/app/src/lib/privateAiService.ts');
+        const conversations = await loadPrivateAiConversations(authUser, 2);
+
+        expect(conversations.map((conversation) => conversation.id)).toEqual(['conversation-newest', 'default']);
+        expect(conversations[1]).toMatchObject({ title: 'Older legacy question' });
+        expect(firebaseMocks.getDocs).toHaveBeenCalledTimes(3);
+        expect(firebaseMocks.startAfter).toHaveBeenCalledWith(newestConversationDocuments[79]);
     });
 
     it('saves the prompt, lets AI request schedule data, and saves the answer privately', async () => {

--- a/tests/unit/app-private-ai-service.test.js
+++ b/tests/unit/app-private-ai-service.test.js
@@ -442,7 +442,7 @@ describe('private AI service', () => {
             data: () => ({
                 role: index % 2 ? 'assistant' : 'user',
                 text: `Newest message ${index}`,
-                conversationId: 'conversation-newest',
+                conversationId: `conversation-${index % 30}`,
                 clientCreatedAt: new Date(Date.UTC(2026, 5, 30, 12, 0, 80 - index)).toISOString()
             })
         }));
@@ -462,9 +462,50 @@ describe('private AI service', () => {
         const { loadPrivateAiConversations } = await import('../../apps/app/src/lib/privateAiService.ts');
         const conversations = await loadPrivateAiConversations(authUser, 2);
 
-        expect(conversations.map((conversation) => conversation.id)).toEqual(['conversation-newest', 'default']);
-        expect(conversations[1]).toMatchObject({ title: 'Older legacy question' });
+        expect(conversations.map((conversation) => conversation.id)).toContain('default');
+        expect(conversations.find((conversation) => conversation.id === 'default')).toMatchObject({ title: 'Older legacy question' });
         expect(firebaseMocks.getDocs).toHaveBeenCalledTimes(3);
+        expect(firebaseMocks.startAfter).toHaveBeenCalledWith(newestConversationDocuments[79]);
+    });
+
+    it('paginates message loading when the selected conversation is older than the newest 80 messages', async () => {
+        const newestConversationDocuments = Array.from({ length: 80 }, (_, index) => ({
+            id: `newest-${index}`,
+            data: () => ({
+                role: index % 2 ? 'assistant' : 'user',
+                text: `Newest message ${index}`,
+                conversationId: 'conversation-newest',
+                clientCreatedAt: new Date(Date.UTC(2026, 5, 30, 12, 0, 80 - index)).toISOString()
+            })
+        }));
+        const olderConversationDocuments = [
+            {
+                id: 'older-answer',
+                data: () => ({
+                    role: 'assistant',
+                    text: 'Older answer',
+                    conversationId: 'conversation-older',
+                    clientCreatedAt: '2026-05-20T12:01:00Z'
+                })
+            },
+            {
+                id: 'older-question',
+                data: () => ({
+                    role: 'user',
+                    text: 'Older question',
+                    conversationId: 'conversation-older',
+                    clientCreatedAt: '2026-05-20T12:00:00Z'
+                })
+            }
+        ];
+        firebaseMocks.getDocs
+            .mockResolvedValueOnce({ docs: newestConversationDocuments })
+            .mockResolvedValueOnce({ docs: olderConversationDocuments });
+
+        const { loadPrivateAiMessages } = await import('../../apps/app/src/lib/privateAiService.ts');
+        const messages = await loadPrivateAiMessages(authUser, undefined, 'conversation-older');
+
+        expect(messages.map((message) => message.id)).toEqual(['older-question', 'older-answer']);
         expect(firebaseMocks.startAfter).toHaveBeenCalledWith(newestConversationDocuments[79]);
     });
 

--- a/tests/unit/app-private-ai-service.test.js
+++ b/tests/unit/app-private-ai-service.test.js
@@ -349,6 +349,92 @@ describe('private AI service', () => {
         );
     });
 
+    it('recovers message-backed conversations missing metadata and keeps them ordered without duplicates', async () => {
+        firebaseMocks.getDocs
+            .mockResolvedValueOnce({
+                docs: [
+                    {
+                        id: 'conversation-1',
+                        data: () => ({
+                            title: 'Saved player plan',
+                            lastMessagePreview: 'Metadata wins for this thread.',
+                            clientCreatedAt: '2026-05-20T12:00:00Z',
+                            clientUpdatedAt: '2026-05-21T12:05:00Z'
+                        })
+                    }
+                ]
+            })
+            .mockResolvedValueOnce({
+                docs: [
+                    {
+                        id: 'legacy-answer',
+                        data: () => ({
+                            role: 'assistant',
+                            text: 'Legacy answer',
+                            clientCreatedAt: '2026-05-23T12:01:00Z'
+                        })
+                    },
+                    {
+                        id: 'legacy-question',
+                        data: () => ({
+                            role: 'user',
+                            text: 'What did I miss?',
+                            clientCreatedAt: '2026-05-23T12:00:00Z'
+                        })
+                    },
+                    {
+                        id: 'orphan-answer',
+                        data: () => ({
+                            role: 'assistant',
+                            text: 'Here is the practice plan.',
+                            conversationId: 'conversation-2',
+                            clientCreatedAt: '2026-05-22T12:01:00Z'
+                        })
+                    },
+                    {
+                        id: 'orphan-question',
+                        data: () => ({
+                            role: 'user',
+                            text: 'Build a practice plan',
+                            conversationId: 'conversation-2',
+                            clientCreatedAt: '2026-05-22T12:00:00Z'
+                        })
+                    },
+                    {
+                        id: 'stored-message',
+                        data: () => ({
+                            role: 'user',
+                            text: 'This must not duplicate conversation-1',
+                            conversationId: 'conversation-1',
+                            clientCreatedAt: '2026-05-21T12:00:00Z'
+                        })
+                    }
+                ]
+            });
+
+        const { loadPrivateAiConversations } = await import('../../apps/app/src/lib/privateAiService.ts');
+        const conversations = await loadPrivateAiConversations(authUser);
+
+        expect(conversations).toEqual([
+            expect.objectContaining({
+                id: 'default',
+                title: 'What did I miss?',
+                lastMessagePreview: 'Legacy answer'
+            }),
+            expect.objectContaining({
+                id: 'conversation-2',
+                title: 'Build a practice plan',
+                lastMessagePreview: 'Here is the practice plan.'
+            }),
+            expect.objectContaining({
+                id: 'conversation-1',
+                title: 'Saved player plan',
+                lastMessagePreview: 'Metadata wins for this thread.'
+            })
+        ]);
+        expect(conversations.filter((conversation) => conversation.id === 'conversation-1')).toHaveLength(1);
+    });
+
     it('saves the prompt, lets AI request schedule data, and saves the answer privately', async () => {
         aiMocks.model.generateContent
             .mockResolvedValueOnce(modelText(JSON.stringify({

--- a/tests/unit/app-private-ai-service.test.js
+++ b/tests/unit/app-private-ai-service.test.js
@@ -349,7 +349,7 @@ describe('private AI service', () => {
         );
     });
 
-    it('recovers message-backed conversations missing metadata and keeps them ordered without duplicates', async () => {
+    it('recovers message-backed conversations without letting legacy default replace a stored initial chat', async () => {
         firebaseMocks.getDocs
             .mockResolvedValueOnce({
                 docs: [
@@ -417,11 +417,6 @@ describe('private AI service', () => {
 
         expect(conversations).toEqual([
             expect.objectContaining({
-                id: 'default',
-                title: 'What did I miss?',
-                lastMessagePreview: 'Legacy answer'
-            }),
-            expect.objectContaining({
                 id: 'conversation-2',
                 title: 'Build a practice plan',
                 lastMessagePreview: 'Here is the practice plan.'
@@ -432,6 +427,7 @@ describe('private AI service', () => {
                 lastMessagePreview: 'Metadata wins for this thread.'
             })
         ]);
+        expect(conversations.some((conversation) => conversation.id === 'default')).toBe(false);
         expect(conversations.filter((conversation) => conversation.id === 'conversation-1')).toHaveLength(1);
     });
 


### PR DESCRIPTION
## Summary

- recover Private AI conversation summaries from persisted message records when metadata is missing
- merge recovered and stored conversations without duplicates and keep newest threads first
- preserve legacy unscoped messages as the default saved chat alongside newer conversations
- rename the ambiguous Chats metric to Saved chats
- add service, component, and browser regression coverage

## Why

Past chats was populated only from the capped `privateAiConversations` metadata query. Persisted message-backed threads could therefore disappear when metadata was incomplete, and legacy default history was recovered only when no metadata records existed at all.

The new read path treats message history as a non-mutating recovery source. It does not invent browser-session boundaries or write migration data during page load.

Closes #4103

## Validation

- `npx vitest run tests/unit/app-private-ai-service.test.js apps/app/src/pages/PrivateAiChat.test.tsx --reporter=dot` — 27 passed
- `SMOKE_BASE_URL=http://127.0.0.1:5185 SMOKE_APP_BASE_URL=http://127.0.0.1:5185 npx playwright test tests/smoke/app-private-ai.spec.js --config=playwright.smoke.config.js --reporter=dot` — 4 passed
- `npm run app:build` — TypeScript check, Vite production build, artifact verification, and bundle visualizer verification passed
- `git diff --check` — passed
