### PR TITLE
Document hosting cutover and rollback controls

### DIFF
--- a/docs/firebase-app-check-rollout.md
+++ b/docs/firebase-app-check-rollout.md
@@ -4,6 +4,11 @@ App Check client initialization is fail-open by design. Deploying this code star
 attestation and metrics collection but does not reject a request if attestation
 fails. Firebase Console enforcement is the separate fail-closed rollout gate.
 
+Candidate-host validation and DNS cutover observation follow the
+[hosting cutover runbook](hosting-cutover-runbook.md). During that entire gate,
+every Firebase API remains **Unenforced**; enforcement is a separate rollout
+decision.
+
 ## Client configuration
 
 ### Web

--- a/docs/hosting-cutover-runbook.md
+++ b/docs/hosting-cutover-runbook.md
@@ -1,0 +1,218 @@
+# Hosting cutover and rollback runbook
+
+This runbook gates a future move of `allplays.ai` and `www.allplays.ai` from
+GitHub Pages to the Firebase Hosting candidate at
+`https://game-flow-c6311.web.app`. It does not authorize or execute that change.
+
+The rollback target is the last known-good GitHub Pages deployment serving the
+canonical domains immediately before cutover. The GitHub Pages origin is
+`pauljsnider.github.io`. The exact pre-cutover DNS provider export is the
+rollback source of truth; do not reconstruct records during an incident.
+
+## Change record
+
+Create one evidence location before validation and record:
+
+- cutover decision owner, DNS operator, rollback owner, and start time in UTC;
+- DNS provider, authoritative nameservers, and provider export of every record
+  for `allplays.ai` and `www.allplays.ai`, including type, name, value, TTL,
+  priority, and proxy mode where applicable;
+- maximum pre-cutover TTL and the time each changed record was last observed
+  with its rollback value;
+- approved Firebase Hosting DNS targets from the Firebase console;
+- last known-good GitHub Pages commit and workflow/deployment URL;
+- Firebase Hosting candidate commit and workflow/deployment URL;
+- tested origin, command, timestamp, exit status, and complete redacted output
+  for every gate in this runbook.
+
+At the time this runbook was written, public DNS returned the GitHub Pages apex
+addresses `185.199.108.153`, `185.199.109.153`, `185.199.110.153`, and
+`185.199.111.153`, with `www CNAME pauljsnider.github.io`. These are context,
+not permission to skip the provider export and second-operator verification.
+GitHub can change its published targets.
+
+Do not capture passwords, cookies, session tokens, App Check debug tokens, or
+user data in the evidence.
+
+## Pre-cutover gate
+
+All items are mandatory. A failed, skipped, stale, or missing-credential result
+is a no-go.
+
+1. Confirm in Firebase Console that every Firebase API remains **Unenforced** in
+   App Check. Keep that state throughout candidate validation, DNS propagation,
+   and cutover observation. Do not use a production debug token, client bypass,
+   or enforcement change to make validation pass.
+2. From the exact candidate deployment commit, run the public route, scoreboard,
+   runtime-config, and configured-header smoke:
+
+   ```bash
+   npm run smoke:candidate-host -- https://game-flow-c6311.web.app
+   ```
+
+3. Run the independent response-header policy check:
+
+   ```bash
+   node scripts/verify-response-headers.mjs https://game-flow-c6311.web.app
+   ```
+
+4. Run authenticated candidate-host smoke with the protected production-smoke
+   account. Supply secrets through the approved secret store, never the command
+   line or evidence log:
+
+   ```bash
+   CANDIDATE_HOST_URL=https://game-flow-c6311.web.app \
+     SMOKE_AUTH_EMAIL="$SMOKE_AUTH_EMAIL" \
+     SMOKE_AUTH_PASSWORD="$SMOKE_AUTH_PASSWORD" \
+     npx playwright test tests/smoke/candidate-host-auth.spec.js \
+       --config=playwright.smoke.config.js --reporter=line
+   ```
+
+5. Retain successful public and authenticated results with the tested origin,
+   timestamp, commit SHA, deployment or workflow URL, exit status, and redacted
+   output. Evidence from a different deployment is stale.
+6. Complete the candidate-origin TLS check and the pre-change DNS snapshot in
+   the next section. Have a second operator compare the provider export,
+   rollback target, candidate targets, and TTLs before the decision owner
+   records go/no-go.
+
+## DNS and TLS validation
+
+### Before changing DNS
+
+Query the authoritative nameservers and at least two independent public
+recursive resolvers. Check A, AAAA, and CNAME records even when an empty result
+is expected, so stale IPv6 or aliases are not missed.
+
+```bash
+dig +short NS allplays.ai
+dig +noall +answer allplays.ai A allplays.ai AAAA allplays.ai CNAME
+dig +noall +answer www.allplays.ai A www.allplays.ai AAAA www.allplays.ai CNAME
+dig @1.1.1.1 +noall +answer allplays.ai A allplays.ai AAAA allplays.ai CNAME
+dig @1.1.1.1 +noall +answer www.allplays.ai A www.allplays.ai AAAA www.allplays.ai CNAME
+dig @8.8.8.8 +noall +answer allplays.ai A allplays.ai AAAA allplays.ai CNAME
+dig @8.8.8.8 +noall +answer www.allplays.ai A www.allplays.ai AAAA www.allplays.ai CNAME
+```
+
+Repeat the A, AAAA, and CNAME queries against each nameserver returned by the NS
+query, using `dig @<authoritative-nameserver> ...`. Save the answers and TTLs.
+Every observed candidate value must exactly match the approved Firebase Hosting
+targets recorded in the change record.
+
+Validate the candidate origin with normal trust checks enabled:
+
+```bash
+curl --fail --silent --show-error --location --output /dev/null \
+  https://game-flow-c6311.web.app/
+openssl s_client -connect game-flow-c6311.web.app:443 \
+  -servername game-flow-c6311.web.app -verify_return_error \
+  -verify_hostname game-flow-c6311.web.app </dev/null
+openssl s_client -connect game-flow-c6311.web.app:443 \
+  -servername game-flow-c6311.web.app </dev/null 2>/dev/null |
+  openssl x509 -noout -subject -issuer -dates -ext subjectAltName
+```
+
+Require a chain to a trusted root, `subjectAltName` coverage for the requested
+hostname, a current `notBefore`/`notAfter` interval, and no intermittent
+handshake failure. Do not use `curl -k`, `--insecure`, or an OpenSSL verification
+bypass.
+
+### During and after propagation
+
+1. Repeat the authoritative and public-resolver queries for both canonical
+   hosts. Record every answer, not only the expected one.
+2. Continue until the authoritative nameservers and both `1.1.1.1` and
+   `8.8.8.8` return only the approved Firebase Hosting targets, and no stale
+   GitHub Pages target remains after the recorded pre-cutover TTL has elapsed.
+3. Validate HTTPS for both canonical hosts using the same `curl` and
+   `openssl s_client` pattern, substituting `allplays.ai` and
+   `www.allplays.ai`. Test from two independent networks or external probes.
+4. Reject a certificate that is pending, expired, not yet valid, untrusted,
+   missing either hostname from its SANs, or reliable only from one probe.
+   Reject redirects whose final origin is not the requested canonical origin.
+5. Run the pre-cutover public, header, and authenticated commands again with
+   `https://allplays.ai` as the supplied origin. Repeat the public and TLS checks
+   for `https://www.allplays.ai` and confirm its intended canonical redirect or
+   same-origin behavior.
+6. Confirm the scoreboard, `/.well-known/allplays-runtime-config.json`, public
+   pages, login, and protected landing page all remain usable.
+
+Do not declare cutover complete while DNS answers are mixed, TLS is incomplete,
+any smoke result fails, or a material cutover-related authentication, HTTP,
+Firebase, or CSP error-rate increase remains open.
+
+## Rollback
+
+Rollback target: the last known-good GitHub Pages deployment at
+`pauljsnider.github.io` and exact pre-cutover record set captured in the change
+record.
+
+Trigger immediate rollback for canonical TLS failure, unexpected-origin
+redirects, DNS misrouting beyond the approved propagation window, failed public
+or authenticated smoke, missing or incorrect required response headers,
+unavailable runtime config, broken scoreboard embedding, or a material
+cutover-related production error-rate increase.
+
+1. Declare rollback. Name the incident owner and freeze further DNS, hosting,
+   App Check, and CSP changes. Keep the Firebase candidate deployment available
+   for diagnosis.
+2. Restore the exact pre-cutover record set from the verified DNS provider
+   export. Restore every saved A, AAAA, and CNAME value and TTL for
+   `allplays.ai` and `www.allplays.ai`; remove only candidate-only records that
+   conflict with that saved set. Do not substitute remembered or current
+   example values.
+3. Verify authoritative DNS returns only the restored GitHub Pages values for
+   both canonical hosts. Record timestamps and full answers.
+4. Verify at least two public recursive resolvers return the restored values.
+   Continue checking through the maximum recorded TTL; mixed answers mean
+   rollback is still in progress.
+5. Validate TLS for `allplays.ai` and `www.allplays.ai` from two independent
+   probes without bypasses. Confirm trusted chains, hostname/SAN coverage,
+   validity dates, and expected-origin behavior.
+6. Run the public and authenticated smoke checks against the restored canonical
+   host. Use the production Playwright smoke for public routes, scoreboard, app
+   boot, and runtime config, and use
+   `tests/smoke/candidate-host-auth.spec.js` with
+   `CANDIDATE_HOST_URL=https://allplays.ai` for authenticated recovery.
+7. Confirm the temporary meta CSP bridge remains present and effective in the
+   GitHub Pages HTML. Preserve browser or page-source evidence without user
+   data.
+8. Close rollback only after the rollback owner records the final DNS export,
+   resolver and TLS evidence, smoke workflow URLs and results, timestamps,
+   incident disposition, and follow-up owner.
+
+Rollback is complete only when DNS, TLS, public smoke, authenticated smoke,
+scoreboard behavior, runtime configuration, and the GitHub Pages meta CSP bridge
+all pass against the rollback target. App Check stays **Unenforced**.
+
+## Meta CSP bridge removal gate
+
+Removing the temporary meta CSP bridge is a separate reviewed change. DNS
+propagation alone is insufficient. Retain the bridge until the change record
+contains all of this evidence:
+
+- authoritative nameservers and at least two public resolvers direct both
+  canonical hosts only to Firebase Hosting for one full recorded pre-cutover
+  TTL and a minimum 24-hour observation window;
+- valid TLS for both canonical hosts from two independent networks or probes,
+  including trusted chain, hostname/SAN, `notBefore`, and `notAfter` evidence;
+- two consecutive successful public, response-header, and authenticated smoke
+  runs against the canonical origin after DNS convergence, including one
+  scheduled or independently rerun check;
+- response captures proving `Content-Security-Policy` and the other required
+  policies are delivered as an HTTP response header on every checked page,
+  widget, runtime-config response, and application asset;
+- browser evidence that no supported route depends on the meta policy and that
+  there are no material CSP violations;
+- no open cutover-related production regression and no material increase in
+  authentication, HTTP, Firebase, or CSP error rates during the observation
+  window;
+- either GitHub Pages is no longer a serving or rollback path, or an equivalent
+  CSP control remains available on every GitHub Pages artifact that can receive
+  traffic;
+- retained timestamp, tested origin, commit and deployment identifiers, command
+  outputs, workflow URLs, monitoring links, release-owner sign-off, security
+  reviewer sign-off, explicit approval to remove the bridge, and a rollback
+  plan for the removal change.
+
+If any evidence is missing or stale, keep the meta CSP bridge.

