### PR TITLE
Allow production deployment retries from master

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 concurrency:
   group: production-deploy
@@ -151,12 +152,20 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          baseline_branch="$GITHUB_REF_NAME"
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            if [[ "$GITHUB_REF" != "refs/heads/master" ]]; then
+              echo "::error::Production deployment retries must target the current master branch."
+              exit 1
+            fi
+            baseline_branch="master"
+          fi
           last_success_sha=""
           lookup_succeeded="false"
           lookup_max_attempts=3
           for ((lookup_attempt = 1; lookup_attempt <= lookup_max_attempts; lookup_attempt += 1)); do
             if last_success_sha="$(gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/deploy-prod.yml/runs" \
-              -f branch="$GITHUB_REF_NAME" \
+              -f branch="$baseline_branch" \
               -f status=success \
               -F per_page=1 \
               --jq '.workflow_runs[0].head_sha // ""')"; then

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: production-deploy
+  group: production-deploy-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -91,7 +91,7 @@ jobs:
     outputs:
       firestore_changed: ${{ steps.firestore_config.outputs.changed }}
       head_sha: ${{ steps.handoff_identity.outputs.head_sha }}
-      storage_changed: ${{ steps.storage_rules.outputs.changed }}
+      storage_changed: ${{ steps.firestore_config.outputs.storage_changed }}
 
     steps:
       - name: Checkout
@@ -135,19 +135,7 @@ jobs:
       - name: Install Functions dependencies
         run: npm ci --prefix functions
 
-      - name: Detect Storage rules changes
-        id: storage_rules
-        shell: bash
-        run: |
-          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          elif git diff --quiet "${{ github.event.before }}" "${{ github.sha }}" -- storage.rules; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Detect Firestore configuration changes
+      - name: Detect Firebase rules changes
         id: firestore_config
         shell: bash
         env:
@@ -181,21 +169,31 @@ jobs:
           done
 
           if [[ "$lookup_succeeded" != "true" ]]; then
-            echo "::warning::The successful production deploy lookup failed; forcing Firestore-first ordering."
+            echo "::warning::The successful production deploy lookup failed; forcing authorization rules-first ordering."
             echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "storage_changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           if [[ ! "$last_success_sha" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "::warning::No valid successful production deploy baseline was found; forcing Firestore-first ordering."
+            echo "::warning::No valid successful production deploy baseline was found; forcing authorization rules-first ordering."
             echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "storage_changed=true" >> "$GITHUB_OUTPUT"
           elif ! git cat-file -e "${last_success_sha}^{commit}" 2>/dev/null; then
-            echo "::warning::The last successful production deploy commit is unavailable locally; forcing Firestore-first ordering."
+            echo "::warning::The last successful production deploy commit is unavailable locally; forcing authorization rules-first ordering."
             echo "changed=true" >> "$GITHUB_OUTPUT"
-          elif git diff --quiet "$last_success_sha" "$GITHUB_SHA" -- firestore.rules firestore.indexes.json; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "storage_changed=true" >> "$GITHUB_OUTPUT"
           else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
+            if git diff --quiet "$last_success_sha" "$GITHUB_SHA" -- firestore.rules firestore.indexes.json; then
+              echo "changed=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+            fi
+            if git diff --quiet "$last_success_sha" "$GITHUB_SHA" -- storage.rules; then
+              echo "storage_changed=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "storage_changed=true" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
       - name: Archive installed Functions runtime into trusted handoff

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -139,7 +139,9 @@ jobs:
         id: storage_rules
         shell: bash
         run: |
