### PR TITLE
Verify candidate response headers

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
 
+      - name: Verify candidate response headers
+        run: node scripts/verify-response-headers.mjs https://game-flow-c6311.web.app
+
       - name: Run production smoke
         run: npx playwright test --config=playwright.smoke.config.js --reporter=line
         env:

--- a/docs/pr-notes/runs/issue-4120-fixer-20260722T015335Z/architecture.md
+++ b/docs/pr-notes/runs/issue-4120-fixer-20260722T015335Z/architecture.md
@@ -1,0 +1,37 @@
+# Current-State Read
+
+- The candidate origin is Firebase Hosting at `https://game-flow-c6311.web.app`.
+- `firebase.json` is already the centralized source for global, widget, and runtime-config response headers.
+- `scripts/write-firebase-hosting-config.mjs` carries those rules into the generated deployment configuration.
+- Static configuration tests exist, but no automated live check detects deploy omission, precedence drift, or effective host behavior.
+
+# Proposed Design
+
+- Keep Firebase Hosting and `firebase.json` as the single policy source.
+- Add a Node 22 response-header verifier with dependency-injected fetch and a CLI.
+- Check root, React shell/direct route, a stable asset, widget, and runtime config.
+- Validate HSTS semantically with `max-age >= 31536000`.
+- Run the verifier in post-deploy smoke against the candidate origin before canonical browser smoke.
+
+# Files And Modules Touched
+
+- `scripts/verify-response-headers.mjs`
+- `tests/unit/verify-response-headers.test.js`
+- `.github/workflows/post-deploy-smoke.yml`
+
+# Data/State Impacts
+
+No Firestore, Storage, authentication, tenant, PHI, DNS, or application-state changes. The check performs anonymous read-only HTTPS requests.
+
+# Security/Permissions Impacts
+
+The verifier guards the default clickjacking boundary, the widget-only embedding exception, and the runtime-config no-store/non-frameable contract. No permissions are expanded.
+
+# Failure Modes And Mitigations
+
+- Deployment/config drift: validate live responses after deployment.
+- Widget exception leakage: assert opposing ancestor policies on widget and non-widget paths.
+- Stale runtime config: require no-store and restrictive CSP.
+- Stronger platform HSTS: enforce a minimum rather than exact equality.
+- CDN propagation delay: use bounded retries with path-specific errors.
+- Meta bridge regression: leave staging code unchanged and retain its existing focused tests.

--- a/docs/pr-notes/runs/issue-4120-fixer-20260722T015335Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-4120-fixer-20260722T015335Z/code-plan.md
@@ -1,0 +1,51 @@
+# Patch Plan
+
+1. Add a dependency-injected live header verifier and CLI.
+2. Verify root, React shell/direct route, stable asset, widget, and runtime config.
+3. Enforce common headers, minimum HSTS, restrictive baseline CSP, widget-only permissive framing, and runtime no-store/restrictive policy.
+4. Add focused mocked-fetch regression tests.
+5. Wire the verifier into post-deploy smoke against the Firebase candidate.
+
+# Code Changes Applied
+
+Planned only at role-analysis time. The main lane owns all edits.
+
+# Validation Run
+
+- Inspect the live candidate response contract.
+- Run focused Vitest files for the verifier, Firebase header configuration, and Pages meta bridge.
+- Run the verifier against the live candidate origin.
+
+# Residual Risks
+
+- The verifier must not hard-code hashed assets.
+- Node fetch may normalize duplicate headers, so static configuration tests remain complementary.
+- Runtime config inherits the baseline Permissions-Policy; tightening it is outside this slice.
+
+# Commit Message Draft
+
+`Verify candidate response headers (#4120)`
+
+# Synthesis
+
+## Acceptance Criteria
+
+Use the issue criteria plus a live endpoint matrix and path-specific failure diagnostics.
+
+## Architecture Decisions
+
+Firebase is the selected candidate. Keep `firebase.json` as the only header configuration and add live verification instead of unused `hosting/headers.conf` or `hosting/routes.json` files.
+
+## QA Plan
+
+Test semantic policy checks with mocked responses, retain existing config/meta tests, then run the verifier against the live candidate.
+
+## Implementation Plan
+
+Add the verifier, tests, and post-deploy workflow step only. No app or staging changes.
+
+## Risks And Rollback
+
+The blast radius is limited to a read-only post-deploy gate. Rollback is removal of the workflow step and verifier; deployed application behavior is unchanged.
+
+Root cause: centralized Firebase rules existed, but only source configuration was tested. No post-deploy contract could detect generated-config drift, rule-precedence errors, or candidate-origin header omissions.

