### PR TITLE
Improve accessible authentication controls

### DIFF
--- a/apps/app/src/pages/AcceptInvite.test.tsx
+++ b/apps/app/src/pages/AcceptInvite.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from '@testing-library/react';
+import { act, cleanup, render, screen } from '@testing-library/react';
 import { HashRouter, MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AcceptInvite } from './AcceptInvite';
@@ -88,6 +88,7 @@ describe('AcceptInvite', () => {
         renderAcceptInvite();
 
         expect(await screen.findByText('Invite accepted.')).toBeTruthy();
+        expect(screen.getByRole('status')).toHaveTextContent('Invite accepted.');
         expect(screen.queryByText('Home route')).toBeNull();
 
         await new Promise((resolve) => setTimeout(resolve, 750));
@@ -100,6 +101,21 @@ describe('AcceptInvite', () => {
             refresh: auth.refresh
         });
         expect(inviteRedemptionMocks.redeemSignedInInvite).toHaveBeenCalledTimes(1);
+    });
+
+    it('announces invite progress and errors with live semantics', async () => {
+        let rejectRedemption: (error: Error) => void = () => undefined;
+        inviteRedemptionMocks.redeemSignedInInvite.mockImplementation(() => new Promise((_resolve, reject) => {
+            rejectRedemption = reject;
+        }));
+
+        renderAcceptInvite();
+
+        expect(await screen.findByRole('status')).toHaveTextContent('Processing invite...');
+        await act(async () => {
+            rejectRedemption(new Error('Invite is no longer valid.'));
+        });
+        expect(await screen.findByRole('alert')).toHaveTextContent('Invite is no longer valid.');
     });
 
     it('does not apply the delayed success redirect after leaving the invite route', async () => {

--- a/apps/app/src/pages/AcceptInvite.tsx
+++ b/apps/app/src/pages/AcceptInvite.tsx
@@ -241,7 +241,11 @@ function Status({ icon: Icon, message, tone }: { icon: typeof KeyRound; message:
   };
 
   return (
-    <div className={`mt-4 flex items-center gap-2 rounded-xl border p-3 text-sm font-bold ${classes[tone]}`}>
+    <div
+      role={tone === 'error' ? 'alert' : 'status'}
+      aria-live={tone === 'error' ? 'assertive' : 'polite'}
+      className={`mt-4 flex items-center gap-2 rounded-xl border p-3 text-sm font-bold ${classes[tone]}`}
+    >
       <Icon className="h-4 w-4 flex-none" aria-hidden="true" />
       {message}
     </div>

--- a/apps/app/src/pages/AuthPage.test.tsx
+++ b/apps/app/src/pages/AuthPage.test.tsx
@@ -92,7 +92,7 @@ describe('AuthPage native post-login routing', () => {
 
     fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'coach@example.com' } });
     fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } });
-    fireEvent.click(screen.getAllByRole('button', { name: 'Sign in' })[1]);
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
 
     await waitFor(() => expect(authServiceMocks.signInWithEmail).toHaveBeenCalledWith('coach@example.com', 'password123'));
     await waitFor(() => expect(window.location.hash).toBe('#/home'));
