### PR TITLE
Report smoke blocked by failed deployment

### DIFF
--- a/scripts/verify-critical-workflow-health.mjs
+++ b/scripts/verify-critical-workflow-health.mjs
@@ -95,12 +95,33 @@ export function evaluateCriticalWorkflowHealth({ now = new Date(), masterSha, de
     if (!Number.isFinite(nowMs)) throw new Error('Current time is invalid.');
 
     const deploySignal = evaluateExactRun('production-deploy', normalizeRuns(deploy), masterSha, nowMs);
-    const smokeSignal = deploySignal.state === 'pending'
-        ? { name: 'production-smoke', healthy: true, state: 'waiting_for_deploy', runId: null }
-        : evaluateExactRun('production-smoke', normalizeRuns(smoke), masterSha, nowMs);
+    let smokeSignal;
+    if (deploySignal.state === 'pending') {
+        smokeSignal = { name: 'production-smoke', healthy: true, state: 'waiting_for_deploy', runId: null };
+    } else {
+        smokeSignal = evaluateExactRun('production-smoke', normalizeRuns(smoke), masterSha, nowMs);
+        if (deploySignal.state.startsWith('completed_') && smokeSignal.state === 'completed_skipped') {
+            smokeSignal = { ...smokeSignal, state: 'blocked_by_failed_deploy' };
+        }
+    }
     const recoverySignal = evaluateRecovery(normalizeRuns(recovery), nowMs);
     const signals = [deploySignal, smokeSignal, recoverySignal];
     return { healthy: signals.every((signal) => signal.healthy), masterSha, signals };
+}
+
+export function formatCriticalWorkflowSummary(result) {
+    const lines = [
+        '## Critical workflow health',
+        '',
+        `- evaluated master: \`${result.masterSha}\``,
+        ...result.signals.map((signal) => `- ${signal.name}: **${signal.state}**${signal.runId ? ` (run ${signal.runId})` : ''}`)
+    ];
+    const smokeSignal = result.signals.find((signal) => signal.name === 'production-smoke');
+    const deploySignal = result.signals.find((signal) => signal.name === 'production-deploy');
+    if (smokeSignal?.state === 'blocked_by_failed_deploy') {
+        lines.push(`- remediation: fix failed production-deploy run ${deploySignal.runId}; production-smoke is blocked until deployment succeeds`);
+    }
+    return [...lines, ''].join('\n');
 }
 
 function required(environment, name) {
@@ -170,13 +191,7 @@ export function verifyCriticalWorkflowHealthFromEnvironment(environment = proces
     console.log(JSON.stringify(result));
     const summaryPath = String(environment.GITHUB_STEP_SUMMARY || '').trim();
     if (summaryPath) {
-        appendFileSync(summaryPath, [
-            '## Critical workflow health',
-            '',
-            `- evaluated master: \`${result.masterSha}\``,
-            ...result.signals.map((signal) => `- ${signal.name}: **${signal.state}**${signal.runId ? ` (run ${signal.runId})` : ''}`),
-            ''
-        ].join('\n'), { encoding: 'utf8' });
+        appendFileSync(summaryPath, formatCriticalWorkflowSummary(result), { encoding: 'utf8' });
     }
     if (!result.healthy) process.exitCode = 1;
     return result;

--- a/tests/unit/critical-workflow-health.test.js
+++ b/tests/unit/critical-workflow-health.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
     evaluateCriticalWorkflowHealth,
+    formatCriticalWorkflowSummary,
     verifyCriticalWorkflowHealthFromEnvironment,
     OBSERVABILITY_REF,
     OBSERVABILITY_REPOSITORY
@@ -70,6 +71,38 @@ describe('critical workflow health evaluation', () => {
         }));
         expect(stale.healthy).toBe(false);
         expect(stale.signals[2].state).toBe('stale');
+    });
+
+    it('reports skipped smoke as blocked by its failed deployment prerequisite', () => {
+        const result = evaluateCriticalWorkflowHealth(healthyInput({
+            deploy: response([run({ id: 10, conclusion: 'failure' })]),
+            smoke: response([run({ id: 11, conclusion: 'skipped' })])
+        }));
+
+        expect(result.healthy).toBe(false);
+        expect(result.signals[0]).toEqual({
+            name: 'production-deploy', healthy: false, state: 'completed_failure', runId: 10
+        });
+        expect(result.signals[1]).toEqual({
+            name: 'production-smoke', healthy: false, state: 'blocked_by_failed_deploy', runId: 11
+        });
+        expect(formatCriticalWorkflowSummary(result)).toContain(
+            'remediation: fix failed production-deploy run 10; production-smoke is blocked until deployment succeeds'
+        );
+    });
+
+    it('keeps skipped smoke independently unhealthy after a successful deployment', () => {
+        const result = evaluateCriticalWorkflowHealth(healthyInput({
+            deploy: response([run({ id: 12 })]),
+            smoke: response([run({ id: 13, conclusion: 'skipped' })])
+        }));
+
+        expect(result.healthy).toBe(false);
+        expect(result.signals[0].state).toBe('success');
+        expect(result.signals[1]).toEqual({
+            name: 'production-smoke', healthy: false, state: 'completed_skipped', runId: 13
+        });
+        expect(formatCriticalWorkflowSummary(result)).not.toContain('remediation: fix failed production-deploy');
     });
 
     it('fails closed on malformed API data and workflow identities', () => {


### PR DESCRIPTION
Closes #4142

## What changed
- Report skipped exact-master smoke as `blocked_by_failed_deploy` when its completed deployment prerequisite failed.
- Keep the aggregate workflow health unhealthy until deployment and smoke both succeed.
- Point the workflow summary to the failed deployment run as the remediation target.

## Root Cause
The verifier evaluated completed deployment and smoke runs independently. It modeled their dependency only while deployment was pending, causing a failed deployment and expected skipped smoke run to appear as unrelated failures.

## Prevention / Learning
Health checks for `workflow_run` pipelines must explicitly model prerequisite outcomes. Dependent skips should be distinguished from independently unhealthy executions without weakening aggregate health.

## Regression Tests
- Failed deployment plus skipped smoke reports `blocked_by_failed_deploy` and names the deployment run in remediation text.
- Successful deployment plus skipped smoke remains `completed_skipped`.
- Normal deployment, smoke, and recovery success remains healthy.
- `npx vitest run tests/unit/critical-workflow-health.test.js --reporter=verbose` passes 10 tests.

## Recurrence Risk
Low. Focused fixtures now enforce dependency correlation, independent smoke failure behavior, successful runs, and remediation summary output.