### PR TITLE
Run candidate smoke after deployment

### DIFF
--- a/.github/workflows/deploy-candidate-host.yml
+++ b/.github/workflows/deploy-candidate-host.yml
@@ -124,3 +124,27 @@ jobs:
             --project game-flow-c6311 \
             --config "$bundle/firebase-candidate.generated.json" \
             --non-interactive
+
+  smoke-candidate:
+    needs: deploy-candidate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CANDIDATE_HOST_URL: https://game-flow-c6311.web.app
+      ALLPLAYS_APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY: ${{ vars.APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 22
+
+      - name: Smoke candidate host
+        run: |
+          set -euo pipefail
+          echo "Testing candidate origin: $CANDIDATE_HOST_URL"
+          npm run smoke:candidate-host -- "$CANDIDATE_HOST_URL"

--- a/tests/unit/candidate-host-deploy-workflow.test.js
+++ b/tests/unit/candidate-host-deploy-workflow.test.js
@@ -55,4 +55,18 @@ describe('candidate-host deployment workflow', () => {
         expect(workflowSource.slice(validation, authentication)).toContain('has("storage") | not');
         expect(workflowSource).not.toMatch(/credentials_json\s*:/i);
     });
+
+    it('smokes and reports the candidate origin only after deployment succeeds', () => {
+        const smokeJob = workflow.jobs['smoke-candidate'];
+        const smokeText = JSON.stringify(smokeJob);
+
+        expect(smokeJob.needs).toBe('deploy-candidate');
+        expect(smokeJob.permissions).toEqual({ contents: 'read' });
+        expect(smokeJob.permissions?.['id-token']).toBeUndefined();
+        expect(smokeJob.env.CANDIDATE_HOST_URL).toBe('https://game-flow-c6311.web.app');
+        expect(smokeJob.env.ALLPLAYS_APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY)
+            .toBe('${{ vars.APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY }}');
+        expect(smokeText).toContain('echo \\"Testing candidate origin: $CANDIDATE_HOST_URL\\"');
+        expect(smokeText).toContain('npm run smoke:candidate-host -- \\"$CANDIDATE_HOST_URL\\"');
+    });
 });


### PR DESCRIPTION
Closes #4135

## What changed
- Added a post-deployment candidate-host smoke job.
- Reports and verifies `https://game-flow-c6311.web.app`.
- Preserves least privilege by excluding OIDC permissions from the smoke job.
- Uses the staged App Check site-key contract when validating runtime configuration.

## Root Cause
The candidate deployment workflow ended after Firebase Hosting deployment and never invoked the existing public candidate-host smoke command. Therefore route, TLS, redirect, asset, widget, and runtime-config verification was not enforced on the candidate deployment path.

## Prevention / Learning
Deployment workflows must include an explicit dependent verification job for existing post-deploy smoke commands. Keep verification separate from credentialed deployment jobs to avoid expanding the OIDC blast radius.

## Regression Tests
- Extended `tests/unit/candidate-host-deploy-workflow.test.js` to require a post-deployment smoke job, fixed HTTPS origin, origin reporting, runtime-config input, and read-only permissions without OIDC access.
- Ran `npx vitest run tests/unit/candidate-host-deploy-workflow.test.js --reporter=verbose` with 4 passing tests.

## Recurrence Risk
Low. Workflow-level regression coverage now fails if the post-deployment smoke dependency, candidate origin, command, or least-privilege boundary is removed.