### PR TITLE
Test public teams browse workflow

### DIFF
--- a/apps/app/src/pages/PublicTeamsBrowse.test.tsx
+++ b/apps/app/src/pages/PublicTeamsBrowse.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ParentHomeTeam } from '../lib/homeLogic';
+import { getPublicTeamsPage } from '../lib/publicTeamsService';
+import { PublicTeamsBrowse } from './PublicTeamsBrowse';
+
+vi.mock('../lib/publicTeamsService', () => ({
+  getPublicTeamsPage: vi.fn()
+}));
+
+const atlantaTeam: ParentHomeTeam = {
+  teamId: 'team-atlanta',
+  teamName: 'Atlanta Fire',
+  photoUrl: '',
+  role: 'Fan',
+  sport: 'Soccer',
+  location: 'Atlanta, GA',
+  players: [],
+  eventCount: 0,
+  unreadCount: 0,
+  openActions: 0,
+  nextEvent: null,
+  appAccess: true,
+  webAccess: true,
+  isPublic: true
+};
+
+const atlantaSecondPageTeam: ParentHomeTeam = {
+  ...atlantaTeam,
+  teamId: 'team-atlanta-2',
+  teamName: 'Atlanta United 2'
+};
+
+function renderBrowseRoute() {
+  return render(
+    <MemoryRouter initialEntries={['/teams/browse']}>
+      <Routes>
+        <Route path="/teams/browse" element={<PublicTeamsBrowse />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('PublicTeamsBrowse', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('auto-browses on mount and paginates location search with the active query', async () => {
+    vi.mocked(getPublicTeamsPage)
+      .mockResolvedValueOnce({ teams: [atlantaTeam], nextCursor: null })
+      .mockResolvedValueOnce({ teams: [atlantaTeam], nextCursor: 'atlanta-cursor-2' })
+      .mockResolvedValueOnce({ teams: [atlantaSecondPageTeam], nextCursor: null });
+
+    renderBrowseRoute();
+
+    await waitFor(() =>
+      expect(getPublicTeamsPage).toHaveBeenNthCalledWith(1, {
+        searchText: undefined,
+        cursor: null
+      })
+    );
+    expect(await screen.findByText('Atlanta Fire')).toBeTruthy();
+
+    const searchInput = screen.getByPlaceholderText('Search by team, city, state, or zip');
+    fireEvent.change(searchInput, { target: { value: 'Atlanta, GA' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Search public teams' }));
+
+    await waitFor(() =>
+      expect(getPublicTeamsPage).toHaveBeenNthCalledWith(2, {
+        searchText: 'Atlanta, GA',
+        cursor: null
+      })
+    );
+    fireEvent.click(await screen.findByRole('button', { name: 'Load more teams' }));
+
+    await waitFor(() =>
+      expect(getPublicTeamsPage).toHaveBeenNthCalledWith(3, {
+        searchText: 'Atlanta, GA',
+        cursor: 'atlanta-cursor-2'
+      })
+    );
+    expect(await screen.findByText('Atlanta United 2')).toBeTruthy();
+  });
+
+  it('recovers from a query-specific empty state by browsing all public teams', async () => {
+    vi.mocked(getPublicTeamsPage)
+      .mockResolvedValueOnce({ teams: [atlantaTeam], nextCursor: null })
+      .mockResolvedValueOnce({ teams: [], nextCursor: null })
+      .mockResolvedValueOnce({ teams: [atlantaTeam], nextCursor: null });
+
+    renderBrowseRoute();
+
+    expect(await screen.findByText('Atlanta Fire')).toBeTruthy();
+
+    fireEvent.change(screen.getByPlaceholderText('Search by team, city, state, or zip'), {
+      target: { value: '00000' }
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Search public teams' }));
+
+    expect(await screen.findByText('No public teams found for "00000". Try a different search or browse all public teams.')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Browse all public teams' }));
+
+    await waitFor(() =>
+      expect(getPublicTeamsPage).toHaveBeenNthCalledWith(3, {
+        searchText: undefined,
+        cursor: null
+      })
+    );
+    expect(await screen.findByText('Atlanta Fire')).toBeTruthy();
+    expect(screen.queryByText(/No public teams found/)).toBeNull();
+  });
+});

--- a/tests/coverage/feature-coverage-map.json
+++ b/tests/coverage/feature-coverage-map.json
@@ -251,6 +251,7 @@
                 "apps/app/src/pages/CreateTeam.test.tsx",
                 "apps/app/src/pages/Home.test.tsx",
                 "apps/app/src/pages/PlayerDetail.test.tsx",
+                "apps/app/src/pages/PublicTeamsBrowse.test.tsx",
                 "apps/app/src/pages/TeamDetail.test.tsx",
                 "apps/app/src/pages/TeamSettings.test.tsx",
                 "apps/app/src/pages/Teams.test.tsx",
@@ -265,12 +266,7 @@
                 "tests/smoke/team-fallback-regressions.spec.js",
                 "tests/smoke/teams-location-search.spec.js"
             ],
-            "knownGaps": [
-                {
-                    "tier": "integration",
-                    "description": "PublicTeamsBrowse needs a direct app page test around empty states, pagination, and location search."
-                }
-            ]
+            "knownGaps": []
         },
         {
             "id": "schedule.calendar-rsvp-availability",


### PR DESCRIPTION
Closes #4146

## What changed
- Added direct `/teams/browse` page tests covering automatic unfiltered browsing, location-search pagination, and empty-search recovery.
- Updated the Teams coverage map to close the recorded integration gap.

## Root Cause
The discovery workflow was tested only through `PublicTeamSearch` in isolation. The page-level `autoBrowseOnMount` contract could regress while component and route-selection tests remained green.

## Prevention / Learning
When a page configures shared-component behavior through props, add a direct page integration test that exercises the configured workflow.

## Regression Tests
- `npx vitest run src/pages/PublicTeamsBrowse.test.tsx --reporter=verbose`
- `npm run typecheck`
- ESLint and Prettier checks passed for the affected files.

## Recurrence Risk
Low. Direct page tests now fail if auto-browse wiring, active-query pagination, query-specific empty state, or browse-all recovery regresses.