@@ -116,6 +116,85 @@ describe('AuthPage native post-login routing', () => {
     await waitFor(() => expect(authServiceMocks.signInWithGoogleAccount).toHaveBeenCalledWith(null));
     await waitFor(() => expect(window.location.hash).toBe('#/home'));
     expect(window.location.reload).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('AuthPage accessibility controls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    auth.refresh = vi.fn();
+    auth.signOut = vi.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('exposes authentication modes as keyboard-operable tabs', () => {
+    renderAuthPage();
+
+    const tablist = screen.getByRole('tablist', { name: 'Authentication mode' });
+    const signInTab = screen.getByRole('tab', { name: 'Sign in' });
+    const signUpTab = screen.getByRole('tab', { name: 'Sign up' });
+
+    expect(tablist).toBeTruthy();
+    expect(signInTab.getAttribute('aria-selected')).toBe('true');
+    expect(document.getElementById(signInTab.getAttribute('aria-controls') || '')).toBeTruthy();
+    expect(document.getElementById(signUpTab.getAttribute('aria-controls') || '')).toBeTruthy();
+    expect(screen.getByRole('tabpanel').getAttribute('aria-labelledby')).toBe('auth-tab-login');
+
+    fireEvent.keyDown(signInTab, { key: 'ArrowRight' });
+    expect(signUpTab.getAttribute('aria-selected')).toBe('true');
+    expect(document.activeElement).toBe(signUpTab);
+    expect(screen.getByRole('tabpanel').getAttribute('aria-labelledby')).toBe('auth-tab-signup');
+
+    fireEvent.keyDown(signUpTab, { key: 'Home' });
+    expect(document.activeElement).toBe(signInTab);
+    fireEvent.keyDown(signInTab, { key: 'End' });
+    expect(document.activeElement).toBe(signUpTab);
+    fireEvent.keyDown(signUpTab, { key: 'ArrowLeft' });
+    expect(document.activeElement).toBe(signInTab);
+  });
+
+  it('shows and hides password fields without clearing their values', () => {
+    renderAuthPage('/auth?mode=signup');
+
+    const password = screen.getByLabelText('Password');
+    const confirmation = screen.getByLabelText('Confirm password');
+    fireEvent.change(password, { target: { value: 'secret1' } });
+    fireEvent.change(confirmation, { target: { value: 'secret1' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show password' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Show confirmation password' }));
+    expect(password.getAttribute('type')).toBe('text');
+    expect(confirmation.getAttribute('type')).toBe('text');
+    expect((password as HTMLInputElement).value).toBe('secret1');
+    expect((confirmation as HTMLInputElement).value).toBe('secret1');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide password' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Hide confirmation password' }));
+    expect(password.getAttribute('type')).toBe('password');
+    expect(confirmation.getAttribute('type')).toBe('password');
+    expect((password as HTMLInputElement).value).toBe('secret1');
+    expect((confirmation as HTMLInputElement).value).toBe('secret1');
+  });
+
+  it('announces authentication errors and progress with live semantics', async () => {
+    authServiceMocks.signInWithEmail.mockImplementation(() => new Promise(() => undefined));
+    renderAuthPage();
+
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'coach@example.com' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+    expect(await screen.findByRole('status')).toHaveTextContent('Authentication in progress.');
+
+    cleanup();
+    authServiceMocks.signInWithEmail.mockRejectedValue(new Error('Email or password is incorrect.'));
+    renderAuthPage();
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'coach@example.com' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'wrong-password' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Email or password is incorrect.');
   });
 });
 
@@ -227,7 +306,7 @@ describe('AuthPage sign-in error state', () => {
 
     const emailInput = screen.getByLabelText('Email');
     const passwordInput = screen.getByLabelText('Password');
-    const submitButton = screen.getAllByRole('button', { name: 'Sign in' })[1];
+    const submitButton = screen.getByRole('button', { name: 'Sign in' });
 
     fireEvent.change(emailInput, { target: { value: 'coach@example.com' } });
     fireEvent.change(passwordInput, { target: { value: 'wrong-password' } });
@@ -270,6 +349,7 @@ describe('AuthPage password reset', () => {
 
     await waitFor(() => expect(authServiceMocks.sendResetEmail).toHaveBeenCalledWith('missing@example.com'));
     expect(await screen.findByText("If an account exists for that email, a reset email has been queued.")).toBeTruthy();
+    expect(screen.getByRole('status')).toHaveTextContent("If an account exists for that email, a reset email has been queued.");
     expect(screen.queryByText(/no all plays account/i)).toBeNull();
   });
 });

