### PR TITLE
Add candidate host deployment workflow

### DIFF
--- a/.github/workflows/deploy-candidate-host.yml
+++ b/.github/workflows/deploy-candidate-host.yml
@@ -1,0 +1,127 @@
+name: deploy-candidate-host
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: candidate-host-deploy
+  cancel-in-progress: true
+
+jobs:
+  prepare-candidate-artifact:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install app dependencies
+        run: npm ci --prefix apps/app
+
+      - name: Build React app
+        run: npm run app:build
+
+      - name: Stage root site and React app
+        env:
+          ALLPLAYS_APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY: ${{ vars.APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY }}
+          ALLPLAYS_APP_CHECK_ENFORCEMENT_READY: ${{ vars.APP_CHECK_ENFORCEMENT_READY }}
+        run: |
+          set -euo pipefail
+          bundle="$RUNNER_TEMP/firebase-candidate-ready"
+          node scripts/stage-pages-bundle.mjs "$bundle/site"
+          node scripts/write-firebase-hosting-config.mjs "$bundle/site" "$bundle/firebase-candidate.generated.json"
+          jq '
+            .hosting.public = "site"
+            | .hosting.site = "game-flow-c6311"
+            | del(.functions, .firestore, .storage)
+          ' "$bundle/firebase-candidate.generated.json" > "$bundle/firebase-candidate.generated.json.tmp"
+          mv "$bundle/firebase-candidate.generated.json.tmp" "$bundle/firebase-candidate.generated.json"
+          printf '%s\n' "$GITHUB_SHA" > "$bundle/head-sha"
+
+      - name: Install isolated Firebase Hosting deploy CLI
+        run: |
+          set -euo pipefail
+          bundle="$RUNNER_TEMP/firebase-candidate-ready"
+          npm install \
+            --prefix "$bundle/firebase-cli" \
+            --ignore-scripts \
+            --no-audit \
+            --no-fund \
+            --package-lock=false \
+            firebase-tools@15.24.0
+          node "$bundle/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js" --version
+
+      - name: Upload trusted candidate deploy handoff
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: firebase-candidate-trusted-ready
+          path: ${{ runner.temp }}/firebase-candidate-ready
+          if-no-files-found: error
+          include-hidden-files: true
+          retention-days: 7
+
+  deploy-candidate:
+    needs: prepare-candidate-artifact
+    runs-on: ubuntu-latest
+    environment: candidate-host
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download trusted candidate deploy handoff
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: firebase-candidate-trusted-ready
+          path: ${{ runner.temp }}/firebase-candidate-ready
+
+      - name: Validate candidate target and artifact before OIDC
+        run: |
+          set -euo pipefail
+          bundle="$RUNNER_TEMP/firebase-candidate-ready"
+          grep -Fxq "$GITHUB_SHA" "$bundle/head-sha"
+          test -f "$bundle/site/index.html"
+          test -f "$bundle/site/app/index.html"
+          test -f "$bundle/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js"
+          jq -e '
+            .hosting.public == "site"
+            and .hosting.site == "game-flow-c6311"
+            and (has("functions") | not)
+            and (has("firestore") | not)
+            and (has("storage") | not)
+          ' "$bundle/firebase-candidate.generated.json" >/dev/null
+
+      - name: Authenticate candidate Hosting deploy through OIDC
+        id: google_auth_candidate
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ vars.FIREBASE_DEPLOY_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.FIREBASE_DEPLOY_SERVICE_ACCOUNT }}
+          project_id: game-flow-c6311
+          create_credentials_file: true
+          cleanup_credentials: true
+
+      - name: Deploy candidate Firebase Hosting site
+        timeout-minutes: 4
+        run: |
+          set -euo pipefail
+          bundle="$RUNNER_TEMP/firebase-candidate-ready"
+          node "$bundle/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js" \
+            deploy \
+            --only hosting \
+            --project game-flow-c6311 \
+            --config "$bundle/firebase-candidate.generated.json" \
+            --non-interactive
+