--- a/docs/pr-notes/runs/issue-4128-fixer-20260723T051512Z/architecture.md
+++ b/docs/pr-notes/runs/issue-4128-fixer-20260723T051512Z/architecture.md
@@ -1,0 +1,48 @@
+# Current-State Read
+
+- `allplays.ai` currently uses GitHub Pages and the repository `CNAME`.
+- The Firebase Hosting candidate is `https://game-flow-c6311.web.app`.
+- Public, response-header, and authenticated candidate checks already exist.
+- GitHub Pages staging injects a temporary meta CSP bridge. Firebase Hosting
+  supplies CSP and related controls as HTTP response headers.
+- No runbook currently joins these controls into a cutover or rollback gate.
+
+# Proposed Design
+
+Add one operational source of truth at `docs/hosting-cutover-runbook.md`. It
+records the pre-change DNS state, runs the existing candidate checks, validates
+DNS and TLS, defines post-change verification, and restores the exact saved DNS
+state on rollback. Add a narrow App Check cross-reference and a documentation
+contract test.
+
+# Files And Modules Touched
+
+- `docs/hosting-cutover-runbook.md`
+- `docs/firebase-app-check-rollout.md`
+- `tests/unit/hosting-cutover-runbook.test.js`
+- Per-run planning artifacts under this directory
+
+# Data/State Impacts
+
+No application, Firestore, authentication, DNS, or hosting state changes. The
+runbook governs later operational changes and evidence capture.
+
+# Security/Permissions Impacts
+
+No new permissions. DNS mutation remains limited to authorized operators. App
+Check remains **Unenforced**, TLS verification cannot be bypassed, and captured
+evidence must exclude credentials, tokens, cookies, and user data.
+
+# Failure Modes And Mitigations
+
+- Partial DNS convergence: keep both origins viable and query authoritative plus
+  two public recursive resolvers through the prior maximum TTL.
+- TLS not ready: block or roll back on trust, hostname, validity, or handshake
+  failure.
+- Public success but auth failure: require both smoke classes before and after
+  cutover.
+- Missing security headers: run response-header verification on the candidate
+  and canonical production origins.
+- Stale rollback values: require a verified provider export before cutover.
+- Early meta bridge removal: require a separate reviewed change backed by
+  converged DNS, TLS, headers, smoke, monitoring, and approval evidence.