--- a/docs/pr-notes/runs/issue-4120-fixer-20260722T015335Z/qa.md
+++ b/docs/pr-notes/runs/issue-4120-fixer-20260722T015335Z/qa.md
@@ -1,0 +1,38 @@
+# Risk Matrix
+
+- High: permissive widget framing policy leaks to other paths.
+- High: runtime config becomes cacheable or frameable.
+- Medium: root, React routes, and assets receive different effective policies.
+- Medium: strict string matching rejects valid stronger HSTS.
+- Low: the unchanged meta bridge regresses; existing staging tests cover it.
+
+# Automated Tests To Add/Update
+
+- Add focused unit tests for successful baseline/widget/runtime responses.
+- Add failures for missing common headers, weak HSTS, permissive CSP leakage, incorrect widget CSP, and cacheable/frameable runtime config.
+- Keep existing hosting configuration and Pages meta-bridge tests as adjacent coverage.
+
+# Manual Test Plan
+
+- Run the new verifier against `https://game-flow-c6311.web.app`.
+- Confirm representative root, React, asset, widget, and runtime-config paths pass.
+- Confirm canonical DNS and the existing Pages meta bridge remain unchanged.
+
+# Negative Tests
+
+- Missing required headers or non-200 responses.
+- `frame-ancestors *` on non-widget paths.
+- Restrictive `frame-ancestors` on the widget.
+- Runtime config without no-store, non-frameable CSP, or no-referrer.
+
+# Release Gates
+
+- Focused verifier, hosting-security-header, and Pages staging unit tests pass.
+- Live candidate verification passes.
+- Diff contains no DNS, App Check, scoreboard behavior, or meta-bridge changes.
+
+# Post-Deploy Checks
+
+- Run the candidate verifier after successful deployment.
+- Record path-specific failure output in the post-deploy workflow.
+- Continue canonical browser smoke independently against `allplays.ai`.

--- a/docs/pr-notes/runs/issue-4120-fixer-20260722T015335Z/requirements.md
+++ b/docs/pr-notes/runs/issue-4120-fixer-20260722T015335Z/requirements.md
@@ -1,0 +1,37 @@
+# Problem Statement
+
+Firebase Hosting already declares and serves the candidate response-header policy, but the repository lacks an end-to-end contract proving the effective headers across root pages, React routes, assets, the scoreboard exception, and runtime config. Add regression verification without removing the GitHub Pages meta bridge before canonical cutover.
+
+# User Segments Impacted
+
+- Coaches, parents, players, and administrators using legacy and React surfaces.
+- External sites embedding the public scoreboard.
+- Platform and security operators validating candidate-host controls.
+
+# Acceptance Criteria
+
+1. Representative root, React shell/route, asset, widget, and runtime-config responses return HTTP 200 over HTTPS.
+2. Every representative response includes CSP, HSTS, nosniff, Referrer-Policy, and Permissions-Policy.
+3. Non-widget responses retain restrictive framing and never receive `frame-ancestors *`.
+4. The widget alone receives `frame-ancestors *` without a conflicting restrictive ancestor directive.
+5. Runtime config receives `Cache-Control: no-store`, `default-src 'none'`, `frame-ancestors 'none'`, and `Referrer-Policy: no-referrer`.
+6. Verification fails with path-specific diagnostics when a contract is violated.
+7. The existing staged CSP/referrer meta bridge remains unchanged.
+
+# Non-Goals
+
+- Canonical DNS cutover.
+- App Check enforcement.
+- Scoreboard API or behavior changes.
+- Replacing Firebase Hosting or duplicating its configuration in another host format.
+
+# Edge Cases
+
+- Accept stronger host-managed HSTS values.
+- Compare header and CSP semantics without depending on directive order or header casing.
+- Do not hard-code changing hashed React asset names.
+- Verify effective path-specific rule precedence, not only `firebase.json` text.
+
+# Open Questions
+
+- Tightening runtime-config Permissions-Policy beyond the inherited baseline requires a separate explicit policy decision.

