### PR TITLE
Add candidate-host authenticated smoke coverage

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -43,6 +43,13 @@ jobs:
       - name: Verify candidate response headers
         run: node scripts/verify-response-headers.mjs https://game-flow-c6311.web.app
 
+      - name: Verify authenticated candidate host
+        run: npx playwright test tests/smoke/candidate-host-auth.spec.js --config=playwright.smoke.config.js --reporter=line
+        env:
+          CANDIDATE_HOST_URL: https://game-flow-c6311.web.app
+          SMOKE_AUTH_EMAIL: ${{ secrets.SMOKE_AUTH_EMAIL }}
+          SMOKE_AUTH_PASSWORD: ${{ secrets.SMOKE_AUTH_PASSWORD }}
+
       - name: Run production smoke
         run: npx playwright test --config=playwright.smoke.config.js --reporter=line
         env:

--- a/tests/smoke/candidate-host-auth.spec.js
+++ b/tests/smoke/candidate-host-auth.spec.js
@@ -3,10 +3,8 @@ import { expect, test } from '@playwright/test';
 const candidateHostUrl = process.env.CANDIDATE_HOST_URL || '';
 const authEmail = process.env.SMOKE_AUTH_EMAIL || '';
 const authPassword = process.env.SMOKE_AUTH_PASSWORD || '';
-const hasCredentials = Boolean(authEmail && authPassword);
 
 test.skip(!candidateHostUrl, 'CANDIDATE_HOST_URL is required for candidate-host auth smoke');
