### PR TITLE
Improve public team visitor paths

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -247,8 +247,8 @@ export default function App() {
         <Route path="/teams" element={<Protected auth={auth}><Teams auth={auth} /></Protected>} />
         <Route path="/teams/new" element={<Protected auth={auth}><CreateTeam auth={auth} /></Protected>} />
         <Route path="/teams/browse" element={<PublicPage auth={auth}><PublicTeamsBrowse /></PublicPage>} />
-        <Route path="/teams/:teamId/public" element={<PublicPage auth={auth}><PublicTeamDetail /></PublicPage>} />
-        <Route path="/teams/:teamId" element={auth.user || auth.loading ? <Protected auth={auth}><TeamDetail auth={auth} /></Protected> : <PublicPage auth={auth}><PublicTeamDetail /></PublicPage>} />
+        <Route path="/teams/:teamId/public" element={<PublicPage auth={auth}><PublicTeamDetail authUser={auth.user} /></PublicPage>} />
+        <Route path="/teams/:teamId" element={auth.user || auth.loading ? <Protected auth={auth}><TeamDetail auth={auth} /></Protected> : <PublicPage auth={auth}><PublicTeamDetail authUser={auth.user} /></PublicPage>} />
         <Route path="/teams/:teamId/edit" element={<Protected auth={auth}><TeamSettings auth={auth} /></Protected>} />
         <Route path="/teams/:teamId/certificates" element={<Protected auth={auth}><TeamCertificates auth={auth} /></Protected>} />
         <Route path="/teams/:teamId/drills" element={<Protected auth={auth}><TeamDrills auth={auth} /></Protected>} />

--- a/apps/app/src/components/PublicTeamSearch.test.tsx
+++ b/apps/app/src/components/PublicTeamSearch.test.tsx
@@ -361,7 +361,11 @@ describe('PublicTeamSearch', () => {
         const atlantaCard = screen.getByText('Atlanta United').closest('article');
         expect(atlantaCard).toBeTruthy();
 
-        fireEvent.click(within(atlantaCard as HTMLElement).getByRole('button', { name: 'View public team' }));
+        const teamLink = within(atlantaCard as HTMLElement).getByRole('link', { name: 'View Atlanta United public team' });
+        expect(teamLink.getAttribute('href')).toBe('/teams/team-atl-1/public');
+        expect(teamLink.className).toContain('!min-h-11');
+        expect(within(atlantaCard as HTMLElement).queryByRole('button', { name: 'View public team' })).toBeNull();
+        fireEvent.click(teamLink);
 
         expect(screen.getByTestId('location-probe').textContent).toBe('/teams/team-atl-1/public');
     });
@@ -375,7 +379,7 @@ describe('PublicTeamSearch', () => {
         const newYorkCard = screen.getByText('New York Knicks').closest('article');
         expect(newYorkCard).toBeTruthy();
 
-        fireEvent.click(within(newYorkCard as HTMLElement).getByRole('button', { name: 'View public team' }));
+        fireEvent.click(within(newYorkCard as HTMLElement).getByRole('link', { name: 'View New York Knicks public team' }));
 
         expect(screen.getByTestId('location-probe').textContent).toBe('/teams/team-nyc-1/public');
     });
@@ -400,7 +404,7 @@ describe('PublicTeamSearch', () => {
         await waitFor(() => expect(screen.getByText('Hidden Club')).toBeTruthy());
         const hiddenCard = screen.getByText('Hidden Club').closest('article');
         expect(hiddenCard).toBeTruthy();
-        fireEvent.click(within(hiddenCard as HTMLElement).getByRole('button', { name: 'View public team' }));
+        fireEvent.click(within(hiddenCard as HTMLElement).getByRole('link', { name: 'View Hidden Club public team' }));
         expect(screen.getByTestId('location-probe').textContent).toBe('/teams/team-private-1/public');
     });
 

--- a/apps/app/src/components/PublicTeamSearch.tsx
+++ b/apps/app/src/components/PublicTeamSearch.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Search, XCircle, Loader2, Users } from 'lucide-react';
 import { type ParentHomeTeam } from '../lib/homeLogic';
 import { TeamAvatar, TeamLauncherChip, Status } from './TeamSummaryPrimitives';
