### PR TITLE
Redact email addresses from auth/session logs

### DIFF
--- a/apps/app/src/lib/logger.test.ts
+++ b/apps/app/src/lib/logger.test.ts
@@ -160,4 +160,16 @@ describe('logger', () => {
             '[schedule-service] Fetch failed for https://example.test/callback?access_token=[REDACTED]&teamId=team-1#id_token=[REDACTED]'
         );
     });
+
+    it('redacts email addresses from auth failures and other free-form logs', () => {
+        const error = new Error('Account parent@example.com could not be restored.');
+
+        expect(normalizeErrorForLogging(error)).toEqual({
+            name: 'Error',
+            message: 'Account [REDACTED_EMAIL] could not be restored.'
+        });
+        expect(sanitizeForLogging('Retry Player+One@Example.CO.UK later.')).toBe(
+            'Retry [REDACTED_EMAIL] later.'
+        );
+    });
 });

--- a/apps/app/src/lib/logger.ts
+++ b/apps/app/src/lib/logger.ts
@@ -77,6 +77,19 @@ function redactSensitiveAssignments(value: string) {
     );
 }
 
+function redactEmailAddresses(value: string) {
+    return value.replace(
+        /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
+        '[REDACTED_EMAIL]'
+    );
+}
+
+function redactFreeFormSecrets(value: string) {
+    return redactEmailAddresses(
+        redactSensitiveAssignments(redactSensitiveQueryParams(redactBearerTokens(value)))
+    );
+}
+
 function isHeadersLike(value: unknown): value is Headers {
     return typeof Headers !== 'undefined' && value instanceof Headers;
 }
