### PR TITLE
Add season-aware team performance insights

### DIFF
--- a/apps/app/src/lib/adapters/legacyTeamDetail.ts
+++ b/apps/app/src/lib/adapters/legacyTeamDetail.ts
@@ -7,7 +7,7 @@ import { inviteExistingTeamAdmin as legacy_inviteExistingTeamAdmin } from '@lega
 import * as legacyFirebase from '@legacy/firebase.js';
 import { collectRosterParentContacts as legacy_collectRosterParentContacts, mergeStandardRosterFieldDefinitions as legacy_mergeStandardRosterFieldDefinitions, normalizeRosterFieldDefinitions as legacy_normalizeRosterFieldDefinitions, splitRosterProfileValuesByVisibility as legacy_splitRosterProfileValuesByVisibility, validateRosterProfileValues as legacy_validateRosterProfileValues } from '@legacy/roster-profile-fields.js';
 import { describeScheduleReminderWindow as legacy_describeScheduleReminderWindow, normalizeScheduleNotificationSettings as legacy_normalizeScheduleNotificationSettings } from '@legacy/schedule-notifications.js';
-import { calculateSeasonRecord as legacy_calculateSeasonRecord, listSeasonLabels as legacy_listSeasonLabels } from '@legacy/season-record.js';
+import { calculateSeasonRecord as legacy_calculateSeasonRecord, getTeamScorePair as legacy_getTeamScorePair, listSeasonLabels as legacy_listSeasonLabels } from '@legacy/season-record.js';
 import { computeNativeStandings as legacy_computeNativeStandings } from '@legacy/native-standings.js';
 import { buildPlayerLeaderboardSnapshot as legacy_buildPlayerLeaderboardSnapshot, normalizeStatTrackerConfig as legacy_normalizeStatTrackerConfig, selectAnalyticsConfig as legacy_selectAnalyticsConfig } from '@legacy/stat-leaderboards.js';
 import { getVisiblePlayerTrackingSummary as legacy_getVisiblePlayerTrackingSummary, normalizeTrackingStatus as legacy_normalizeTrackingStatus } from '@legacy/player-tracking-summary.js';
@@ -83,6 +83,7 @@ export const validateRosterProfileValues = legacy_validateRosterProfileValues as
 export const describeScheduleReminderWindow = legacy_describeScheduleReminderWindow as (...args: any[]) => any;
 export const normalizeScheduleNotificationSettings = legacy_normalizeScheduleNotificationSettings as (...args: any[]) => any;
 export const calculateSeasonRecord = legacy_calculateSeasonRecord as (...args: any[]) => any;
+export const getTeamScorePair = legacy_getTeamScorePair as (...args: any[]) => any;
 export const listSeasonLabels = legacy_listSeasonLabels as (...args: any[]) => any;
 export const computeNativeStandings = legacy_computeNativeStandings as (...args: any[]) => any;
 export const buildPlayerLeaderboardSnapshot = legacy_buildPlayerLeaderboardSnapshot as (...args: any[]) => any;

--- a/apps/app/src/lib/teamDetailService.test.ts
+++ b/apps/app/src/lib/teamDetailService.test.ts
@@ -50,6 +50,11 @@ const authServiceMocks = vi.hoisted(() => ({
   getNativeAuthIdToken: vi.fn()
 }));
 
+const seasonRecordMocks = vi.hoisted(() => ({
+  calculateSeasonRecord: vi.fn(() => ({ wins: 0, losses: 0, ties: 0 })),
+  listSeasonLabels: vi.fn((): string[] => [])
+}));
+
 vi.mock('@capacitor/core', () => ({ Capacitor: { isNativePlatform: vi.fn(() => false), getPlatform: vi.fn(() => 'web') } }));
 vi.mock('@capacitor-firebase/authentication', () => ({ FirebaseAuthentication: {} }));
 vi.mock('../../../../js/db.js', () => dbMocks);
@@ -74,10 +79,7 @@ vi.mock('../../../../js/schedule-notifications.js', () => ({
   describeScheduleReminderWindow: vi.fn(() => '24 hours'),
   normalizeScheduleNotificationSettings: vi.fn((value) => ({ enabled: Boolean(value?.enabled), reminderHours: 24, delivery: 'team_chat' }))
 }));