@@ -14,7 +14,6 @@ function publicTeamRequestKey(searchText?: string | null) {
 }
 
 export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = false }: { autoBrowseOnMount?: boolean; showBackLink?: boolean }) {
-  const navigate = useNavigate();
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [publicTeams, setPublicTeams] = useState<ParentHomeTeam[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
@@ -111,10 +110,6 @@ export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = fal
     setLoading(false);
     setNextCursor(null);
   };
-
-  const handleOpenTeam = useCallback((team: ParentHomeTeam) => {
-    navigate(`/teams/${encodeURIComponent(team.teamId)}/public`);
-  }, [navigate]);
 
   useEffect(() => {
     if (!autoBrowseOnMount || autoBrowseTriggeredRef.current) {
@@ -228,7 +223,7 @@ export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = fal
               <h3 className="text-lg font-black text-gray-950">{location}</h3>
               <div className="grid gap-2 sm:grid-cols-2">
                 {teams.map(team => (
-                  <PublicTeamCard key={team.teamId} team={team} onOpenTeam={handleOpenTeam} />
+                  <PublicTeamCard key={team.teamId} team={team} />
                 ))}
               </div>
             </div>
@@ -277,7 +272,7 @@ export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = fal
   );
 }
 
-function PublicTeamCard({ team, onOpenTeam }: { team: ParentHomeTeam; onOpenTeam: (team: ParentHomeTeam) => void | Promise<void> }) {
+function PublicTeamCard({ team }: { team: ParentHomeTeam }) {
   const hasRosterCount = typeof team.publicRosterCount === 'number';
   const rosterCountLabel = hasRosterCount
     ? `${team.publicRosterCount}${team.publicRosterCountCapped ? '+' : ''} player${team.publicRosterCount === 1 && !team.publicRosterCountCapped ? '' : 's'}`
@@ -296,15 +291,12 @@ function PublicTeamCard({ team, onOpenTeam }: { team: ParentHomeTeam; onOpenTeam
         </span>
       </div>
 
-      <button
-        type="button"
-        className="primary-button mt-3 w-full justify-center !min-h-10 text-sm"
-        onClick={() => {
-          void onOpenTeam(team);
-        }}
+      <Link
+        to={`/teams/${encodeURIComponent(team.teamId)}/public`}
+        className="primary-button mt-3 w-full justify-center !min-h-11 text-sm"
       >
-        View public team
-      </button>
+        View {team.teamName} public team
+      </Link>
     </article>
   );
 }

--- a/apps/app/src/pages/PublicTeamDetail.test.tsx
+++ b/apps/app/src/pages/PublicTeamDetail.test.tsx
@@ -21,7 +21,7 @@ describe('PublicTeamDetail', () => {
   it('announces loading while the public team request is pending', () => {
     publicTeamMocks.getPublicTeamDetail.mockImplementation(() => new Promise(() => {}));
 
-    render(<MemoryRouter initialEntries={['/teams/team-1/public']}><Routes><Route path="/teams/:teamId/public" element={<PublicTeamDetail />} /></Routes></MemoryRouter>);
+    render(<MemoryRouter initialEntries={['/teams/team-1/public']}><Routes><Route path="/teams/:teamId/public" element={<PublicTeamDetail authUser={null} />} /></Routes></MemoryRouter>);
 
     expect(screen.getByRole('status').textContent).toContain('Loading public team');
   });
@@ -39,7 +39,7 @@ describe('PublicTeamDetail', () => {
       location: 'Austin, TX'
     });
 
-    render(<MemoryRouter initialEntries={['/teams/team-1/public']}><Routes><Route path="/teams/:teamId/public" element={<PublicTeamDetail />} /></Routes></MemoryRouter>);
+    render(<MemoryRouter initialEntries={['/teams/team-1/public']}><Routes><Route path="/teams/:teamId/public" element={<PublicTeamDetail authUser={null} />} /></Routes></MemoryRouter>);
 
     expect(await screen.findByRole('heading', { name: 'Austin Bats' })).toBeTruthy();
     expect(screen.getByText('Public-safe profile')).toBeTruthy();
@@ -48,6 +48,26 @@ describe('PublicTeamDetail', () => {
     expect(screen.getByRole('link', { name: 'Back to team search' }).getAttribute('href')).toBe('/teams/browse');
     expect(screen.getByRole('link', { name: 'Enter a join code' }).getAttribute('href')).toBe('/accept-invite');
     expect(screen.getByRole('link', { name: 'Sign in' }).getAttribute('href')).toBe('/auth');
+  });
+
+  it('hides the sign-in action from authenticated visitors', async () => {
+    publicTeamMocks.getPublicTeamDetail.mockResolvedValue({
+      id: 'team-1',
+      name: 'Austin Bats',
+      sport: 'Baseball',
+      description: 'Community baseball team.',
+      photoUrl: null,
+      city: 'Austin',
+      state: 'TX',
+      zip: '78701',
+      location: 'Austin, TX'
+    });
+
+    const authUser = { uid: 'parent-1', email: 'parent@example.com', displayName: 'Parent', roles: ['parent' as const] };
+    render(<MemoryRouter initialEntries={['/teams/team-1/public']}><Routes><Route path="/teams/:teamId/public" element={<PublicTeamDetail authUser={authUser} />} /></Routes></MemoryRouter>);
+
+    expect(await screen.findByRole('heading', { name: 'Austin Bats' })).toBeTruthy();
+    expect(screen.queryByRole('link', { name: 'Sign in' })).toBeNull();
   });
 
   it('provides recovery actions and retries the same public team', async () => {
@@ -65,7 +85,7 @@ describe('PublicTeamDetail', () => {
         location: 'Austin, TX'
       });
 
-    render(<MemoryRouter initialEntries={['/teams/team-1/public']}><Routes><Route path="/teams/:teamId/public" element={<PublicTeamDetail />} /></Routes></MemoryRouter>);
+    render(<MemoryRouter initialEntries={['/teams/team-1/public']}><Routes><Route path="/teams/:teamId/public" element={<PublicTeamDetail authUser={null} />} /></Routes></MemoryRouter>);
 
     expect(await screen.findByText('Public team could not load.')).toBeTruthy();
     const backLink = screen.getByRole('link', { name: 'Back to team search' });
@@ -97,7 +117,7 @@ describe('PublicTeamDetail', () => {
     render(
       <MemoryRouter initialEntries={['/teams/team-1/public']}>
         <Link to="/teams/missing/public">Next team</Link>
-        <Routes><Route path="/teams/:teamId/public" element={<PublicTeamDetail />} /></Routes>
+        <Routes><Route path="/teams/:teamId/public" element={<PublicTeamDetail authUser={null} />} /></Routes>
       </MemoryRouter>
     );
 

--- a/apps/app/src/pages/PublicTeamDetail.test.tsx
+++ b/apps/app/src/pages/PublicTeamDetail.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Link, MemoryRouter, Route, Routes } from 'react-router-dom';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PublicTeamDetail } from './PublicTeamDetail';
 
 const publicTeamMocks = vi.hoisted(() => ({ getPublicTeamDetail: vi.fn() }));
@@ -14,6 +14,18 @@ vi.mock('lucide-react', () => {
 afterEach(() => cleanup());
 
 describe('PublicTeamDetail', () => {
+  beforeEach(() => {
+    publicTeamMocks.getPublicTeamDetail.mockReset();
+  });
+
+  it('announces loading while the public team request is pending', () => {
+    publicTeamMocks.getPublicTeamDetail.mockImplementation(() => new Promise(() => {}));
+
+    render(<MemoryRouter initialEntries={['/teams/team-1/public']}><Routes><Route path="/teams/:teamId/public" element={<PublicTeamDetail />} /></Routes></MemoryRouter>);
+
+    expect(screen.getByRole('status').textContent).toContain('Loading public team');
+  });
+
   it('renders an allow-listed public team profile without private collections', async () => {
     publicTeamMocks.getPublicTeamDetail.mockResolvedValue({
       id: 'team-1',
@@ -33,6 +45,38 @@ describe('PublicTeamDetail', () => {
     expect(screen.getByText('Public-safe profile')).toBeTruthy();
     expect(screen.getByText('Community baseball team.')).toBeTruthy();
     expect(publicTeamMocks.getPublicTeamDetail).toHaveBeenCalledWith('team-1');
+    expect(screen.getByRole('link', { name: 'Back to team search' }).getAttribute('href')).toBe('/teams/browse');
+    expect(screen.getByRole('link', { name: 'Enter a join code' }).getAttribute('href')).toBe('/accept-invite');
+    expect(screen.getByRole('link', { name: 'Sign in' }).getAttribute('href')).toBe('/auth');
+  });
+
+  it('provides recovery actions and retries the same public team', async () => {
+    publicTeamMocks.getPublicTeamDetail
+      .mockRejectedValueOnce(new Error('Public team could not load.'))
+      .mockResolvedValueOnce({
+        id: 'team-1',
+        name: 'Austin Bats',
+        sport: 'Baseball',
+        description: 'Community baseball team.',
+        photoUrl: null,
+        city: 'Austin',
+        state: 'TX',
+        zip: '78701',
+        location: 'Austin, TX'
+      });
+
+    render(<MemoryRouter initialEntries={['/teams/team-1/public']}><Routes><Route path="/teams/:teamId/public" element={<PublicTeamDetail />} /></Routes></MemoryRouter>);
+
+    expect(await screen.findByText('Public team could not load.')).toBeTruthy();
+    const backLink = screen.getByRole('link', { name: 'Back to team search' });
+    expect(backLink.getAttribute('href')).toBe('/teams/browse');
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(screen.getByRole('status').textContent).toContain('Loading public team');
+    expect(await screen.findByRole('heading', { name: 'Austin Bats' })).toBeTruthy();
+    await waitFor(() => expect(publicTeamMocks.getPublicTeamDetail).toHaveBeenCalledTimes(2));
+    expect(publicTeamMocks.getPublicTeamDetail).toHaveBeenNthCalledWith(2, 'team-1');
+    expect(screen.queryByText('Public team could not load.')).toBeNull();
   });
 
   it('clears the prior public team when a new route fails to load', async () => {

--- a/apps/app/src/pages/PublicTeamDetail.tsx
+++ b/apps/app/src/pages/PublicTeamDetail.tsx
@@ -9,6 +9,7 @@ export function PublicTeamDetail() {
   const [team, setTeam] = useState<PublicTeamProfile | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [loadAttempt, setLoadAttempt] = useState(0);
 
   useEffect(() => {
     let active = true;
@@ -20,14 +21,35 @@ export function PublicTeamDetail() {
       .catch((loadError: any) => { if (active) { setTeam(null); setError(loadError?.message || 'Unable to load this public team.'); } })
       .finally(() => { if (active) setLoading(false); });
     return () => { active = false; };
-  }, [teamId]);
+  }, [teamId, loadAttempt]);
 
-  if (loading) return <div className="app-card p-10 text-center"><Loader2 className="mx-auto h-7 w-7 animate-spin text-primary-600" /></div>;
-  if (!team) return <Status tone="error" message={error || 'Public team not found.'} />;
+  if (loading) return (
+    <div className="app-card p-10 text-center" role="status" aria-live="polite">
+      <Loader2 className="mx-auto h-7 w-7 animate-spin text-primary-600" aria-hidden="true" />
+      <div className="mt-3 text-sm font-black text-gray-900">Loading public team</div>
+    </div>
+  );
+  if (!team) return (
+    <div className="app-card space-y-4 p-5 sm:p-6">
+      <Status tone="error" message={error || 'Public team not found.'} />
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <button type="button" className="primary-button w-full justify-center !min-h-11 text-sm sm:w-auto" onClick={() => setLoadAttempt((attempt) => attempt + 1)}>
+          Retry
+        </button>
+        <Link to="/teams/browse" className="secondary-button w-full justify-center !min-h-11 text-sm sm:w-auto">
+          Back to team search
+        </Link>
+      </div>
+    </div>
+  );
 
   return (
     <div className="mx-auto max-w-3xl space-y-4">
-      <div className="flex flex-wrap gap-3 text-sm font-black"><Link to="/discover?tab=teams" className="text-primary-700">← Find teams</Link><Link to="/discover" className="text-primary-700">Browse opportunities</Link></div>
+      <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+        <Link to="/teams/browse" className="ghost-button w-full justify-center !min-h-11 text-sm sm:w-auto">Back to team search</Link>
+        <Link to="/accept-invite" className="secondary-button w-full justify-center !min-h-11 text-sm sm:w-auto">Enter a join code</Link>
+        <Link to="/auth" className="primary-button w-full justify-center !min-h-11 text-sm sm:w-auto">Sign in</Link>
+      </div>
       <section className="app-card overflow-hidden">
         <div className="bg-gradient-to-br from-primary-700 to-primary-950 p-6 text-white sm:p-8">
           <div className="flex items-start gap-4">

--- a/apps/app/src/pages/PublicTeamDetail.tsx
+++ b/apps/app/src/pages/PublicTeamDetail.tsx
@@ -3,8 +3,9 @@ import { Loader2, MapPin, ShieldCheck, Users } from 'lucide-react';
 import { Link, useParams } from 'react-router-dom';
 import { Status } from '../components/TeamSummaryPrimitives';
 import { getPublicTeamDetail, type PublicTeamProfile } from '../lib/publicTeamsService';
+import type { AuthState } from '../lib/types';
 
-export function PublicTeamDetail() {
+export function PublicTeamDetail({ authUser }: { authUser: AuthState['user'] }) {
   const { teamId = '' } = useParams();
   const [team, setTeam] = useState<PublicTeamProfile | null>(null);
   const [loading, setLoading] = useState(true);
@@ -48,7 +49,7 @@ export function PublicTeamDetail() {
       <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
         <Link to="/teams/browse" className="ghost-button w-full justify-center !min-h-11 text-sm sm:w-auto">Back to team search</Link>
         <Link to="/accept-invite" className="secondary-button w-full justify-center !min-h-11 text-sm sm:w-auto">Enter a join code</Link>
-        <Link to="/auth" className="primary-button w-full justify-center !min-h-11 text-sm sm:w-auto">Sign in</Link>
+        {!authUser ? <Link to="/auth" className="primary-button w-full justify-center !min-h-11 text-sm sm:w-auto">Sign in</Link> : null}
       </div>
       <section className="app-card overflow-hidden">
         <div className="bg-gradient-to-br from-primary-700 to-primary-950 p-6 text-white sm:p-8">

--- a/docs/pr-notes/runs/issue-4117-fixer-20260721T193405Z/architecture.md
+++ b/docs/pr-notes/runs/issue-4117-fixer-20260721T193405Z/architecture.md
@@ -1,0 +1,27 @@
+# Architecture Review: Issue #4117
+
+## Current state
+
+- `PublicTeamSearch` renders a generic `View public team` button and calls `useNavigate`.
+- The action is only 40px high and its accessible name does not distinguish teams.
+- `PublicTeamDetail` renders an unlabeled spinner and a terminal error `Status` with no retry path.
+- Successful profiles point discovery to `/discover?tab=teams` and omit account-entry paths.
+
+## Root cause
+
+The public flow was implemented as a success-path display and navigation surface. Semantic navigation, complete async state handling, canonical recovery routes, and visitor exit paths were not encoded as component contracts or regression tests.
+
+## Minimal design
+
+- Replace imperative result navigation with a React Router `Link` to the encoded public route, named for the team and styled with `!min-h-11`.
+- Model detail retry with a local attempt counter while retaining the effect cleanup guard against stale responses.
+- Render loading as a polite status with visible text and a decorative spinner.
+- Render failure with the existing error message, `Retry`, and a `/teams/browse` link.
+- Add `/teams/browse`, `/accept-invite`, and `/auth` links to the successful public profile.
+
+## Safety, blast radius, and rollback
+
+- No data service, Firebase query, rule, index, or route definition changes are required.
+- The view continues to consume only `PublicTeamProfile` allow-listed fields.
+- Blast radius is limited to two public React components and focused tests.
+- Rollback is a source/test revert with no data or configuration migration.

--- a/docs/pr-notes/runs/issue-4117-fixer-20260721T193405Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-4117-fixer-20260721T193405Z/code-plan.md
@@ -1,0 +1,19 @@
+# Code Plan: Issue #4117
+
+## Test first
+
+1. Update `PublicTeamSearch.test.tsx` to require team-named links, encoded public-profile destinations, and `!min-h-11`; convert button navigation assertions to semantic links.
+2. Update `PublicTeamDetail.test.tsx` to cover announced loading, error recovery, retry success, canonical search navigation, join-code entry, and sign-in.
+3. Extend the focused 390×844 smoke path to measure the result target and verify profile visitor links without horizontal overflow.
+
+## Implementation
+
+1. Remove `useNavigate`, the open-team callback, and button plumbing from `PublicTeamSearch`.
+2. Render each card action as a descriptive React Router `Link` to the encoded public route with a 44px minimum height.
+3. Add a local retry trigger to `PublicTeamDetail`, preserving the existing effect cleanup guard.
+4. Add a polite loading status, recoverable failure actions, and successful-profile search/account-entry links.
+5. Leave `publicTeamsService`, Firebase access, routes, invite redemption, and authentication logic untouched.
+
+## Prevention / learning
+
+Treat discovery results as navigation contracts: test semantic role, entity-specific accessible name, destination, and touch-target size. For async public pages, test loading, failure recovery, and success paths separately rather than relying on success-only coverage.

--- a/docs/pr-notes/runs/issue-4117-fixer-20260721T193405Z/qa.md
+++ b/docs/pr-notes/runs/issue-4117-fixer-20260721T193405Z/qa.md
@@ -1,0 +1,28 @@
+# QA Strategy: Issue #4117
+
+## Focused regression coverage
+
+| Criterion | Guardrail |
+| --- | --- |
+| Descriptive result links | Query links by team-specific accessible name and assert the encoded `/teams/:id/public` destination. |
+| 44px touch targets | Assert `!min-h-11` in the component test and computed height `>= 44` at 390×844. |
+| Announced loading | Hold the request pending and assert a `role="status"` containing `Loading public team`; spinner is `aria-hidden`. |
+| Recoverable failure | Reject once, assert error, Retry, and exact `/teams/browse` destination; retry the same ID and recover in place. |
+| Visitor account paths | Assert `/accept-invite` and `/auth` links on the successful profile. |
+| Public boundary | Keep the existing allow-listed profile test; do not change the public service/query contract. |
+| Route race safety | Preserve the route-transition test that clears stale profile content before a later failure. |
+
+## Validation
+
+```bash
+cd apps/app
+npx vitest run src/components/PublicTeamSearch.test.tsx src/pages/PublicTeamDetail.test.tsx --reporter=verbose
+cd ../..
+npm run app:build
+```
+
+At the existing 390×844 Playwright viewport, verify no horizontal overflow, descriptive result link semantics, a computed 44px target, and the canonical visitor actions.
+
+## Recurrence risk
+
+Medium until browser validation passes because jsdom verifies semantics and classes but not computed target size or mobile overflow. Async refactors can also regress live announcements, retry behavior, or canonical recovery destinations.

--- a/docs/pr-notes/runs/issue-4117-fixer-20260721T193405Z/requirements.md
+++ b/docs/pr-notes/runs/issue-4117-fixer-20260721T193405Z/requirements.md
@@ -1,0 +1,36 @@
+# Requirements: Issue #4117
+
+## Objective
+
+Make public team discovery and profile visits understandable, accessible, recoverable, and usable at 390×844 without changing public data access or authentication behavior.
+
+## Observable requirements
+
+- Each result exposes a semantic link to `/teams/{encodedTeamId}/public` whose accessible name identifies the team.
+- Result links use the existing `min-h-11` convention for a 44px minimum touch target.
+- Public detail loading exposes meaningful status text through a live status region; the spinner is decorative.
+- Detail failures retain the error and provide `Retry` plus `Back to team search` linking exactly to `/teams/browse`.
+- Successful profiles provide `Enter a join code` to `/accept-invite` and `Sign in` to `/auth`.
+- Existing public routes and the allow-listed `PublicTeamProfile` data boundary remain unchanged.
+
+## Visitor journeys
+
+1. A visitor browses or searches, finds a descriptive team link, and opens the public-safe profile with touch, keyboard, or assistive technology.
+2. While the profile loads, assistive technology announces `Loading public team`.
+3. If loading fails, the visitor can retry the same team request or return to canonical team search.
+4. From a successful profile, a visitor can enter an existing join code or sign in without changing invite redemption or authentication behavior.
+
+## Accessibility and mobile constraints
+
+- Use links for navigation rather than buttons plus programmatic navigation.
+- Derive each link's accessible name from `team.teamName`.
+- Keep decorative icons and spinners `aria-hidden`.
+- Stack recovery and account-entry actions on narrow screens and avoid horizontal overflow.
+- Preserve intentional truncation for long card content without shortening the accessible link name.
+
+## Boundaries and assumptions
+
+- Continue using `getPublicTeamsPage` and `getPublicTeamDetail` only.
+- Do not load rosters, private schedules, contacts, member records, or authenticated team details.
+- Do not change Firebase queries, rules, indexes, route definitions, invite redemption, signup, or auth behavior.
+- A full-width descriptive link inside the card satisfies the result-card link requirement without creating nested interactive content.

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -729,7 +729,7 @@ test.describe('mobile My Teams', () => {
         await expect(page.getByRole('heading', { name: 'Atlanta Fire' })).toBeVisible();
         await expect(page.getByRole('link', { name: 'Back to team search' })).toHaveAttribute('href', '#/teams/browse');
         await expect(page.getByRole('link', { name: 'Enter a join code' })).toHaveAttribute('href', '#/accept-invite');
-        await expect(page.getByRole('link', { name: 'Sign in' })).toHaveAttribute('href', '#/auth');
+        await expect(page.getByRole('link', { name: 'Sign in' })).toHaveCount(0);
         await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
     });
 

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -547,6 +547,20 @@ async function mockPublicTeamsBrowseModule(page, { slowSearch = false } = {}) {
                     }
                     return { teams: [], nextCursor: null };
                 }
+
+                export async function getPublicTeamDetail(teamId) {
+                    return {
+                        id: teamId,
+                        name: teamId === 'search-atl-1' ? 'Atlanta Fire' : 'Public Team',
+                        sport: 'Soccer',
+                        description: 'Community soccer team.',
+                        photoUrl: null,
+                        city: 'Atlanta',
+                        state: 'GA',
+                        zip: '30303',
+                        location: 'Atlanta, GA'
+                    };
+                }
             `
         });
     });
@@ -692,20 +706,31 @@ test.describe('mobile My Teams', () => {
         await expect(page.getByText('Searching public teams for "atlanta".')).toBeVisible();
         await expect(page.getByText('Browsing teams across all regions.')).toHaveCount(0);
         await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
-        await expect(page.getByText('Atlanta Fire')).toBeVisible();
+        await expect(page.getByText('Atlanta Fire', { exact: true })).toBeVisible();
         await expect(page.getByRole('button', { name: 'Load more teams' })).toBeVisible();
         await expect.poll(() => page.evaluate(() => window.__publicTeamSearchCalls.at(-1))).toEqual({ searchText: 'atlanta', cursor: null });
 
         await page.getByRole('button', { name: 'Load more teams' }).click();
 
-        await expect(page.getByText('Atlanta United 2')).toBeVisible();
-        await expect(page.getByText('Kansas City Current')).toBeVisible();
+        await expect(page.getByText('Atlanta United 2', { exact: true })).toBeVisible();
+        await expect(page.getByText('Kansas City Current', { exact: true })).toBeVisible();
         await expect(searchInput).toHaveValue('atlanta');
         await expect(page.getByRole('heading', { level: 3 })).toHaveCount(2);
         await expect(page.getByRole('button', { name: 'Load more teams' })).toHaveCount(0);
         await expect.poll(() => page.evaluate(() => window.__publicTeamSearchCalls.at(-1))).toEqual({ searchText: 'atlanta', cursor: 'search-page-2' });
         await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
         await expect(page).toHaveURL(/#\/teams\/browse$/);
+
+        const atlantaFireLink = page.getByRole('link', { name: 'View Atlanta Fire public team' });
+        await expect(atlantaFireLink).toHaveAttribute('href', '#/teams/search-atl-1/public');
+        await expect.poll(async () => atlantaFireLink.evaluate((node) => node.getBoundingClientRect().height)).toBeGreaterThanOrEqual(44);
+        await atlantaFireLink.click();
+
+        await expect(page.getByRole('heading', { name: 'Atlanta Fire' })).toBeVisible();
+        await expect(page.getByRole('link', { name: 'Back to team search' })).toHaveAttribute('href', '#/teams/browse');
+        await expect(page.getByRole('link', { name: 'Enter a join code' })).toHaveAttribute('href', '#/accept-invite');
+        await expect(page.getByRole('link', { name: 'Sign in' })).toHaveAttribute('href', '#/auth');
+        await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
     });
 
     test('shows load failures without trapping the user in loading state', async ({ page, baseURL }) => {


### PR DESCRIPTION
Closes #4117

## What changed
- Replaced generic public-team buttons with descriptive 44px links.
- Added announced detail loading and recoverable failure actions.
- Added canonical team-search, join-code, and sign-in paths.
- Preserved existing routes and public-data boundaries.

## Root Cause
The public discovery UI covered only the success path. Navigation used a generic 40px button, while detail loading and failure states lacked accessibility and recovery contracts.

## Prevention / Learning
Test public discovery as a complete navigation and async-state contract: semantic entity-specific links, touch-target sizing, announced loading, recoverable failures, and successful visitor exit paths.

## Regression Tests
- Focused Vitest suites: 25 tests passed.
- Production app build and artifact verification passed.
- Focused Playwright validation passed at 390×844, including 44px target measurement and overflow checks.
- `git diff --check` passed.

## Recurrence Risk
Low. Focused component and mobile browser tests now guard the exact semantics, routes, recovery behavior, target size, and overflow constraints.