-test.skip(!hasCredentials, 'SMOKE_AUTH_EMAIL and SMOKE_AUTH_PASSWORD are required for candidate-host auth smoke');
 
 function candidateUrl(path) {
     return new URL(path, candidateHostUrl).toString();
@@ -14,6 +12,8 @@ function candidateUrl(path) {
 
 test('candidate host accepts authentication and loads a protected landing page', async ({ page }) => {
     test.setTimeout(45_000);
+    expect(authEmail, 'SMOKE_AUTH_EMAIL is required for candidate-host auth smoke').toBeTruthy();
+    expect(authPassword, 'SMOKE_AUTH_PASSWORD is required for candidate-host auth smoke').toBeTruthy();
 
     await test.step(`authenticate at ${candidateHostUrl}`, async () => {
         await page.goto(candidateUrl('/login.html'), { waitUntil: 'domcontentloaded' });
@@ -36,9 +36,13 @@ test('candidate host accepts authentication and loads a protected landing page',
     await test.step(`verify authenticated landing page at ${candidateHostUrl}`, async () => {
         const landingUrl = new URL(page.url());
         expect(
-            ['/dashboard.html', '/parent-dashboard.html'],
+            landingUrl.origin,
+            `Candidate post-login assertion failed at ${candidateHostUrl}: unexpected origin ${landingUrl.origin}`
+        ).toBe(new URL(candidateHostUrl).origin);
+        expect(
+            landingUrl.pathname,
             `Candidate post-login assertion failed at ${candidateHostUrl}: unexpected route ${landingUrl.pathname}`
-        ).toContain(landingUrl.pathname);
+        ).toMatch(/^\/(?:dashboard|parent-dashboard)\.html$/);
         await expect(
             page.locator('h1').first(),
             `Candidate post-login assertion failed at ${candidateHostUrl}: authenticated heading was not visible`

--- a/tests/smoke/candidate-host-auth.spec.js
+++ b/tests/smoke/candidate-host-auth.spec.js
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test';
+
+const candidateHostUrl = process.env.CANDIDATE_HOST_URL || '';
+const authEmail = process.env.SMOKE_AUTH_EMAIL || '';
+const authPassword = process.env.SMOKE_AUTH_PASSWORD || '';
+const hasCredentials = Boolean(authEmail && authPassword);
+
+test.skip(!candidateHostUrl, 'CANDIDATE_HOST_URL is required for candidate-host auth smoke');
+test.skip(!hasCredentials, 'SMOKE_AUTH_EMAIL and SMOKE_AUTH_PASSWORD are required for candidate-host auth smoke');
+
+function candidateUrl(path) {
+    return new URL(path, candidateHostUrl).toString();
+}
+
+test('candidate host accepts authentication and loads a protected landing page', async ({ page }) => {
+    test.setTimeout(45_000);
+
+    await test.step(`authenticate at ${candidateHostUrl}`, async () => {
+        await page.goto(candidateUrl('/login.html'), { waitUntil: 'domcontentloaded' });
+        await expect(page.locator('#login-form'), `Authentication form did not load at candidate URL ${candidateHostUrl}`)
+            .toBeVisible({ timeout: 10_000 });
+        await page.locator('#email').fill(authEmail);
+        await page.locator('#password').fill(authPassword);
+        await page.locator('#submit-btn').click();
+
+        try {
+            await page.waitForURL((url) => !url.pathname.endsWith('/login.html'), { timeout: 20_000 });
+        } catch (error) {
+            const authError = await page.locator('#error-message').textContent().catch(() => '');
+            throw new Error(
+                `Candidate authentication failed at ${candidateHostUrl}: ${authError?.trim() || error.message}`
+            );
+        }
+    });
+
+    await test.step(`verify authenticated landing page at ${candidateHostUrl}`, async () => {
+        const landingUrl = new URL(page.url());
+        expect(
+            ['/dashboard.html', '/parent-dashboard.html'],
+            `Candidate post-login assertion failed at ${candidateHostUrl}: unexpected route ${landingUrl.pathname}`
+        ).toContain(landingUrl.pathname);
+        await expect(
+            page.locator('h1').first(),
+            `Candidate post-login assertion failed at ${candidateHostUrl}: authenticated heading was not visible`
+        ).toContainText(/My Teams|Parent Dashboard/, { timeout: 10_000 });
+    });
+});

--- a/tests/unit/candidate-host-auth-smoke.test.js
+++ b/tests/unit/candidate-host-auth-smoke.test.js
@@ -17,6 +17,13 @@ describe('candidate-host authenticated smoke coverage', () => {
         expect(spec).toContain("process.env.CANDIDATE_HOST_URL");
         expect(spec).toContain('Candidate authentication failed at ${candidateHostUrl}');
         expect(spec).toContain('Candidate post-login assertion failed at ${candidateHostUrl}');
+        expect(spec).toContain("expect(authEmail, 'SMOKE_AUTH_EMAIL is required for candidate-host auth smoke').toBeTruthy()");
+        expect(spec).toContain("expect(authPassword, 'SMOKE_AUTH_PASSWORD is required for candidate-host auth smoke').toBeTruthy()");
+        expect(spec).not.toContain('test.skip(!hasCredentials');
+        expect(spec).toContain('landingUrl.origin');
+        expect(spec).toContain('toBe(new URL(candidateHostUrl).origin)');
+        expect(spec).toContain("landingUrl.pathname,\n            `Candidate post-login assertion failed");
+        expect(spec).toContain('toMatch(/^\\/(?:dashboard|parent-dashboard)\\.html$/)');
     });
 
     it('does not enable App Check enforcement for candidate authentication', () => {

--- a/tests/unit/candidate-host-auth-smoke.test.js
+++ b/tests/unit/candidate-host-auth-smoke.test.js
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = path.resolve(import.meta.dirname, '../..');
+const readRepoFile = (file) => readFileSync(path.join(repoRoot, file), 'utf8');
+
+describe('candidate-host authenticated smoke coverage', () => {
+    it('targets the candidate origin with protected CI credentials', () => {
+        const workflow = readRepoFile('.github/workflows/post-deploy-smoke.yml');
+        const spec = readRepoFile('tests/smoke/candidate-host-auth.spec.js');
+
+        expect(workflow).toContain('npx playwright test tests/smoke/candidate-host-auth.spec.js');
+        expect(workflow).toContain('CANDIDATE_HOST_URL: https://game-flow-c6311.web.app');
+        expect(workflow).toContain('SMOKE_AUTH_EMAIL: ${{ secrets.SMOKE_AUTH_EMAIL }}');
+        expect(workflow).toContain('SMOKE_AUTH_PASSWORD: ${{ secrets.SMOKE_AUTH_PASSWORD }}');
+        expect(spec).toContain("process.env.CANDIDATE_HOST_URL");
+        expect(spec).toContain('Candidate authentication failed at ${candidateHostUrl}');
+        expect(spec).toContain('Candidate post-login assertion failed at ${candidateHostUrl}');
+    });
+
+    it('does not enable App Check enforcement for candidate authentication', () => {
+        const workflow = readRepoFile('.github/workflows/post-deploy-smoke.yml');
+
+        expect(workflow).not.toContain('ALLPLAYS_APP_CHECK_ENFORCEMENT_READY');
+        expect(workflow).not.toContain('APP_CHECK_ENFORCEMENT_READY');
+    });
+});


### PR DESCRIPTION
Closes #4127

## What changed
- Added a bounded Playwright test that authenticates against `CANDIDATE_HOST_URL`.
- Verifies redirect to a stable authenticated dashboard route.
- Added explicit candidate URL diagnostics for authentication and post-login failures.
- Wired the test into protected post-deploy smoke using existing CI credentials.
- Preserved App Check unenforced mode.

## Root Cause
Candidate-host response headers were validated after deployment, but credentialed browser tests only targeted production or local origins. Candidate authentication and protected-route loading were therefore unverified.

## Prevention / Learning
Candidate cutover gates should pair public protocol checks with bounded authenticated browser coverage against the same candidate origin. Failure diagnostics must identify both the origin and failed phase.

## Regression Tests
- `npx vitest run tests/unit/candidate-host-auth-smoke.test.js tests/unit/verify-response-headers.test.js tests/unit/preview-deploy-trust-boundary.test.js --reporter=verbose` passed 31 tests.
- Playwright discovered the candidate-host test and skipped it locally because protected environment inputs were absent.
- `git diff --check` passed.

## Recurrence Risk
Low. Workflow contract tests lock candidate-origin wiring, protected credentials, failure diagnostics, and unchanged App Check enforcement behavior.