### PR TITLE
Fix missing team access after creation

### DIFF
--- a/apps/app/src/lib/authService.test.ts
+++ b/apps/app/src/lib/authService.test.ts
@@ -269,6 +269,22 @@ describe('hydrateFirebaseUser', () => {
     expect(hydrated.user.roles).toContain('coach');
     expect(hydrated.user.roles).not.toEqual(['parent']);
   });
+
+  it('queries owned teams and merges them when the stored coachOf list is already non-empty', async () => {
+    legacyAuthMocks.getUserTeams.mockResolvedValue([
+      { id: 'team-1', name: 'Current Team' },
+      { id: 'team-2', name: 'Vipers' }
+    ]);
+
+    const hydrated = await hydrateFirebaseUser({
+      uid: 'coach-1',
+      email: 'coach@example.com'
+    });
+
+    expect(legacyAuthMocks.getUserTeams).toHaveBeenCalledWith('coach-1');
+    expect(hydrated.profile.coachOf).toEqual(['team-1', 'team-2']);
+    expect(hydrated.user.coachOf).toEqual(['team-1', 'team-2']);
+  });
 });
 
 describe('signOut', () => {

--- a/apps/app/src/lib/authService.ts
+++ b/apps/app/src/lib/authService.ts
@@ -29,6 +29,7 @@ import {
 import { createLogger } from './logger';
 import { getPrimaryAppCheckHeaders } from './adapters/legacyFirebaseAppCheck';
 import { clearAppDataCache } from './appDataCache';
+import { mergeOwnedTeamIds } from './teamAccess';
 import type { AuthUser, UserRole } from './types';
 
 export const firebaseAuth = auth;
@@ -934,22 +935,21 @@ export async function hydrateFirebaseUser(user: FirebaseUser): Promise<HydratedU
     logger.warn('Failed to sync approved parent membership requests.', { error });
   }
 
-  if (!Array.isArray(profile.coachOf) || profile.coachOf.length === 0) {
-    try {
-      const teams = await withTimeout(
-        Promise.resolve(dbModule.getUserTeams(user.uid)),
-        'Team access load timed out.',
-        profileHydrationTimeoutMs
-      );
-      if (Array.isArray(teams) && teams.length > 0) {
-        profile = {
-          ...profile,
-          coachOf: teams.map((team: Record<string, unknown>) => team.id).filter(Boolean)
-        };
-      }
-    } catch (error) {
-      logger.warn('Failed to load owned teams.', { error });
+  try {
+    const teams = await withTimeout(
+      Promise.resolve(dbModule.getUserTeams(user.uid)),
+      'Team access load timed out.',
+      profileHydrationTimeoutMs
+    );
+    const coachOf = mergeOwnedTeamIds(profile.coachOf, teams);
+    if (coachOf.length > 0) {
+      profile = {
+        ...profile,
+        coachOf
+      };
     }
+  } catch (error) {
+    logger.warn('Failed to load owned teams.', { error });
   }
 
   return {

--- a/apps/app/src/lib/teamAccess.ts
+++ b/apps/app/src/lib/teamAccess.ts
@@ -1,0 +1,15 @@
+export function mergeOwnedTeamIds(
+  profileTeamIds: unknown,
+  ownedTeams: unknown
+): string[] {
+  const normalizedProfileTeamIds = Array.isArray(profileTeamIds)
+    ? profileTeamIds.map((teamId) => String(teamId || '').trim()).filter(Boolean)
+    : [];
+  const ownedTeamIds = Array.isArray(ownedTeams)
+    ? ownedTeams
+      .map((team) => String((team as Record<string, unknown>)?.id || '').trim())
+      .filter(Boolean)
+    : [];
+
+  return [...new Set([...normalizedProfileTeamIds, ...ownedTeamIds])];
+}

--- a/dashboard.html
+++ b/dashboard.html
@@ -88,7 +88,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeams, getUserTeamsWithAccess, getParentTeams, deleteTeam, getUserProfile, getUnreadChatCounts } from './js/db.js?v=117';
+        import { getTeams, getUserTeamsWithAccess, getParentTeams, deleteTeam, getUserProfile, getUnreadChatCounts } from './js/db.js?v=118';
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=18';
         import { checkAuth } from './js/auth.js?v=129';
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -6876,7 +6876,9 @@ exports.syncTeamNotificationRecipientsOnTeamWrite = functions.firestore
     return null;
   });
 
-exports.syncTeamOwnerAccessOnCreate = functions.firestore
+exports.syncTeamOwnerAccessOnCreate = functions
+  .runWith({ failurePolicy: true })
+  .firestore
   .document('teams/{teamId}')
   .onCreate(createTeamOwnerAccessSyncHandler({
     firestore,

--- a/functions/index.js
+++ b/functions/index.js
@@ -238,6 +238,7 @@ const {
 } = require('./friend-message-access-core.cjs');
 const { hasTeamAdminAccess } = require('./team-admin-access-core.cjs');
 const { createAutoAcceptParentInviteHandler } = require('./parent-invite-auto-link-callable.cjs');
+const { createTeamOwnerAccessSyncHandler } = require('./team-owner-access-core.cjs');
 const {
   normalizeParentInviteEmail,
   appendUniqueParentLink,
@@ -6874,6 +6875,13 @@ exports.syncTeamNotificationRecipientsOnTeamWrite = functions.firestore
     await syncNotificationRecipientsForTeamChange(context.params.teamId, before, after);
     return null;
   });
+
+exports.syncTeamOwnerAccessOnCreate = functions.firestore
+  .document('teams/{teamId}')
+  .onCreate(createTeamOwnerAccessSyncHandler({
+    firestore,
+    fieldValue: admin.firestore.FieldValue
+  }));
 
 exports.syncTeamNotificationTargetsOnPreferenceWrite = functions.firestore
   .document('users/{uid}/notificationPreferences/{teamId}')

--- a/functions/team-owner-access-core.cjs
+++ b/functions/team-owner-access-core.cjs
@@ -1,0 +1,27 @@
+function createTeamOwnerAccessSyncHandler({ firestore, fieldValue }) {
+  if (!firestore || !fieldValue) {
+    throw new Error('Firestore and FieldValue are required.');
+  }
+
+  return async function syncTeamOwnerAccess(snapshot, context) {
+    const teamId = String(context?.params?.teamId || snapshot?.id || '').trim();
+    const team = snapshot?.data?.() || {};
+    const ownerId = String(team.ownerId || '').trim();
+
+    if (!teamId || !ownerId) {
+      return null;
+    }
+
+    await firestore.doc(`users/${ownerId}`).set({
+      coachOf: fieldValue.arrayUnion(teamId),
+      roles: fieldValue.arrayUnion('coach'),
+      updatedAt: fieldValue.serverTimestamp()
+    }, { merge: true });
+
+    return { ownerId, teamId };
+  };
+}
+
+module.exports = {
+  createTeamOwnerAccessSyncHandler
+};

--- a/js/db.js
+++ b/js/db.js
@@ -1001,6 +1001,10 @@ export async function getTeams(options = {}) {
                 : Promise.resolve({ docs: [] }),
             currentUserEmail
                 ? getDocs(query(teamsRef, where("adminEmails", "array-contains", currentUserEmail)))
+                    .catch((error) => {
+                        console.warn('Unable to load teams granted through admin email; continuing with public and owned teams.', error);
+                        return { docs: [] };
+                    })
                 : Promise.resolve({ docs: [] })
         ]);
         const teamsById = new Map();
@@ -1832,7 +1836,12 @@ export async function getUserTeamsWithAccess(userId, email, options = {}) {
         : Promise.resolve({ docs: [] });
     const [ownedSnap, adminSnap, ...ownerEmailSnaps] = await Promise.all([
         getDocs(query(collection(db, "teams"), where("ownerId", "==", userId))),
-        normalizedEmail ? getDocs(query(collection(db, "teams"), where("adminEmails", "array-contains", normalizedEmail))) : Promise.resolve({ docs: [] }),
+        normalizedEmail
+            ? optionalTeamQuery(
+                getDocs(query(collection(db, "teams"), where("adminEmails", "array-contains", normalizedEmail))),
+                `adminEmails:${normalizedEmail}`
+            )
+            : Promise.resolve({ docs: [] }),
         ownerEmailLowerQuery,
         ...ownerEmailQueries
     ]);
@@ -2221,24 +2230,7 @@ export async function createTeam(teamData) {
         teamData.deactivatedBy = null;
     }
     const docRef = await addDoc(collection(db, "teams"), teamData);
-    if (teamData.ownerId) {
-        await grantCoachRoleForTeam(teamData.ownerId, docRef.id);
-    }
     return docRef.id;
-}
-
-export async function grantCoachRoleForTeam(userId, teamId) {
-    if (!userId || !teamId) return false;
-    try {
-        await setDoc(doc(db, "users", userId), {
-            coachOf: arrayUnion(teamId),
-            roles: arrayUnion('coach')
-        }, { merge: true });
-        return true;
-    } catch (error) {
-        console.warn('Unable to grant coach role for team owner:', error);
-        return false;
-    }
 }
 
 function getSelectedTeamMediaManagerIds(teamPermissions = {}) {

--- a/tests/coverage/feature-coverage-map.json
+++ b/tests/coverage/feature-coverage-map.json
@@ -228,7 +228,8 @@
                 "queueInviteEmail",
                 "queueParentInviteEmail",
                 "syncApprovedParentMembershipRequestUserLink",
-                "syncPublicUserProfileProjection"
+                "syncPublicUserProfileProjection",
+                "syncTeamOwnerAccessOnCreate"
             ],
             "unitTests": [
                 "tests/unit/app-friend-profile.test.jsx",
@@ -242,6 +243,7 @@
                 "tests/unit/edit-roster-registration-import.test.js",
                 "tests/unit/edit-team-registration-sync.test.js",
                 "tests/unit/public-user-profile-sync.test.js",
+                "tests/unit/team-owner-access-trigger.test.js",
                 "tests/unit/teams-public-visibility.test.js"
             ],
             "integrationTests": [

--- a/tests/unit/app-team-access-hydration.test.js
+++ b/tests/unit/app-team-access-hydration.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { mergeOwnedTeamIds } from '../../apps/app/src/lib/teamAccess.ts';
+
+describe('mergeOwnedTeamIds', () => {
+  it('adds owned teams even when the stored coachOf list is already non-empty', () => {
+    expect(mergeOwnedTeamIds(
+      ['jr-kc-current'],
+      [{ id: 'jr-kc-current' }, { id: 'vipers' }]
+    )).toEqual(['jr-kc-current', 'vipers']);
+  });
+
+  it('normalizes invalid and duplicate IDs', () => {
+    expect(mergeOwnedTeamIds(
+      [' team-1 ', '', null],
+      [{ id: 'team-1' }, { id: ' team-2 ' }, {}, null]
+    )).toEqual(['team-1', 'team-2']);
+  });
+});

--- a/tests/unit/dashboard-parent-membership-sync.test.js
+++ b/tests/unit/dashboard-parent-membership-sync.test.js
@@ -21,7 +21,7 @@ describe('dashboard parent membership sync', () => {
     const html = readRepoFile('dashboard.html');
 
     it('uses the rich auth path before loading parent-linked teams', () => {
-        expect(html).toContain("import { getTeams, getUserTeamsWithAccess, getParentTeams, deleteTeam, getUserProfile, getUnreadChatCounts } from './js/db.js?v=117';");
+        expect(html).toContain("import { getTeams, getUserTeamsWithAccess, getParentTeams, deleteTeam, getUserProfile, getUnreadChatCounts } from './js/db.js?v=118';");
         expect(html).toContain("import { checkAuth } from './js/auth.js?v=129';");
         expect(html).toContain('function requireSyncedAuth()');
         expect(html).toContain('const user = await requireSyncedAuth();');

--- a/tests/unit/db-create-team-coach-role.test.js
+++ b/tests/unit/db-create-team-coach-role.test.js
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 
 const dbSource = readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
@@ -7,9 +7,7 @@ function getFunctionSource(functionName) {
     const start = dbSource.indexOf(`export async function ${functionName}(`);
     expect(start).toBeGreaterThanOrEqual(0);
     const nextExport = dbSource.indexOf('\nexport async function ', start + 1);
-    const nextImport = dbSource.indexOf('\nimport ', start + 1);
-    const candidates = [nextExport, nextImport].filter((value) => value !== -1);
-    const end = candidates.length > 0 ? Math.min(...candidates) : dbSource.length;
+    const end = nextExport === -1 ? dbSource.length : nextExport;
     return dbSource.slice(start, end);
 }
 
@@ -23,150 +21,30 @@ function buildCreateTeam(deps) {
         'addDoc',
         'collection',
         'db',
-        'grantCoachRoleForTeam',
         functionSource
     )(
         deps.Timestamp,
         deps.buildPublicTeamSearchFields,
         deps.addDoc,
         deps.collection,
-        deps.db,
-        deps.grantCoachRoleForTeam
+        deps.db
     );
 }
 
-function buildGrantCoachRoleForTeam(deps) {
-    const functionSource = getFunctionSource('grantCoachRoleForTeam')
-        .replace('export async function grantCoachRoleForTeam', 'return async function grantCoachRoleForTeam');
-
-    return new Function(
-        'setDoc',
-        'doc',
-        'db',
-        'arrayUnion',
-        functionSource
-    )(
-        deps.setDoc,
-        deps.doc,
-        deps.db,
-        deps.arrayUnion
-    );
-}
-
-function makeCreateTeamDeps(overrides = {}) {
-    return {
-        Timestamp: { now: () => 'NOW' },
-        buildPublicTeamSearchFields: () => ({}),
-        addDoc: vi.fn(async () => ({ id: 'team-new' })),
-        collection: (_db, path) => ({ path }),
-        db: {},
-        grantCoachRoleForTeam: vi.fn(async () => true),
-        ...overrides
-    };
-}
-
-describe('createTeam coach role grant', () => {
-    afterEach(() => {
-        vi.restoreAllMocks();
-    });
-
-    it('grants the coach role to the creator after the team is created', async () => {
-        const deps = makeCreateTeamDeps();
-        const createTeam = buildCreateTeam(deps);
-
-        const teamId = await createTeam({ name: 'Jr Current', ownerId: 'owner-uid' });
-
-        expect(teamId).toBe('team-new');
-        expect(deps.grantCoachRoleForTeam).toHaveBeenCalledTimes(1);
-        expect(deps.grantCoachRoleForTeam).toHaveBeenCalledWith('owner-uid', 'team-new');
-    });
-
-    it('skips the coach role grant when no ownerId is present', async () => {
-        const deps = makeCreateTeamDeps();
-        const createTeam = buildCreateTeam(deps);
-
-        const teamId = await createTeam({ name: 'Ownerless Team' });
-
-        expect(teamId).toBe('team-new');
-        expect(deps.grantCoachRoleForTeam).not.toHaveBeenCalled();
-    });
-
-    it('still resolves with the team id when the coach role grant fails', async () => {
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-        const setDoc = vi.fn(async () => {
-            throw new Error('permission denied');
-        });
-        const grantCoachRoleForTeam = buildGrantCoachRoleForTeam({
-            setDoc,
-            doc: (_db, collectionPath, id) => ({ path: `${collectionPath}/${id}` }),
-            db: {},
-            arrayUnion: (...values) => ({ __arrayUnion: values })
-        });
-        const deps = makeCreateTeamDeps({ grantCoachRoleForTeam });
-        const createTeam = buildCreateTeam(deps);
-
-        const teamId = await createTeam({ name: 'Jr Current', ownerId: 'owner-uid' });
-
-        expect(teamId).toBe('team-new');
-        expect(setDoc).toHaveBeenCalledTimes(1);
-        expect(warnSpy).toHaveBeenCalled();
-    });
-});
-
-describe('grantCoachRoleForTeam', () => {
-    it('merges coachOf and the coach role onto the users doc', async () => {
-        const writes = [];
-        const grantCoachRoleForTeam = buildGrantCoachRoleForTeam({
-            setDoc: vi.fn(async (ref, data, options) => {
-                writes.push({ path: ref.path, data, options });
-            }),
-            doc: (_db, collectionPath, id) => ({ path: `${collectionPath}/${id}` }),
-            db: {},
-            arrayUnion: (...values) => ({ __arrayUnion: values })
+describe('createTeam owner access grant', () => {
+    it('creates the team without attempting a client write to server-managed user roles', async () => {
+        const addDoc = vi.fn(async () => ({ id: 'team-new' }));
+        const createTeam = buildCreateTeam({
+            Timestamp: { now: () => 'NOW' },
+            buildPublicTeamSearchFields: () => ({}),
+            addDoc,
+            collection: (_db, path) => ({ path }),
+            db: {}
         });
 
-        const result = await grantCoachRoleForTeam('owner-uid', 'team-new');
-
-        expect(result).toBe(true);
-        expect(writes).toEqual([
-            {
-                path: 'users/owner-uid',
-                data: {
-                    coachOf: { __arrayUnion: ['team-new'] },
-                    roles: { __arrayUnion: ['coach'] }
-                },
-                options: { merge: true }
-            }
-        ]);
-    });
-
-    it('returns false without throwing when the write is rejected', async () => {
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-        const grantCoachRoleForTeam = buildGrantCoachRoleForTeam({
-            setDoc: vi.fn(async () => {
-                throw new Error('permission denied');
-            }),
-            doc: (_db, collectionPath, id) => ({ path: `${collectionPath}/${id}` }),
-            db: {},
-            arrayUnion: (...values) => ({ __arrayUnion: values })
-        });
-
-        await expect(grantCoachRoleForTeam('owner-uid', 'team-new')).resolves.toBe(false);
-        expect(warnSpy).toHaveBeenCalled();
-        warnSpy.mockRestore();
-    });
-
-    it('returns false when userId or teamId is missing', async () => {
-        const setDoc = vi.fn();
-        const grantCoachRoleForTeam = buildGrantCoachRoleForTeam({
-            setDoc,
-            doc: () => ({}),
-            db: {},
-            arrayUnion: (...values) => values
-        });
-
-        await expect(grantCoachRoleForTeam('', 'team-new')).resolves.toBe(false);
-        await expect(grantCoachRoleForTeam('owner-uid', '')).resolves.toBe(false);
-        expect(setDoc).not.toHaveBeenCalled();
+        await expect(createTeam({ name: 'Vipers', ownerId: 'owner-uid' })).resolves.toBe('team-new');
+        expect(addDoc).toHaveBeenCalledTimes(1);
+        expect(getFunctionSource('createTeam')).not.toContain('grantCoachRoleForTeam');
+        expect(dbSource).not.toContain('export async function grantCoachRoleForTeam');
     });
 });

--- a/tests/unit/db-team-access-query-resilience.test.js
+++ b/tests/unit/db-team-access-query-resilience.test.js
@@ -1,27 +1,131 @@
-import { describe, expect, it } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const dbSource = readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
+const firebaseMocks = vi.hoisted(() => ({
+  auth: { currentUser: null },
+  collection: vi.fn((_database, path) => ({ path })),
+  doc: vi.fn((_database, path, id) => ({ path: `${path}/${id}` })),
+  getDoc: vi.fn(),
+  getDocs: vi.fn(),
+  query: vi.fn((collectionRef, ...constraints) => ({ collectionRef, constraints })),
+  where: vi.fn((field, op, value) => ({ field, op, value }))
+}));
 
-function getFunctionSource(functionName) {
-  const start = dbSource.indexOf(`export async function ${functionName}(`);
-  expect(start).toBeGreaterThanOrEqual(0);
-  const nextExport = dbSource.indexOf('\nexport async function ', start + 1);
-  return dbSource.slice(start, nextExport === -1 ? dbSource.length : nextExport);
+vi.mock('../../js/firebase.js?v=22', () => ({
+  db: {},
+  auth: firebaseMocks.auth,
+  storage: {},
+  collection: firebaseMocks.collection,
+  getDocs: firebaseMocks.getDocs,
+  getDoc: firebaseMocks.getDoc,
+  doc: firebaseMocks.doc,
+  addDoc: vi.fn(),
+  updateDoc: vi.fn(),
+  deleteDoc: vi.fn(),
+  setDoc: vi.fn(),
+  query: firebaseMocks.query,
+  where: firebaseMocks.where,
+  orderBy: vi.fn(),
+  Timestamp: { now: vi.fn() },
+  increment: vi.fn(),
+  arrayUnion: vi.fn(),
+  arrayRemove: vi.fn(),
+  deleteField: vi.fn(),
+  limit: vi.fn(),
+  startAfter: vi.fn(),
+  getCountFromServer: vi.fn(),
+  onSnapshot: vi.fn(),
+  serverTimestamp: vi.fn(),
+  collectionGroup: vi.fn(),
+  writeBatch: vi.fn(),
+  runTransaction: vi.fn(),
+  functions: {},
+  httpsCallable: vi.fn(),
+  ref: vi.fn(),
+  uploadBytes: vi.fn(),
+  getDownloadURL: vi.fn(),
+  deleteObject: vi.fn()
+}));
+
+vi.mock('../../js/firebase-images.js?v=10', () => ({
+  imageStorage: {},
+  ensureImageAuth: vi.fn(),
+  requireImageAuth: vi.fn()
+}));
+
+function createTeamDoc(id, data) {
+  return {
+    id,
+    data: () => data
+  };
 }
 
+function getWhereConstraint(queryValue) {
+  return queryValue.constraints.find((constraint) => constraint?.field);
+}
+
+const { getTeams, getUserTeamsWithAccess } = await import('../../js/db.js?v=118');
+
 describe('team access query resilience', () => {
-  it('keeps public and owned teams when the optional admin-email query is denied', () => {
-    const source = getFunctionSource('getTeams');
-    expect(source).toContain("where(\"adminEmails\", \"array-contains\", currentUserEmail)");
-    expect(source).toContain('.catch((error) => {');
-    expect(source).toContain('continuing with public and owned teams');
+  beforeEach(() => {
+    vi.clearAllMocks();
+    firebaseMocks.auth.currentUser = {
+      uid: 'owner-1',
+      email: 'coach@example.com'
+    };
   });
 
-  it('keeps owned and owner-email teams when the optional admin-email query is denied', () => {
-    const source = getFunctionSource('getUserTeamsWithAccess');
-    expect(source).toContain("where(\"adminEmails\", \"array-contains\", normalizedEmail)");
-    expect(source).toContain('optionalTeamQuery(');
-    expect(source).toContain('`adminEmails:${normalizedEmail}`');
+  it('keeps public and owned teams when the optional admin-email query is denied', async () => {
+    const publicTeam = createTeamDoc('public-1', { name: 'Falcons', isPublic: true });
+    const ownedTeam = createTeamDoc('owned-1', { name: 'Vipers', ownerId: 'owner-1' });
+    const permissionError = Object.assign(new Error('Missing or insufficient permissions.'), {
+      code: 'permission-denied'
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    firebaseMocks.getDocs.mockImplementation(async (queryValue) => {
+      const constraint = getWhereConstraint(queryValue);
+      if (constraint.field === 'isPublic') return { docs: [publicTeam] };
+      if (constraint.field === 'ownerId') return { docs: [ownedTeam] };
+      if (constraint.field === 'adminEmails') throw permissionError;
+      throw new Error(`Unexpected query: ${constraint.field}`);
+    });
+
+    await expect(getTeams()).resolves.toEqual([
+      { id: 'public-1', name: 'Falcons', isPublic: true },
+      { id: 'owned-1', name: 'Vipers', ownerId: 'owner-1' }
+    ]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Unable to load teams granted through admin email; continuing with public and owned teams.',
+      permissionError
+    );
+  });
+
+  it('keeps owned and owner-email teams when the optional admin-email query is denied', async () => {
+    const ownedTeam = createTeamDoc('owned-1', { name: 'Falcons', ownerId: 'owner-1' });
+    const emailTeam = createTeamDoc('email-1', { name: 'Vipers', ownerEmail: 'coach@example.com' });
+    const permissionError = Object.assign(new Error('Missing or insufficient permissions.'), {
+      code: 'permission-denied'
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    firebaseMocks.getDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => ({ email: 'coach@example.com' })
+    });
+    firebaseMocks.getDocs.mockImplementation(async (queryValue) => {
+      const constraint = getWhereConstraint(queryValue);
+      if (constraint.field === 'ownerId') return { docs: [ownedTeam] };
+      if (constraint.field === 'adminEmails') throw permissionError;
+      if (constraint.field === 'ownerEmail') return { docs: [emailTeam] };
+      if (constraint.field === 'ownerEmailLower') return { docs: [] };
+      throw new Error(`Unexpected query: ${constraint.field}`);
+    });
+
+    await expect(getUserTeamsWithAccess('owner-1', 'coach@example.com')).resolves.toEqual([
+      { id: 'owned-1', name: 'Falcons', ownerId: 'owner-1' },
+      { id: 'email-1', name: 'Vipers', ownerEmail: 'coach@example.com' }
+    ]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Optional team access query failed (adminEmails:coach@example.com).',
+      permissionError
+    );
   });
 });

--- a/tests/unit/db-team-access-query-resilience.test.js
+++ b/tests/unit/db-team-access-query-resilience.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const dbSource = readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
+
+function getFunctionSource(functionName) {
+  const start = dbSource.indexOf(`export async function ${functionName}(`);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const nextExport = dbSource.indexOf('\nexport async function ', start + 1);
+  return dbSource.slice(start, nextExport === -1 ? dbSource.length : nextExport);
+}
+
+describe('team access query resilience', () => {
+  it('keeps public and owned teams when the optional admin-email query is denied', () => {
+    const source = getFunctionSource('getTeams');
+    expect(source).toContain("where(\"adminEmails\", \"array-contains\", currentUserEmail)");
+    expect(source).toContain('.catch((error) => {');
+    expect(source).toContain('continuing with public and owned teams');
+  });
+
+  it('keeps owned and owner-email teams when the optional admin-email query is denied', () => {
+    const source = getFunctionSource('getUserTeamsWithAccess');
+    expect(source).toContain("where(\"adminEmails\", \"array-contains\", normalizedEmail)");
+    expect(source).toContain('optionalTeamQuery(');
+    expect(source).toContain('`adminEmails:${normalizedEmail}`');
+  });
+});

--- a/tests/unit/team-owner-access-trigger.test.js
+++ b/tests/unit/team-owner-access-trigger.test.js
@@ -1,0 +1,55 @@
+import { createRequire } from 'node:module';
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const require = createRequire(import.meta.url);
+const { createTeamOwnerAccessSyncHandler } = require('../../functions/team-owner-access-core.cjs');
+const functionsSource = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
+
+describe('team owner access trigger', () => {
+  it('atomically grants the created team and coach role to the owner', async () => {
+    const set = vi.fn(async () => {});
+    const fieldValue = {
+      arrayUnion: (...values) => ({ arrayUnion: values }),
+      serverTimestamp: () => ({ serverTimestamp: true })
+    };
+    const handler = createTeamOwnerAccessSyncHandler({
+      firestore: { doc: () => ({ set }) },
+      fieldValue
+    });
+
+    await expect(handler(
+      { id: 'vipers', data: () => ({ ownerId: 'owner-1' }) },
+      { params: { teamId: 'vipers' } }
+    )).resolves.toEqual({ ownerId: 'owner-1', teamId: 'vipers' });
+
+    expect(set).toHaveBeenCalledWith({
+      coachOf: { arrayUnion: ['vipers'] },
+      roles: { arrayUnion: ['coach'] },
+      updatedAt: { serverTimestamp: true }
+    }, { merge: true });
+  });
+
+  it('does nothing for an ownerless team', async () => {
+    const set = vi.fn();
+    const handler = createTeamOwnerAccessSyncHandler({
+      firestore: { doc: () => ({ set }) },
+      fieldValue: {
+        arrayUnion: vi.fn(),
+        serverTimestamp: vi.fn()
+      }
+    });
+
+    await expect(handler(
+      { id: 'team-1', data: () => ({}) },
+      { params: { teamId: 'team-1' } }
+    )).resolves.toBeNull();
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it('wires the handler to team creation in Cloud Functions', () => {
+    expect(functionsSource).toContain("exports.syncTeamOwnerAccessOnCreate = functions.firestore");
+    expect(functionsSource).toContain(".document('teams/{teamId}')");
+    expect(functionsSource).toContain('.onCreate(createTeamOwnerAccessSyncHandler({');
+  });
+});

--- a/tests/unit/team-owner-access-trigger.test.js
+++ b/tests/unit/team-owner-access-trigger.test.js
@@ -47,8 +47,31 @@ describe('team owner access trigger', () => {
     expect(set).not.toHaveBeenCalled();
   });
 
+  it('propagates a transient write failure and succeeds when the event is retried', async () => {
+    const transientError = new Error('Firestore temporarily unavailable');
+    const set = vi.fn()
+      .mockRejectedValueOnce(transientError)
+      .mockResolvedValueOnce();
+    const handler = createTeamOwnerAccessSyncHandler({
+      firestore: { doc: () => ({ set }) },
+      fieldValue: {
+        arrayUnion: (...values) => ({ arrayUnion: values }),
+        serverTimestamp: () => ({ serverTimestamp: true })
+      }
+    });
+    const snapshot = { id: 'vipers', data: () => ({ ownerId: 'owner-1' }) };
+    const context = { params: { teamId: 'vipers' } };
+
+    await expect(handler(snapshot, context)).rejects.toBe(transientError);
+    await expect(handler(snapshot, context)).resolves.toEqual({
+      ownerId: 'owner-1',
+      teamId: 'vipers'
+    });
+    expect(set).toHaveBeenCalledTimes(2);
+  });
+
   it('wires the handler to team creation in Cloud Functions', () => {
-    expect(functionsSource).toContain("exports.syncTeamOwnerAccessOnCreate = functions.firestore");
+    expect(functionsSource).toContain("exports.syncTeamOwnerAccessOnCreate = functions\n  .runWith({ failurePolicy: true })\n  .firestore");
     expect(functionsSource).toContain(".document('teams/{teamId}')");
     expect(functionsSource).toContain('.onCreate(createTeamOwnerAccessSyncHandler({');
   });


### PR DESCRIPTION
## What changed

- Grant a new team owner’s `coachOf` membership and `coach` role from an idempotent Firestore `onCreate` trigger.
- Stop the browser client from attempting to write server-managed role fields.
- Always merge teams owned by the signed-in user into the hydrated app profile, even when `coachOf` already contains another team.
- Treat the admin-email lookup as optional so a denied query cannot discard valid owned/public team results or leave My Teams loading indefinitely.
- Add regression coverage for team creation, profile hydration, query resilience, and the server trigger.

## Why

Creating Vipers wrote the team with the correct `ownerId`, but the client-side profile update was rejected by Firestore because `coachOf` and `roles` are server-managed. The failure was swallowed, leaving Paul’s existing Jr KC Current membership as the only team in the app model. My Teams therefore auto-opened Jr KC Current and Vipers was absent from schedule/team selectors.

## User impact

After deployment, newly created teams receive owner access automatically. Existing partial profiles also recover owned teams during authentication, and optional lookup failures no longer hide owned teams.

## Validation

- `npx vitest run tests/unit/db-create-team-coach-role.test.js tests/unit/app-team-access-hydration.test.js tests/unit/team-owner-access-trigger.test.js tests/unit/db-team-access-query-resilience.test.js tests/unit/backfill-owner-coach-roles.test.js --reporter=dot`
- `node --check functions/index.js`
- `npm run typecheck --prefix apps/app`
- `npm exec --prefix apps/app -- vitest run src/pages/Teams.test.tsx --reporter=dot`

All checks pass (9 focused regression tests and 11 Teams-page tests).