--- a/.github/workflows/deploy-candidate-host.yml
+++ b/.github/workflows/deploy-candidate-host.yml
@@ -49,19 +49,6 @@ jobs:
           mv "$bundle/firebase-candidate.generated.json.tmp" "$bundle/firebase-candidate.generated.json"
           printf '%s\n' "$GITHUB_SHA" > "$bundle/head-sha"
 
-      - name: Install isolated Firebase Hosting deploy CLI
-        run: |
-          set -euo pipefail
-          bundle="$RUNNER_TEMP/firebase-candidate-ready"
-          npm install \
-            --prefix "$bundle/firebase-cli" \
-            --ignore-scripts \
-            --no-audit \
-            --no-fund \
-            --package-lock=false \
-            firebase-tools@15.24.0
-          node "$bundle/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js" --version
-
       - name: Upload trusted candidate deploy handoff
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
@@ -81,6 +68,23 @@ jobs:
       id-token: write
 
     steps:
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 22
+
+      - name: Install isolated Firebase Hosting deploy CLI
+        run: |
+          set -euo pipefail
+          npm install \
+            --prefix "$RUNNER_TEMP/firebase-cli" \
+            --ignore-scripts \
+            --no-audit \
+            --no-fund \
+            --package-lock=false \
+            firebase-tools@15.24.0
+          node "$RUNNER_TEMP/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js" --version
+
       - name: Download trusted candidate deploy handoff
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -94,7 +98,6 @@ jobs:
           grep -Fxq "$GITHUB_SHA" "$bundle/head-sha"
           test -f "$bundle/site/index.html"
           test -f "$bundle/site/app/index.html"
-          test -f "$bundle/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js"
           jq -e '
             .hosting.public == "site"
             and .hosting.site == "game-flow-c6311"
@@ -118,10 +121,9 @@ jobs:
         run: |
           set -euo pipefail
           bundle="$RUNNER_TEMP/firebase-candidate-ready"
-          node "$bundle/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js" \
+          node "$RUNNER_TEMP/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js" \
             deploy \
             --only hosting \
             --project game-flow-c6311 \
             --config "$bundle/firebase-candidate.generated.json" \
             --non-interactive
-

--- a/.github/workflows/deploy-candidate-host.yml
+++ b/.github/workflows/deploy-candidate-host.yml
@@ -49,6 +49,19 @@ jobs:
           mv "$bundle/firebase-candidate.generated.json.tmp" "$bundle/firebase-candidate.generated.json"
           printf '%s\n' "$GITHUB_SHA" > "$bundle/head-sha"
 
+      - name: Install isolated Firebase Hosting deploy CLI without OIDC or lifecycle scripts
+        run: |
+          set -euo pipefail
+          bundle="$RUNNER_TEMP/firebase-candidate-ready"
+          npm install \
+            --prefix "$bundle/firebase-cli" \
+            --ignore-scripts \
+            --no-audit \
+            --no-fund \
+            --package-lock=false \
+            firebase-tools@15.24.0
+          node "$bundle/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js" --version
+
       - name: Upload trusted candidate deploy handoff
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
@@ -68,23 +81,6 @@ jobs:
       id-token: write
 
     steps:
-      - name: Setup Node
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
-        with:
-          node-version: 22
-
-      - name: Install isolated Firebase Hosting deploy CLI
-        run: |
-          set -euo pipefail
-          npm install \
-            --prefix "$RUNNER_TEMP/firebase-cli" \
-            --ignore-scripts \
-            --no-audit \
-            --no-fund \
-            --package-lock=false \
-            firebase-tools@15.24.0
-          node "$RUNNER_TEMP/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js" --version
-
       - name: Download trusted candidate deploy handoff
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -98,6 +94,7 @@ jobs:
           grep -Fxq "$GITHUB_SHA" "$bundle/head-sha"
           test -f "$bundle/site/index.html"
           test -f "$bundle/site/app/index.html"