-vi.mock('../../../../js/season-record.js', () => ({
-  calculateSeasonRecord: vi.fn(() => ({ wins: 0, losses: 0, ties: 0 })),
-  listSeasonLabels: vi.fn(() => [])
-}));
+vi.mock('../../../../js/season-record.js', () => seasonRecordMocks);
 vi.mock('../../../../js/native-standings.js', () => ({ computeNativeStandings: vi.fn(() => []) }));
 vi.mock('../../../../js/stat-leaderboards.js', async () => {
   const actual = await vi.importActual<any>('../../../../js/stat-leaderboards.js');
@@ -113,6 +115,7 @@ import {
   createStatTrackerConfigForApp,
   loadParentTeamDetail,
   loadParentTeamDetailBootstrap,
+  loadTeamDetailInsights,
   loadTeamTrackingAdmin,
   revokeTeamAdminAccessForApp,
   saveTeamTrackingItemForApp,
@@ -215,6 +218,7 @@ describe('buildTeamAnalytics', () => {
 
 beforeEach(() => {
   vi.mocked(hasFullTeamAccess).mockImplementation(() => true);
+  seasonRecordMocks.listSeasonLabels.mockReturnValue([]);
   dbMocks.getPlayersWithPrivateRosterContacts.mockImplementation((_teamId: string, options: any = {}) => (
     Array.isArray(options.players) ? options.players : dbMocks.getPlayers(_teamId, options)
   ));
@@ -352,6 +356,20 @@ describe('team detail bootstrap loading', () => {
     expect(dbMocks.getPlayers).toHaveBeenCalledTimes(1);
     expect(dbMocks.getGames).toHaveBeenCalledTimes(1);
     expect(dbMocks.getConfigs).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps deferred insights aligned to the current header season without final scores', async () => {
+    seasonRecordMocks.listSeasonLabels.mockReturnValue(['2026', '2025']);
+    dbMocks.getGames.mockResolvedValue([
+      { id: 'current', type: 'game', status: 'scheduled', seasonLabel: '2026', date: '2026-03-01T18:00:00Z' },
+      { id: 'older', type: 'game', status: 'completed', seasonLabel: '2025', date: '2025-10-01T18:00:00Z', homeScore: 5, awayScore: 0 }
+    ]);
+
+    const insights = await loadTeamDetailInsights('team-1', { uid: 'parent-1' } as any);
+
+    expect(insights.teamAnalytics.seasonLabel).toBe('2026');
+    expect(insights.teamAnalytics.completedGameCount).toBe(0);
+    expect(insights.teamAnalytics.availableSeasons).toEqual(['2026', '2025']);
   });
 
   it('never hydrates or returns private roster contacts for a non-manager', async () => {

--- a/apps/app/src/lib/teamDetailService.test.ts
+++ b/apps/app/src/lib/teamDetailService.test.ts
@@ -131,6 +131,7 @@ describe('buildTeamAnalytics', () => {
     ]);
 
     expect(analytics).toMatchObject({
+      seasonLabel: '2026',
       completedGameCount: 3,
       recentWins: 1,
       recentLosses: 1,
@@ -156,6 +157,7 @@ describe('buildTeamAnalytics', () => {
 
   it('returns an explicit empty snapshot without completed score-bearing games', () => {
     expect(buildTeamAnalytics([])).toEqual({
+      seasonLabel: String(new Date().getFullYear()),
       completedGameCount: 0,
       recentWins: 0,
       recentLosses: 0,
@@ -164,8 +166,23 @@ describe('buildTeamAnalytics', () => {
       averagePointsAgainst: 0,
       scoreDifferential: 0,
       recentForm: [],
-      progression: []
+      progression: [],
+      availableSeasons: [],
+      seasons: []
     });
+  });
+
+  it('keeps season snapshots separate and honors the preferred season', () => {
+    const analytics = buildTeamAnalytics([
+      { id: 'older', status: 'completed', seasonLabel: '2025', date: '2025-10-01T18:00:00Z', homeScore: 5, awayScore: 0 },
+      { id: 'current', status: 'completed', seasonLabel: '2026', date: '2026-03-01T18:00:00Z', homeScore: 1, awayScore: 3 }
+    ], '2026');
+
+    expect(analytics.availableSeasons).toEqual(['2026', '2025']);
+    expect(analytics.seasonLabel).toBe('2026');
+    expect(analytics.completedGameCount).toBe(1);
+    expect(analytics.scoreDifferential).toBe(-2);
+    expect(analytics.seasons.map((season) => [season.seasonLabel, season.completedGameCount])).toEqual([['2026', 1], ['2025', 1]]);
   });
 });
 

--- a/apps/app/src/lib/teamDetailService.test.ts
+++ b/apps/app/src/lib/teamDetailService.test.ts
@@ -52,6 +52,13 @@ const authServiceMocks = vi.hoisted(() => ({
 
 const seasonRecordMocks = vi.hoisted(() => ({
   calculateSeasonRecord: vi.fn(() => ({ wins: 0, losses: 0, ties: 0 })),
+  getTeamScorePair: vi.fn((game: any) => {
+    const useStoredScoreOrder = Boolean(String(game?.sharedScheduleSourceTeamId || '').trim()) || game?.isHome !== false;
+    return {
+      teamScore: useStoredScoreOrder ? game?.homeScore : game?.awayScore,
+      opponentScore: useStoredScoreOrder ? game?.awayScore : game?.homeScore
+    };
+  }),
   listSeasonLabels: vi.fn((): string[] => [])
 }));
 

--- a/apps/app/src/lib/teamDetailService.test.ts
+++ b/apps/app/src/lib/teamDetailService.test.ts
@@ -173,6 +173,27 @@ describe('buildTeamAnalytics', () => {
     expect(analytics.scoreDifferential).toBe(3);
   });
 
+  it('preserves team-oriented score order for shared-schedule away mirrors', () => {
+    const analytics = buildTeamAnalytics([{
+      id: 'mirrored-away-win',
+      status: 'completed',
+      isHome: false,
+      date: '2026-03-04T18:00:00Z',
+      opponent: 'Bears',
+      homeScore: 71,
+      awayScore: 68,
+      sharedScheduleSourceTeamId: 'team-alpha'
+    }], '2026');
+
+    expect(analytics.progression[0]).toMatchObject({
+      id: 'mirrored-away-win',
+      pointsFor: 71,
+      pointsAgainst: 68,
+      result: 'W',
+      differential: 3
+    });
+  });
+
   it('returns an explicit empty snapshot without completed score-bearing games', () => {
     expect(buildTeamAnalytics([])).toEqual({
       seasonLabel: String(new Date().getFullYear()),

--- a/apps/app/src/lib/teamDetailService.test.ts
+++ b/apps/app/src/lib/teamDetailService.test.ts
@@ -155,6 +155,21 @@ describe('buildTeamAnalytics', () => {
     expect(analytics.progression[0]).toMatchObject({ id: 'live-finished', result: 'W', differential: 1 });
   });
 
+  it('orders the team score correctly for completed away games', () => {
+    const analytics = buildTeamAnalytics([
+      { id: 'away-win', status: 'completed', isHome: false, date: '2026-03-04T18:00:00Z', opponent: 'Bears', homeScore: 68, awayScore: 71 }
+    ], '2026');
+
+    expect(analytics.progression[0]).toMatchObject({
+      id: 'away-win',
+      pointsFor: 71,
+      pointsAgainst: 68,
+      result: 'W',
+      differential: 3
+    });
+    expect(analytics.scoreDifferential).toBe(3);
+  });
+
   it('returns an explicit empty snapshot without completed score-bearing games', () => {
     expect(buildTeamAnalytics([])).toEqual({
       seasonLabel: String(new Date().getFullYear()),
@@ -183,6 +198,18 @@ describe('buildTeamAnalytics', () => {
     expect(analytics.completedGameCount).toBe(1);
     expect(analytics.scoreDifferential).toBe(-2);
     expect(analytics.seasons.map((season) => [season.seasonLabel, season.completedGameCount])).toEqual([['2026', 1], ['2025', 1]]);
+  });
+
+  it('keeps the preferred season selected when only an older season has final scores', () => {
+    const analytics = buildTeamAnalytics([
+      { id: 'older', status: 'completed', seasonLabel: '2025', date: '2025-10-01T18:00:00Z', homeScore: 5, awayScore: 0 },
+      { id: 'scheduled-current', status: 'scheduled', seasonLabel: '2026', date: '2026-03-01T18:00:00Z' }
+    ], '2026');
+
+    expect(analytics.seasonLabel).toBe('2026');
+    expect(analytics.completedGameCount).toBe(0);
+    expect(analytics.availableSeasons).toEqual(['2026', '2025']);
+    expect(analytics.seasons.map((season) => [season.seasonLabel, season.completedGameCount])).toEqual([['2026', 0], ['2025', 1]]);
   });
 });
 

--- a/apps/app/src/lib/teamDetailService.test.ts
+++ b/apps/app/src/lib/teamDetailService.test.ts
@@ -108,6 +108,7 @@ vi.mock('./profileService', () => ({ loadProfileDocument: vi.fn(async () => ({})
 
 import {
   __resetTeamDetailBaseSnapshotCacheForTests,
+  buildTeamAnalytics,
   buildTeamDetailModel,
   createStatTrackerConfigForApp,
   loadParentTeamDetail,
@@ -120,6 +121,53 @@ import {
 } from './teamDetailService';
 import { computeNativeStandings } from '../../../../js/native-standings.js';
 import { hasFullTeamAccess } from '../../../../js/team-access.js';
+
+describe('buildTeamAnalytics', () => {
+  it('builds chronological score trends, recent form, averages, and differential', () => {
+    const analytics = buildTeamAnalytics([
+      { id: 'game-3', status: 'completed', date: '2026-03-03T18:00:00Z', opponent: 'Owls', homeScore: 2, awayScore: 2 },
+      { id: 'game-1', status: 'completed', date: '2026-03-01T18:00:00Z', opponent: 'Bears', homeScore: 4, awayScore: 1 },
+      { id: 'game-2', status: 'completed', date: '2026-03-02T18:00:00Z', opponent: 'Cats', homeScore: 1, awayScore: 3 }
+    ]);
+
+    expect(analytics).toMatchObject({
+      completedGameCount: 3,
+      recentWins: 1,
+      recentLosses: 1,
+      recentTies: 1,
+      averagePointsFor: 2.3,
+      averagePointsAgainst: 2,
+      scoreDifferential: 1
+    });
+    expect(analytics.progression.map((game) => game.id)).toEqual(['game-1', 'game-2', 'game-3']);
+    expect(analytics.progression.map((game) => game.result)).toEqual(['W', 'L', 'T']);
+  });
+
+  it('accepts live-completed games and ignores games without final scores', () => {
+    const analytics = buildTeamAnalytics([
+      { id: 'live-finished', status: 'scheduled', liveStatus: 'completed', date: '2026-03-01T18:00:00Z', homeScore: 5, awayScore: 4 },
+      { id: 'no-score', status: 'completed', date: '2026-03-02T18:00:00Z' },
+      { id: 'practice', type: 'practice', status: 'completed', date: '2026-03-03T18:00:00Z', homeScore: 1, awayScore: 0 }
+    ]);
+
+    expect(analytics.completedGameCount).toBe(1);
+    expect(analytics.progression[0]).toMatchObject({ id: 'live-finished', result: 'W', differential: 1 });
+  });
+
+  it('returns an explicit empty snapshot without completed score-bearing games', () => {
+    expect(buildTeamAnalytics([])).toEqual({
+      completedGameCount: 0,
+      recentWins: 0,
+      recentLosses: 0,
+      recentTies: 0,
+      averagePointsFor: 0,
+      averagePointsAgainst: 0,
+      scoreDifferential: 0,
+      recentForm: [],
+      progression: []
+    });
+  });
+});
 
 beforeEach(() => {
   vi.mocked(hasFullTeamAccess).mockImplementation(() => true);

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -2463,11 +2463,11 @@ export function buildTeamAnalytics(games: any[] = [], preferredSeasonLabel = '')
   const completedGames = (Array.isArray(games) ? games : [])
     .filter(isCompletedGame)
     .map((game, index): TeamDetailAnalyticsGame => {
-      const isHome = game?.isHome !== false;
+      const useStoredScoreOrder = Boolean(cleanString(game?.sharedScheduleSourceTeamId)) || game?.isHome !== false;
       const homeScore = toNullableNumber(game?.homeScore) || 0;
       const awayScore = toNullableNumber(game?.awayScore) || 0;
-      const pointsFor = isHome ? homeScore : awayScore;
-      const pointsAgainst = isHome ? awayScore : homeScore;
+      const pointsFor = useStoredScoreOrder ? homeScore : awayScore;
+      const pointsAgainst = useStoredScoreOrder ? awayScore : homeScore;
       const date = toDate(game?.date);
       const opponent = cleanString(game?.opponent || game?.awayTeam || game?.title)
         .replace(/^vs\.?\s*/i, '') || 'Opponent';

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -1541,6 +1541,9 @@ export function loadTeamDetailInsights(teamId: string, user: AuthUser | null): P
     if (!team) throw new Error('Team not found.');
 
     const linkedPlayerIds = getLinkedPlayerIds(user, normalizedTeamId, players);
+    const seasonLabels = listSeasonLabels(games);
+    const currentYearLabel = String(new Date().getFullYear());
+    const seasonLabel = seasonLabels.includes(currentYearLabel) ? currentYearLabel : (seasonLabels[0] || currentYearLabel);
     const completedGameIds = (Array.isArray(games) ? games : [])
       .filter(isCompletedGame)
       .map((game: any) => cleanString(game.id || game.gameId))
@@ -1556,7 +1559,7 @@ export function loadTeamDetailInsights(teamId: string, user: AuthUser | null): P
     return {
       leaderboards: buildLeaderboards(configs, normalizedPlayers, seasonStatsByPlayerId, team?.sport),
       trackingSummaries: buildTrackingSummaries(normalizedPlayers, linkedPlayerIds, trackingItems, trackingStatuses),
-      teamAnalytics: buildTeamAnalytics(games)
+      teamAnalytics: buildTeamAnalytics(games, seasonLabel)
     };
   })();
   teamDetailInsightsCache.set(cacheKey, request);

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -197,6 +197,29 @@ export type TeamDetailTrackingSummary = {
   }>;
 };
 
+export type TeamDetailAnalyticsGame = {
+  id: string;
+  date: Date;
+  dateLabel: string;
+  opponent: string;
+  pointsFor: number;
+  pointsAgainst: number;
+  differential: number;
+  result: 'W' | 'L' | 'T';
+};
+
+export type TeamDetailAnalytics = {
+  completedGameCount: number;
+  recentWins: number;
+  recentLosses: number;
+  recentTies: number;
+  averagePointsFor: number;
+  averagePointsAgainst: number;
+  scoreDifferential: number;
+  recentForm: TeamDetailAnalyticsGame[];
+  progression: TeamDetailAnalyticsGame[];
+};
+
 export type TeamDetailSponsor = {
   id: string;
   name: string;
@@ -311,6 +334,7 @@ export type TeamDetailModel = {
   };
   leaderboards: TeamDetailLeaderboard[];
   trackingSummaries: TeamDetailTrackingSummary[];
+  teamAnalytics: TeamDetailAnalytics;
   sponsors: TeamDetailSponsor[];
   statTrackerConfigs: TeamDetailStatTrackerConfig[];
   canManageTeam: boolean;
@@ -357,6 +381,7 @@ export type TeamTrackingItemForAppInput = {
 export type TeamDetailInsightsPayload = {
   leaderboards: TeamDetailLeaderboard[];
   trackingSummaries: TeamDetailTrackingSummary[];
+  teamAnalytics: TeamDetailAnalytics;
 };
 
 export type TeamDetailSponsorsPayload = {
@@ -1523,7 +1548,8 @@ export function loadTeamDetailInsights(teamId: string, user: AuthUser | null): P
     const normalizedPlayers = normalizePlayers(players, linkedPlayerIds);
     return {
       leaderboards: buildLeaderboards(configs, normalizedPlayers, seasonStatsByPlayerId, team?.sport),
-      trackingSummaries: buildTrackingSummaries(normalizedPlayers, linkedPlayerIds, trackingItems, trackingStatuses)
+      trackingSummaries: buildTrackingSummaries(normalizedPlayers, linkedPlayerIds, trackingItems, trackingStatuses),
+      teamAnalytics: buildTeamAnalytics(games)
     };
   })();
   teamDetailInsightsCache.set(cacheKey, request);
@@ -1742,6 +1768,7 @@ export function buildTeamDetailModel({
   const standings = buildStandings(team, games);
   const leaderboards = includeInsights ? buildLeaderboards(configs, normalizedPlayers, seasonStatsByPlayerId, team?.sport) : [];
   const trackingSummaries = includeInsights ? buildTrackingSummaries(normalizedPlayers, linkedPlayerIds, trackingItems, trackingStatuses) : [];
+  const teamAnalytics = buildTeamAnalytics(games);
   const canManageAdmins = canManageTeamAdmins(user, team);
   const staffPermissions = canManageTeam && includeStaffPermissions
     ? buildTeamStaffPermissionsSummary({ teamId, team, players, pendingAdminInvites, confirmedTeamMembers })
@@ -1785,6 +1812,7 @@ export function buildTeamDetailModel({
     standings,
     leaderboards,
     trackingSummaries,
+    teamAnalytics,
     sponsors: sponsors.slice(0, 4),
     statTrackerConfigs: normalizedStatTrackerConfigs.items,
     canManageTeam,
@@ -2421,10 +2449,67 @@ function getStreamUrl(team: Record<string, any>) {
   return getFirstUrl(embedUrl);
 }
 
+export function buildTeamAnalytics(games: any[] = []): TeamDetailAnalytics {
+  const completedGames = (Array.isArray(games) ? games : [])
+    .filter(isCompletedGame)
+    .map((game, index): TeamDetailAnalyticsGame => {
+      const pointsFor = toNullableNumber(game?.homeScore) || 0;
+      const pointsAgainst = toNullableNumber(game?.awayScore) || 0;
+      const date = toDate(game?.date);
+      const opponent = cleanString(game?.opponent || game?.awayTeam || game?.title)
+        .replace(/^vs\.?\s*/i, '') || 'Opponent';
+      return {
+        id: cleanString(game?.id || game?.gameId) || `game-${index + 1}`,
+        date,
+        dateLabel: date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+        opponent,
+        pointsFor,
+        pointsAgainst,
+        differential: pointsFor - pointsAgainst,
+        result: pointsFor > pointsAgainst ? 'W' : pointsFor < pointsAgainst ? 'L' : 'T'
+      };
+    })
+    .sort((a, b) => a.date.getTime() - b.date.getTime());
+
+  if (!completedGames.length) {
+    return {
+      completedGameCount: 0,
+      recentWins: 0,
+      recentLosses: 0,
+      recentTies: 0,
+      averagePointsFor: 0,
+      averagePointsAgainst: 0,
+      scoreDifferential: 0,
+      recentForm: [],
+      progression: []
+    };
+  }
+
+  const recentForm = completedGames.slice(-5);
+  const pointsFor = completedGames.reduce((total, game) => total + game.pointsFor, 0);
+  const pointsAgainst = completedGames.reduce((total, game) => total + game.pointsAgainst, 0);
+  const roundToTenth = (value: number) => Math.round(value * 10) / 10;
+
+  return {
+    completedGameCount: completedGames.length,
+    recentWins: recentForm.filter((game) => game.result === 'W').length,
+    recentLosses: recentForm.filter((game) => game.result === 'L').length,
+    recentTies: recentForm.filter((game) => game.result === 'T').length,
+    averagePointsFor: roundToTenth(pointsFor / completedGames.length),
+    averagePointsAgainst: roundToTenth(pointsAgainst / completedGames.length),
+    scoreDifferential: pointsFor - pointsAgainst,
+    recentForm,
+    progression: completedGames.slice(-10)
+  };
+}
+
 function isCompletedGame(game: any) {
   if (!game || game.type === 'practice') return false;
-  const status = cleanString(game.status || game.liveStatus).toLowerCase();
-  return (status === 'completed' || status === 'final') && toNullableNumber(game.homeScore) !== null && toNullableNumber(game.awayScore) !== null;
+  const status = cleanString(game.status).toLowerCase();
+  const liveStatus = cleanString(game.liveStatus).toLowerCase();
+  return (status === 'completed' || status === 'final' || liveStatus === 'completed' || liveStatus === 'final')
+    && toNullableNumber(game.homeScore) !== null
+    && toNullableNumber(game.awayScore) !== null;
 }
 
 function getWinPercentage(record: { wins: number; losses: number; ties: number }) {

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -26,6 +26,7 @@ import {
   getPublicTrackingItems,
   getRosterFieldDefinitions,
   getTeam,
+  getTeamScorePair,
   getVisiblePlayerTrackingSummary,
   grantScorekeeperAccess,
   grantTeamMediaManagerAccess,
@@ -2463,11 +2464,9 @@ export function buildTeamAnalytics(games: any[] = [], preferredSeasonLabel = '')
   const completedGames = (Array.isArray(games) ? games : [])
     .filter(isCompletedGame)
     .map((game, index): TeamDetailAnalyticsGame => {
-      const useStoredScoreOrder = Boolean(cleanString(game?.sharedScheduleSourceTeamId)) || game?.isHome !== false;
-      const homeScore = toNullableNumber(game?.homeScore) || 0;
-      const awayScore = toNullableNumber(game?.awayScore) || 0;
-      const pointsFor = useStoredScoreOrder ? homeScore : awayScore;
-      const pointsAgainst = useStoredScoreOrder ? awayScore : homeScore;
+      const scorePair = getTeamScorePair(game);
+      const pointsFor = toNullableNumber(scorePair.teamScore) || 0;
+      const pointsAgainst = toNullableNumber(scorePair.opponentScore) || 0;
       const date = toDate(game?.date);
       const opponent = cleanString(game?.opponent || game?.awayTeam || game?.title)
         .replace(/^vs\.?\s*/i, '') || 'Opponent';

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -201,6 +201,7 @@ export type TeamDetailAnalyticsGame = {
   id: string;
   date: Date;
   dateLabel: string;
+  seasonLabel: string;
   opponent: string;
   pointsFor: number;
   pointsAgainst: number;
@@ -208,7 +209,8 @@ export type TeamDetailAnalyticsGame = {
   result: 'W' | 'L' | 'T';
 };
 
-export type TeamDetailAnalytics = {
+export type TeamDetailAnalyticsSnapshot = {
+  seasonLabel: string;
   completedGameCount: number;
   recentWins: number;
   recentLosses: number;
@@ -218,6 +220,11 @@ export type TeamDetailAnalytics = {
   scoreDifferential: number;
   recentForm: TeamDetailAnalyticsGame[];
   progression: TeamDetailAnalyticsGame[];
+};
+
+export type TeamDetailAnalytics = TeamDetailAnalyticsSnapshot & {
+  availableSeasons: string[];
+  seasons: TeamDetailAnalyticsSnapshot[];
 };
 
 export type TeamDetailSponsor = {
@@ -1768,7 +1775,7 @@ export function buildTeamDetailModel({
   const standings = buildStandings(team, games);
   const leaderboards = includeInsights ? buildLeaderboards(configs, normalizedPlayers, seasonStatsByPlayerId, team?.sport) : [];
   const trackingSummaries = includeInsights ? buildTrackingSummaries(normalizedPlayers, linkedPlayerIds, trackingItems, trackingStatuses) : [];
-  const teamAnalytics = buildTeamAnalytics(games);
+  const teamAnalytics = buildTeamAnalytics(games, seasonLabel);
   const canManageAdmins = canManageTeamAdmins(user, team);
   const staffPermissions = canManageTeam && includeStaffPermissions
     ? buildTeamStaffPermissionsSummary({ teamId, team, players, pendingAdminInvites, confirmedTeamMembers })
@@ -2449,7 +2456,7 @@ function getStreamUrl(team: Record<string, any>) {
   return getFirstUrl(embedUrl);
 }
 
-export function buildTeamAnalytics(games: any[] = []): TeamDetailAnalytics {
+export function buildTeamAnalytics(games: any[] = [], preferredSeasonLabel = ''): TeamDetailAnalytics {
   const completedGames = (Array.isArray(games) ? games : [])
     .filter(isCompletedGame)
     .map((game, index): TeamDetailAnalyticsGame => {
@@ -2462,6 +2469,7 @@ export function buildTeamAnalytics(games: any[] = []): TeamDetailAnalytics {
         id: cleanString(game?.id || game?.gameId) || `game-${index + 1}`,
         date,
         dateLabel: date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+        seasonLabel: getAnalyticsSeasonLabel(game, date),
         opponent,
         pointsFor,
         pointsAgainst,
@@ -2470,37 +2478,45 @@ export function buildTeamAnalytics(games: any[] = []): TeamDetailAnalytics {
       };
     })
     .sort((a, b) => a.date.getTime() - b.date.getTime());
+  const availableSeasons = Array.from(new Set(completedGames.map((game) => game.seasonLabel)))
+    .filter(Boolean)
+    .sort((a, b) => b.localeCompare(a, undefined, { numeric: true, sensitivity: 'base' }));
+  const currentYear = String(new Date().getFullYear());
+  const seasonLabel = availableSeasons.includes(preferredSeasonLabel)
+    ? preferredSeasonLabel
+    : availableSeasons.includes(currentYear) ? currentYear : (availableSeasons[0] || preferredSeasonLabel || currentYear);
+  const seasons = availableSeasons.map((label) => buildTeamAnalyticsSnapshot(
+    completedGames.filter((game) => game.seasonLabel === label),
+    label
+  ));
+  const selectedSeason = seasons.find((season) => season.seasonLabel === seasonLabel)
+    || buildTeamAnalyticsSnapshot([], seasonLabel);
 
-  if (!completedGames.length) {
-    return {
-      completedGameCount: 0,
-      recentWins: 0,
-      recentLosses: 0,
-      recentTies: 0,
-      averagePointsFor: 0,
-      averagePointsAgainst: 0,
-      scoreDifferential: 0,
-      recentForm: [],
-      progression: []
-    };
-  }
+  return { ...selectedSeason, availableSeasons, seasons };
+}
 
+function buildTeamAnalyticsSnapshot(completedGames: TeamDetailAnalyticsGame[], seasonLabel: string): TeamDetailAnalyticsSnapshot {
   const recentForm = completedGames.slice(-5);
   const pointsFor = completedGames.reduce((total, game) => total + game.pointsFor, 0);
   const pointsAgainst = completedGames.reduce((total, game) => total + game.pointsAgainst, 0);
   const roundToTenth = (value: number) => Math.round(value * 10) / 10;
-
   return {
+    seasonLabel,
     completedGameCount: completedGames.length,
     recentWins: recentForm.filter((game) => game.result === 'W').length,
     recentLosses: recentForm.filter((game) => game.result === 'L').length,
     recentTies: recentForm.filter((game) => game.result === 'T').length,
-    averagePointsFor: roundToTenth(pointsFor / completedGames.length),
-    averagePointsAgainst: roundToTenth(pointsAgainst / completedGames.length),
+    averagePointsFor: completedGames.length ? roundToTenth(pointsFor / completedGames.length) : 0,
+    averagePointsAgainst: completedGames.length ? roundToTenth(pointsAgainst / completedGames.length) : 0,
     scoreDifferential: pointsFor - pointsAgainst,
     recentForm,
     progression: completedGames.slice(-10)
   };
+}
+
+function getAnalyticsSeasonLabel(game: any, date: Date) {
+  const explicit = cleanString(game?.seasonLabel);
+  return explicit || String(date.getFullYear());
 }
 
 function isCompletedGame(game: any) {

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -2460,8 +2460,11 @@ export function buildTeamAnalytics(games: any[] = [], preferredSeasonLabel = '')
   const completedGames = (Array.isArray(games) ? games : [])
     .filter(isCompletedGame)
     .map((game, index): TeamDetailAnalyticsGame => {
-      const pointsFor = toNullableNumber(game?.homeScore) || 0;
-      const pointsAgainst = toNullableNumber(game?.awayScore) || 0;
+      const isHome = game?.isHome !== false;
+      const homeScore = toNullableNumber(game?.homeScore) || 0;
+      const awayScore = toNullableNumber(game?.awayScore) || 0;
+      const pointsFor = isHome ? homeScore : awayScore;
+      const pointsAgainst = isHome ? awayScore : homeScore;
       const date = toDate(game?.date);
       const opponent = cleanString(game?.opponent || game?.awayTeam || game?.title)
         .replace(/^vs\.?\s*/i, '') || 'Opponent';
@@ -2478,13 +2481,12 @@ export function buildTeamAnalytics(games: any[] = [], preferredSeasonLabel = '')
       };
     })
     .sort((a, b) => a.date.getTime() - b.date.getTime());
-  const availableSeasons = Array.from(new Set(completedGames.map((game) => game.seasonLabel)))
+  const availableSeasons = Array.from(new Set([preferredSeasonLabel, ...completedGames.map((game) => game.seasonLabel)]))
     .filter(Boolean)
     .sort((a, b) => b.localeCompare(a, undefined, { numeric: true, sensitivity: 'base' }));
   const currentYear = String(new Date().getFullYear());
-  const seasonLabel = availableSeasons.includes(preferredSeasonLabel)
-    ? preferredSeasonLabel
-    : availableSeasons.includes(currentYear) ? currentYear : (availableSeasons[0] || preferredSeasonLabel || currentYear);
+  const seasonLabel = preferredSeasonLabel
+    || (availableSeasons.includes(currentYear) ? currentYear : (availableSeasons[0] || currentYear));
   const seasons = availableSeasons.map((label) => buildTeamAnalyticsSnapshot(
     completedGames.filter((game) => game.seasonLabel === label),
     label

--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -167,6 +167,17 @@ const model = {
   standings: { enabled: true, label: 'Standings', rows: [], currentRow: null },
   leaderboards: [],
   trackingSummaries: [],
+  teamAnalytics: {
+    completedGameCount: 0,
+    recentWins: 0,
+    recentLosses: 0,
+    recentTies: 0,
+    averagePointsFor: 0,
+    averagePointsAgainst: 0,
+    scoreDifferential: 0,
+    recentForm: [],
+    progression: []
+  },
   sponsors: [],
   statTrackerConfigs: [],
   canManageTeam: false,
@@ -238,7 +249,7 @@ describe('TeamDetail', () => {
     teamDetailServiceMocks.loadParentTeamDetail.mockResolvedValue(model);
     teamDetailServiceMocks.loadParentTeamDetailBootstrap.mockImplementation((...args: any[]) => teamDetailServiceMocks.loadParentTeamDetail(...args));
     teamDetailServiceMocks.loadRosterFieldDefinitionsForApp.mockResolvedValue([]);
-    teamDetailServiceMocks.loadTeamDetailInsights.mockResolvedValue({ leaderboards: [], trackingSummaries: [] });
+    teamDetailServiceMocks.loadTeamDetailInsights.mockResolvedValue({ leaderboards: [], trackingSummaries: [], teamAnalytics: model.teamAnalytics });
     teamDetailServiceMocks.loadTeamDetailSponsors.mockResolvedValue({ sponsors: [] });
     teamDetailServiceMocks.loadTeamRosterParentInvites.mockResolvedValue([]);
     teamDetailServiceMocks.loadTeamStaffPermissions.mockResolvedValue(null);
@@ -716,6 +727,55 @@ describe('TeamDetail', () => {
 
     expect(await screen.findByRole('heading', { name: 'Bears' })).toBeTruthy();
     await waitFor(() => expect(teamDetailServiceMocks.loadTeamDetailInsights).toHaveBeenCalledWith('team-1', auth.user));
+  });
+
+  it('renders team performance metrics and accessible score graphs in Insights', async () => {
+    const teamAnalytics = {
+      completedGameCount: 3,
+      recentWins: 1,
+      recentLosses: 1,
+      recentTies: 1,
+      averagePointsFor: 2.3,
+      averagePointsAgainst: 2,
+      scoreDifferential: 1,
+      recentForm: [
+        { id: 'game-1', date: new Date('2026-03-01'), dateLabel: 'Mar 1', opponent: 'Bears', pointsFor: 4, pointsAgainst: 1, differential: 3, result: 'W' as const },
+        { id: 'game-2', date: new Date('2026-03-02'), dateLabel: 'Mar 2', opponent: 'Cats', pointsFor: 1, pointsAgainst: 3, differential: -2, result: 'L' as const },
+        { id: 'game-3', date: new Date('2026-03-03'), dateLabel: 'Mar 3', opponent: 'Owls', pointsFor: 2, pointsAgainst: 2, differential: 0, result: 'T' as const }
+      ],
+      progression: [
+        { id: 'game-1', date: new Date('2026-03-01'), dateLabel: 'Mar 1', opponent: 'Bears', pointsFor: 4, pointsAgainst: 1, differential: 3, result: 'W' as const },
+        { id: 'game-2', date: new Date('2026-03-02'), dateLabel: 'Mar 2', opponent: 'Cats', pointsFor: 1, pointsAgainst: 3, differential: -2, result: 'L' as const },
+        { id: 'game-3', date: new Date('2026-03-03'), dateLabel: 'Mar 3', opponent: 'Owls', pointsFor: 2, pointsAgainst: 2, differential: 0, result: 'T' as const }
+      ]
+    };
+    teamDetailServiceMocks.loadTeamDetailInsights.mockResolvedValue({ leaderboards: [], trackingSummaries: [], teamAnalytics });
+
+    render(
+      <MemoryRouter initialEntries={['/teams/team-1?tab=insights']}>
+        <Routes>
+          <Route path="/teams/:teamId" element={<TeamDetail auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Team performance')).toBeTruthy();
+    expect((await screen.findAllByText('2.3')).length).toBeGreaterThan(0);
+    expect(screen.getByText('Game-by-game scoring')).toBeTruthy();
+    expect(screen.getByLabelText('W against Bears, 4 to 1')).toBeTruthy();
+    expect(screen.getByLabelText('Mar 2 against Cats: 1 points for and 3 points against')).toBeTruthy();
+  });
+
+  it('renders an explicit team performance empty state in Insights', async () => {
+    render(
+      <MemoryRouter initialEntries={['/teams/team-1?tab=insights']}>
+        <Routes>
+          <Route path="/teams/:teamId" element={<TeamDetail auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Team performance appears after a completed game has a final score.')).toBeTruthy();
   });
 
   it('opens player detail when the roster row surface is clicked', async () => {

--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -168,6 +168,7 @@ const model = {
   leaderboards: [],
   trackingSummaries: [],
   teamAnalytics: {
+    seasonLabel: '2100',
     completedGameCount: 0,
     recentWins: 0,
     recentLosses: 0,
@@ -176,7 +177,9 @@ const model = {
     averagePointsAgainst: 0,
     scoreDifferential: 0,
     recentForm: [],
-    progression: []
+    progression: [],
+    availableSeasons: [],
+    seasons: []
   },
   sponsors: [],
   statTrackerConfigs: [],
@@ -730,7 +733,8 @@ describe('TeamDetail', () => {
   });
 
   it('renders team performance metrics and accessible score graphs in Insights', async () => {
-    const teamAnalytics = {
+    const teamAnalytics: any = {
+      seasonLabel: '2026',
       completedGameCount: 3,
       recentWins: 1,
       recentLosses: 1,
@@ -739,15 +743,28 @@ describe('TeamDetail', () => {
       averagePointsAgainst: 2,
       scoreDifferential: 1,
       recentForm: [
-        { id: 'game-1', date: new Date('2026-03-01'), dateLabel: 'Mar 1', opponent: 'Bears', pointsFor: 4, pointsAgainst: 1, differential: 3, result: 'W' as const },
-        { id: 'game-2', date: new Date('2026-03-02'), dateLabel: 'Mar 2', opponent: 'Cats', pointsFor: 1, pointsAgainst: 3, differential: -2, result: 'L' as const },
-        { id: 'game-3', date: new Date('2026-03-03'), dateLabel: 'Mar 3', opponent: 'Owls', pointsFor: 2, pointsAgainst: 2, differential: 0, result: 'T' as const }
+        { id: 'game-1', date: new Date('2026-03-01'), dateLabel: 'Mar 1', seasonLabel: '2026', opponent: 'Bears', pointsFor: 4, pointsAgainst: 1, differential: 3, result: 'W' as const },
+        { id: 'game-2', date: new Date('2026-03-02'), dateLabel: 'Mar 2', seasonLabel: '2026', opponent: 'Cats', pointsFor: 1, pointsAgainst: 3, differential: -2, result: 'L' as const },
+        { id: 'game-3', date: new Date('2026-03-03'), dateLabel: 'Mar 3', seasonLabel: '2026', opponent: 'Owls', pointsFor: 2, pointsAgainst: 2, differential: 0, result: 'T' as const }
       ],
       progression: [
-        { id: 'game-1', date: new Date('2026-03-01'), dateLabel: 'Mar 1', opponent: 'Bears', pointsFor: 4, pointsAgainst: 1, differential: 3, result: 'W' as const },
-        { id: 'game-2', date: new Date('2026-03-02'), dateLabel: 'Mar 2', opponent: 'Cats', pointsFor: 1, pointsAgainst: 3, differential: -2, result: 'L' as const },
-        { id: 'game-3', date: new Date('2026-03-03'), dateLabel: 'Mar 3', opponent: 'Owls', pointsFor: 2, pointsAgainst: 2, differential: 0, result: 'T' as const }
-      ]
+        { id: 'game-1', date: new Date('2026-03-01'), dateLabel: 'Mar 1', seasonLabel: '2026', opponent: 'Bears', pointsFor: 4, pointsAgainst: 1, differential: 3, result: 'W' as const },
+        { id: 'game-2', date: new Date('2026-03-02'), dateLabel: 'Mar 2', seasonLabel: '2026', opponent: 'Cats', pointsFor: 1, pointsAgainst: 3, differential: -2, result: 'L' as const },
+        { id: 'game-3', date: new Date('2026-03-03'), dateLabel: 'Mar 3', seasonLabel: '2026', opponent: 'Owls', pointsFor: 2, pointsAgainst: 2, differential: 0, result: 'T' as const }
+      ],
+      availableSeasons: ['2026', '2025'],
+      seasons: [{
+        seasonLabel: '2025',
+        completedGameCount: 1,
+        recentWins: 1,
+        recentLosses: 0,
+        recentTies: 0,
+        averagePointsFor: 5,
+        averagePointsAgainst: 0,
+        scoreDifferential: 5,
+        recentForm: [{ id: 'older-game', date: new Date('2025-10-01'), dateLabel: 'Oct 1', seasonLabel: '2025', opponent: 'Foxes', pointsFor: 5, pointsAgainst: 0, differential: 5, result: 'W' as const }],
+        progression: [{ id: 'older-game', date: new Date('2025-10-01'), dateLabel: 'Oct 1', seasonLabel: '2025', opponent: 'Foxes', pointsFor: 5, pointsAgainst: 0, differential: 5, result: 'W' as const }]
+      }]
     };
     teamDetailServiceMocks.loadTeamDetailInsights.mockResolvedValue({ leaderboards: [], trackingSummaries: [], teamAnalytics });
 
@@ -762,8 +779,12 @@ describe('TeamDetail', () => {
     expect(await screen.findByText('Team performance')).toBeTruthy();
     expect((await screen.findAllByText('2.3')).length).toBeGreaterThan(0);
     expect(screen.getByText('Game-by-game scoring')).toBeTruthy();
+    expect(screen.getByText('Season pulse')).toBeTruthy();
     expect(screen.getByLabelText('W against Bears, 4 to 1')).toBeTruthy();
-    expect(screen.getByLabelText('Mar 2 against Cats: 1 points for and 3 points against')).toBeTruthy();
+    expect(screen.getByLabelText('Mar 2 against Cats: 1 point for and 3 points against')).toBeTruthy();
+    fireEvent.change(screen.getByLabelText('Season'), { target: { value: '2025' } });
+    expect(await screen.findByText('Positive margin: +5 points per game')).toBeTruthy();
+    expect(screen.getByLabelText('W against Foxes, 5 to 0')).toBeTruthy();
   });
 
   it('renders an explicit team performance empty state in Insights', async () => {

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -448,6 +448,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
       ...nextModel,
       leaderboards: model?.leaderboards || nextModel.leaderboards,
       trackingSummaries: model?.trackingSummaries || nextModel.trackingSummaries,
+      teamAnalytics: model?.teamAnalytics || nextModel.teamAnalytics,
       sponsors: model?.sponsors || nextModel.sponsors,
       staffPermissions: model?.staffPermissions || nextModel.staffPermissions
     };
@@ -1654,6 +1655,8 @@ function TrackingAdminCard({
 function InsightsTab({ model, loading, error }: { model: TeamDetailModel; loading: boolean; error: string }) {
   return (
     <div className="space-y-4">
+      <TeamPerformanceCard model={model} loading={loading} error={error} />
+
       <section className="app-card p-4">
         <div className="text-sm font-black text-gray-950">Player checklist</div>
         <div className="mt-0.5 text-xs font-semibold text-gray-500">Public tracking items visible for your linked player.</div>
@@ -1718,6 +1721,115 @@ function InsightsTab({ model, loading, error }: { model: TeamDetailModel; loadin
       </section>
     </div>
   );
+}
+
+function TeamPerformanceCard({ model, loading, error }: { model: TeamDetailModel; loading: boolean; error: string }) {
+  const analytics = model.teamAnalytics;
+  const maxAverage = Math.max(analytics.averagePointsFor, analytics.averagePointsAgainst, 1);
+  const maxGameScore = Math.max(...analytics.progression.flatMap((game) => [game.pointsFor, game.pointsAgainst]), 1);
+  const resultTone = {
+    W: 'bg-emerald-100 text-emerald-800',
+    L: 'bg-rose-100 text-rose-800',
+    T: 'bg-gray-200 text-gray-700'
+  } as const;
+
+  return (
+    <section className="app-card p-4" aria-labelledby="team-performance-heading">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div id="team-performance-heading" className="text-sm font-black text-gray-950">Team performance</div>
+          <div className="mt-0.5 text-xs font-semibold text-gray-500">Score trends from completed games.</div>
+        </div>
+        {analytics.completedGameCount ? <div className="rounded-full bg-primary-50 px-2.5 py-1 text-[10px] font-black uppercase tracking-[0.04em] text-primary-700">{analytics.completedGameCount} games</div> : null}
+      </div>
+
+      {loading ? <div className="mt-3"><InlineDeferredLoading copy="Loading team performance…" /></div> : null}
+      {!loading && error ? <div className="mt-3"><InlineDeferredError title="Team performance unavailable" message={error} /></div> : null}
+      {!loading && !error && !analytics.completedGameCount ? (
+        <div className="mt-3 rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm font-semibold text-gray-500">Team performance appears after a completed game has a final score.</div>
+      ) : null}
+
+      {!loading && !error && analytics.completedGameCount ? (
+        <div className="mt-4 space-y-3">
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+            <TeamMetric label="Points for / game" value={formatTeamMetric(analytics.averagePointsFor)} tone="text-emerald-700" />
+            <TeamMetric label="Points against / game" value={formatTeamMetric(analytics.averagePointsAgainst)} tone="text-rose-700" />
+            <TeamMetric label="Score differential" value={`${analytics.scoreDifferential > 0 ? '+' : ''}${analytics.scoreDifferential}`} tone={analytics.scoreDifferential >= 0 ? 'text-emerald-700' : 'text-rose-700'} />
+            <TeamMetric label="Last 5" value={`${analytics.recentWins}-${analytics.recentLosses}${analytics.recentTies ? `-${analytics.recentTies}` : ''}`} tone="text-primary-700" />
+          </div>
+
+          <div className="grid gap-3 lg:grid-cols-2">
+            <div className="rounded-xl border border-gray-200 bg-white p-3">
+              <div className="flex items-center justify-between gap-3">
+                <div className="text-sm font-black text-gray-950">Recent form</div>
+                <div className="text-[10px] font-black uppercase tracking-[0.04em] text-gray-500">Last {analytics.recentForm.length}</div>
+              </div>
+              <div className="mt-3 grid grid-cols-5 gap-2">
+                {analytics.recentForm.map((game) => (
+                  <div key={game.id} className="min-w-0 text-center">
+                    <div className={`flex h-10 items-center justify-center rounded-lg text-sm font-black ${resultTone[game.result]}`} aria-label={`${game.result} against ${game.opponent}, ${game.pointsFor} to ${game.pointsAgainst}`}>{game.result}</div>
+                    <div className="mt-1 truncate text-[10px] font-bold text-gray-500">{game.dateLabel}</div>
+                  </div>
+                ))}
+              </div>
+              <div className="mt-3 grid grid-cols-3 gap-2 border-t border-gray-100 pt-3 text-center">
+                <TeamFormTotal label="Wins" value={analytics.recentWins} tone="text-emerald-700" />
+                <TeamFormTotal label="Losses" value={analytics.recentLosses} tone="text-rose-700" />
+                <TeamFormTotal label="Ties" value={analytics.recentTies} tone="text-gray-600" />
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-gray-200 bg-white p-3">
+              <div className="text-sm font-black text-gray-950">Scoring comparison</div>
+              <div className="mt-4 space-y-4">
+                <TeamAverageBar label="Points for" value={analytics.averagePointsFor} width={(analytics.averagePointsFor / maxAverage) * 100} color="bg-emerald-600" />
+                <TeamAverageBar label="Points against" value={analytics.averagePointsAgainst} width={(analytics.averagePointsAgainst / maxAverage) * 100} color="bg-rose-600" />
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-gray-200 bg-white p-3">
+            <div className="flex items-center justify-between gap-3">
+              <div className="text-sm font-black text-gray-950">Game-by-game scoring</div>
+              <div className="text-[10px] font-black uppercase tracking-[0.04em] text-gray-500">Last {analytics.progression.length}</div>
+            </div>
+            <div className="mt-3 flex h-48 items-end gap-2 overflow-x-auto rounded-lg bg-gray-50 px-2 pb-2 pt-4">
+              {analytics.progression.map((game) => (
+                <div key={game.id} className="flex h-full min-w-12 flex-1 flex-col items-center justify-end gap-1">
+                  <div className="text-[10px] font-black text-gray-700">{game.pointsFor}-{game.pointsAgainst}</div>
+                  <div className="flex h-full w-full items-end justify-center gap-1" aria-label={`${game.dateLabel} against ${game.opponent}: ${game.pointsFor} points for and ${game.pointsAgainst} points against`}>
+                    <div className="w-2/5 rounded-t bg-primary-600" style={{ height: `${Math.max(7, (game.pointsFor / maxGameScore) * 100)}%` }} />
+                    <div className="w-2/5 rounded-t bg-gray-300" style={{ height: `${Math.max(7, (game.pointsAgainst / maxGameScore) * 100)}%` }} />
+                  </div>
+                  <div className="w-full truncate text-center text-[9px] font-bold text-gray-500">{game.dateLabel}</div>
+                </div>
+              ))}
+            </div>
+            <div className="mt-2 flex justify-center gap-4 text-[10px] font-bold text-gray-500">
+              <span className="inline-flex items-center gap-1"><span className="h-2 w-2 rounded-sm bg-primary-600" />Points for</span>
+              <span className="inline-flex items-center gap-1"><span className="h-2 w-2 rounded-sm bg-gray-300" />Points against</span>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function TeamMetric({ label, value, tone }: { label: string; value: string; tone: string }) {
+  return <div className="rounded-xl border border-gray-200 bg-gray-50 p-3"><div className={`text-xl font-black ${tone}`}>{value}</div><div className="mt-1 text-[10px] font-black uppercase tracking-[0.04em] text-gray-500">{label}</div></div>;
+}
+
+function TeamFormTotal({ label, value, tone }: { label: string; value: number; tone: string }) {
+  return <div><div className={`text-lg font-black ${tone}`}>{value}</div><div className="text-[10px] font-bold text-gray-500">{label}</div></div>;
+}
+
+function TeamAverageBar({ label, value, width, color }: { label: string; value: number; width: number; color: string }) {
+  return <div><div className="mb-1 flex items-center justify-between gap-3"><div className="text-[10px] font-black uppercase tracking-[0.04em] text-gray-500">{label}</div><div className="text-xs font-black text-gray-950">{formatTeamMetric(value)}</div></div><div className="h-3 overflow-hidden rounded-full bg-gray-100"><div className={`h-full rounded-full ${color}`} style={{ width: `${Math.max(6, width)}%` }} aria-label={`${label} average ${formatTeamMetric(value)}`} /></div></div>;
+}
+
+function formatTeamMetric(value: number) {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
 }
 
 function MoreTab({ model, auth, staffPermissionsLoading, staffPermissionsError, sponsorsLoading, sponsorsError, onTeamDetailRefresh }: { model: TeamDetailModel; auth: AuthState; staffPermissionsLoading: boolean; staffPermissionsError: string; sponsorsLoading: boolean; sponsorsError: string; onTeamDetailRefresh: () => Promise<void> }) {

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -42,7 +42,7 @@ import { getEventDetailPath } from '../lib/homeLogic';
 import { buildPrivateTeamCalendarFeedUrl, getAppleCalendarFeedUrl, getGoogleCalendarFeedUrl } from '../lib/parentToolsService';
 import { createStaffRsvpReminderPreviewLoader, sendStaffRsvpReminder, type StaffRsvpReminderSendResult } from '../lib/scheduleService';
 import type { ParentScheduleEvent, StaffRsvpReminderPreview } from '../lib/scheduleLogic';
-import { addRosterPlayerForApp, archiveTeamTrackingItemForApp, buildPublicTeamGamesIcsUrl, canExposePublicFanFeed, createRosterParentInviteForApp, createStatTrackerConfigForApp, deactivateRosterPlayerForApp, grantScorekeeperAccessForApp, grantTeamMediaManagerAccessForApp, grantVideographerAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, loadParentTeamDetailBootstrap, loadRosterFieldDefinitionsForApp, loadTeamDetailInsights, loadTeamDetailSponsors, loadTeamRosterParentInvites, loadTeamStaffPermissions, loadTeamTrackingAdmin, reactivateRosterPlayerForApp, revokeScorekeeperAccessForApp, revokeTeamAdminAccessForApp, revokeTeamMediaManagerAccessForApp, revokeVideographerAccessForApp, saveTeamScheduleNotificationsForApp, saveTeamTrackingItemForApp, setPlayerTrackingStatusForApp, updateStatTrackerConfigForApp, type CreateRosterParentInviteForAppResult, type InviteTeamAdminForAppResult, type TeamDetailAnalyticsSnapshot, type TeamDetailEvent, type TeamDetailModel, type TeamDetailPlayer, type TeamRosterFieldDefinition, type TeamRosterParentInviteSummary, type TeamScorekeeperGrantTarget, type TeamTrackingAdminItem } from '../lib/teamDetailService';
+import { addRosterPlayerForApp, archiveTeamTrackingItemForApp, buildPublicTeamGamesIcsUrl, canExposePublicFanFeed, createRosterParentInviteForApp, createStatTrackerConfigForApp, deactivateRosterPlayerForApp, grantScorekeeperAccessForApp, grantTeamMediaManagerAccessForApp, grantVideographerAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, loadParentTeamDetailBootstrap, loadRosterFieldDefinitionsForApp, loadTeamDetailInsights, loadTeamDetailSponsors, loadTeamRosterParentInvites, loadTeamStaffPermissions, loadTeamTrackingAdmin, reactivateRosterPlayerForApp, revokeScorekeeperAccessForApp, revokeTeamAdminAccessForApp, revokeTeamMediaManagerAccessForApp, revokeVideographerAccessForApp, saveTeamScheduleNotificationsForApp, saveTeamTrackingItemForApp, setPlayerTrackingStatusForApp, updateStatTrackerConfigForApp, type CreateRosterParentInviteForAppResult, type InviteTeamAdminForAppResult, type TeamDetailAnalytics, type TeamDetailAnalyticsSnapshot, type TeamDetailEvent, type TeamDetailModel, type TeamDetailPlayer, type TeamRosterFieldDefinition, type TeamRosterParentInviteSummary, type TeamScorekeeperGrantTarget, type TeamTrackingAdminItem } from '../lib/teamDetailService';
 import { buildStatTrackerConfigPayload, createBlankStatTrackerConfigColumnDraft, createEmptyStatTrackerConfigDraft, createStatTrackerConfigDraft, createStatTrackerConfigDraftFromPreset, getStatTrackerConfigPresetCatalog, validateStatTrackerConfigDraft, type StatTrackerConfigDraft } from '../lib/statTrackerConfigEditor';
 import { useViewLoadTimer } from '../lib/viewLoadTiming';
 import { buildTeamDetailNavigation, type TeamNavigationItem, type TeamNavigationSection } from '../lib/teamNavigation';
@@ -50,6 +50,21 @@ import type { AuthState } from '../lib/types';
 import { InviteResultCard } from './parent-tools/shared';
 
 type TeamTab = 'overview' | 'schedule' | 'roster' | 'insights' | 'more';
+
+const EMPTY_TEAM_ANALYTICS: TeamDetailAnalytics = {
+  seasonLabel: '',
+  completedGameCount: 0,
+  recentWins: 0,
+  recentLosses: 0,
+  recentTies: 0,
+  averagePointsFor: 0,
+  averagePointsAgainst: 0,
+  scoreDifferential: 0,
+  recentForm: [],
+  progression: [],
+  availableSeasons: [],
+  seasons: []
+};
 type RosterAiImportModule = typeof import('../lib/rosterAiImport');
 type RosterAiImportPreviewRow = import('../lib/rosterAiImport').RosterAiImportPreviewRow;
 
@@ -1724,9 +1739,9 @@ function InsightsTab({ model, loading, error }: { model: TeamDetailModel; loadin
 }
 
 function TeamPerformanceCard({ model, loading, error }: { model: TeamDetailModel; loading: boolean; error: string }) {
-  const analyticsRoot = model.teamAnalytics;
+  const analyticsRoot = model.teamAnalytics || EMPTY_TEAM_ANALYTICS;
   const [selectedSeason, setSelectedSeason] = useState(analyticsRoot.seasonLabel);
-  const availableSeasons = analyticsRoot.availableSeasons || [];
+  const availableSeasons = useMemo(() => analyticsRoot.availableSeasons || [], [analyticsRoot.availableSeasons]);
   const analytics = (analyticsRoot.seasons || []).find((season) => season.seasonLabel === selectedSeason) || analyticsRoot;
   const scoringLabels = getTeamScoringLabels(model.team.sport);
   const maxAverage = Math.max(analytics.averagePointsFor, analytics.averagePointsAgainst, 1);

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -42,7 +42,7 @@ import { getEventDetailPath } from '../lib/homeLogic';
 import { buildPrivateTeamCalendarFeedUrl, getAppleCalendarFeedUrl, getGoogleCalendarFeedUrl } from '../lib/parentToolsService';
 import { createStaffRsvpReminderPreviewLoader, sendStaffRsvpReminder, type StaffRsvpReminderSendResult } from '../lib/scheduleService';
 import type { ParentScheduleEvent, StaffRsvpReminderPreview } from '../lib/scheduleLogic';
-import { addRosterPlayerForApp, archiveTeamTrackingItemForApp, buildPublicTeamGamesIcsUrl, canExposePublicFanFeed, createRosterParentInviteForApp, createStatTrackerConfigForApp, deactivateRosterPlayerForApp, grantScorekeeperAccessForApp, grantTeamMediaManagerAccessForApp, grantVideographerAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, loadParentTeamDetailBootstrap, loadRosterFieldDefinitionsForApp, loadTeamDetailInsights, loadTeamDetailSponsors, loadTeamRosterParentInvites, loadTeamStaffPermissions, loadTeamTrackingAdmin, reactivateRosterPlayerForApp, revokeScorekeeperAccessForApp, revokeTeamAdminAccessForApp, revokeTeamMediaManagerAccessForApp, revokeVideographerAccessForApp, saveTeamScheduleNotificationsForApp, saveTeamTrackingItemForApp, setPlayerTrackingStatusForApp, updateStatTrackerConfigForApp, type CreateRosterParentInviteForAppResult, type InviteTeamAdminForAppResult, type TeamDetailEvent, type TeamDetailModel, type TeamDetailPlayer, type TeamRosterFieldDefinition, type TeamRosterParentInviteSummary, type TeamScorekeeperGrantTarget, type TeamTrackingAdminItem } from '../lib/teamDetailService';
+import { addRosterPlayerForApp, archiveTeamTrackingItemForApp, buildPublicTeamGamesIcsUrl, canExposePublicFanFeed, createRosterParentInviteForApp, createStatTrackerConfigForApp, deactivateRosterPlayerForApp, grantScorekeeperAccessForApp, grantTeamMediaManagerAccessForApp, grantVideographerAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, loadParentTeamDetailBootstrap, loadRosterFieldDefinitionsForApp, loadTeamDetailInsights, loadTeamDetailSponsors, loadTeamRosterParentInvites, loadTeamStaffPermissions, loadTeamTrackingAdmin, reactivateRosterPlayerForApp, revokeScorekeeperAccessForApp, revokeTeamAdminAccessForApp, revokeTeamMediaManagerAccessForApp, revokeVideographerAccessForApp, saveTeamScheduleNotificationsForApp, saveTeamTrackingItemForApp, setPlayerTrackingStatusForApp, updateStatTrackerConfigForApp, type CreateRosterParentInviteForAppResult, type InviteTeamAdminForAppResult, type TeamDetailAnalyticsSnapshot, type TeamDetailEvent, type TeamDetailModel, type TeamDetailPlayer, type TeamRosterFieldDefinition, type TeamRosterParentInviteSummary, type TeamScorekeeperGrantTarget, type TeamTrackingAdminItem } from '../lib/teamDetailService';
 import { buildStatTrackerConfigPayload, createBlankStatTrackerConfigColumnDraft, createEmptyStatTrackerConfigDraft, createStatTrackerConfigDraft, createStatTrackerConfigDraftFromPreset, getStatTrackerConfigPresetCatalog, validateStatTrackerConfigDraft, type StatTrackerConfigDraft } from '../lib/statTrackerConfigEditor';
 import { useViewLoadTimer } from '../lib/viewLoadTiming';
 import { buildTeamDetailNavigation, type TeamNavigationItem, type TeamNavigationSection } from '../lib/teamNavigation';
@@ -206,7 +206,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
       setLoading(true);
       setError(null);
       try {
-        const shouldHydrateOverviewCollections = activeTabRef.current === 'overview';
+        const shouldHydrateOverviewCollections = activeTabRef.current === 'overview' || activeTabRef.current === 'insights';
         const nextModel = shouldHydrateOverviewCollections
           ? await loadParentTeamDetail(teamId, authUserRef.current, { includeDeferredData: false })
           : await loadParentTeamDetailBootstrap(teamId, authUserRef.current);
@@ -1724,14 +1724,25 @@ function InsightsTab({ model, loading, error }: { model: TeamDetailModel; loadin
 }
 
 function TeamPerformanceCard({ model, loading, error }: { model: TeamDetailModel; loading: boolean; error: string }) {
-  const analytics = model.teamAnalytics;
+  const analyticsRoot = model.teamAnalytics;
+  const [selectedSeason, setSelectedSeason] = useState(analyticsRoot.seasonLabel);
+  const availableSeasons = analyticsRoot.availableSeasons || [];
+  const analytics = (analyticsRoot.seasons || []).find((season) => season.seasonLabel === selectedSeason) || analyticsRoot;
+  const scoringLabels = getTeamScoringLabels(model.team.sport);
   const maxAverage = Math.max(analytics.averagePointsFor, analytics.averagePointsAgainst, 1);
   const maxGameScore = Math.max(...analytics.progression.flatMap((game) => [game.pointsFor, game.pointsAgainst]), 1);
+  const seasonPulse = getSeasonPulse(analytics, scoringLabels.unitSingular);
   const resultTone = {
     W: 'bg-emerald-100 text-emerald-800',
     L: 'bg-rose-100 text-rose-800',
     T: 'bg-gray-200 text-gray-700'
   } as const;
+
+  useEffect(() => {
+    if (availableSeasons.length && !availableSeasons.includes(selectedSeason)) {
+      setSelectedSeason(analyticsRoot.seasonLabel);
+    }
+  }, [analyticsRoot.seasonLabel, availableSeasons, selectedSeason]);
 
   return (
     <section className="app-card p-4" aria-labelledby="team-performance-heading">
@@ -1740,7 +1751,17 @@ function TeamPerformanceCard({ model, loading, error }: { model: TeamDetailModel
           <div id="team-performance-heading" className="text-sm font-black text-gray-950">Team performance</div>
           <div className="mt-0.5 text-xs font-semibold text-gray-500">Score trends from completed games.</div>
         </div>
-        {analytics.completedGameCount ? <div className="rounded-full bg-primary-50 px-2.5 py-1 text-[10px] font-black uppercase tracking-[0.04em] text-primary-700">{analytics.completedGameCount} games</div> : null}
+        <div className="flex items-center gap-2">
+          {availableSeasons.length > 1 ? (
+            <label className="flex items-center gap-1.5 text-[10px] font-black uppercase tracking-[0.04em] text-gray-500">
+              Season
+              <select className="rounded-lg border border-gray-200 bg-white px-2 py-1 text-xs font-black normal-case tracking-normal text-gray-800" value={selectedSeason} onChange={(event) => setSelectedSeason(event.target.value)}>
+                {availableSeasons.map((season) => <option key={season} value={season}>{season}</option>)}
+              </select>
+            </label>
+          ) : null}
+          {analytics.completedGameCount ? <div className="rounded-full bg-primary-50 px-2.5 py-1 text-[10px] font-black uppercase tracking-[0.04em] text-primary-700">{analytics.completedGameCount} games</div> : null}
+        </div>
       </div>
 
       {loading ? <div className="mt-3"><InlineDeferredLoading copy="Loading team performance…" /></div> : null}
@@ -1752,10 +1773,16 @@ function TeamPerformanceCard({ model, loading, error }: { model: TeamDetailModel
       {!loading && !error && analytics.completedGameCount ? (
         <div className="mt-4 space-y-3">
           <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-            <TeamMetric label="Points for / game" value={formatTeamMetric(analytics.averagePointsFor)} tone="text-emerald-700" />
-            <TeamMetric label="Points against / game" value={formatTeamMetric(analytics.averagePointsAgainst)} tone="text-rose-700" />
-            <TeamMetric label="Score differential" value={`${analytics.scoreDifferential > 0 ? '+' : ''}${analytics.scoreDifferential}`} tone={analytics.scoreDifferential >= 0 ? 'text-emerald-700' : 'text-rose-700'} />
+            <TeamMetric label={`${scoringLabels.for} / game`} value={formatTeamMetric(analytics.averagePointsFor)} tone="text-emerald-700" />
+            <TeamMetric label={`${scoringLabels.against} / game`} value={formatTeamMetric(analytics.averagePointsAgainst)} tone="text-rose-700" />
+            <TeamMetric label={scoringLabels.differential} value={`${analytics.scoreDifferential > 0 ? '+' : ''}${analytics.scoreDifferential}`} tone={analytics.scoreDifferential >= 0 ? 'text-emerald-700' : 'text-rose-700'} />
             <TeamMetric label="Last 5" value={`${analytics.recentWins}-${analytics.recentLosses}${analytics.recentTies ? `-${analytics.recentTies}` : ''}`} tone="text-primary-700" />
+          </div>
+
+          <div className="rounded-xl border border-primary-100 bg-gradient-to-r from-primary-50 via-white to-emerald-50 p-4">
+            <div className="text-[10px] font-black uppercase tracking-[0.06em] text-primary-700">Season pulse</div>
+            <div className="mt-1 text-base font-black text-gray-950">{seasonPulse.headline}</div>
+            <div className="mt-1 text-xs font-semibold leading-5 text-gray-600">{seasonPulse.detail}</div>
           </div>
 
           <div className="grid gap-3 lg:grid-cols-2">
@@ -1764,11 +1791,13 @@ function TeamPerformanceCard({ model, loading, error }: { model: TeamDetailModel
                 <div className="text-sm font-black text-gray-950">Recent form</div>
                 <div className="text-[10px] font-black uppercase tracking-[0.04em] text-gray-500">Last {analytics.recentForm.length}</div>
               </div>
-              <div className="mt-3 grid grid-cols-5 gap-2">
+              <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-5">
                 {analytics.recentForm.map((game) => (
-                  <div key={game.id} className="min-w-0 text-center">
-                    <div className={`flex h-10 items-center justify-center rounded-lg text-sm font-black ${resultTone[game.result]}`} aria-label={`${game.result} against ${game.opponent}, ${game.pointsFor} to ${game.pointsAgainst}`}>{game.result}</div>
-                    <div className="mt-1 truncate text-[10px] font-bold text-gray-500">{game.dateLabel}</div>
+                  <div key={game.id} className="min-w-0 rounded-lg border border-gray-100 bg-gray-50 p-2 text-center">
+                    <div className={`mx-auto flex h-8 w-8 items-center justify-center rounded-full text-xs font-black ${resultTone[game.result]}`} aria-label={`${game.result} against ${game.opponent}, ${game.pointsFor} to ${game.pointsAgainst}`}>{game.result}</div>
+                    <div className="mt-1 text-sm font-black text-gray-950">{game.pointsFor}-{game.pointsAgainst}</div>
+                    <div className="truncate text-[10px] font-bold text-gray-600" title={game.opponent}>vs {game.opponent}</div>
+                    <div className="mt-0.5 text-[9px] font-bold uppercase tracking-wide text-gray-400">{game.dateLabel}</div>
                   </div>
                 ))}
               </div>
@@ -1782,22 +1811,22 @@ function TeamPerformanceCard({ model, loading, error }: { model: TeamDetailModel
             <div className="rounded-xl border border-gray-200 bg-white p-3">
               <div className="text-sm font-black text-gray-950">Scoring comparison</div>
               <div className="mt-4 space-y-4">
-                <TeamAverageBar label="Points for" value={analytics.averagePointsFor} width={(analytics.averagePointsFor / maxAverage) * 100} color="bg-emerald-600" />
-                <TeamAverageBar label="Points against" value={analytics.averagePointsAgainst} width={(analytics.averagePointsAgainst / maxAverage) * 100} color="bg-rose-600" />
+                <TeamAverageBar label={scoringLabels.for} value={analytics.averagePointsFor} width={(analytics.averagePointsFor / maxAverage) * 100} color="bg-emerald-600" />
+                <TeamAverageBar label={scoringLabels.against} value={analytics.averagePointsAgainst} width={(analytics.averagePointsAgainst / maxAverage) * 100} color="bg-rose-600" />
               </div>
             </div>
           </div>
 
           <div className="rounded-xl border border-gray-200 bg-white p-3">
             <div className="flex items-center justify-between gap-3">
-              <div className="text-sm font-black text-gray-950">Game-by-game scoring</div>
+              <div className="text-sm font-black text-gray-950">Game-by-game {scoringLabels.graphNoun}</div>
               <div className="text-[10px] font-black uppercase tracking-[0.04em] text-gray-500">Last {analytics.progression.length}</div>
             </div>
             <div className="mt-3 flex h-48 items-end gap-2 overflow-x-auto rounded-lg bg-gray-50 px-2 pb-2 pt-4">
               {analytics.progression.map((game) => (
                 <div key={game.id} className="flex h-full min-w-12 flex-1 flex-col items-center justify-end gap-1">
-                  <div className="text-[10px] font-black text-gray-700">{game.pointsFor}-{game.pointsAgainst}</div>
-                  <div className="flex h-full w-full items-end justify-center gap-1" aria-label={`${game.dateLabel} against ${game.opponent}: ${game.pointsFor} points for and ${game.pointsAgainst} points against`}>
+                  <div className={`rounded-full px-1.5 py-0.5 text-[9px] font-black ${resultTone[game.result]}`}>{game.result} {game.pointsFor}-{game.pointsAgainst}</div>
+                  <div className="flex h-full w-full items-end justify-center gap-1" aria-label={`${game.dateLabel} against ${game.opponent}: ${formatScoringCount(game.pointsFor, scoringLabels.unitSingular, scoringLabels.unitPlural)} for and ${formatScoringCount(game.pointsAgainst, scoringLabels.unitSingular, scoringLabels.unitPlural)} against`}>
                     <div className="w-2/5 rounded-t bg-primary-600" style={{ height: `${Math.max(7, (game.pointsFor / maxGameScore) * 100)}%` }} />
                     <div className="w-2/5 rounded-t bg-gray-300" style={{ height: `${Math.max(7, (game.pointsAgainst / maxGameScore) * 100)}%` }} />
                   </div>
@@ -1806,8 +1835,8 @@ function TeamPerformanceCard({ model, loading, error }: { model: TeamDetailModel
               ))}
             </div>
             <div className="mt-2 flex justify-center gap-4 text-[10px] font-bold text-gray-500">
-              <span className="inline-flex items-center gap-1"><span className="h-2 w-2 rounded-sm bg-primary-600" />Points for</span>
-              <span className="inline-flex items-center gap-1"><span className="h-2 w-2 rounded-sm bg-gray-300" />Points against</span>
+              <span className="inline-flex items-center gap-1"><span className="h-2 w-2 rounded-sm bg-primary-600" />{scoringLabels.for}</span>
+              <span className="inline-flex items-center gap-1"><span className="h-2 w-2 rounded-sm bg-gray-300" />{scoringLabels.against}</span>
             </div>
           </div>
         </div>
@@ -1830,6 +1859,40 @@ function TeamAverageBar({ label, value, width, color }: { label: string; value: 
 
 function formatTeamMetric(value: number) {
   return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+function formatScoringCount(value: number, singular: string, plural: string) {
+  return `${value} ${value === 1 ? singular : plural}`;
+}
+
+function getTeamScoringLabels(sport: string) {
+  const normalizedSport = String(sport || '').trim().toLowerCase();
+  if (['soccer', 'hockey', 'lacrosse', 'field hockey', 'water polo'].includes(normalizedSport)) {
+    return { for: 'Goals for', against: 'Goals against', differential: 'Goal difference', graphNoun: 'goals', unitSingular: 'goal', unitPlural: 'goals' };
+  }
+  if (['baseball', 'softball', 'cricket'].includes(normalizedSport)) {
+    return { for: 'Runs for', against: 'Runs against', differential: 'Run difference', graphNoun: 'runs', unitSingular: 'run', unitPlural: 'runs' };
+  }
+  return { for: 'Points for', against: 'Points against', differential: 'Point difference', graphNoun: 'scoring', unitSingular: 'point', unitPlural: 'points' };
+}
+
+function getSeasonPulse(analytics: TeamDetailAnalyticsSnapshot, unitSingular: string) {
+  const averageGap = Math.round(Math.abs(analytics.averagePointsFor - analytics.averagePointsAgainst) * 10) / 10;
+  const bestResult = [...analytics.progression].sort((a, b) => b.differential - a.differential)[0];
+  const recentSummary = `${analytics.recentWins} win${analytics.recentWins === 1 ? '' : 's'}, ${analytics.recentLosses} loss${analytics.recentLosses === 1 ? '' : 'es'}${analytics.recentTies ? `, and ${analytics.recentTies} tie${analytics.recentTies === 1 ? '' : 's'}` : ''} in the last ${analytics.recentForm.length}.`;
+  if (analytics.averagePointsFor > analytics.averagePointsAgainst) {
+    return {
+      headline: `Positive margin: +${formatTeamMetric(averageGap)} ${unitSingular}${averageGap === 1 ? '' : 's'} per game`,
+      detail: `${recentSummary}${bestResult ? ` Best result in this view: ${bestResult.pointsFor}-${bestResult.pointsAgainst} vs ${bestResult.opponent}.` : ''}`
+    };
+  }
+  if (analytics.averagePointsFor < analytics.averagePointsAgainst) {
+    return {
+      headline: `The clearest opportunity is closing a ${formatTeamMetric(averageGap)}-${unitSingular}-per-game gap`,
+      detail: `${recentSummary}${bestResult && bestResult.differential > 0 ? ` Best result in this view: ${bestResult.pointsFor}-${bestResult.pointsAgainst} vs ${bestResult.opponent}.` : ''}`
+    };
+  }
+  return { headline: 'Scoring is level across the season', detail: recentSummary };
 }
 
 function MoreTab({ model, auth, staffPermissionsLoading, staffPermissionsError, sponsorsLoading, sponsorsError, onTeamDetailRefresh }: { model: TeamDetailModel; auth: AuthState; staffPermissionsLoading: boolean; staffPermissionsError: string; sponsorsLoading: boolean; sponsorsError: string; onTeamDetailRefresh: () => Promise<void> }) {

--- a/js/season-record.js
+++ b/js/season-record.js
@@ -21,7 +21,19 @@ export function isCompletedGame(game) {
 }
 
 export function getTeamScorePair(game) {
-  const useStoredScoreOrder = !!String(game?.sharedScheduleSourceTeamId || '').trim()
+  const orientation = String(game?.scoreOrientation || '').trim().toLowerCase();
+  const isSharedMirror = !!String(game?.sharedScheduleSourceTeamId || '').trim();
+  const hasLegacyTrackerPayload = game?.liveHasData === true
+    || Object.prototype.hasOwnProperty.call(game || {}, 'opponentStats');
+  const hasFinalLiveStatus = ['completed', 'final'].includes(String(game?.liveStatus || '').trim().toLowerCase());
+
+  // Shared mirrors and legacy trackers store team/opponent scores in the two
+  // score fields. App/manual venue score writers store true home/away scores.
+  // Prefer the persisted contract, while retaining a fallback for historical
+  // tracker games completed before scoreOrientation was introduced.
+  const useStoredScoreOrder = isSharedMirror
+    || orientation === 'team-opponent'
+    || (orientation !== 'venue' && hasLegacyTrackerPayload && !hasFinalLiveStatus)
     || game?.isHome !== false;
   return {
     teamScore: useStoredScoreOrder ? game?.homeScore : game?.awayScore,

--- a/js/season-record.js
+++ b/js/season-record.js
@@ -25,7 +25,7 @@ export function getTeamScorePair(game) {
   const isSharedMirror = !!String(game?.sharedScheduleSourceTeamId || '').trim();
   const hasLegacyTrackerPayload = game?.liveHasData === true
     || Object.prototype.hasOwnProperty.call(game || {}, 'opponentStats');
-  const hasFinalLiveStatus = ['completed', 'final'].includes(String(game?.liveStatus || '').trim().toLowerCase());
+  const hasAppVenueTrackingMetadata = game?.liveStartedAt != null;
 
   // Shared mirrors and legacy trackers store team/opponent scores in the two
   // score fields. App/manual venue score writers store true home/away scores.
@@ -33,7 +33,7 @@ export function getTeamScorePair(game) {
   // tracker games completed before scoreOrientation was introduced.
   const useStoredScoreOrder = isSharedMirror
     || orientation === 'team-opponent'
-    || (orientation !== 'venue' && hasLegacyTrackerPayload && !hasFinalLiveStatus)
+    || (orientation !== 'venue' && hasLegacyTrackerPayload && !hasAppVenueTrackingMetadata)
     || game?.isHome !== false;
   return {
     teamScore: useStoredScoreOrder ? game?.homeScore : game?.awayScore,

--- a/js/season-record.js
+++ b/js/season-record.js
@@ -20,6 +20,15 @@ export function isCompletedGame(game) {
   return typeof game.homeScore === 'number' && typeof game.awayScore === 'number';
 }
 
+export function getTeamScorePair(game) {
+  const useStoredScoreOrder = !!String(game?.sharedScheduleSourceTeamId || '').trim()
+    || game?.isHome !== false;
+  return {
+    teamScore: useStoredScoreOrder ? game?.homeScore : game?.awayScore,
+    opponentScore: useStoredScoreOrder ? game?.awayScore : game?.homeScore
+  };
+}
+
 export function calculateSeasonRecord(games, { seasonLabel } = {}) {
   let wins = 0;
   let losses = 0;
@@ -30,8 +39,9 @@ export function calculateSeasonRecord(games, { seasonLabel } = {}) {
     if (!gameCountsTowardSeasonRecord(game)) return;
     if (seasonLabel && inferSeasonLabelFromGame(game) !== seasonLabel) return;
 
-    if (game.homeScore > game.awayScore) wins += 1;
-    else if (game.homeScore < game.awayScore) losses += 1;
+    const { teamScore, opponentScore } = getTeamScorePair(game);
+    if (teamScore > opponentScore) wins += 1;
+    else if (teamScore < opponentScore) losses += 1;
     else ties += 1;
   });
 

--- a/js/track-finish.js
+++ b/js/track-finish.js
@@ -224,6 +224,7 @@ export async function commitStandardTrackerFinishData({
     gameUpdateBatch.update(gameRef, {
         homeScore: finalHome,
         awayScore: finalAway,
+        scoreOrientation: 'team-opponent',
         summary,
         status: 'completed',
         opponentStats

--- a/tests/unit/season-record.test.js
+++ b/tests/unit/season-record.test.js
@@ -58,7 +58,8 @@ describe('season record helpers', () => {
       isHome: false,
       homeScore: 71,
       awayScore: 68,
-      opponentStats: {}
+      opponentStats: {},
+      liveStatus: 'completed'
     };
     const explicitTeamOrientedGame = {
       isHome: false,
@@ -73,10 +74,19 @@ describe('season record helpers', () => {
       opponentStats: {},
       scoreOrientation: 'venue'
     };
+    const appTrackedAwayGame = {
+      isHome: false,
+      homeScore: 68,
+      awayScore: 71,
+      opponentStats: {},
+      liveStatus: 'completed',
+      liveStartedAt: '2026-03-04T18:00:00Z'
+    };
 
     expect(getTeamScorePair(legacyTrackedAwayGame)).toEqual({ teamScore: 71, opponentScore: 68 });
     expect(getTeamScorePair(explicitTeamOrientedGame)).toEqual({ teamScore: 3, opponentScore: 1 });
     expect(getTeamScorePair(explicitVenueGameWithLegacyPayload)).toEqual({ teamScore: 71, opponentScore: 68 });
+    expect(getTeamScorePair(appTrackedAwayGame)).toEqual({ teamScore: 71, opponentScore: 68 });
   });
 
   it('lists unique season labels in descending order', () => {

--- a/tests/unit/season-record.test.js
+++ b/tests/unit/season-record.test.js
@@ -53,6 +53,32 @@ describe('season record helpers', () => {
     ], { seasonLabel: '2026' })).toEqual({ wins: 2, losses: 0, ties: 0 });
   });
 
+  it('preserves team-oriented scores from legacy trackers and explicit writer metadata', () => {
+    const legacyTrackedAwayGame = {
+      isHome: false,
+      homeScore: 71,
+      awayScore: 68,
+      opponentStats: {}
+    };
+    const explicitTeamOrientedGame = {
+      isHome: false,
+      homeScore: 3,
+      awayScore: 1,
+      scoreOrientation: 'team-opponent'
+    };
+    const explicitVenueGameWithLegacyPayload = {
+      isHome: false,
+      homeScore: 68,
+      awayScore: 71,
+      opponentStats: {},
+      scoreOrientation: 'venue'
+    };
+
+    expect(getTeamScorePair(legacyTrackedAwayGame)).toEqual({ teamScore: 71, opponentScore: 68 });
+    expect(getTeamScorePair(explicitTeamOrientedGame)).toEqual({ teamScore: 3, opponentScore: 1 });
+    expect(getTeamScorePair(explicitVenueGameWithLegacyPayload)).toEqual({ teamScore: 71, opponentScore: 68 });
+  });
+
   it('lists unique season labels in descending order', () => {
     const games = [
       { type: 'game', seasonLabel: '2024' },

--- a/tests/unit/season-record.test.js
+++ b/tests/unit/season-record.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   inferSeasonLabelFromGame,
   gameCountsTowardSeasonRecord,
+  getTeamScorePair,
   isCompletedGame,
   calculateSeasonRecord,
   listSeasonLabels
@@ -38,6 +39,18 @@ describe('season record helpers', () => {
 
     expect(calculateSeasonRecord(games, { seasonLabel: '2026' })).toEqual({ wins: 1, losses: 1, ties: 1 });
     expect(calculateSeasonRecord(games, { seasonLabel: '2025' })).toEqual({ wins: 1, losses: 0, ties: 0 });
+  });
+
+  it('normalizes venue-oriented away scores and preserves mirrored score order', () => {
+    const awayGame = { isHome: false, homeScore: 68, awayScore: 71 };
+    const mirroredAwayGame = { ...awayGame, homeScore: 71, awayScore: 68, sharedScheduleSourceTeamId: 'team-alpha' };
+
+    expect(getTeamScorePair(awayGame)).toEqual({ teamScore: 71, opponentScore: 68 });
+    expect(getTeamScorePair(mirroredAwayGame)).toEqual({ teamScore: 71, opponentScore: 68 });
+    expect(calculateSeasonRecord([
+      { ...awayGame, type: 'game', status: 'completed', seasonLabel: '2026' },
+      { ...mirroredAwayGame, type: 'game', status: 'completed', seasonLabel: '2026' }
+    ], { seasonLabel: '2026' })).toEqual({ wins: 2, losses: 0, ties: 0 });
   });
 
   it('lists unique season labels in descending order', () => {

--- a/tests/unit/track-finish-batch-limit.test.js
+++ b/tests/unit/track-finish-batch-limit.test.js
@@ -546,6 +546,7 @@ describe('standard tracker finish batch limits', () => {
                 data: expect.objectContaining({
                     homeScore: 14,
                     awayScore: 12,
+                    scoreOrientation: 'team-opponent',
                     summary: 'Partial finish failed at the end.',
                     status: 'completed'
                 })

--- a/track-live.html
+++ b/track-live.html
@@ -3485,6 +3485,7 @@ Write the match report now:`;
                 batch.update(gameRef, {
                     homeScore: finalHome,
                     awayScore: finalAway,
+                    scoreOrientation: 'team-opponent',
                     summary: summary,
                     status: 'completed',
                     opponentStats: gameState.opponentStats,


### PR DESCRIPTION
## Summary

- add team performance analytics to the React/Capacitor Insights tab
- show season-aware recent form, scoring averages, differential, and game-by-game graphs
- add a season selector and sport-specific goals/runs/points terminology
- add a Season pulse summary with recent form and best-result context
- preserve the existing player checklist and public leaderboards
- hydrate complete team header data when Insights is opened directly
- handle older cached/test models that do not yet include team analytics

## Why

The app Insights tab could appear empty even when the team had completed games and a visible record. The legacy team experience already exposed score-derived analytics, while the app required separately configured tracking items or leaderboards.

The implementation now derives analytics from completed, score-bearing games and keeps the selected analytics season aligned with the team header record.

## User impact

Parents and team members can understand recent form and scoring trends directly in the app across web, iOS, and Android. Visuals use the established player-stats style and include accessible text labels.

## Validation

- focused Vitest — 85 tests passed, including the previously failing integration suite
- exact four previously failing Playwright smoke scenarios — passed
- app ESLint — passed with no errors
- `npm run app:build` — passed
- bundle visualizer verification — passed
- `git diff --check` — passed
- browser-validated the authenticated team Insights route with 2026 and 2025 Fall seasons

## Ownership

Manual Codex closeout and merge authorized by the repository owner on July 21, 2026.

Closes #4106