### PR TITLE
Keep My Teams on the team chooser

### DIFF
--- a/apps/app/src/pages/Teams.test.tsx
+++ b/apps/app/src/pages/Teams.test.tsx
@@ -395,7 +395,7 @@ describe('Teams launcher navigation', () => {
   });
 });
 
-describe('Teams single-team auto-navigate', () => {
+describe('Teams single-team navigation', () => {
   const singleTeam = {
     teamId: 'team-solo',
     teamName: 'Solo Bears',
@@ -429,15 +429,13 @@ describe('Teams single-team auto-navigate', () => {
     cleanup();
   });
 
-  it('opens the team page directly when the user has exactly one linked team', async () => {
+  it('keeps the My Teams chooser open when the initial load contains one linked team', async () => {
     renderTeamsWithNav();
 
-    await waitFor(() => {
-      expect(screen.getByTestId('team-hub')).toBeTruthy();
-    });
-
-    expect(screen.getByTestId('team-hub').textContent).toBe('Team hub: team-solo');
-    expect(screen.queryByText('Choose a team')).toBeNull();
+    expect(await screen.findByRole('heading', { name: '1 team ready' })).toBeTruthy();
+    expect(screen.getByText('Choose a team')).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Open Solo Bears' })).toHaveAttribute('href', '/teams/team-solo');
+    expect(screen.queryByTestId('team-hub')).toBeNull();
     expect(screen.queryByText('Loading teams')).toBeNull();
   });
 
@@ -452,7 +450,7 @@ describe('Teams single-team auto-navigate', () => {
     expect(screen.queryByText('Choose a team')).toBeNull();
   });
 
-  it('opens the team page directly when the only team has no linked players yet', async () => {
+  it('keeps the chooser open when the only loaded team has no linked players yet', async () => {
     homeServiceMocks.loadParentTeamsSummaryBootstrap.mockResolvedValue(makeTeamSummaryBootstrap({
       ...singleTeamHome,
       teams: [{
@@ -472,7 +470,9 @@ describe('Teams single-team auto-navigate', () => {
 
     renderTeamsWithNav();
 
-    expect(await screen.findByTestId('team-hub')).toBeTruthy();
-    expect(screen.queryByText('Choose a team')).toBeNull();
+    expect(await screen.findByRole('heading', { name: '1 team ready' })).toBeTruthy();
+    expect(screen.getByText('Choose a team')).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Open Solo Bears' })).toHaveAttribute('href', '/teams/team-solo');
+    expect(screen.queryByTestId('team-hub')).toBeNull();
   });
 });

--- a/apps/app/src/pages/Teams.tsx
+++ b/apps/app/src/pages/Teams.tsx
@@ -163,7 +163,9 @@ export function Teams({ auth }: { auth: AuthState }) {
   const teamRoles = useMemo(() => getLoadedTeamRoles(home.teams), [home.teams]);
 
   useEffect(() => {
-    if (loading || selectedTeamId || !hasLoadedTeamSummary) return;
+    // My Teams is a chooser, even when a partial/fast load temporarily contains
+    // only one team. Only explicit workflow links may skip the chooser.
+    if (loading || selectedTeamId || !hasLoadedTeamSummary || !requestedWorkflow) return;
     if (shouldOpenSingleTeamDirectly(home.teams)) {
       navigate(getSingleTeamDestination(home.teams[0].teamId, requestedWorkflow), { replace: true });
     }

--- a/tests/unit/app-teams-integration.test.jsx
+++ b/tests/unit/app-teams-integration.test.jsx
@@ -420,7 +420,7 @@ describe('React app Teams page', () => {
         expect(container.textContent).not.toContain('Website tools available');
     });
 
-    it('opens the team page directly when the user has exactly one team', async () => {
+    it('keeps the team chooser open when the user has exactly one team', async () => {
         const singleTeamModel = {
             players: [],
             upcomingEvents: [],
@@ -445,31 +445,11 @@ describe('React app Teams page', () => {
         homeMocks.loadParentTeamsSummaryBootstrap.mockResolvedValueOnce(makeTeamSummaryBootstrap(singleTeamModel));
         homeMocks.loadParentHomeSummary.mockResolvedValueOnce(singleTeamModel);
 
-        const container = document.createElement('div');
-        document.body.appendChild(container);
-        const root = createRoot(container);
-        mountedRoots.add(root);
+        const { container } = await renderTeams('/teams');
 
-        function TeamHubRoute() {
-            return React.createElement('div', { 'data-testid': 'team-hub' }, 'Team hub stub');
-        }
-
-        await act(async () => {
-            root.render(React.createElement(
-                MemoryRouter,
-                { initialEntries: ['/teams'] },
-                React.createElement(
-                    Routes,
-                    null,
-                    React.createElement(Route, { path: '/teams', element: React.createElement(Teams, { auth }) }),
-                    React.createElement(Route, { path: '/teams/:teamId', element: React.createElement(TeamHubRoute) })
-                )
-            ));
-        });
-
-        await waitForText(container, 'Team hub stub');
-        expect(container.textContent).not.toContain('Choose a team');
-        expect(container.querySelector('[data-testid="team-hub"]')).toBeTruthy();
+        await waitForText(container, 'Choose a team');
+        expect(container.textContent).toContain('1 team ready');
+        expect(linkByAriaLabel(container, 'Open Solo Bears').getAttribute('href')).toBe('/teams/team-solo');
         expect(container.textContent).not.toContain('Loading teams');
     });
 


### PR DESCRIPTION
## What changed

- Keep `/teams` on the My Teams chooser instead of auto-opening the only team returned by an initial or partial load.
- Preserve direct navigation for explicit workflow URLs such as `/teams?workflow=fees`.
- Update the Teams regression suite for one-team and empty-roster cases.

## Why

The Teams page auto-redirected whenever its initial model contained one team. If Vipers arrived after the fast summary, tapping My Teams immediately replaced the route with Jr KC Current before the full team list could render.

## User impact

Tapping My Teams now reliably opens the team chooser, allowing Paul to select either Jr KC Current or Vipers. Purpose-built workflow deep links still skip the chooser.

## Validation

- `npm run typecheck --prefix apps/app`
- `npx vitest run src/pages/Teams.test.tsx --reporter=verbose` from `apps/app`

All 11 Teams-page tests pass.