--- a/docs/pr-notes/runs/issue-4128-fixer-20260723T051512Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-4128-fixer-20260723T051512Z/code-plan.md
@@ -1,0 +1,64 @@
+# Acceptance Criteria
+
+- Candidate DNS/TLS validation is objective and reproducible.
+- Public and authenticated candidate smoke must pass before cutover.
+- App Check remains **Unenforced** throughout candidate validation.
+- GitHub Pages is the named rollback target with exact saved DNS values and an
+  ordered reversal procedure.
+- Meta CSP bridge removal requires retained DNS, TLS, header, smoke, monitoring,
+  and approval evidence.
+
+# Architecture Decisions
+
+- Add documentation and a focused contract test only.
+- Treat the pre-cutover DNS provider export as authoritative. Current GitHub
+  Pages values are useful context but not a substitute for that export.
+- Keep the meta CSP bridge and GitHub Pages unchanged in this slice.
+
+# QA Plan
+
+Add a Vitest documentation contract, prove it fails before the runbook exists,
+then run only that focused test after implementation.
+
+# Implementation Plan
+
+1. Add `tests/unit/hosting-cutover-runbook.test.js`.
+2. Confirm the focused test fails because the runbook is absent.
+3. Add `docs/hosting-cutover-runbook.md`.
+4. Cross-reference it from `docs/firebase-app-check-rollout.md`.
+5. Run the focused test and inspect the final diff.
+
+# Risks And Rollback
+
+The patch changes documentation and its regression contract only. Revert the
+single commit if the operational guidance is incorrect. The requirements and
+architecture roles differed on hard-coding GitHub Pages IPs; the synthesis uses
+the safer direction: identify currently observed values as context, but require
+the verified pre-cutover provider export as the exact rollback source of truth.
+
+# Patch Plan
+
+Keep the runbook operator-focused, use commands already present in the
+repository, and avoid provider-specific mutation commands that cannot be
+verified from repository context.
+
+# Code Changes Applied
+
+- Added the hosting cutover and rollback runbook.
+- Added the App Check rollout cross-reference and **Unenforced** reminder.
+- Added a focused documentation contract test.
+
+# Validation Run
+
+Passed:
+`npx vitest run tests/unit/hosting-cutover-runbook.test.js --reporter=verbose`
+(5 tests).
+
+# Residual Risks
+
+Authenticated smoke requires protected CI or operator credentials and is an
+execution-time gate, not a local unit-test prerequisite.
+
+# Commit Message Draft
+
+`Document hosting cutover rollback runbook (#4128)`