@@ -87,7 +100,7 @@ function sanitizeValue(value: unknown, seen: WeakSet<object>, depth: number, key
     if (typeof value === 'string') {
         return isSensitiveKey(keyHint)
             ? redactedValue
-            : redactSensitiveAssignments(redactSensitiveQueryParams(redactBearerTokens(value)));
+            : redactFreeFormSecrets(value);
     }
 
     if (typeof value !== 'object') {

--- a/docs/pr-notes/runs/issue-4101-fixer-20260720T235037Z/architecture.md
+++ b/docs/pr-notes/runs/issue-4101-fixer-20260720T235037Z/architecture.md
@@ -1,0 +1,27 @@
+# Current-State Read
+
+The shared logger redacts secret-shaped keys, bearer tokens, sensitive URL parameters, and assignments, but not identity-shaped PII embedded in ordinary strings. Auth/session errors can therefore leak email addresses after passing through the approved logger.
+
+# Proposed Design
+
+Add a small email-address redactor to the existing free-form sanitizer composition. Keep `sanitizeValue` as the single entry point so direct messages, nested values, normalized errors, and telemetry consumers inherit the protection.
+
+# Files And Modules Touched
+
+- `apps/app/src/lib/logger.ts`
+- `apps/app/src/lib/logger.test.ts`
+
+# Data/State Impacts
+
+No persisted data, schema, auth state, session state, cache, or Firebase changes. Only emitted diagnostic text changes.
+
+# Security/Permissions Impacts
+
+PII exposure is reduced without changing permissions, tenant isolation, plugins, native shells, credentials, or signing policy.
+
+# Failure Modes And Mitigations
+
+- Conservative false positives are acceptable in logs; surrounding diagnostic context remains.
+- Unusual internationalized address forms may be missed; broader PII detection is a separate reviewed slice.
+- Existing sanitizer tests protect token and secret behavior from composition regressions.
+- Raw `console.*` calls remain outside this slice.

--- a/docs/pr-notes/runs/issue-4101-fixer-20260720T235037Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-4101-fixer-20260720T235037Z/code-plan.md
@@ -1,0 +1,22 @@
+# Patch Plan
+
+1. Add a regression test showing that account emails survive the current shared sanitizer.
+2. Add `redactEmailAddresses` and compose it with the existing free-form secret redactors.
+3. Route non-sensitive-key strings through the composed sanitizer.
+4. Run the focused app logger test and `git diff --check`.
+
+# Code Changes Applied
+
+None during role analysis. Intended changes are limited to `logger.ts` and `logger.test.ts`.
+
+# Validation Run
+
+The code role ran the current-master baseline: one logger test file passed with six tests. Post-patch validation remains for the main run.
+
+# Residual Risks
+
+The pragmatic regex may miss unusual address syntax. Direct `console.*` calls bypass the shared sanitizer and remain out of scope. Recurrence risk is low once the centralized regression is present.
+
+# Commit Message Draft
+
+`Redact email addresses from auth logs (#4101)`

--- a/docs/pr-notes/runs/issue-4101-fixer-20260720T235037Z/qa.md
+++ b/docs/pr-notes/runs/issue-4101-fixer-20260720T235037Z/qa.md
@@ -1,0 +1,38 @@
+# Risk Matrix
+
+| Risk | Level | Mitigation |
+|---|---|---|
+| Email PII remains in normalized auth/session errors | High | Test `normalizeErrorForLogging` with a representative account email. |
+| Nested/free-form values bypass redaction | High | Test direct `sanitizeForLogging` with plus-address and multi-part domain. |
+| Existing token/secret redaction regresses | Medium | Retain the focused logger suite unchanged. |
+| Regex over-redacts diagnostic text | Low | Use a bounded conventional-email pattern and preserve surrounding text. |
+| Signing-dependent work enters scope | High | Limit the diff to logger implementation, test, and run notes. |
+
+# Automated Tests To Add/Update
+
+- Add a focused logger regression covering normalized `Error.message` email PII.
+- Cover plus-addressed and multi-part-domain email text through the shared sanitizer.
+- Run the complete focused logger test file to retain credential-redaction coverage.
+
+# Manual Test Plan
+
+No user-facing behavior changes. Inspect a representative sanitized auth failure and confirm the email is replaced while operation/error context remains.
+
+# Negative Tests
+
+- Existing bearer token, URL secret, structured secret-key, circular value, and truncation cases remain green.
+- Confirm ordinary non-email prose is unchanged.
+
+# Release Gates
+
+- Focused logger test passes.
+- `git diff --check` passes.
+- No auth persistence, bootstrap hint, install epoch, association, signing, or native build files change.
+
+# Post-Deploy Checks
+
+Sample auth/session diagnostics for one release window and verify account emails are absent while error scopes and status metadata remain usable.
+
+## Role Conflict Note
+
+QA initially recommended bootstrap-hint minimization. The orchestrator selected logger redaction because three roles converged on it and it has the smaller state and routing blast radius. Bootstrap hints remain an independent follow-up PR.

--- a/docs/pr-notes/runs/issue-4101-fixer-20260720T235037Z/requirements.md
+++ b/docs/pr-notes/runs/issue-4101-fixer-20260720T235037Z/requirements.md
@@ -1,0 +1,34 @@
+# Problem Statement
+
+Current logging sanitizes credentials but leaves email addresses intact in free-form messages and normalized errors. Auth/session failures can therefore expose parent, coach, athlete, or administrator identity data. The narrowest self-contained PR is email redaction in the shared logger.
+
+# User Segments Impacted
+
+- Parents, coaches, and administrators whose account identifiers may appear in diagnostics.
+- Support and engineering operators, who still need safe error type, status, operation, and message context.
+
+# Acceptance Criteria
+
+1. Conventional email addresses in strings processed by the shared sanitizer become `[REDACTED_EMAIL]`.
+2. Mixed-case, plus-addressed, and multi-part-domain addresses are covered.
+3. `Error.message`, nested structured values, and direct logger messages use the same redaction path.
+4. Existing credential redaction and safe diagnostic context remain unchanged.
+5. Auth/session UI and authorization behavior do not change.
+6. Focused regression tests fail on current master and pass after the fix.
+
+# Non-Goals
+
+- Secure session storage, image-upload session migration, install epochs, or bootstrap-hint minimization.
+- Association-file enforcement, signing evidence, session purge, or auth-routing changes.
+- Reviving or rebasing the frozen #4046 branch.
+
+# Edge Cases
+
+- Multiple and nested email addresses.
+- Plus-addresses and multi-label domains.
+- Email and token data in the same message.
+- Non-email text containing `@` should not be broadly erased.
+
+# Open Questions
+
+None blocking.

--- a/docs/pr-notes/runs/issue-4101-fixer-20260720T235037Z/synthesis.md
+++ b/docs/pr-notes/runs/issue-4101-fixer-20260720T235037Z/synthesis.md
@@ -1,0 +1,21 @@
+# Acceptance Criteria
+
+1. Shared logger strings redact conventional email addresses as `[REDACTED_EMAIL]`.
+2. Normalized errors and nested/free-form values share the protection.
+3. Existing credential redaction and diagnostic context remain intact.
+
+# Architecture Decisions
+
+Implement only at the centralized logger boundary. Do not change auth state, storage, routing, native plugins, or signing enforcement.
+
+# QA Plan
+
+Prove the defect with a focused regression first, then run the complete logger test file and whitespace validation.
+
+# Implementation Plan
+
+Add one composed free-form redaction helper in `logger.ts` and one focused test in `logger.test.ts`.
+
+# Risks And Rollback
+
+Blast radius is shared diagnostic output only. A rollback is a two-file revert. Bootstrap-hint minimization was considered but rejected for this PR because it changes persisted state and an app routing consumer; it remains a separate issue slice.


### PR DESCRIPTION
Closes #4101

## What changed
- Redact conventional email addresses in shared app log messages, nested context, and normalized errors.
- Preserve existing token, secret, and URL-parameter redaction.
- Add focused regression coverage for standard, mixed-case, plus-addressed, and multi-part-domain emails.
- Exclude signing enforcement, association files, session storage, install epochs, and bootstrap hints.

## Root Cause
The shared logger recognized credential-shaped keys and token syntax but treated identity-shaped PII embedded in ordinary strings and error messages as safe. Auth/session failures could therefore emit account email addresses through the approved logging path.

## Prevention / Learning
Sensitive identifier classes must be redacted by value pattern at the centralized logging boundary. Each new identifier class should have regressions covering both free-form strings and normalized errors.

## Regression Tests
- `npx vitest run src/lib/logger.test.ts --reporter=verbose` passed all 7 tests.
- The new regression failed before the fix by exposing `parent@example.com`.
- `git diff --check` passed.

## Recurrence Risk
Low. All approved shared logger string paths use the centralized sanitizer, and focused tests cover representative email formats.