### PR TITLE
Quarantine flaky auth preview visual

### DIFF
--- a/playwright.smoke.config.js
+++ b/playwright.smoke.config.js
@@ -1,9 +1,25 @@
+const quarantinedAuthVisual = /@visual app auth screen exposes sign in, sign up, Google, activation code, invite, and reset flows/;
+
 export default {
     testDir: './tests/smoke',
     testMatch: ['**/*.spec.js'],
     snapshotPathTemplate: '{testDir}/{testFilePath}-snapshots/{arg}{ext}',
     timeout: 30000,
-    retries: process.env.CI ? 1 : 0,
+    retries: 0,
+    projects: [
+        {
+            // Targeted quarantine for the auth-join-code-signup.png flake; tracked by #4100.
+            name: 'auth-profile-visual-quarantine',
+            testMatch: ['**/app-auth-profile.spec.js'],
+            grep: quarantinedAuthVisual,
+            retries: process.env.CI ? 1 : 0
+        },
+        {
+            name: 'smoke',
+            grepInvert: quarantinedAuthVisual,
+            retries: 0
+        }
+    ],
     expect: {
         toHaveScreenshot: {
             animations: 'disabled',

--- a/tests/unit/visual-regression-wiring.test.js
+++ b/tests/unit/visual-regression-wiring.test.js
@@ -1,11 +1,31 @@
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
+import smokeConfig from '../../playwright.smoke.config.js';
 
 const repoRoot = path.resolve(import.meta.dirname, '../..');
 const readRepoFile = (file) => readFileSync(path.join(repoRoot, file), 'utf8');
 
 describe('visual regression CI wiring', () => {
+    it('retries only the tracked auth visual in CI', () => {
+        const quarantine = smokeConfig.projects.find(
+            ({ name }) => name === 'auth-profile-visual-quarantine'
+        );
+        const remainingSmoke = smokeConfig.projects.find(({ name }) => name === 'smoke');
+
+        expect(smokeConfig.retries).toBe(0);
+        expect(quarantine).toMatchObject({
+            testMatch: ['**/app-auth-profile.spec.js'],
+            retries: process.env.CI ? 1 : 0
+        });
+        expect(quarantine.grep.source).toBe(
+            '@visual app auth screen exposes sign in, sign up, Google, activation code, invite, and reset flows'
+        );
+        expect(quarantine.grep).toEqual(remainingSmoke.grepInvert);
+        expect(remainingSmoke.retries).toBe(0);
+        expect(readRepoFile('playwright.smoke.config.js')).toContain('tracked by #4100');
+    });
+
     it('runs visual checks explicitly after non-visual preview smoke and retains failure diffs', () => {
         const workflow = readRepoFile('.github/workflows/preview-smoke.yml');
 


### PR DESCRIPTION
Closes #4110

## What changed
- Isolated the tracked `auth-join-code-signup.png` visual test in a dedicated Playwright project.
- Retained one CI retry only for that test.
- Set all remaining smoke tests to zero retries.
- Added inline tracking for #4100 and focused wiring coverage.

## Root Cause
The suite-level retry setting caused every preview-smoke test to retry in CI, masking unrelated regressions instead of quarantining the known flaky auth visual.

## Prevention / Learning
Known flaky tests should use a uniquely matched Playwright project paired with a complementary zero-retry project. Never place quarantine retries at the suite root.

## Regression Tests
- `CI=1 npx vitest run tests/unit/visual-regression-wiring.test.js --reporter=verbose`
- Playwright discovery confirmed the auth visual belongs only to `auth-profile-visual-quarantine`.
- Playwright discovery confirmed another auth-profile test belongs only to the zero-retry `smoke` project.
- `git diff --check`

## Recurrence Risk
Low. Focused wiring coverage asserts the exact quarantined test, tracking reference, complementary project filters, and both retry policies.