--- a/docs/pr-notes/runs/issue-4128-fixer-20260723T051512Z/qa.md
+++ b/docs/pr-notes/runs/issue-4128-fixer-20260723T051512Z/qa.md
@@ -1,0 +1,44 @@
+# Risk Matrix
+
+- High: ambiguous rollback records or order can extend an outage.
+- High: public-only validation can miss authentication failures.
+- Medium: partial DNS propagation or incomplete TLS issuance can create regional
+  failures.
+- Medium: early meta CSP bridge removal can weaken browser controls.
+- Low: App Check state can drift unless both documents repeat the
+  **Unenforced** gate.
+
+# Automated Tests To Add/Update
+
+Add `tests/unit/hosting-cutover-runbook.test.js` using the existing
+documentation-contract pattern. Assert DNS/TLS checks, mandatory public and
+authenticated smoke, the GitHub Pages rollback target and ordered reversal,
+App Check state, and the evidence threshold for meta CSP bridge removal.
+
+# Manual Test Plan
+
+Perform a tabletop review only. Confirm the runbook captures owners, exact DNS
+records and TTLs, deployment identifiers, evidence location, validation order,
+rollback order, and objective completion criteria.
+
+# Negative Tests
+
+- Block on stale or unexpected DNS, incomplete TLS, skipped smoke, or a
+  cross-origin redirect.
+- Block when any Firebase API is **Enforced**.
+- Block when rollback records were not captured before the change.
+- Retain the meta CSP bridge when production header, smoke, DNS, TLS, monitoring,
+  or approval evidence is incomplete.
+
+# Release Gates
+
+- Focused documentation contract test passes.
+- Existing candidate public and authenticated contract tests remain unchanged.
+- No DNS, hosting, GitHub Pages, or App Check configuration changes are present.
+- Full GitHub CI remains the merge gate.
+
+# Post-Deploy Checks
+
+Verify both Markdown documents render and link correctly. When the runbook is
+later executed, retain timestamped DNS, TLS, smoke, commit/deployment, App Check,
+monitoring, and operator approval evidence.