--- a/apps/app/src/pages/AuthPage.tsx
+++ b/apps/app/src/pages/AuthPage.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useMemo, useState } from 'react';
-import type { FormEvent, ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { FormEvent, KeyboardEvent, ReactNode } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
-import { Eye, KeyRound, LogIn, Mail, ShieldCheck } from 'lucide-react';
+import { Eye, EyeOff, KeyRound, LogIn, Mail, ShieldCheck } from 'lucide-react';
 import { AuthFrame } from '../components/AuthFrame';
 import {
   completeGoogleRedirect,
@@ -41,9 +41,13 @@ export function AuthPage({ auth }: { auth: AuthState }) {
   const [activationCode, setActivationCode] = useState(inviteCode);
   const [resetEmail, setResetEmail] = useState('');
   const [showReset, setShowReset] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
+  const loginTabRef = useRef<HTMLButtonElement>(null);
+  const signupTabRef = useRef<HTMLButtonElement>(null);
 
   const title = mode === 'signup' ? 'Create your account' : 'Sign in';
   const subtitle = mode === 'signup'
@@ -95,6 +99,30 @@ export function AuthPage({ auth }: { auth: AuthState }) {
   const clearStatus = () => {
     setError('');
     setMessage('');
+  };
+
+  const selectMode = (nextMode: AuthMode, focus = false) => {
+    setMode(nextMode);
+    if (focus) {
+      const tabRef = nextMode === 'login' ? loginTabRef : signupTabRef;
+      tabRef.current?.focus();
+    }
+  };
+
+  const handleTabKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    let nextMode: AuthMode | null = null;
+    if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+      nextMode = mode === 'login' ? 'signup' : 'login';
+    } else if (event.key === 'Home') {
+      nextMode = 'login';
+    } else if (event.key === 'End') {
+      nextMode = 'signup';
+    }
+
+    if (nextMode) {
+      event.preventDefault();
+      selectMode(nextMode, true);
+    }
   };
 
   const handleEmailSubmit = async (event: FormEvent) => {
@@ -220,18 +248,42 @@ export function AuthPage({ auth }: { auth: AuthState }) {
         </div>
       ) : null}
 
-      <div className="mt-4 grid grid-cols-2 gap-2 rounded-xl bg-gray-100 p-1">
-        <button type="button" className={`min-h-10 rounded-lg text-sm font-black ${mode === 'login' ? 'bg-white text-primary-700 shadow-sm' : 'text-gray-600'}`} onClick={() => setMode('login')}>
+      <div className="mt-4 grid grid-cols-2 gap-2 rounded-xl bg-gray-100 p-1" role="tablist" aria-label="Authentication mode">
+        <button
+          ref={loginTabRef}
+          id="auth-tab-login"
+          type="button"
+          role="tab"
+          aria-selected={mode === 'login'}
+          aria-controls="auth-panel-login"
+          tabIndex={mode === 'login' ? 0 : -1}
+          className={`min-h-10 rounded-lg text-sm font-black ${mode === 'login' ? 'bg-white text-primary-700 shadow-sm' : 'text-gray-600'}`}
+          onClick={() => selectMode('login')}
+          onKeyDown={handleTabKeyDown}
+        >
           Sign in
         </button>
-        <button type="button" className={`min-h-10 rounded-lg text-sm font-black ${mode === 'signup' ? 'bg-white text-primary-700 shadow-sm' : 'text-gray-600'}`} onClick={() => setMode('signup')}>
+        <button
+          ref={signupTabRef}
+          id="auth-tab-signup"
+          type="button"
+          role="tab"
+          aria-selected={mode === 'signup'}
+          aria-controls="auth-panel-signup"
+          tabIndex={mode === 'signup' ? 0 : -1}
+          className={`min-h-10 rounded-lg text-sm font-black ${mode === 'signup' ? 'bg-white text-primary-700 shadow-sm' : 'text-gray-600'}`}
+          onClick={() => selectMode('signup')}
+          onKeyDown={handleTabKeyDown}
+        >
           Sign up
         </button>
       </div>
 
+      <div id={`auth-panel-${mode}`} role="tabpanel" aria-labelledby={`auth-tab-${mode}`}>
       <form className="mt-4 space-y-3" onSubmit={handleEmailSubmit}>
-        <Field icon={Mail} label="Email">
+        <Field icon={Mail} label="Email" htmlFor="auth-email">
           <input
+            id="auth-email"
             className="auth-input"
             type="email"
             value={email}
@@ -243,38 +295,41 @@ export function AuthPage({ auth }: { auth: AuthState }) {
             autoComplete="email"
           />
         </Field>
-        <Field icon={KeyRound} label="Password">
-          <input
-            className="auth-input"
-            type="password"
+        <Field icon={KeyRound} label="Password" htmlFor="auth-password">
+          <PasswordInput
+            id="auth-password"
             value={password}
-            onChange={(event) => {
-              setPassword(event.target.value);
+            visible={showPassword}
+            onChange={(value) => {
+              setPassword(value);
               clearStatus();
             }}
-            required
-            minLength={6}
+            onToggle={() => setShowPassword((current) => !current)}
             autoComplete={mode === 'signup' ? 'new-password' : 'current-password'}
+            showLabel="Show password"
+            hideLabel="Hide password"
           />
         </Field>
         {mode === 'signup' ? (
           <>
-            <Field icon={KeyRound} label="Confirm password">
-              <input
-                className="auth-input"
-                type="password"
+            <Field icon={KeyRound} label="Confirm password" htmlFor="auth-confirm-password">
+              <PasswordInput
+                id="auth-confirm-password"
                 value={confirmPassword}
-                onChange={(event) => {
-                  setConfirmPassword(event.target.value);
+                visible={showConfirmPassword}
+                onChange={(value) => {
+                  setConfirmPassword(value);
                   clearStatus();
                 }}
-                required
-                minLength={6}
+                onToggle={() => setShowConfirmPassword((current) => !current)}
                 autoComplete="new-password"
+                showLabel="Show confirmation password"
+                hideLabel="Hide confirmation password"
               />
             </Field>
-            <Field icon={Eye} label="Join code">
+            <Field icon={Eye} label="Join code" htmlFor="auth-join-code">
               <input
+                id="auth-join-code"
                 className="auth-input font-mono uppercase tracking-widest"
                 value={activationCode}
                 onChange={(event) => {
@@ -288,8 +343,9 @@ export function AuthPage({ auth }: { auth: AuthState }) {
           </>
         ) : null}
 
-        {error ? <div className="rounded-xl border border-rose-200 bg-rose-50 p-3 text-sm font-bold text-rose-700">{error}</div> : null}
-        {message ? <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm font-bold text-emerald-700">{message}</div> : null}
+        {error ? <div role="alert" className="rounded-xl border border-rose-200 bg-rose-50 p-3 text-sm font-bold text-rose-700">{error}</div> : null}
+        {message ? <div role="status" aria-live="polite" className="rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm font-bold text-emerald-700">{message}</div> : null}
+        {busy ? <div role="status" aria-live="polite" className="sr-only">Authentication in progress.</div> : null}
 
         <button type="submit" className="primary-button w-full" disabled={busy}>
           {busy ? 'Working...' : mode === 'signup' ? 'Create account' : 'Sign in'}
@@ -315,6 +371,13 @@ export function AuthPage({ auth }: { auth: AuthState }) {
           </button>
         </form>
       ) : null}
+      </div>
+      <div
+        id={`auth-panel-${mode === 'login' ? 'signup' : 'login'}`}
+        role="tabpanel"
+        aria-labelledby={`auth-tab-${mode === 'login' ? 'signup' : 'login'}`}
+        hidden
+      />
 
       <div className="mt-4 flex flex-wrap justify-center gap-3 text-xs font-bold text-gray-500">
         <Link to="/accept-invite" className="text-primary-700">Enter join code</Link>
@@ -323,14 +386,49 @@ export function AuthPage({ auth }: { auth: AuthState }) {
   );
 }
 
-function Field({ icon: Icon, label, children }: { icon: typeof Mail; label: string; children: ReactNode }) {
+function Field({ icon: Icon, label, htmlFor, children }: { icon: typeof Mail; label: string; htmlFor: string; children: ReactNode }) {
   return (
-    <label className="block">
-      <span className="mb-1.5 flex items-center gap-1.5 text-xs font-extrabold uppercase tracking-[0.04em] text-gray-500">
+    <div className="block">
+      <label htmlFor={htmlFor} className="mb-1.5 flex items-center gap-1.5 text-xs font-extrabold uppercase tracking-[0.04em] text-gray-500">
         <Icon className="h-3.5 w-3.5" aria-hidden="true" />
         {label}
-      </span>
+      </label>
       {children}
-    </label>
+    </div>
+  );
+}
+
+function PasswordInput({ id, value, visible, onChange, onToggle, autoComplete, showLabel, hideLabel }: {
+  id: string;
+  value: string;
+  visible: boolean;
+  onChange: (value: string) => void;
+  onToggle: () => void;
+  autoComplete: string;
+  showLabel: string;
+  hideLabel: string;
+}) {
+  return (
+    <div className="relative">
+      <input
+        id={id}
+        className="auth-input pr-12"
+        type={visible ? 'text' : 'password'}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        required
+        minLength={6}
+        autoComplete={autoComplete}
+      />
+      <button
+        type="button"
+        className="absolute inset-y-0 right-0 flex w-12 items-center justify-center text-gray-500"
+        aria-label={visible ? hideLabel : showLabel}
+        aria-pressed={visible}
+        onClick={onToggle}
+      >
+        {visible ? <EyeOff className="h-5 w-5" aria-hidden="true" /> : <Eye className="h-5 w-5" aria-hidden="true" />}
+      </button>
+    </div>
   );
 }

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -596,14 +596,14 @@ test('@visual app auth screen exposes sign in, sign up, Google, activation code,
         maxDiffPixelRatio: 0.01
     });
 
-    await page.getByRole('button', { name: 'Sign in' }).first().click();
+    await page.getByRole('tab', { name: 'Sign in' }).click();
     await page.getByRole('button', { name: 'Forgot password?' }).click();
     await page.locator('form').filter({ hasText: 'Password reset email' }).locator('input[type="email"]').fill('parent@example.com');
     await page.getByRole('button', { name: 'Send reset email' }).click();
     await expect(page.getByText("If an account exists for that email, we've sent a reset link.")).toBeVisible();
     expect(await page.evaluate(() => window.__appAuthCalls.sendResetEmail)).toEqual(['parent@example.com']);
 
-    await page.getByRole('button', { name: 'Sign up' }).first().click();
+    await page.getByRole('tab', { name: 'Sign up' }).click();
     await page.getByRole('button', { name: 'Continue with Google' }).click();
     expect(await page.evaluate(() => window.__appAuthCalls.signInWithGoogleAccount)).toEqual([{ activationCode: 'AB12CD34' }]);
 });


### PR DESCRIPTION
Closes #4115

## What changed
- Added semantic, keyboard-operable tabs for sign-in and sign-up modes.
- Added descriptive password visibility controls that preserve entered values.
- Added alert semantics for errors and status/live semantics for progress and confirmations.
- Preserved existing Firebase authentication and invite-redemption behavior.

## Root Cause
Authentication controls were visually styled but lacked the ARIA relationships, keyboard interaction model, password visibility state, and live-region roles required by keyboard and assistive-technology users.

## Prevention / Learning
Treat accessibility behavior as part of the component contract. Tab selectors need the complete keyboard pattern, password fields need labeled value-preserving visibility controls, and asynchronous states need alert or status semantics with focused tests.

## Regression Tests
- `npx vitest run src/pages/AuthPage.test.tsx src/pages/AcceptInvite.test.tsx --reporter=verbose` passed 16 tests.
- `npm run app:build` passed TypeScript, Vite production build, artifact verification, and bundle visualizer verification.
- `git diff --check` passed.

## Recurrence Risk
Low. Focused component tests now cover tab semantics and navigation, password value preservation, and authentication and invite live-region behavior.