### PR TITLE
Add candidate host public smoke

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:functions:notifications": "npm run test:notifications --prefix functions",
     "test:functions:auth-email": "node --test functions/test/auth-email-*.test.cjs",
     "test:functions:team-email": "node --test functions/test/team-email-*.test.cjs",
+    "smoke:candidate-host": "node scripts/smoke-candidate-host.mjs",
     "test:smoke": "playwright test --config=playwright.smoke.config.js",
     "test:smoke:visual": "npm run test:smoke:visual:assets && playwright test --config=playwright.smoke.config.js --grep @visual",
     "test:smoke:visual:assets": "node scripts/build-legacy-visual-css.mjs --check",

--- a/scripts/smoke-candidate-host.mjs
+++ b/scripts/smoke-candidate-host.mjs
@@ -1,0 +1,129 @@
+import { isDeepStrictEqual } from 'node:util';
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+import { getPublicSmokePages } from '../tests/smoke/page-registry.js';
+
+const widgetPath = '/widget-scoreboard.html';
+const runtimeConfigPath = '/.well-known/allplays-runtime-config.json';
+const firebaseConfig = JSON.parse(
+    readFileSync(new URL('../firebase.json', import.meta.url), 'utf8')
+);
+const expectedRuntimeConfig = JSON.parse(
+    readFileSync(new URL(`..${runtimeConfigPath}`, import.meta.url), 'utf8')
+);
+
+function configuredHeadersFor(path) {
+    const headers = new Map();
+    for (const rule of firebaseConfig.hosting.headers) {
+        if (rule.source !== '**' && rule.source !== path) continue;
+        for (const header of rule.headers || []) {
+            headers.set(header.key, header.value);
+        }
+    }
+    return headers;
+}
+
+export function normalizeCandidateOrigin(candidateOrigin) {
+    let url;
+    try {
+        url = new URL(String(candidateOrigin).trim());
+    } catch {
+        throw new Error(`Invalid candidate origin: ${candidateOrigin}`);
+    }
+    if (url.protocol !== 'https:') {
+        throw new Error(`Candidate origin must use HTTPS: ${candidateOrigin}`);
+    }
+    if (url.username || url.password) {
+        throw new Error('Candidate origin must not include credentials.');
+    }
+    return url.origin;
+}
+
+export function getCandidateHostChecks() {
+    const paths = [
+        ...getPublicSmokePages().map(({ path }) => path),
+        widgetPath,
+        runtimeConfigPath
+    ];
+    return [...new Set(paths)].map((path) => ({
+        path,
+        expectedHeaders: configuredHeadersFor(path)
+    }));
+}
+
+function fail(url, message) {
+    throw new Error(`${url}: ${message}`);
+}
+
+function validateHeaders(url, response, expectedHeaders) {
+    for (const [name, expected] of expectedHeaders) {
+        const observed = response.headers.get(name)?.trim() ?? '<missing>';
+        if (observed !== expected) {
+            fail(
+                url,
+                `header "${name}" expected "${expected}" but observed "${observed}"`
+            );
+        }
+    }
+}
+
+async function validateRuntimeConfig(url, response) {
+    let observed;
+    try {
+        observed = await response.json();
+    } catch {
+        fail(url, 'runtime configuration expected valid JSON but observed an invalid JSON response');
+    }
+    if (!isDeepStrictEqual(observed, expectedRuntimeConfig)) {
+        fail(
+            url,
+            `runtime configuration expected ${JSON.stringify(expectedRuntimeConfig)} but observed ${JSON.stringify(observed)}`
+        );
+    }
+}
+
+export async function smokeCandidateHost(candidateOrigin, { fetchImpl = fetch } = {}) {
+    const origin = normalizeCandidateOrigin(candidateOrigin);
+    const verifiedUrls = [];
+
+    for (const { path, expectedHeaders } of getCandidateHostChecks()) {
+        const url = new URL(path, `${origin}/`).toString();
+        const response = await fetchImpl(url, {
+            redirect: 'follow',
+            headers: { 'Cache-Control': 'no-cache' }
+        });
+
+        if (!response.ok) {
+            fail(url, `expected HTTP 200 but observed HTTP ${response.status}`);
+        }
+        if (response.url && new URL(response.url).origin !== origin) {
+            fail(url, `expected candidate origin "${origin}" but observed redirect "${response.url}"`);
+        }
+
+        validateHeaders(url, response, expectedHeaders);
+        if (path === runtimeConfigPath) {
+            await validateRuntimeConfig(url, response);
+        }
+        verifiedUrls.push(url);
+    }
+
+    return verifiedUrls;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    const candidateOrigin = process.argv[2] ?? process.env.CANDIDATE_HOST_URL;
+    if (!candidateOrigin) {
+        console.error('Usage: npm run smoke:candidate-host -- https://candidate.example');
+        process.exitCode = 1;
+    } else {
+        try {
+            const verifiedUrls = await smokeCandidateHost(candidateOrigin);
+            console.log(`Candidate host smoke passed for ${verifiedUrls.length} URLs:`);
+            for (const url of verifiedUrls) console.log(`- ${url}`);
+        } catch (error) {
+            console.error(`Candidate host smoke failed: ${error.message}`);
+            process.exitCode = 1;
+        }
+    }
+}