--- a/scripts/verify-response-headers.mjs
+++ b/scripts/verify-response-headers.mjs
@@ -1,0 +1,232 @@
+import { pathToFileURL } from 'node:url';
+
+const minimumHstsMaxAge = 31536000;
+const requiredSecurityHeaders = [
+    'Content-Security-Policy',
+    'Strict-Transport-Security',
+    'X-Content-Type-Options',
+    'Referrer-Policy',
+    'Permissions-Policy'
+];
+const baselinePaths = ['/', '/app/', '/app/teams'];
+const widgetPath = '/widget-scoreboard.html';
+const runtimeConfigPath = '/.well-known/allplays-runtime-config.json';
+
+function fail(path, message) {
+    throw new Error(`${path}: ${message}`);
+}
+
+function requireHeader(response, path, name) {
+    const value = response.headers.get(name)?.trim();
+    if (!value) {
+        fail(path, `missing ${name} response header`);
+    }
+    return value;
+}
+
+function cspDirectives(policy) {
+    return new Map(policy.split(';').map((directive) => directive.trim()).filter(Boolean).map((directive) => {
+        const [name, ...values] = directive.split(/\s+/);
+        return [name.toLowerCase(), values];
+    }));
+}
+
+function directiveIncludes(directives, name, value) {
+    return directives.get(name)?.includes(value) ?? false;
+}
+
+function validateCommonHeaders(response, path) {
+    const headers = new Map(requiredSecurityHeaders.map((name) => [
+        name,
+        requireHeader(response, path, name)
+    ]));
+    const hsts = headers.get('Strict-Transport-Security');
+    const maxAge = Number.parseInt(/(?:^|;)\s*max-age=(\d+)(?:;|$)/i.exec(hsts)?.[1] ?? '', 10);
+    if (!Number.isSafeInteger(maxAge) || maxAge < minimumHstsMaxAge) {
+        fail(path, `Strict-Transport-Security max-age must be at least ${minimumHstsMaxAge} seconds`);
+    }
+    if (headers.get('X-Content-Type-Options').toLowerCase() !== 'nosniff') {
+        fail(path, 'X-Content-Type-Options must be nosniff');
+    }
+    return headers;
+}
+
+function validateBaselinePolicy(response, path) {
+    const headers = validateCommonHeaders(response, path);
+    const csp = headers.get('Content-Security-Policy');
+    const directives = cspDirectives(csp);
+
+    if (!directiveIncludes(directives, 'default-src', "'self'")) {
+        fail(path, "baseline CSP must include default-src 'self'");
+    }
+    if (!directiveIncludes(directives, 'object-src', "'none'")) {
+        fail(path, "baseline CSP must include object-src 'none'");
+    }
+    if (directiveIncludes(directives, 'frame-ancestors', '*')) {
+        fail(path, 'baseline CSP must not allow frame-ancestors *');
+    }
+    if (!directiveIncludes(directives, 'frame-ancestors', "'self'")) {
+        fail(path, "baseline CSP must include frame-ancestors 'self'");
+    }
+    if (csp.includes("'unsafe-eval'")) {
+        fail(path, "baseline CSP must not allow 'unsafe-eval'");
+    }
+    if (!directives.has('upgrade-insecure-requests')) {
+        fail(path, 'baseline CSP must include upgrade-insecure-requests');
+    }
+    if (headers.get('Referrer-Policy').toLowerCase() !== 'strict-origin-when-cross-origin') {
+        fail(path, 'Referrer-Policy must be strict-origin-when-cross-origin');
+    }
+}
+
+function validateWidgetPolicy(response) {
+    const headers = validateCommonHeaders(response, widgetPath);
+    const csp = headers.get('Content-Security-Policy');
+    const directives = cspDirectives(csp);
+
+    if (!directiveIncludes(directives, 'frame-ancestors', '*')) {
+        fail(widgetPath, 'widget CSP must allow frame-ancestors *');
+    }
+    if (directiveIncludes(directives, 'frame-ancestors', "'self'")) {
+        fail(widgetPath, "widget CSP must not include frame-ancestors 'self'");
+    }
+    for (const requiredSource of [
+        'https://www.gstatic.com',
+        'https://*.firebaseapp.com',
+        'https://recaptcha.google.com'
+    ]) {
+        if (!csp.includes(requiredSource)) {
+            fail(widgetPath, `widget CSP must preserve ${requiredSource}`);
+        }
+    }
+    if (csp.includes("'unsafe-eval'")) {
+        fail(widgetPath, "widget CSP must not allow 'unsafe-eval'");
+    }
+}
+
+function validateRuntimeConfigPolicy(response) {
+    const headers = validateCommonHeaders(response, runtimeConfigPath);
+    const csp = headers.get('Content-Security-Policy');
+    const directives = cspDirectives(csp);
+    const cacheControl = requireHeader(response, runtimeConfigPath, 'Cache-Control');
+
+    if (!cacheControl.split(',').some((directive) => directive.trim().toLowerCase() === 'no-store')) {
+        fail(runtimeConfigPath, 'Cache-Control must include no-store');
+    }
+    if (!directiveIncludes(directives, 'default-src', "'none'")) {
+        fail(runtimeConfigPath, "runtime CSP must include default-src 'none'");
+    }
+    if (!directiveIncludes(directives, 'frame-ancestors', "'none'")) {
+        fail(runtimeConfigPath, "runtime CSP must include frame-ancestors 'none'");
+    }
+    if (headers.get('Referrer-Policy').toLowerCase() !== 'no-referrer') {
+        fail(runtimeConfigPath, 'Referrer-Policy must be no-referrer');
+    }
+}
+
+function normalizeCandidateOrigin(candidateUrl) {
+    let url;
+    try {
+        url = new URL(candidateUrl);
+    } catch {
+        throw new Error(`Invalid candidate URL: ${candidateUrl}`);
+    }
+    if (url.protocol !== 'https:') {
+        throw new Error('Candidate URL must use HTTPS.');
+    }
+    if (url.username || url.password || url.pathname !== '/' || url.search || url.hash) {
+        throw new Error('Candidate URL must contain only an HTTPS origin.');
+    }
+    return url.origin;
+}
+
+async function fetchPath(origin, path, fetchImpl) {
+    const response = await fetchImpl(new URL(path, origin), {
+        redirect: 'follow',
+        headers: { 'Cache-Control': 'no-cache' }
+    });
+    if (!response.ok) {
+        fail(path, `expected HTTP 200 but received ${response.status}`);
+    }
+    if (response.status !== 200) {
+        fail(path, `expected HTTP 200 but received ${response.status}`);
+    }
+    if (response.url && new URL(response.url).origin !== origin) {
+        fail(path, `redirected outside candidate origin to ${response.url}`);
+    }
+    return response;
+}
+
+function discoverAppAssetPath(appHtml, origin) {
+    for (const match of appHtml.matchAll(/(?:src|href)\s*=\s*["']([^"']+)["']/gi)) {
+        const assetUrl = new URL(match[1], `${origin}/app/`);
+        if (assetUrl.origin === origin && assetUrl.pathname.startsWith('/app/assets/')) {
+            return assetUrl.pathname;
+        }
+    }
+    fail('/app/', 'no /app/assets/ URL was found in the React shell');
+}
+
+export async function verifyResponseHeaders(candidateUrl, { fetchImpl = fetch } = {}) {
+    const origin = normalizeCandidateOrigin(candidateUrl);
+    const verifiedPaths = [];
+    let appHtml;
+
+    for (const path of baselinePaths) {
+        const response = await fetchPath(origin, path, fetchImpl);
+        validateBaselinePolicy(response, path);
+        verifiedPaths.push(path);
+        if (path === '/app/') {
+            appHtml = await response.text();
+        }
+    }
+
+    const assetPath = discoverAppAssetPath(appHtml, origin);
+    const assetResponse = await fetchPath(origin, assetPath, fetchImpl);
+    validateBaselinePolicy(assetResponse, assetPath);
+    verifiedPaths.push(assetPath);
+
+    const widgetResponse = await fetchPath(origin, widgetPath, fetchImpl);
+    validateWidgetPolicy(widgetResponse);
+    verifiedPaths.push(widgetPath);
+
+    const runtimeResponse = await fetchPath(origin, runtimeConfigPath, fetchImpl);
+    validateRuntimeConfigPolicy(runtimeResponse);
+    verifiedPaths.push(runtimeConfigPath);
+
+    return verifiedPaths;
+}
+
+async function verifyWithRetry(candidateUrl, attempts = 3) {
+    let lastError;
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+        try {
+            return await verifyResponseHeaders(candidateUrl);
+        } catch (error) {
+            lastError = error;
+            if (attempt < attempts) {
+                const delayMs = attempt * 2000;
+                console.error(`Candidate header verification attempt ${attempt} failed: ${error.message}`);
+                await new Promise((resolve) => setTimeout(resolve, delayMs));
+            }
+        }
+    }
+    throw lastError;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    const candidateUrl = process.argv[2] ?? process.env.CANDIDATE_HOST_URL;
+    if (!candidateUrl) {
+        console.error('Usage: node scripts/verify-response-headers.mjs https://candidate.example');
+        process.exitCode = 1;
+    } else {
+        try {
+            const paths = await verifyWithRetry(candidateUrl);
+            console.log(`Verified candidate response headers on ${paths.length} paths at ${candidateUrl}:`);
+            for (const path of paths) console.log(`- ${path}`);
+        } catch (error) {
+            console.error(`Candidate response header verification failed: ${error.message}`);
+            process.exitCode = 1;
+        }
+    }
+}