-          if git diff --quiet "${{ github.event.before }}" "${{ github.sha }}" -- storage.rules; then
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          elif git diff --quiet "${{ github.event.before }}" "${{ github.sha }}" -- storage.rules; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -256,6 +256,16 @@ export function validateFirebaseDeployWorkloadIdentity(workflow, label) {
 }
 
 export function validateProductionDeployCommand(deployProd) {
+    assertMatches(
+        deployProd,
+        /on:\s*\n\s+push:\s*\n\s+branches:\s*\n\s+- master\s*\n\s+workflow_dispatch:\s*(?:\n|$)/,
+        'Production push and manual retry triggers'
+    );
+    assertIncludes(deployProd, 'baseline_branch="$GITHUB_REF_NAME"', 'Production push baseline branch');
+    assertIncludes(deployProd, 'if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then', 'Production manual retry baseline selection');
+    assertIncludes(deployProd, 'if [[ "$GITHUB_REF" != "refs/heads/master" ]]; then', 'Production manual retry master restriction');
+    assertIncludes(deployProd, 'baseline_branch="master"', 'Production manual retry master baseline');
+
     const deployCommands = Array.from(deployProd.matchAll(/^\s*(?:npx firebase-tools@\S+|node "\$firebase_cli") deploy\b[^\n]*$/gm), match => match[0]);
     const deployCommand = deployCommands.find(command => /--only(?:=|\s+)"\$deploy_targets"/.test(command)) || '';
     if (!deployCommand) {
@@ -269,7 +279,7 @@ export function validateProductionDeployCommand(deployProd) {
     assertIncludes(deployProd, 'actions: read', 'Production workflow-run read permission');
     assertIncludes(deployProd, 'GH_TOKEN: ${{ github.token }}', 'Production workflow-run authentication');
     assertIncludes(deployProd, 'actions/workflows/deploy-prod.yml/runs', 'Production successful deploy lookup');
-    assertIncludes(deployProd, '-f branch="$GITHUB_REF_NAME"', 'Production successful deploy branch filter');
+    assertIncludes(deployProd, '-f branch="$baseline_branch"', 'Production successful deploy branch filter');
     assertIncludes(deployProd, '-f status=success', 'Production successful deploy filter');
     assertIncludes(deployProd, 'for ((lookup_attempt = 1; lookup_attempt <= lookup_max_attempts; lookup_attempt += 1)); do', 'Production successful deploy lookup retries');
     assertIncludes(deployProd, 'if last_success_sha="$(gh api', 'Production successful deploy guarded lookup');

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -316,7 +316,11 @@ export function validateProductionDeployCommand(deployProd) {
     assertMatches(storageDeployCommand, /--project game-flow-c6311(?:\s|$)/, 'Production Storage rules deploy project');
     assertMatches(storageDeployCommand, /--config "\$firebase_config"(?:\s|$)/, 'Production Storage rules generated config');
     assertIncludes(deployProd, 'fetch-depth: 0', 'Production Storage rules change history');
-    assertIncludes(deployProd, 'git diff --quiet "${{ github.event.before }}" "${{ github.sha }}" -- storage.rules', 'Production Storage rules change detection');
+    assertMatches(
+        deployProd,
+        /if \[\[ "\$GITHUB_EVENT_NAME" == "workflow_dispatch" \]\]; then\s+echo "changed=false" >> "\$GITHUB_OUTPUT"\s+elif git diff --quiet "\$\{\{ github\.event\.before \}\}" "\$\{\{ github\.sha \}\}" -- storage\.rules; then/,
+        'Production Storage rules manual retry-safe change detection'
+    );
     assertIncludes(deployProd, 'STORAGE_RULES_CHANGED: ${{ needs.prepare-deploy.outputs.storage_changed }}', 'Production Storage rules change output');
     assertIncludes(deployProd, "sed -E 's/\\x1B\\[[0-9;]*[[:alpha:]]//g' \"$storage_log\" > \"$storage_plain_log\"", 'Production Storage rules ANSI log normalization');
     assertIncludes(deployProd, '[[ "$STORAGE_RULES_CHANGED" != "true" ]]', 'Production Storage rules unchanged-only skip');

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -261,6 +261,7 @@ export function validateProductionDeployCommand(deployProd) {
         /on:\s*\n\s+push:\s*\n\s+branches:\s*\n\s+- master\s*\n\s+workflow_dispatch:\s*(?:\n|$)/,
         'Production push and manual retry triggers'
     );
+    assertIncludes(deployProd, 'group: production-deploy-${{ github.ref }}', 'Production ref-scoped concurrency');
     assertIncludes(deployProd, 'baseline_branch="$GITHUB_REF_NAME"', 'Production push baseline branch');
     assertIncludes(deployProd, 'if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then', 'Production manual retry baseline selection');
     assertIncludes(deployProd, 'if [[ "$GITHUB_REF" != "refs/heads/master" ]]; then', 'Production manual retry master restriction');
@@ -284,12 +285,16 @@ export function validateProductionDeployCommand(deployProd) {
     assertIncludes(deployProd, 'for ((lookup_attempt = 1; lookup_attempt <= lookup_max_attempts; lookup_attempt += 1)); do', 'Production successful deploy lookup retries');
     assertIncludes(deployProd, 'if last_success_sha="$(gh api', 'Production successful deploy guarded lookup');
     assertIncludes(deployProd, 'if [[ "$lookup_succeeded" != "true" ]]; then', 'Production successful deploy lookup failure fallback');
-    assertIncludes(deployProd, 'The successful production deploy lookup failed; forcing Firestore-first ordering.', 'Production successful deploy lookup warning');
+    assertIncludes(deployProd, 'The successful production deploy lookup failed; forcing authorization rules-first ordering.', 'Production successful deploy lookup warning');
     const lookupFallbackStart = deployProd.indexOf('if [[ "$lookup_succeeded" != "true" ]]; then');
     const baselineValidationStart = deployProd.indexOf('if [[ ! "$last_success_sha" =~', lookupFallbackStart);
     const lookupFallback = deployProd.slice(lookupFallbackStart, baselineValidationStart);
-    if (!lookupFallback.includes('echo "changed=true" >> "$GITHUB_OUTPUT"') || !lookupFallback.includes('exit 0')) {
-        throw new Error('Production successful deploy lookup failure must force Firestore-first ordering.');
+    if (
+        !lookupFallback.includes('echo "changed=true" >> "$GITHUB_OUTPUT"')
+        || !lookupFallback.includes('echo "storage_changed=true" >> "$GITHUB_OUTPUT"')
+        || !lookupFallback.includes('exit 0')
+    ) {
+        throw new Error('Production successful deploy lookup failure must force authorization rules-first ordering.');
     }
     assertIncludes(deployProd, 'git diff --quiet "$last_success_sha" "$GITHUB_SHA" -- firestore.rules firestore.indexes.json', 'Production Firestore change detection');
     if (deployProd.includes('git diff --quiet "${{ github.event.before }}" "${{ github.sha }}" -- firestore.rules firestore.indexes.json')) {
@@ -316,11 +321,11 @@ export function validateProductionDeployCommand(deployProd) {
     assertMatches(storageDeployCommand, /--project game-flow-c6311(?:\s|$)/, 'Production Storage rules deploy project');
     assertMatches(storageDeployCommand, /--config "\$firebase_config"(?:\s|$)/, 'Production Storage rules generated config');
     assertIncludes(deployProd, 'fetch-depth: 0', 'Production Storage rules change history');
-    assertMatches(
-        deployProd,
-        /if \[\[ "\$GITHUB_EVENT_NAME" == "workflow_dispatch" \]\]; then\s+echo "changed=false" >> "\$GITHUB_OUTPUT"\s+elif git diff --quiet "\$\{\{ github\.event\.before \}\}" "\$\{\{ github\.sha \}\}" -- storage\.rules; then/,
-        'Production Storage rules manual retry-safe change detection'
-    );
+    assertIncludes(deployProd, 'git diff --quiet "$last_success_sha" "$GITHUB_SHA" -- storage.rules', 'Production Storage rules successful-deploy baseline');
+    if (deployProd.includes('git diff --quiet "${{ github.event.before }}" "${{ github.sha }}" -- storage.rules')) {
+        throw new Error('Production Storage rules changes must not use the immediately previous push as the deploy baseline.');
+    }
+    assertIncludes(deployProd, 'storage_changed: ${{ steps.firestore_config.outputs.storage_changed }}', 'Production Storage rules baseline output');
     assertIncludes(deployProd, 'STORAGE_RULES_CHANGED: ${{ needs.prepare-deploy.outputs.storage_changed }}', 'Production Storage rules change output');
     assertIncludes(deployProd, "sed -E 's/\\x1B\\[[0-9;]*[[:alpha:]]//g' \"$storage_log\" > \"$storage_plain_log\"", 'Production Storage rules ANSI log normalization');
     assertIncludes(deployProd, '[[ "$STORAGE_RULES_CHANGED" != "true" ]]', 'Production Storage rules unchanged-only skip');

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -87,6 +87,12 @@ service firebase.storage {
 
     it('skips an unavailable Storage service only when rules are unchanged', () => {
         const validDeployCommand = `
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
       - name: Checkout
         uses: actions/checkout@v5
         with:
@@ -101,9 +107,16 @@ service firebase.storage {
         env:
           GH_TOKEN: \${{ github.token }}
         run: |
+          baseline_branch="$GITHUB_REF_NAME"
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            if [[ "$GITHUB_REF" != "refs/heads/master" ]]; then
+              exit 1
+            fi
+            baseline_branch="master"
+          fi
           lookup_max_attempts=3
           for ((lookup_attempt = 1; lookup_attempt <= lookup_max_attempts; lookup_attempt += 1)); do
-            if last_success_sha="$(gh api --method GET "repos/\${GITHUB_REPOSITORY}/actions/workflows/deploy-prod.yml/runs" -f branch="$GITHUB_REF_NAME" -f status=success)"; then
+            if last_success_sha="$(gh api --method GET "repos/\${GITHUB_REPOSITORY}/actions/workflows/deploy-prod.yml/runs" -f branch="$baseline_branch" -f status=success)"; then
               lookup_succeeded="true"
             fi
           done
@@ -138,6 +151,18 @@ service firebase.storage {
         `;
 
         expect(() => validateProductionDeployCommand(validDeployCommand)).not.toThrow();
+        expect(() => validateProductionDeployCommand(
+            validDeployCommand.replace('  workflow_dispatch:', '  pull_request:')
+        )).toThrow('Production push and manual retry triggers');
+        expect(() => validateProductionDeployCommand(
+            validDeployCommand.replace('baseline_branch="$GITHUB_REF_NAME"', 'baseline_branch="master"')
+        )).toThrow('Production push baseline branch');
+        expect(() => validateProductionDeployCommand(
+            validDeployCommand.replace('if [[ "$GITHUB_REF" != "refs/heads/master" ]]; then', 'if [[ "$GITHUB_REF" != "refs/heads/release" ]]; then')
+        )).toThrow('Production manual retry master restriction');
+        expect(() => validateProductionDeployCommand(
+            validDeployCommand.replace('-f branch="$baseline_branch"', '-f branch="$GITHUB_REF_NAME"')
+        )).toThrow('Production successful deploy branch filter');
         expect(() => validateProductionDeployCommand(validDeployCommand.replace('[[ "$STORAGE_RULES_CHANGED" != "true" ]]', '[[ true ]]'))).toThrow(
             'Production Storage rules unchanged-only skip'
         );

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -93,21 +93,19 @@ on:
       - master
   workflow_dispatch:
 
+concurrency:
+  group: production-deploy-\${{ github.ref }}
+  cancel-in-progress: true
+
       - name: Checkout
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
       permissions:
         actions: read
-      - name: Detect Storage rules changes
-        id: storage_rules
-        run: |
-          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          elif git diff --quiet "\${{ github.event.before }}" "\${{ github.sha }}" -- storage.rules; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Detect Firestore configuration changes
+      outputs:
+        storage_changed: \${{ steps.firestore_config.outputs.storage_changed }}
+      - name: Detect Firebase rules changes
         id: firestore_config
         env:
           GH_TOKEN: \${{ github.token }}
@@ -126,11 +124,13 @@ on:
             fi
           done
           if [[ "$lookup_succeeded" != "true" ]]; then
-            echo "The successful production deploy lookup failed; forcing Firestore-first ordering."
+            echo "The successful production deploy lookup failed; forcing authorization rules-first ordering."
             echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "storage_changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git diff --quiet "$last_success_sha" "$GITHUB_SHA" -- firestore.rules firestore.indexes.json
+          git diff --quiet "$last_success_sha" "$GITHUB_SHA" -- storage.rules
       - name: Deploy Firebase Storage rules when available
         env:
           STORAGE_RULES_CHANGED: \${{ needs.prepare-deploy.outputs.storage_changed }}
@@ -160,6 +160,9 @@ on:
             validDeployCommand.replace('  workflow_dispatch:', '  pull_request:')
         )).toThrow('Production push and manual retry triggers');
         expect(() => validateProductionDeployCommand(
+            validDeployCommand.replace('group: production-deploy-${{ github.ref }}', 'group: production-deploy')
+        )).toThrow('Production ref-scoped concurrency');
+        expect(() => validateProductionDeployCommand(
             validDeployCommand.replace('baseline_branch="$GITHUB_REF_NAME"', 'baseline_branch="master"')
         )).toThrow('Production push baseline branch');
         expect(() => validateProductionDeployCommand(
@@ -170,12 +173,10 @@ on:
         )).toThrow('Production successful deploy branch filter');
         expect(() => validateProductionDeployCommand(
             validDeployCommand.replace(
-                `if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          elif git diff --quiet "\${{ github.event.before }}" "\${{ github.sha }}" -- storage.rules; then`,
-                'if git diff --quiet "\${{ github.event.before }}" "\${{ github.sha }}" -- storage.rules; then'
+                'git diff --quiet "$last_success_sha" "$GITHUB_SHA" -- storage.rules',
+                'git diff --quiet "\${{ github.event.before }}" "\${{ github.sha }}" -- storage.rules'
             )
-        )).toThrow('Production Storage rules manual retry-safe change detection');
+        )).toThrow('Production Storage rules successful-deploy baseline');
         expect(() => validateProductionDeployCommand(validDeployCommand.replace('[[ "$STORAGE_RULES_CHANGED" != "true" ]]', '[[ true ]]'))).toThrow(
             'Production Storage rules unchanged-only skip'
         );
@@ -193,7 +194,11 @@ on:
         expect(() => validateProductionDeployCommand(validDeployCommand.replace(
             'echo "changed=true" >> "$GITHUB_OUTPUT"',
             'echo "changed=false" >> "$GITHUB_OUTPUT"'
-        ))).toThrow('Production successful deploy lookup failure must force Firestore-first ordering');
+        ))).toThrow('Production successful deploy lookup failure must force authorization rules-first ordering');
+        expect(() => validateProductionDeployCommand(validDeployCommand.replace(
+            'echo "storage_changed=true" >> "$GITHUB_OUTPUT"',
+            'echo "storage_changed=false" >> "$GITHUB_OUTPUT"'
+        ))).toThrow('Production successful deploy lookup failure must force authorization rules-first ordering');
         expect(() => validateProductionDeployCommand(validDeployCommand.replace(
             'HTTP Error:[[:space:]]*409,[[:space:]]*Requested entity already exists',
             '(^|[^[:alnum:]])409([^[:alnum:]]|$)'

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -101,7 +101,12 @@ on:
         actions: read
       - name: Detect Storage rules changes
         id: storage_rules
-        run: git diff --quiet "\${{ github.event.before }}" "\${{ github.sha }}" -- storage.rules
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          elif git diff --quiet "\${{ github.event.before }}" "\${{ github.sha }}" -- storage.rules; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Detect Firestore configuration changes
         id: firestore_config
         env:
@@ -163,6 +168,14 @@ on:
         expect(() => validateProductionDeployCommand(
             validDeployCommand.replace('-f branch="$baseline_branch"', '-f branch="$GITHUB_REF_NAME"')
         )).toThrow('Production successful deploy branch filter');
+        expect(() => validateProductionDeployCommand(
+            validDeployCommand.replace(
+                `if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          elif git diff --quiet "\${{ github.event.before }}" "\${{ github.sha }}" -- storage.rules; then`,
+                'if git diff --quiet "\${{ github.event.before }}" "\${{ github.sha }}" -- storage.rules; then'
+            )
+        )).toThrow('Production Storage rules manual retry-safe change detection');
         expect(() => validateProductionDeployCommand(validDeployCommand.replace('[[ "$STORAGE_RULES_CHANGED" != "true" ]]', '[[ true ]]'))).toThrow(
             'Production Storage rules unchanged-only skip'
         );


### PR DESCRIPTION
Closes #4141

## What changed
- Added a `workflow_dispatch` trigger to `deploy-prod`.
- Restricted manual retries to the current `master` branch.
- Preserved successful-deployment baseline detection and Firestore-first fail-closed ordering.
- Extended workflow validation for push and manual-dispatch behavior.

## Root Cause
`deploy-prod` only accepted pushes to `master`, so operators could not retry the current production commit after a transient Firestore Rules API failure.

## Prevention / Learning
Production workflows involving recoverable external services should provide a bounded manual retry path, restrict its target ref, and calculate change gates from the last successful deployment.

## Regression Tests
- `npx vitest run tests/unit/validate-firebase-rules-ci.test.js --reporter=verbose`
- `npm run ci:firebase-rules`
- `git diff --check`

## Recurrence Risk
Low. The validator now rejects missing dispatch support, non-master retry targets, and incorrect baseline branch selection.