--- a/docs/pr-notes/runs/issue-4128-fixer-20260723T051512Z/requirements.md
+++ b/docs/pr-notes/runs/issue-4128-fixer-20260723T051512Z/requirements.md
@@ -1,0 +1,55 @@
+# Problem Statement
+
+ALL PLAYS lacks one authoritative gate for moving `allplays.ai` from GitHub
+Pages to Firebase Hosting. Operators need a repeatable cutover and rollback
+procedure that preserves the existing security controls.
+
+# User Segments Impacted
+
+- Release and DNS operators need explicit go/no-go, rollback, and evidence gates.
+- Coaches and parents need authenticated access to survive the origin change.
+- Public visitors and scoreboard consumers need stable routes, runtime config,
+  TLS, and response headers.
+
+# Acceptance Criteria
+
+1. Name `https://game-flow-c6311.web.app` as the candidate origin and the
+   pre-cutover GitHub Pages deployment as the rollback target.
+2. Require successful public, response-header, and authenticated candidate
+   smoke evidence before DNS changes.
+3. Keep every Firebase API **Unenforced** in App Check during candidate
+   validation and cutover observation.
+4. Validate authoritative DNS, at least two public recursive resolvers, TTL
+   convergence, and A, AAAA, or CNAME values for `allplays.ai` and
+   `www.allplays.ai`.
+5. Validate the TLS trust chain, hostname/SAN coverage, validity period, and
+   HTTPS behavior without certificate bypasses.
+6. Provide ordered rollback steps that restore the exact captured GitHub Pages
+   DNS record set and verify DNS, TLS, public smoke, and authenticated smoke.
+7. Require objective DNS, TLS, header, smoke, monitoring, and approval evidence
+   before removing the temporary meta CSP bridge.
+
+# Non-Goals
+
+- Executing DNS changes or a production cutover.
+- Removing GitHub Pages or the meta CSP bridge.
+- Changing hosting configuration.
+- Enabling App Check enforcement.
+
+# Edge Cases
+
+- Apex and `www` records converge at different times.
+- IPv4 converges while stale IPv6 continues to reach the old origin.
+- TLS is ready for one canonical hostname but not the other.
+- Public routes pass while authenticated navigation fails.
+- A smoke test is skipped because credentials are unavailable.
+- Rollback DNS is authoritative but remains stale in recursive caches.
+
+# Open Questions
+
+- The operator must capture the actual pre-cutover provider export because it is
+  the rollback source of truth.
+- The change record must name the cutover owner, rollback owner, DNS operator,
+  and evidence location.
+- The operator must select two independent networks or external probes for TLS
+  validation.