--- a/scripts/smoke-candidate-host.mjs
+++ b/scripts/smoke-candidate-host.mjs
@@ -71,15 +71,24 @@ export function normalizeCandidateOrigin(candidateOrigin) {
 }
 
 export function getCandidateHostChecks() {
-    const paths = [
-        ...getPublicSmokePages().map(({ path }) => path),
-        widgetPath,
-        runtimeConfigPath
+    const pages = [
+        ...getPublicSmokePages(),
+        {
+            name: 'scoreboard widget',
+            path: widgetPath,
+            titlePatterns: [/ALL PLAYS Scoreboard Widget/i],
+            readySelectors: ['#scoreboard-widget']
+        }
     ];
-    return [...new Set(paths)].map((path) => ({
-        path,
-        expectedHeaders: configuredHeadersFor(path)
+    const checks = pages.map((page) => ({
+        ...page,
+        expectedHeaders: configuredHeadersFor(page.path)
     }));
+    checks.push({
+        path: runtimeConfigPath,
+        expectedHeaders: configuredHeadersFor(runtimeConfigPath)
+    });
+    return checks;
 }
 
 function fail(url, message) {
@@ -95,6 +104,40 @@ function validateHeaders(url, response, expectedHeaders) {
                 `header "${name}" expected "${expected}" but observed "${observed}"`
             );
         }
+    }
+}
+
+function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function htmlContainsSelector(html, selector) {
+    if (/^#[A-Za-z][\w:-]*$/.test(selector)) {
+        const id = escapeRegExp(selector.slice(1));
+        return new RegExp(`\\bid\\s*=\\s*["']${id}["']`, 'i').test(html);
+    }
+    if (/^[A-Za-z][\w-]*$/.test(selector)) {
+        return new RegExp(`<${escapeRegExp(selector)}\\b`, 'i').test(html);
+    }
+    throw new Error(`Unsupported candidate host readiness selector: ${selector}`);
+}
+
+async function validateHtmlContent(url, response, { titlePatterns, readySelectors }) {
+    const html = await response.text();
+    const title = html.match(/<title\b[^>]*>([\s\S]*?)<\/title>/i)?.[1]
+        .replace(/\s+/g, ' ')
+        .trim() ?? '<missing>';
+    if (!titlePatterns.some((pattern) => pattern.test(title))) {
+        fail(
+            url,
+            `title expected ${titlePatterns.map(String).join(' or ')} but observed "${title}"`
+        );
+    }
+    if (!readySelectors.some((selector) => htmlContainsSelector(html, selector))) {
+        fail(
+            url,
+            `expected at least one readiness selector: ${readySelectors.join(', ')}`
+        );
     }
 }
 
@@ -123,7 +166,8 @@ export async function smokeCandidateHost(
     const origin = normalizeCandidateOrigin(candidateOrigin);
     const verifiedUrls = [];
 
-    for (const { path, expectedHeaders } of getCandidateHostChecks()) {
+    for (const check of getCandidateHostChecks()) {
+        const { path, expectedHeaders } = check;
         const url = new URL(path, `${origin}/`).toString();
         const response = await fetchImpl(url, {
             redirect: 'follow',
@@ -140,6 +184,8 @@ export async function smokeCandidateHost(
         validateHeaders(url, response, expectedHeaders);
         if (path === runtimeConfigPath) {
             await validateRuntimeConfig(url, response, expectedRuntimeConfig);
+        } else {
+            await validateHtmlContent(url, response, check);
         }
         verifiedUrls.push(url);
     }

--- a/scripts/smoke-candidate-host.mjs
+++ b/scripts/smoke-candidate-host.mjs
@@ -6,16 +6,46 @@ import { getPublicSmokePages } from '../tests/smoke/page-registry.js';
 
 const widgetPath = '/widget-scoreboard.html';
 const runtimeConfigPath = '/.well-known/allplays-runtime-config.json';
-const firebaseConfig = JSON.parse(
-    readFileSync(new URL('../firebase.json', import.meta.url), 'utf8')
+
+export function loadJson(fileUrl, label, { readFile = readFileSync } = {}) {
+    try {
+        return JSON.parse(readFile(fileUrl, 'utf8'));
+    } catch (error) {
+        throw new Error(`Failed to load ${label}: ${error.message}`);
+    }
+}
+
+const firebaseConfig = loadJson(
+    new URL('../firebase.json', import.meta.url),
+    'firebase.json'
 );
-const expectedRuntimeConfig = JSON.parse(
-    readFileSync(new URL(`..${runtimeConfigPath}`, import.meta.url), 'utf8')
+const fallbackRuntimeConfig = loadJson(
+    new URL(`..${runtimeConfigPath}`, import.meta.url),
+    runtimeConfigPath
 );
 
-function configuredHeadersFor(path) {
+export function getExpectedRuntimeConfig({
+    siteKey = process.env.ALLPLAYS_APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY,
+    fallback = fallbackRuntimeConfig
+} = {}) {
+    const normalizedSiteKey = typeof siteKey === 'string' ? siteKey.trim() : '';
+    if (!/^[A-Za-z0-9_-]{10,200}$/.test(normalizedSiteKey)) return fallback;
+
+    return {
+        appCheck: {
+            enabled: true,
+            recaptchaEnterpriseSiteKey: normalizedSiteKey,
+            isTokenAutoRefreshEnabled: true
+        }
+    };
+}
+
+export function configuredHeadersFor(path, config = firebaseConfig) {
     const headers = new Map();
-    for (const rule of firebaseConfig.hosting.headers) {
+    const rules = config?.hosting?.headers;
+    if (!Array.isArray(rules)) return headers;
+
+    for (const rule of rules) {
         if (rule.source !== '**' && rule.source !== path) continue;
         for (const header of rule.headers || []) {
             headers.set(header.key, header.value);
@@ -68,7 +98,7 @@ function validateHeaders(url, response, expectedHeaders) {
     }
 }
 
-async function validateRuntimeConfig(url, response) {
+async function validateRuntimeConfig(url, response, expectedRuntimeConfig) {
     let observed;
     try {
         observed = await response.json();
@@ -83,7 +113,13 @@ async function validateRuntimeConfig(url, response) {
     }
 }
 
-export async function smokeCandidateHost(candidateOrigin, { fetchImpl = fetch } = {}) {
+export async function smokeCandidateHost(
+    candidateOrigin,
+    {
+        fetchImpl = fetch,
+        expectedRuntimeConfig = getExpectedRuntimeConfig()
+    } = {}
+) {
     const origin = normalizeCandidateOrigin(candidateOrigin);
     const verifiedUrls = [];
 
@@ -103,7 +139,7 @@ export async function smokeCandidateHost(candidateOrigin, { fetchImpl = fetch } 
 
         validateHeaders(url, response, expectedHeaders);
         if (path === runtimeConfigPath) {
-            await validateRuntimeConfig(url, response);
+            await validateRuntimeConfig(url, response, expectedRuntimeConfig);
         }
         verifiedUrls.push(url);
     }

--- a/tests/unit/smoke-candidate-host.test.js
+++ b/tests/unit/smoke-candidate-host.test.js
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+import {
+    getCandidateHostChecks,
+    normalizeCandidateOrigin,
+    smokeCandidateHost
+} from '../../scripts/smoke-candidate-host.mjs';
+
+const candidateOrigin = 'https://candidate.example.test';
+const runtimeConfig = JSON.parse(
+    readFileSync(new URL('../../.well-known/allplays-runtime-config.json', import.meta.url), 'utf8')
+);
+
+function successfulResponse(path) {
+    const check = getCandidateHostChecks().find((candidate) => candidate.path === path);
+    const body = path === '/.well-known/allplays-runtime-config.json'
+        ? JSON.stringify(runtimeConfig)
+        : '<!doctype html>';
+    return new Response(body, {
+        status: 200,
+        headers: Object.fromEntries(check.expectedHeaders)
+    });
+}
+
+function createFetch(overrides = {}) {
+    return vi.fn(async (input) => {
+        const path = new URL(input).pathname;
+        return overrides[path]?.(path) ?? successfulResponse(path);
+    });
+}
+
+describe('candidate host public smoke', () => {
+    it('normalizes the supplied URL to one HTTPS origin for every configured request', async () => {
+        const fetchImpl = createFetch();
+
+        const verifiedUrls = await smokeCandidateHost(
+            ' https://candidate.example.test/preview/path?channel=test#ignored ',
+            { fetchImpl }
+        );
+
+        expect(normalizeCandidateOrigin('https://candidate.example.test/')).toBe(candidateOrigin);
+        expect(verifiedUrls).toEqual([
+            `${candidateOrigin}/`,
+            `${candidateOrigin}/login.html`,
+            `${candidateOrigin}/teams.html`,
+            `${candidateOrigin}/widget-scoreboard.html`,
+            `${candidateOrigin}/.well-known/allplays-runtime-config.json`
+        ]);
+        expect(fetchImpl.mock.calls.every(([url]) => new URL(url).origin === candidateOrigin)).toBe(true);
+    });
+
+    it('reports the failing URL, header name, expected value, and observed value', async () => {
+        const fetchImpl = createFetch({
+            '/teams.html': (path) => {
+                const response = successfulResponse(path);
+                response.headers.set('X-Content-Type-Options', 'unsafe');
+                return response;
+            }
+        });
+
+        await expect(smokeCandidateHost(candidateOrigin, { fetchImpl })).rejects.toThrow(
+            `${candidateOrigin}/teams.html: header "X-Content-Type-Options" expected "nosniff" but observed "unsafe"`
+        );
+    });
+
+    it('fails with the requested URL when a route is unavailable', async () => {
+        const fetchImpl = createFetch({
+            '/login.html': () => new Response('missing', { status: 404 })
+        });
+
+        await expect(smokeCandidateHost(candidateOrigin, { fetchImpl })).rejects.toThrow(
+            `${candidateOrigin}/login.html: expected HTTP 200 but observed HTTP 404`
+        );
+    });
+
+    it('fails when the candidate runtime configuration differs from the staged contract', async () => {
+        const fetchImpl = createFetch({
+            '/.well-known/allplays-runtime-config.json': (path) => {
+                const response = successfulResponse(path);
+                return new Response(JSON.stringify({ appCheck: { enabled: true } }), {
+                    status: 200,
+                    headers: response.headers
+                });
+            }
+        });
+
+        await expect(smokeCandidateHost(candidateOrigin, { fetchImpl })).rejects.toThrow(
+            `${candidateOrigin}/.well-known/allplays-runtime-config.json: runtime configuration expected`
+        );
+    });
+
+    it('exposes a package command and rejects insecure candidate origins', () => {
+        const packageJson = JSON.parse(
+            readFileSync(new URL('../../package.json', import.meta.url), 'utf8')
+        );
+
+        expect(packageJson.scripts['smoke:candidate-host'])
+            .toBe('node scripts/smoke-candidate-host.mjs');
+        expect(() => normalizeCandidateOrigin('http://candidate.example.test'))
+            .toThrow('Candidate origin must use HTTPS');
+    });
+});

--- a/tests/unit/smoke-candidate-host.test.js
+++ b/tests/unit/smoke-candidate-host.test.js
@@ -2,20 +2,21 @@ import { describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 
 import {
+    configuredHeadersFor,
+    getExpectedRuntimeConfig,
     getCandidateHostChecks,
+    loadJson,
     normalizeCandidateOrigin,
     smokeCandidateHost
 } from '../../scripts/smoke-candidate-host.mjs';
 
 const candidateOrigin = 'https://candidate.example.test';
-const runtimeConfig = JSON.parse(
-    readFileSync(new URL('../../.well-known/allplays-runtime-config.json', import.meta.url), 'utf8')
-);
 
 function successfulResponse(path) {
     const check = getCandidateHostChecks().find((candidate) => candidate.path === path);
+    if (!check) throw new Error(`Test setup error: path ${path} not found in checks`);
     const body = path === '/.well-known/allplays-runtime-config.json'
-        ? JSON.stringify(runtimeConfig)
+        ? JSON.stringify(getExpectedRuntimeConfig())
         : '<!doctype html>';
     return new Response(body, {
         status: 200,
@@ -31,6 +32,35 @@ function createFetch(overrides = {}) {
 }
 
 describe('candidate host public smoke', () => {
+    it.each([
+        'firebase.json',
+        '/.well-known/allplays-runtime-config.json'
+    ])('reports %s parse failures with the source name', (sourceName) => {
+        expect(() => loadJson(
+            new URL('../../firebase.json', import.meta.url),
+            sourceName,
+            { readFile: () => '{invalid' }
+        )).toThrow(`Failed to load ${sourceName}:`);
+    });
+
+    it('treats a missing Firebase hosting header configuration as no expected headers', () => {
+        expect(configuredHeadersFor('/teams.html', {})).toEqual(new Map());
+        expect(configuredHeadersFor('/teams.html', { hosting: {} })).toEqual(new Map());
+    });
+
+    it('derives the expected runtime configuration from the staging site-key contract', () => {
+        expect(getExpectedRuntimeConfig({
+            siteKey: ' public-site-key_123 ',
+            fallback: { appCheck: { enabled: false } }
+        })).toEqual({
+            appCheck: {
+                enabled: true,
+                recaptchaEnterpriseSiteKey: 'public-site-key_123',
+                isTokenAutoRefreshEnabled: true
+            }
+        });
+    });
+
     it('normalizes the supplied URL to one HTTPS origin for every configured request', async () => {
         const fetchImpl = createFetch();
 

--- a/tests/unit/smoke-candidate-host.test.js
+++ b/tests/unit/smoke-candidate-host.test.js
@@ -11,13 +11,20 @@ import {
 } from '../../scripts/smoke-candidate-host.mjs';
 
 const candidateOrigin = 'https://candidate.example.test';
+const successfulHtmlByPath = {
+    '/': '<!doctype html><title>ALL PLAYS</title><body></body>',
+    '/login.html': '<!doctype html><title>Login - ALL PLAYS</title><form id="login-form"></form>',
+    '/teams.html': '<!doctype html><title>Browse Teams - ALL PLAYS</title><div id="teams-list"></div>',
+    '/widget-scoreboard.html': '<!doctype html><title>ALL PLAYS Scoreboard Widget</title><main id="scoreboard-widget"></main>'
+};
 
 function successfulResponse(path) {
     const check = getCandidateHostChecks().find((candidate) => candidate.path === path);
     if (!check) throw new Error(`Test setup error: path ${path} not found in checks`);
     const body = path === '/.well-known/allplays-runtime-config.json'
         ? JSON.stringify(getExpectedRuntimeConfig())
-        : '<!doctype html>';
+        : successfulHtmlByPath[path];
+    if (!body) throw new Error(`Test setup error: no successful body for path ${path}`);
     return new Response(body, {
         status: 200,
         headers: Object.fromEntries(check.expectedHeaders)
@@ -101,6 +108,38 @@ describe('candidate host public smoke', () => {
 
         await expect(smokeCandidateHost(candidateOrigin, { fetchImpl })).rejects.toThrow(
             `${candidateOrigin}/login.html: expected HTTP 200 but observed HTTP 404`
+        );
+    });
+
+    it('rejects a catch-all rewrite that serves homepage HTML for a public route', async () => {
+        const fetchImpl = createFetch({
+            '/login.html': (path) => {
+                const response = successfulResponse(path);
+                return new Response(successfulHtmlByPath['/'], {
+                    status: 200,
+                    headers: response.headers
+                });
+            }
+        });
+
+        await expect(smokeCandidateHost(candidateOrigin, { fetchImpl })).rejects.toThrow(
+            `${candidateOrigin}/login.html: title expected /Login - ALL PLAYS/i but observed "ALL PLAYS"`
+        );
+    });
+
+    it('rejects route HTML that has the expected title but not its readiness marker', async () => {
+        const fetchImpl = createFetch({
+            '/teams.html': (path) => {
+                const response = successfulResponse(path);
+                return new Response('<title>Teams - ALL PLAYS</title><body></body>', {
+                    status: 200,
+                    headers: response.headers
+                });
+            }
+        });
+
+        await expect(smokeCandidateHost(candidateOrigin, { fetchImpl })).rejects.toThrow(
+            `${candidateOrigin}/teams.html: expected at least one readiness selector: #teams-list`
         );
     });
 


### PR DESCRIPTION
Closes #4126

## What changed
- Added a runnable candidate-host smoke command.
- Validates configured public routes, the scoreboard widget, runtime configuration content, and Firebase-configured response headers.
- Normalizes every request to the supplied HTTPS origin.
- Reports URL-specific status and runtime failures plus header name, expected value, and observed value.

## Root Cause
Candidate checks were split between local route coverage and a live header verifier with hard-coded paths and generic diagnostics. No single runnable contract validated every configured public route, runtime content, and exact deployed header value against one normalized origin.

## Prevention / Learning
Derive cutover checks from repository route and hosting configuration. Normalize the candidate origin once and require failures to expose the full URL and expected-versus-observed contract.

## Regression Tests
- `npx vitest run tests/unit/smoke-candidate-host.test.js tests/unit/verify-response-headers.test.js tests/unit/hosting-security-headers.test.js --reporter=verbose`
- 19 focused tests passed.
- `git diff --check` passed.

## Recurrence Risk
Low. Focused tests lock origin normalization, configured route coverage, exact header diagnostics, HTTP failures, and runtime configuration drift detection.