### PR TITLE
Harden team fee financial writes

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -950,6 +950,12 @@ service cloud.firestore {
              hasRecipientMatch;
     }
 
+    // Fee balances and payment statuses are authoritative financial state.
+    // Parent access is read-only; only team owners/admins may mutate recipient records.
+    function canWriteTeamFeeFinancialState(teamId) {
+      return isTeamOwnerOrAdmin(teamId);
+    }
+
     function hasNoPrivateTeamFeeBillingFields(data) {
       return !data.keys().hasAny([
                'stripeCheckoutSessionId',
@@ -3749,7 +3755,7 @@ service cloud.firestore {
                            request.resource.data.teamId == teamId &&
                            request.resource.data.batchId == batchId &&
                            hasNoPrivateTeamFeeBillingFields(request.resource.data);
-          allow update: if isTeamOwnerOrAdmin(teamId) &&
+          allow update: if canWriteTeamFeeFinancialState(teamId) &&
                            resource.data.teamId == teamId &&
                            resource.data.batchId == batchId &&
                            request.resource.data.teamId == teamId &&

--- a/tests/unit/team-fee-recipient-rules.test.js
+++ b/tests/unit/team-fee-recipient-rules.test.js
@@ -52,6 +52,12 @@ describe('team fee recipient Firestore rules', () => {
         expect(nestedRecipientBlock).toContain('hasNoIntroducedPrivateTeamFeeBillingFields()');
     });
 
+    it('uses the owner/admin-only fee financial state guard for recipient updates', () => {
+        expect(rules).toContain('function canWriteTeamFeeFinancialState(teamId)');
+        expect(rules).toContain('return isTeamOwnerOrAdmin(teamId);');
+        expect(nestedRecipientBlock).toContain('allow update: if canWriteTeamFeeFinancialState(teamId)');
+    });
+
     it('blocks private billing fields on parent-readable fee recipient documents while keeping adminBilling admin-only', () => {
         expect(rules).toContain('function hasNoPrivateTeamFeeBillingFields(data)');
         expect(rules).toContain('function hasNoIntroducedPrivateTeamFeeBillingFields()');
@@ -150,6 +156,46 @@ describe('team fee recipient Firestore rules', () => {
             await assertFails(updateDoc(validRef, { batchId: 'batch-b' }));
             await assertSucceeds(updateDoc(validRef, { status: 'paid' }));
             await assertSucceeds(deleteDoc(validRef));
+        });
+
+        it('denies parent fee amount/status tampering while allowing owner and admin updates', async () => {
+            await seedRecipient(
+                'teams/team-a/feeBatches/batch-a/feeRecipients/financial-state',
+                recipientPayload()
+            );
+
+            const parentRef = recipientRef(
+                authedFirestore('parent-a', 'parent-a@example.com'),
+                'team-a',
+                'batch-a',
+                'financial-state'
+            );
+            await assertFails(updateDoc(parentRef, {
+                amountDueCents: 1,
+                status: 'paid'
+            }));
+
+            const ownerRef = recipientRef(
+                authedFirestore('owner-a', 'owner-a@example.com'),
+                'team-a',
+                'batch-a',
+                'financial-state'
+            );
+            await assertSucceeds(updateDoc(ownerRef, {
+                amountDueCents: 2000,
+                status: 'partial'
+            }));
+
+            const adminRef = recipientRef(
+                authedFirestore('admin-a', 'admin-a@example.com'),
+                'team-a',
+                'batch-a',
+                'financial-state'
+            );
+            await assertSucceeds(updateDoc(adminRef, {
+                amountDueCents: 0,
+                status: 'paid'
+            }));
         });
 
         it('preserves scoped collection-group reads for linked parents and team admins', async () => {


### PR DESCRIPTION
Closes #4111

## What changed
- Added an explicit owner/admin-only guard for fee recipient financial-state updates.
- Added Firestore emulator coverage proving parents cannot alter fee amount/status while team owners and admins can.

## Root Cause
Fee recipient updates depended directly on a generic team authorization predicate without emulator coverage for a linked parent's attempt to mutate authoritative financial fields. The behavior was restrictive, but the financial boundary was implicit and vulnerable to undetected authorization drift.

## Prevention / Learning
Use named authorization boundaries for authoritative financial state. Rules-emulator tests must cover the denied actor as well as every allowed role.

## Regression Tests
- `npx vitest run tests/unit/team-fee-recipient-rules.test.js --reporter=verbose`
- Firestore emulator suite: 10 tests passed, including parent denial and owner/admin success.
- `npm run ci:firebase-rules`
- `git diff --check`

## Recurrence Risk
Low. Fee updates now use an explicit guard, and actor-level emulator coverage protects the boundary.