--- a/tests/unit/hosting-cutover-runbook.test.js
+++ b/tests/unit/hosting-cutover-runbook.test.js
@@ -1,0 +1,87 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = process.cwd();
+const runbook = readFileSync(
+    join(repoRoot, 'docs', 'hosting-cutover-runbook.md'),
+    'utf8'
+);
+const appCheckRollout = readFileSync(
+    join(repoRoot, 'docs', 'firebase-app-check-rollout.md'),
+    'utf8'
+);
+
+function section(source, heading) {
+    const start = source.indexOf(`## ${heading}`);
+    expect(start, `missing "${heading}" section`).toBeGreaterThanOrEqual(0);
+    const next = source.indexOf('\n## ', start + 4);
+    return source.slice(start, next === -1 ? source.length : next);
+}
+
+function normalize(source) {
+    return source.replace(/\s+/g, ' ').trim();
+}
+
+describe('hosting cutover runbook contract', () => {
+    it('gates cutover on candidate public and authenticated smoke while App Check is unenforced', () => {
+        const gate = normalize(section(runbook, 'Pre-cutover gate'));
+
+        expect(gate).toContain('https://game-flow-c6311.web.app');
+        expect(gate).toContain('npm run smoke:candidate-host -- https://game-flow-c6311.web.app');
+        expect(gate).toContain('node scripts/verify-response-headers.mjs https://game-flow-c6311.web.app');
+        expect(gate).toContain('tests/smoke/candidate-host-auth.spec.js');
+        expect(gate).toContain('successful public and authenticated');
+        expect(gate).toContain('every Firebase API remains **Unenforced**');
+        expect(gate).toMatch(/failed, skipped, stale, or missing-credential result is a no-go/i);
+    });
+
+    it('defines objective DNS propagation and TLS certificate checks', () => {
+        const validation = normalize(section(runbook, 'DNS and TLS validation'));
+
+        expect(validation).toContain('authoritative nameservers');
+        expect(validation).toContain('1.1.1.1');
+        expect(validation).toContain('8.8.8.8');
+        expect(validation).toContain('A, AAAA, and CNAME');
+        expect(validation).toContain('recorded pre-cutover TTL');
+        expect(validation).toContain('subjectAltName');
+        expect(validation).toContain('notBefore');
+        expect(validation).toContain('notAfter');
+        expect(validation).toContain('trusted root');
+        expect(validation).toContain('two independent networks or external probes');
+        expect(validation).toContain('Do not use `curl -k`');
+    });
+
+    it('names the rollback target and orders reversal through recovery verification', () => {
+        const rollback = normalize(section(runbook, 'Rollback'));
+
+        expect(rollback).toContain('last known-good GitHub Pages deployment');
+        expect(rollback).toContain('pauljsnider.github.io');
+        expect(rollback).toMatch(/1\. Declare rollback[\s\S]*2\. Restore[\s\S]*3\. Verify authoritative DNS[\s\S]*4\. Verify at least two public recursive resolvers[\s\S]*5\. Validate TLS[\s\S]*6\. Run the public and authenticated smoke checks[\s\S]*7\. Confirm the temporary meta CSP bridge[\s\S]*8\. Close rollback/);
+        expect(rollback).toContain('exact pre-cutover record set');
+        expect(rollback).toContain('Rollback is complete only when DNS, TLS, public smoke, authenticated smoke');
+    });
+
+    it('requires retained evidence before removing the temporary meta CSP bridge', () => {
+        const bridge = normalize(section(runbook, 'Meta CSP bridge removal gate'));
+
+        expect(bridge).toContain('separate reviewed change');
+        expect(bridge).toContain('one full recorded pre-cutover TTL');
+        expect(bridge).toContain('minimum 24-hour observation window');
+        expect(bridge).toContain('two consecutive');
+        expect(bridge).toContain('Content-Security-Policy');
+        expect(bridge).toContain('HTTP response header');
+        expect(bridge).toContain('no material CSP violations');
+        expect(bridge).toContain('timestamp');
+        expect(bridge).toContain('tested origin');
+        expect(bridge).toContain('commit and deployment identifiers');
+        expect(bridge).toContain('explicit approval');
+    });
+
+    it('cross-references the cutover gate from the App Check rollout', () => {
+        const normalizedRollout = normalize(appCheckRollout);
+        expect(normalizedRollout).toContain('[hosting cutover runbook](hosting-cutover-runbook.md)');
+        expect(normalizedRollout).toMatch(/candidate-host validation and DNS cutover observation/i);
+        expect(normalizedRollout).toContain('every Firebase API remains **Unenforced**');
+    });
+});


### PR DESCRIPTION
Closes #4128

## What changed
- Added the production DNS and TLS cutover validation sequence.
- Documented the GitHub Pages rollback target, ordered reversal steps, and recovery criteria.
- Required successful public, header, and authenticated candidate-host smoke results while App Check remains **Unenforced**.
- Defined objective evidence required before removing the temporary meta CSP bridge.
- Added an App Check rollout cross-reference and focused documentation contract tests.

## Root Cause
Candidate-host validation controls existed independently, but no authoritative runbook connected them into a production cutover gate, rollback procedure, or CSP bridge removal decision.

## Prevention / Learning
Operational changes that alter production origins must ship with a tested contract covering pre-change evidence, control equivalence, rollback state, ordered recovery, and objective completion criteria.

## Regression Tests
- `npx vitest run tests/unit/hosting-cutover-runbook.test.js --reporter=verbose`
- Result: 5 tests passed.