--- a/scripts/verify-response-headers.mjs
+++ b/scripts/verify-response-headers.mjs
@@ -24,11 +24,17 @@ function requireHeader(response, path, name) {
     return value;
 }
 
-function cspDirectives(policy) {
-    return new Map(policy.split(';').map((directive) => directive.trim()).filter(Boolean).map((directive) => {
+function cspDirectives(policy, path) {
+    const directives = new Map();
+    for (const directive of policy.split(';').map((value) => value.trim()).filter(Boolean)) {
         const [name, ...values] = directive.split(/\s+/);
-        return [name.toLowerCase(), values];
-    }));
+        const normalizedName = name.toLowerCase();
+        if (directives.has(normalizedName)) {
+            fail(path, `CSP must not contain duplicate ${normalizedName} directives`);
+        }
+        directives.set(normalizedName, values);
+    }
+    return directives;
 }
 
 function directiveIncludes(directives, name, value) {
@@ -54,7 +60,7 @@ function validateCommonHeaders(response, path) {
 function validateBaselinePolicy(response, path) {
     const headers = validateCommonHeaders(response, path);
     const csp = headers.get('Content-Security-Policy');
-    const directives = cspDirectives(csp);
+    const directives = cspDirectives(csp, path);
 
     if (!directiveIncludes(directives, 'default-src', "'self'")) {
         fail(path, "baseline CSP must include default-src 'self'");
@@ -82,7 +88,7 @@ function validateBaselinePolicy(response, path) {
 function validateWidgetPolicy(response) {
     const headers = validateCommonHeaders(response, widgetPath);
     const csp = headers.get('Content-Security-Policy');
-    const directives = cspDirectives(csp);
+    const directives = cspDirectives(csp, widgetPath);
 
     if (!directiveIncludes(directives, 'frame-ancestors', '*')) {
         fail(widgetPath, 'widget CSP must allow frame-ancestors *');
@@ -95,7 +101,9 @@ function validateWidgetPolicy(response) {
         'https://*.firebaseapp.com',
         'https://recaptcha.google.com'
     ]) {
-        if (!csp.includes(requiredSource)) {
+        const hasSource = Array.from(directives.values())
+            .some((sources) => sources.includes(requiredSource));
+        if (!hasSource) {
             fail(widgetPath, `widget CSP must preserve ${requiredSource}`);
         }
     }
@@ -107,7 +115,7 @@ function validateWidgetPolicy(response) {
 function validateRuntimeConfigPolicy(response) {
     const headers = validateCommonHeaders(response, runtimeConfigPath);
     const csp = headers.get('Content-Security-Policy');
-    const directives = cspDirectives(csp);
+    const directives = cspDirectives(csp, runtimeConfigPath);
     const cacheControl = requireHeader(response, runtimeConfigPath, 'Cache-Control');
 
     if (!cacheControl.split(',').some((directive) => directive.trim().toLowerCase() === 'no-store')) {
@@ -146,9 +154,6 @@ async function fetchPath(origin, path, fetchImpl) {
         headers: { 'Cache-Control': 'no-cache' }
     });
     if (!response.ok) {
-        fail(path, `expected HTTP 200 but received ${response.status}`);
-    }
-    if (response.status !== 200) {
         fail(path, `expected HTTP 200 but received ${response.status}`);
     }
     if (response.url && new URL(response.url).origin !== origin) {

--- a/tests/unit/verify-response-headers.test.js
+++ b/tests/unit/verify-response-headers.test.js
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+import { verifyResponseHeaders } from '../../scripts/verify-response-headers.mjs';
+
+const candidateOrigin = 'https://candidate.example.test';
+const baselineCsp = "default-src 'self'; object-src 'none'; frame-ancestors 'self'; upgrade-insecure-requests";
+const widgetCsp = "default-src 'self'; object-src 'none'; script-src 'self' https://www.gstatic.com; connect-src 'self' https:; frame-src 'self' https://*.firebaseapp.com https://recaptcha.google.com; frame-ancestors *; upgrade-insecure-requests";
+const runtimeCsp = "default-src 'none'; frame-ancestors 'none'";
+
+function securityHeaders(csp = baselineCsp, overrides = {}) {
+    return {
+        'Content-Security-Policy': csp,
+        'Strict-Transport-Security': 'max-age=31556926; includeSubDomains; preload',
+        'X-Content-Type-Options': 'nosniff',
+        'Referrer-Policy': 'strict-origin-when-cross-origin',
+        'Permissions-Policy': 'camera=(self), microphone=(self), geolocation=()',
+        ...overrides
+    };
+}
+
+function responseFor(path, overrides = {}) {
+    if (path === '/app/') {
+        return new Response('<link rel="stylesheet" href="./assets/app.css"><script src="./assets/app.js"></script>', {
+            status: 200,
+            headers: securityHeaders()
+        });
+    }
+    if (path === '/widget-scoreboard.html') {
+        return new Response('widget', { status: 200, headers: securityHeaders(widgetCsp) });
+    }
+    if (path === '/.well-known/allplays-runtime-config.json') {
+        return new Response('{}', {
+            status: 200,
+            headers: securityHeaders(runtimeCsp, {
+                'Cache-Control': 'no-store',
+                'Referrer-Policy': 'no-referrer'
+            })
+        });
+    }
+    return new Response('ok', { status: 200, headers: securityHeaders() });
+}
+
+function createFetch(overrides = {}) {
+    return vi.fn(async (input) => {
+        const path = new URL(input).pathname;
+        return overrides[path]?.(path) ?? responseFor(path);
+    });
+}
+
+describe('candidate response header verification', () => {
+    it('runs against the candidate origin after a successful deployment', () => {
+        const workflow = readFileSync(
+            new URL('../../.github/workflows/post-deploy-smoke.yml', import.meta.url),
+            'utf8'
+        );
+
+        expect(workflow).toContain('node scripts/verify-response-headers.mjs https://game-flow-c6311.web.app');
+        expect(workflow.indexOf('node scripts/verify-response-headers.mjs'))
+            .toBeLessThan(workflow.indexOf('Run production smoke'));
+    });
+
+    it('validates root, React routes, discovered assets, widget, and runtime config', async () => {
+        const fetchImpl = createFetch();
+
+        const verifiedPaths = await verifyResponseHeaders(candidateOrigin, { fetchImpl });
+
+        expect(verifiedPaths).toEqual([
+            '/',
+            '/app/',
+            '/app/teams',
+            '/app/assets/app.css',
+            '/widget-scoreboard.html',
+            '/.well-known/allplays-runtime-config.json'
+        ]);
+        expect(fetchImpl).toHaveBeenCalledTimes(6);
+    });
+
+    it('reports the path when a common security header is missing', async () => {
+        const fetchImpl = createFetch({
+            '/app/teams': () => new Response('ok', {
+                status: 200,
+                headers: securityHeaders(baselineCsp, { 'Permissions-Policy': '' })
+            })
+        });
+
+        await expect(verifyResponseHeaders(candidateOrigin, { fetchImpl }))
+            .rejects.toThrow('/app/teams: missing Permissions-Policy response header');
+    });
+
+    it('rejects weak HSTS and permissive framing on baseline responses', async () => {
+        const weakHstsFetch = createFetch({
+            '/': () => new Response('ok', {
+                status: 200,
+                headers: securityHeaders(baselineCsp, { 'Strict-Transport-Security': 'max-age=300' })
+            })
+        });
+        const leakedWidgetPolicyFetch = createFetch({
+            '/app/teams': () => new Response('ok', {
+                status: 200,
+                headers: securityHeaders(widgetCsp)
+            })
+        });
+
+        await expect(verifyResponseHeaders(candidateOrigin, { fetchImpl: weakHstsFetch }))
+            .rejects.toThrow('/: Strict-Transport-Security max-age must be at least 31536000 seconds');
+        await expect(verifyResponseHeaders(candidateOrigin, { fetchImpl: leakedWidgetPolicyFetch }))
+            .rejects.toThrow('/app/teams: baseline CSP must not allow frame-ancestors *');
+    });
+
+    it('rejects a restrictive or incomplete scoreboard embed policy', async () => {
+        const fetchImpl = createFetch({
+            '/widget-scoreboard.html': () => new Response('widget', {
+                status: 200,
+                headers: securityHeaders(baselineCsp)
+            })
+        });
+
+        await expect(verifyResponseHeaders(candidateOrigin, { fetchImpl }))
+            .rejects.toThrow('/widget-scoreboard.html: widget CSP must allow frame-ancestors *');
+    });
+
+    it('rejects cacheable or frameable runtime configuration', async () => {
+        const cacheableFetch = createFetch({
+            '/.well-known/allplays-runtime-config.json': () => new Response('{}', {
+                status: 200,
+                headers: securityHeaders(runtimeCsp, {
+                    'Cache-Control': 'public, max-age=300',
+                    'Referrer-Policy': 'no-referrer'
+                })
+            })
+        });
+        const frameableFetch = createFetch({
+            '/.well-known/allplays-runtime-config.json': () => new Response('{}', {
+                status: 200,
+                headers: securityHeaders("default-src 'none'; frame-ancestors *", {
+                    'Cache-Control': 'no-store',
+                    'Referrer-Policy': 'no-referrer'
+                })
+            })
+        });
+
+        await expect(verifyResponseHeaders(candidateOrigin, { fetchImpl: cacheableFetch }))
+            .rejects.toThrow('/.well-known/allplays-runtime-config.json: Cache-Control must include no-store');
+        await expect(verifyResponseHeaders(candidateOrigin, { fetchImpl: frameableFetch }))
+            .rejects.toThrow("/.well-known/allplays-runtime-config.json: runtime CSP must include frame-ancestors 'none'");
+    });
+
+    it('fails when the React shell does not expose a deployed asset', async () => {
+        const fetchImpl = createFetch({
+            '/app/': () => new Response('<main>App</main>', {
+                status: 200,
+                headers: securityHeaders()
+            })
+        });
+
+        await expect(verifyResponseHeaders(candidateOrigin, { fetchImpl }))
+            .rejects.toThrow('/app/: no /app/assets/ URL was found in the React shell');
+    });
+});

--- a/tests/unit/verify-response-headers.test.js
+++ b/tests/unit/verify-response-headers.test.js
@@ -120,6 +120,38 @@ describe('candidate response header verification', () => {
             .rejects.toThrow('/widget-scoreboard.html: widget CSP must allow frame-ancestors *');
     });
 
+    it('requires exact scoreboard CSP source values', async () => {
+        const spoofedSourceCsp = widgetCsp.replace(
+            'https://www.gstatic.com',
+            'https://www.gstatic.com.evil.example'
+        );
+        const fetchImpl = createFetch({
+            '/widget-scoreboard.html': () => new Response('widget', {
+                status: 200,
+                headers: securityHeaders(spoofedSourceCsp)
+            })
+        });
+
+        await expect(verifyResponseHeaders(candidateOrigin, { fetchImpl }))
+            .rejects.toThrow('/widget-scoreboard.html: widget CSP must preserve https://www.gstatic.com');
+    });
+
+    it('rejects duplicate scoreboard CSP directives', async () => {
+        const duplicateFrameAncestorsCsp = widgetCsp.replace(
+            'frame-ancestors *',
+            "frame-ancestors 'self'; frame-ancestors *"
+        );
+        const fetchImpl = createFetch({
+            '/widget-scoreboard.html': () => new Response('widget', {
+                status: 200,
+                headers: securityHeaders(duplicateFrameAncestorsCsp)
+            })
+        });
+
+        await expect(verifyResponseHeaders(candidateOrigin, { fetchImpl }))
+            .rejects.toThrow('/widget-scoreboard.html: CSP must not contain duplicate frame-ancestors directives');
+    });
+
     it('rejects cacheable or frameable runtime configuration', async () => {
         const cacheableFetch = createFetch({
             '/.well-known/allplays-runtime-config.json': () => new Response('{}', {


### PR DESCRIPTION
Closes #4120

## What changed
- Added live verification for required security headers across root, React routes, deployed assets, the scoreboard widget, and runtime config.
- Added the verifier to post-deploy smoke against the Firebase candidate origin.
- Preserved the existing Firebase policy source and GitHub Pages meta bridge.

## Root Cause
Firebase Hosting declared the centralized policy, but tests only inspected source configuration. Deployment drift, rule-precedence errors, CDN behavior, or missing effective headers could therefore escape detection.

## Prevention / Learning
Pair centralized hosting configuration tests with credential-free post-deploy verification across normal routes, assets, exceptional embed paths, and non-cacheable runtime configuration. Validate provider-managed policies such as HSTS semantically.

## Regression Tests
- Focused verifier suite covers required headers, minimum HSTS, widget-only permissive framing, runtime no-store policy, asset discovery, and workflow wiring.
- Existing Firebase configuration and Pages meta-bridge suites remain passing.
- Live verification passed against all six candidate response classes.

## Recurrence Risk
Low. Static configuration tests and live post-deploy verification now cover both declared and effective policy.