+          test -f "$bundle/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js"
           jq -e '
             .hosting.public == "site"
             and .hosting.site == "game-flow-c6311"
@@ -121,7 +118,7 @@ jobs:
         run: |
           set -euo pipefail
           bundle="$RUNNER_TEMP/firebase-candidate-ready"
-          node "$RUNNER_TEMP/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js" \
+          node "$bundle/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js" \
             deploy \
             --only hosting \
             --project game-flow-c6311 \

--- a/tests/unit/candidate-host-deploy-workflow.test.js
+++ b/tests/unit/candidate-host-deploy-workflow.test.js
@@ -21,7 +21,7 @@ describe('candidate-host deployment workflow', () => {
         expect(workflowSource).not.toMatch(/\b(dns|domain:|functions|firestore|storage)\s+deploy\b/i);
     });
 
-    it('keeps executable tooling out of the branch-built artifact', () => {
+    it('prepares executable tooling outside the OIDC-capable deploy job', () => {
         const prepareJob = workflow.jobs['prepare-candidate-artifact'];
         const deployJob = workflow.jobs['deploy-candidate'];
         const prepareText = JSON.stringify(prepareJob);
@@ -32,11 +32,10 @@ describe('candidate-host deployment workflow', () => {
         expect(prepareText).toContain('scripts/write-firebase-hosting-config.mjs');
         expect(deployText).toContain('$bundle/site/index.html');
         expect(deployText).toContain('$bundle/site/app/index.html');
-        expect(prepareText).not.toContain('firebase-tools');
-        expect(prepareText).not.toContain('firebase.js');
-        expect(deployText).toContain('firebase-tools@15.24.0');
-        expect(deployText).toContain('$RUNNER_TEMP/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js');
-        expect(deployText).not.toContain('$bundle/firebase-cli');
+        expect(prepareText).toContain('firebase-tools@15.24.0');
+        expect(prepareText).toContain('$bundle/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js');
+        expect(deployText).not.toMatch(/npm (?:ci|install)/);
+        expect(deployText).toContain('$bundle/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js');
         expect(prepareJob.permissions?.['id-token']).toBeUndefined();
         expect(deployJob.permissions?.['id-token']).toBe('write');
         expect(deployText).not.toMatch(/stage-pages-bundle|write-firebase-hosting-config/);

--- a/tests/unit/candidate-host-deploy-workflow.test.js
+++ b/tests/unit/candidate-host-deploy-workflow.test.js
@@ -21,7 +21,7 @@ describe('candidate-host deployment workflow', () => {
         expect(workflowSource).not.toMatch(/\b(dns|domain:|functions|firestore|storage)\s+deploy\b/i);
     });
 
-    it('stages the root site and React app before entering the OIDC job', () => {
+    it('keeps executable tooling out of the branch-built artifact', () => {
         const prepareJob = workflow.jobs['prepare-candidate-artifact'];
         const deployJob = workflow.jobs['deploy-candidate'];
         const prepareText = JSON.stringify(prepareJob);
@@ -32,9 +32,14 @@ describe('candidate-host deployment workflow', () => {
         expect(prepareText).toContain('scripts/write-firebase-hosting-config.mjs');
         expect(deployText).toContain('$bundle/site/index.html');
         expect(deployText).toContain('$bundle/site/app/index.html');
+        expect(prepareText).not.toContain('firebase-tools');
+        expect(prepareText).not.toContain('firebase.js');
+        expect(deployText).toContain('firebase-tools@15.24.0');
+        expect(deployText).toContain('$RUNNER_TEMP/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js');
+        expect(deployText).not.toContain('$bundle/firebase-cli');
         expect(prepareJob.permissions?.['id-token']).toBeUndefined();
         expect(deployJob.permissions?.['id-token']).toBe('write');
-        expect(deployText).not.toMatch(/npm (?:ci|install)|stage-pages-bundle|write-firebase-hosting-config/);
+        expect(deployText).not.toMatch(/stage-pages-bundle|write-firebase-hosting-config/);
     });
 
     it('validates the explicit Hosting-only handoff before authentication', () => {

--- a/tests/unit/candidate-host-deploy-workflow.test.js
+++ b/tests/unit/candidate-host-deploy-workflow.test.js
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { parse as parseYaml } from 'yaml';
+
+const workflowPath = '.github/workflows/deploy-candidate-host.yml';
+const workflowSource = readFileSync(resolve(process.cwd(), workflowPath), 'utf8');
+const workflow = parseYaml(workflowSource);
+
+describe('candidate-host deployment workflow', () => {
+    it('is manually gated and targets only the fixed candidate Hosting site', () => {
+        expect(workflow.on).toHaveProperty('workflow_dispatch');
+        expect(workflow.on).not.toHaveProperty('push');
+
+        const deployJob = workflow.jobs['deploy-candidate'];
+        expect(deployJob.environment).toBe('candidate-host');
+        expect(workflowSource).toContain('.hosting.site = "game-flow-c6311"');
+        expect(workflowSource).toContain('--project game-flow-c6311');
+        expect(workflowSource).toContain('--only hosting');
+        expect(workflowSource).not.toContain('allplays.ai');
+        expect(workflowSource).not.toMatch(/\b(dns|domain:|functions|firestore|storage)\s+deploy\b/i);
+    });
+
+    it('stages the root site and React app before entering the OIDC job', () => {
+        const prepareJob = workflow.jobs['prepare-candidate-artifact'];
+        const deployJob = workflow.jobs['deploy-candidate'];
+        const prepareText = JSON.stringify(prepareJob);
+        const deployText = JSON.stringify(deployJob);
+
+        expect(prepareText).toContain('npm run app:build');
+        expect(prepareText).toContain('scripts/stage-pages-bundle.mjs');
+        expect(prepareText).toContain('scripts/write-firebase-hosting-config.mjs');
+        expect(deployText).toContain('$bundle/site/index.html');
+        expect(deployText).toContain('$bundle/site/app/index.html');
+        expect(prepareJob.permissions?.['id-token']).toBeUndefined();
+        expect(deployJob.permissions?.['id-token']).toBe('write');
+        expect(deployText).not.toMatch(/npm (?:ci|install)|stage-pages-bundle|write-firebase-hosting-config/);
+    });
+
+    it('validates the explicit Hosting-only handoff before authentication', () => {
+        const validation = workflowSource.indexOf('name: Validate candidate target and artifact before OIDC');
+        const authentication = workflowSource.indexOf('name: Authenticate candidate Hosting deploy through OIDC');
+        const deployment = workflowSource.indexOf('name: Deploy candidate Firebase Hosting site');
+
+        expect(validation).toBeGreaterThan(-1);
+        expect(authentication).toBeGreaterThan(validation);
+        expect(deployment).toBeGreaterThan(authentication);
+        expect(workflowSource.slice(validation, authentication)).toContain('.hosting.site == "game-flow-c6311"');
+        expect(workflowSource.slice(validation, authentication)).toContain('has("functions") | not');
+        expect(workflowSource.slice(validation, authentication)).toContain('has("firestore") | not');
+        expect(workflowSource.slice(validation, authentication)).toContain('has("storage") | not');
+        expect(workflowSource).not.toMatch(/credentials_json\s*:/i);
+    });
+});

--- a/tests/unit/firebase-deploy-workload-identity.test.js
+++ b/tests/unit/firebase-deploy-workload-identity.test.js
@@ -10,6 +10,7 @@ function read(path) {
 
 const production = read('.github/workflows/deploy-prod.yml');
 const preview = read('.github/workflows/deploy-preview-trusted.yml');
+const candidate = read('.github/workflows/deploy-candidate-host.yml');
 const productionExtractorSha256 = createHash('sha256')
     .update(read('scripts/extract-production-functions-handoff.py'))
     .digest('hex');
@@ -30,8 +31,8 @@ function expectPinnedActions(workflow) {
 }
 
 describe('Firebase deploy Workload Identity boundary', () => {
-    it('uses only pinned keyless authentication in both credentialed deployers', () => {
-        for (const workflow of [production, preview]) {
+    it('uses only pinned keyless authentication in all credentialed deployers', () => {
+        for (const workflow of [production, preview, candidate]) {
             expectPinnedActions(workflow);
             expect(workflow).toContain('id-token: write');
             expect(workflow).toMatch(/google-github-actions\/auth@[0-9a-f]{40}/);
@@ -46,6 +47,7 @@ describe('Firebase deploy Workload Identity boundary', () => {
         }
         expect(production.match(/google-github-actions\/auth@[0-9a-f]{40}/g)).toHaveLength(2);
         expect(preview.match(/google-github-actions\/auth@[0-9a-f]{40}/g)).toHaveLength(1);
+        expect(candidate.match(/google-github-actions\/auth@[0-9a-f]{40}/g)).toHaveLength(1);
     });
 
     it('keeps raw preview input and dependency preparation in a separate no-OIDC job', () => {
@@ -121,6 +123,20 @@ describe('Firebase deploy Workload Identity boundary', () => {
         expect(production).toContain('functions-runtime.tar');
         expect(production).toContain('cp scripts/extract-production-functions-handoff.py "$FIREBASE_PRODUCTION_BUNDLE/context/"');
         expect(production).not.toContain('cp -R functions "$FIREBASE_PRODUCTION_BUNDLE/functions"');
+    });
+
+    it('keeps candidate build and dependency work outside the minimal OIDC deploy job', () => {
+        const install = candidate.indexOf('firebase-tools@15.24.0');
+        const handoff = candidate.indexOf('name: Upload trusted candidate deploy handoff');
+        const authentication = candidate.indexOf('name: Authenticate candidate Hosting deploy through OIDC');
+
+        expect(install).toBeGreaterThan(-1);
+        expect(handoff).toBeGreaterThan(install);
+        expect(authentication).toBeGreaterThan(handoff);
+        const oidcJobs = workflowJobs(candidate).filter((job) => job.permissions?.['id-token'] === 'write');
+        expect(oidcJobs).toHaveLength(1);
+        expect(JSON.stringify(oidcJobs[0])).not.toMatch(/npm (?:ci|install)|stage-pages-bundle|write-firebase-hosting-config/);
+        expect(JSON.stringify(oidcJobs[0])).toMatch(/actions\/download-artifact@[0-9a-f]{40}/);
     });
 
     it('keeps rule-changing releases rules-first and skips unchanged rule writes', () => {


### PR DESCRIPTION
Closes #4133

## What changed
- Added a manually dispatched, environment-gated candidate-host workflow.
- Stages the root static site and React app before the credential boundary.
- Deploys Hosting only to the explicit `game-flow-c6311` Firebase site.
- Validates the artifact, target, and excluded Firebase surfaces before OIDC authentication.

## Root Cause
The repository had candidate artifact staging helpers but no dedicated Hosting-only deployment path. Candidate deployment therefore depended on the broader production workflow, which also deploys Functions and other production surfaces.

## Prevention / Learning
Candidate hosts need explicit, independently gated workflows. Build without credentials, validate a fixed Hosting-only handoff, and grant OIDC only to the minimal deployment job.

## Regression Tests
- `tests/unit/candidate-host-deploy-workflow.test.js`
- `tests/unit/pages-bundle-staging.test.js`
- `tests/unit/firebase-deploy-workload-identity.test.js`
- `git diff --check`

## Recurrence Risk
Low. Focused workflow tests prevent automatic triggers, target drift, broader Firebase deployment scope, missing root/app artifacts, and credential-boundary drift.