### PR TITLE
Summarize exhausted Firestore deploy retries

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -465,9 +465,10 @@ jobs:
                     echo "| Google API surface | ${api_surface} |"
                     echo "| Final error class | ${final_error_class} |"
                     echo "| Attempts exhausted | ${max_attempts}/${max_attempts} |"
-                    echo '| Not deployed | `firestore:rules`, `firestore:indexes`, `hosting`, `functions` |'
+                    echo '| Guaranteed not deployed | `hosting`, `functions` |'
+                    echo "| Firestore configuration | Rules and indexes may be partially deployed; verify both before retrying. |"
                     echo
-                    echo "The external transient failure exhausted all bounded attempts. Firestore configuration changes remain fail-closed, so Hosting and Functions were not deployed."
+                    echo "The external transient failure exhausted all bounded attempts. Application deployment remains fail-closed, so Hosting and Functions were not deployed."
                     echo
                     echo "Recovery: follow the [production Firestore deploy retry procedure](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/blob/master/docs/observability-runbook.md#firestore-rules-api-retry-exhaustion)."
                   } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -416,6 +416,7 @@ jobs:
             local max_attempts="${3:-3}"
             local base_delay_seconds="${4:-15}"
             local attempt deploy_log deploy_status retry_delay_seconds
+            local api_surface final_error_class final_http_status
 
             for ((attempt = 1; attempt <= max_attempts; attempt += 1)); do
               deploy_log="$RUNNER_TEMP/firebase-${deploy_label}-deploy-attempt-${attempt}.log"
@@ -437,6 +438,40 @@ jobs:
               fi
 
               if (( attempt == max_attempts )); then
+                if [[ "$deploy_label" == "firestore" ]]; then
+                  api_surface="Firebase Firestore deployment API"
+                  if grep -Eiq 'firebaserules\.googleapis\.com|ruleset|rules release' "$deploy_log"; then
+                    api_surface="Firestore Rules API (firebaserules.googleapis.com)"
+                  elif grep -Eiq 'firestore\.googleapis\.com|firestore index' "$deploy_log"; then
+                    api_surface="Cloud Firestore Admin API (firestore.googleapis.com)"
+                  fi
+
+                  final_http_status="$(
+                    grep -Eio 'HTTP Error:[[:space:]]*(429|500|502|503|504)|(^|[^[:digit:]])(429|500|502|503|504)([^[:digit:]]|$)' "$deploy_log" \
+                      | grep -Eo '(429|500|502|503|504)' \
+                      | tail -n 1 \
+                      || true
+                  )"
+                  final_error_class="Transient service/network error (no HTTP status reported)"
+                  if [[ -n "$final_http_status" ]]; then
+                    final_error_class="HTTP ${final_http_status}"
+                  fi
+
+                  {
+                    echo "### Firestore configuration deploy blocked"
+                    echo
+                    echo "| Signal | Result |"
+                    echo "| --- | --- |"
+                    echo "| Google API surface | ${api_surface} |"
+                    echo "| Final error class | ${final_error_class} |"
+                    echo "| Attempts exhausted | ${max_attempts}/${max_attempts} |"
+                    echo '| Not deployed | `firestore:rules`, `firestore:indexes`, `hosting`, `functions` |'
+                    echo
+                    echo "The external transient failure exhausted all bounded attempts. Firestore configuration changes remain fail-closed, so Hosting and Functions were not deployed."
+                    echo
+                    echo "Recovery: follow the [production Firestore deploy retry procedure](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/blob/master/docs/observability-runbook.md#firestore-rules-api-retry-exhaustion)."
+                  } >> "$GITHUB_STEP_SUMMARY"
+                fi
                 echo "Firebase ${deploy_label} deploy failed after ${max_attempts} transient attempts." >&2
                 return "$deploy_status"
               fi

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -447,8 +447,8 @@ jobs:
                   fi
 
                   final_http_status="$(
-                    grep -Eio 'HTTP Error:[[:space:]]*(429|500|502|503|504)|(^|[^[:digit:]])(429|500|502|503|504)([^[:digit:]]|$)' "$deploy_log" \
-                      | grep -Eo '(429|500|502|503|504)' \
+                    grep -Eio 'HTTP Error:[[:space:]]*(409|429|500|502|503|504)|(^|[^[:digit:]])(409|429|500|502|503|504)([^[:digit:]]|$)' "$deploy_log" \
+                      | grep -Eo '(409|429|500|502|503|504)' \
                       | tail -n 1 \
                       || true
                   )"

--- a/docs/observability-runbook.md
+++ b/docs/observability-runbook.md
@@ -67,6 +67,21 @@ Telemetry must never justify rolling back unrelated product code. If the collect
 
 If the critical workflow monitor is noisy, disable only its schedule while investigating and leave deploy, post-deploy smoke, and Firestore recovery workflows enabled. Close its managed issue only after a successful exact check.
 
+## Firestore Rules API retry exhaustion
+
+The production workflow makes eight bounded attempts when a transient Firestore configuration deployment fails. If those attempts are exhausted, the job summary identifies the Google API surface, final HTTP error class, attempt count, and surfaces that were not deployed. The summary uses only fixed operational labels and does not copy API response bodies, credentials, tenant identifiers, or application data.
+
+Firestore configuration changes remain fail-closed. When Rules or indexes differ from the last successful production deployment, Hosting and Functions do not deploy until the Firestore configuration succeeds. Existing production remains active; do not bypass the workflow or deploy application surfaces separately.
+
+Safe manual retry:
+
+1. Confirm the failed run targeted `master` and that its summary reports a transient Google API failure rather than a configuration or authorization error.
+2. Confirm `master` still contains the intended Firestore configuration. If a newer production deployment succeeded, no retry is needed.
+3. In GitHub Actions, open `deploy-prod`, choose **Run workflow**, select `master`, and run it. Manual dispatch is restricted to the current `master` branch and repeats the protected tests, change detection, keyless authentication, bounded retries, and fail-closed ordering.
+4. Confirm the Firestore configuration step succeeds before Hosting and Functions, then confirm the production smoke workflow succeeds.
+
+Do not run a local `firebase deploy`, increase retry limits, expose raw API output in the summary, or bypass the protected production environment. If another bounded run ends with the same external error class, treat it as an ongoing Google service incident and leave production on the last successful configuration.
+
 ## Critical workflow alert
 
 The managed incident title is `[Observability] Critical production signals are unhealthy`. The reconciler mutates an exact issue only when it was created by `github-actions[bot]`, carries the `security` label, and contains the private management marker. Duplicate or user-created collisions fail closed.

--- a/docs/observability-runbook.md
+++ b/docs/observability-runbook.md
@@ -71,11 +71,11 @@ If the critical workflow monitor is noisy, disable only its schedule while inves
 
 The production workflow makes eight bounded attempts when a transient Firestore configuration deployment fails. If those attempts are exhausted, the job summary identifies the Google API surface, final HTTP error class, attempt count, and surfaces that were not deployed. The summary uses only fixed operational labels and does not copy API response bodies, credentials, tenant identifiers, or application data.
 
-Firestore configuration changes remain fail-closed. When Rules or indexes differ from the last successful production deployment, Hosting and Functions do not deploy until the Firestore configuration succeeds. Existing production remains active; do not bypass the workflow or deploy application surfaces separately.
+Application deployment remains fail-closed. When Rules or indexes differ from the last successful production deployment, Hosting and Functions do not deploy until the combined Firestore configuration command succeeds. The Firebase CLI may apply indexes before a later Rules API failure, so treat the Rules and index state as potentially partial and verify both before retrying. Existing Hosting and Functions production remains active; do not bypass the workflow or deploy application surfaces separately.
 
 Safe manual retry:
 
-1. Confirm the failed run targeted `master` and that its summary reports a transient Google API failure rather than a configuration or authorization error.
+1. Confirm the failed run targeted `master` and that its summary reports a transient Google API failure rather than a configuration or authorization error. Check the Firebase deploy log or console to determine whether Rules or indexes were already applied.
 2. Confirm `master` still contains the intended Firestore configuration. If a newer production deployment succeeded, no retry is needed.
 3. In GitHub Actions, open `deploy-prod`, choose **Run workflow**, select `master`, and run it. Manual dispatch is restricted to the current `master` branch and repeats the protected tests, change detection, keyless authentication, bounded retries, and fail-closed ordering.
 4. Confirm the Firestore configuration step succeeds before Hosting and Functions, then confirm the production smoke workflow succeeds.

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -279,6 +279,12 @@ export function validateProductionDeployCommand(deployProd) {
     assertIncludes(deployProd, 'HTTP Error:[[:space:]]*409,[[:space:]]*Requested entity already exists', 'Production Firestore release-race retry');
     assertIncludes(deployProd, 'if [[ "$deploy_label" == "firestore" ]]; then', 'Production Firestore retry-exhaustion summary scope');
     assertIncludes(deployProd, 'Firestore Rules API (firebaserules.googleapis.com)', 'Production Firestore retry-exhaustion API surface');
+    assertIncludes(
+        deployProd,
+        `grep -Eio 'HTTP Error:[[:space:]]*(409|429|500|502|503|504)|(^|[^[:digit:]])(409|429|500|502|503|504)([^[:digit:]]|$)'`,
+        'Production Firestore retry-exhaustion HTTP status extraction'
+    );
+    assertIncludes(deployProd, `grep -Eo '(409|429|500|502|503|504)'`, 'Production Firestore retry-exhaustion HTTP status normalization');
     assertIncludes(deployProd, 'final_error_class="HTTP ${final_http_status}"', 'Production Firestore retry-exhaustion HTTP error class');
     assertIncludes(deployProd, 'echo "| Attempts exhausted | ${max_attempts}/${max_attempts} |"', 'Production Firestore retry-exhaustion attempt count');
     assertIncludes(deployProd, 'echo \'| Not deployed | `firestore:rules`, `firestore:indexes`, `hosting`, `functions` |\'', 'Production Firestore retry-exhaustion blocked surfaces');

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -287,14 +287,19 @@ export function validateProductionDeployCommand(deployProd) {
     assertIncludes(deployProd, `grep -Eo '(409|429|500|502|503|504)'`, 'Production Firestore retry-exhaustion HTTP status normalization');
     assertIncludes(deployProd, 'final_error_class="HTTP ${final_http_status}"', 'Production Firestore retry-exhaustion HTTP error class');
     assertIncludes(deployProd, 'echo "| Attempts exhausted | ${max_attempts}/${max_attempts} |"', 'Production Firestore retry-exhaustion attempt count');
-    assertIncludes(deployProd, 'echo \'| Not deployed | `firestore:rules`, `firestore:indexes`, `hosting`, `functions` |\'', 'Production Firestore retry-exhaustion blocked surfaces');
+    assertIncludes(deployProd, 'echo \'| Guaranteed not deployed | `hosting`, `functions` |\'', 'Production Firestore retry-exhaustion blocked application surfaces');
+    assertIncludes(
+        deployProd,
+        'Rules and indexes may be partially deployed; verify both before retrying.',
+        'Production Firestore retry-exhaustion partial configuration status'
+    );
     assertIncludes(deployProd, '} >> "$GITHUB_STEP_SUMMARY"', 'Production Firestore retry-exhaustion job summary');
     assertIncludes(
         deployProd,
         '${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/blob/master/docs/observability-runbook.md#firestore-rules-api-retry-exhaustion',
         'Production Firestore retry-exhaustion recovery link'
     );
-    assertIncludes(deployProd, 'Firestore configuration changes remain fail-closed, so Hosting and Functions were not deployed.', 'Production Firestore retry-exhaustion fail-closed guidance');
+    assertIncludes(deployProd, 'Application deployment remains fail-closed, so Hosting and Functions were not deployed.', 'Production Firestore retry-exhaustion fail-closed guidance');
     assertIncludes(deployProd, 'actions: read', 'Production workflow-run read permission');
     assertIncludes(deployProd, 'GH_TOKEN: ${{ github.token }}', 'Production workflow-run authentication');
     assertIncludes(deployProd, 'actions/workflows/deploy-prod.yml/runs', 'Production successful deploy lookup');

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -277,6 +277,18 @@ export function validateProductionDeployCommand(deployProd) {
     assertIncludes(deployProd, 'retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30', 'Production Firestore deploy targets and bounded extended retry');
     assertIncludes(deployProd, 'if (( retry_delay_seconds > 120 )); then', 'Production Firebase retry delay cap');
     assertIncludes(deployProd, 'HTTP Error:[[:space:]]*409,[[:space:]]*Requested entity already exists', 'Production Firestore release-race retry');
+    assertIncludes(deployProd, 'if [[ "$deploy_label" == "firestore" ]]; then', 'Production Firestore retry-exhaustion summary scope');
+    assertIncludes(deployProd, 'Firestore Rules API (firebaserules.googleapis.com)', 'Production Firestore retry-exhaustion API surface');
+    assertIncludes(deployProd, 'final_error_class="HTTP ${final_http_status}"', 'Production Firestore retry-exhaustion HTTP error class');
+    assertIncludes(deployProd, 'echo "| Attempts exhausted | ${max_attempts}/${max_attempts} |"', 'Production Firestore retry-exhaustion attempt count');
+    assertIncludes(deployProd, 'echo \'| Not deployed | `firestore:rules`, `firestore:indexes`, `hosting`, `functions` |\'', 'Production Firestore retry-exhaustion blocked surfaces');
+    assertIncludes(deployProd, '} >> "$GITHUB_STEP_SUMMARY"', 'Production Firestore retry-exhaustion job summary');
+    assertIncludes(
+        deployProd,
+        '${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/blob/master/docs/observability-runbook.md#firestore-rules-api-retry-exhaustion',
+        'Production Firestore retry-exhaustion recovery link'
+    );
+    assertIncludes(deployProd, 'Firestore configuration changes remain fail-closed, so Hosting and Functions were not deployed.', 'Production Firestore retry-exhaustion fail-closed guidance');
     assertIncludes(deployProd, 'actions: read', 'Production workflow-run read permission');
     assertIncludes(deployProd, 'GH_TOKEN: ${{ github.token }}', 'Production workflow-run authentication');
     assertIncludes(deployProd, 'actions/workflows/deploy-prod.yml/runs', 'Production successful deploy lookup');

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -147,6 +147,15 @@ concurrency:
           if (( retry_delay_seconds > 120 )); then
             retry_delay_seconds=120
           fi
+          if [[ "$deploy_label" == "firestore" ]]; then
+            api_surface="Firestore Rules API (firebaserules.googleapis.com)"
+            final_error_class="HTTP \${final_http_status}"
+            echo "| Attempts exhausted | \${max_attempts}/\${max_attempts} |"
+            echo '| Not deployed | \`firestore:rules\`, \`firestore:indexes\`, \`hosting\`, \`functions\` |'
+            echo "Firestore configuration changes remain fail-closed, so Hosting and Functions were not deployed."
+            echo "Recovery: \${GITHUB_SERVER_URL}/\${GITHUB_REPOSITORY}/blob/master/docs/observability-runbook.md#firestore-rules-api-retry-exhaustion"
+          } >> "$GITHUB_STEP_SUMMARY"
+          fi
           if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then
             retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30
             retry_firebase_deploy "hosting,functions" "application"
@@ -203,6 +212,26 @@ concurrency:
             'HTTP Error:[[:space:]]*409,[[:space:]]*Requested entity already exists',
             '(^|[^[:alnum:]])409([^[:alnum:]]|$)'
         ))).toThrow('Production Firestore release-race retry');
+        expect(() => validateProductionDeployCommand(validDeployCommand.replace(
+            'Firestore Rules API (firebaserules.googleapis.com)',
+            'Firestore API'
+        ))).toThrow('Production Firestore retry-exhaustion API surface');
+        expect(() => validateProductionDeployCommand(validDeployCommand.replace(
+            'final_error_class="HTTP ${final_http_status}"',
+            'final_error_class="transient failure"'
+        ))).toThrow('Production Firestore retry-exhaustion HTTP error class');
+        expect(() => validateProductionDeployCommand(validDeployCommand.replace(
+            'echo "| Attempts exhausted | ${max_attempts}/${max_attempts} |"',
+            'echo "Retries exhausted"'
+        ))).toThrow('Production Firestore retry-exhaustion attempt count');
+        expect(() => validateProductionDeployCommand(validDeployCommand.replace(
+            'echo \'| Not deployed | `firestore:rules`, `firestore:indexes`, `hosting`, `functions` |\'',
+            'echo "Deployment blocked"'
+        ))).toThrow('Production Firestore retry-exhaustion blocked surfaces');
+        expect(() => validateProductionDeployCommand(validDeployCommand.replace(
+            '${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/blob/master/docs/observability-runbook.md#firestore-rules-api-retry-exhaustion',
+            'docs/observability-runbook.md'
+        ))).toThrow('Production Firestore retry-exhaustion recovery link');
         expect(() => validateProductionDeployCommand(validDeployCommand.replace(
             `retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30
             retry_firebase_deploy "hosting,functions" "application"`,

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -153,8 +153,9 @@ concurrency:
               | grep -Eo '(409|429|500|502|503|504)'
             final_error_class="HTTP \${final_http_status}"
             echo "| Attempts exhausted | \${max_attempts}/\${max_attempts} |"
-            echo '| Not deployed | \`firestore:rules\`, \`firestore:indexes\`, \`hosting\`, \`functions\` |'
-            echo "Firestore configuration changes remain fail-closed, so Hosting and Functions were not deployed."
+            echo '| Guaranteed not deployed | \`hosting\`, \`functions\` |'
+            echo "| Firestore configuration | Rules and indexes may be partially deployed; verify both before retrying. |"
+            echo "Application deployment remains fail-closed, so Hosting and Functions were not deployed."
             echo "Recovery: \${GITHUB_SERVER_URL}/\${GITHUB_REPOSITORY}/blob/master/docs/observability-runbook.md#firestore-rules-api-retry-exhaustion"
           } >> "$GITHUB_STEP_SUMMARY"
           fi
@@ -233,9 +234,13 @@ concurrency:
             'echo "Retries exhausted"'
         ))).toThrow('Production Firestore retry-exhaustion attempt count');
         expect(() => validateProductionDeployCommand(validDeployCommand.replace(
-            'echo \'| Not deployed | `firestore:rules`, `firestore:indexes`, `hosting`, `functions` |\'',
+            'echo \'| Guaranteed not deployed | `hosting`, `functions` |\'',
             'echo "Deployment blocked"'
-        ))).toThrow('Production Firestore retry-exhaustion blocked surfaces');
+        ))).toThrow('Production Firestore retry-exhaustion blocked application surfaces');
+        expect(() => validateProductionDeployCommand(validDeployCommand.replace(
+            'Rules and indexes may be partially deployed; verify both before retrying.',
+            'Rules and indexes were not deployed.'
+        ))).toThrow('Production Firestore retry-exhaustion partial configuration status');
         expect(() => validateProductionDeployCommand(validDeployCommand.replace(
             '${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/blob/master/docs/observability-runbook.md#firestore-rules-api-retry-exhaustion',
             'docs/observability-runbook.md'

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -149,6 +149,8 @@ concurrency:
           fi
           if [[ "$deploy_label" == "firestore" ]]; then
             api_surface="Firestore Rules API (firebaserules.googleapis.com)"
+            grep -Eio 'HTTP Error:[[:space:]]*(409|429|500|502|503|504)|(^|[^[:digit:]])(409|429|500|502|503|504)([^[:digit:]]|$)' "$deploy_log" \\
+              | grep -Eo '(409|429|500|502|503|504)'
             final_error_class="HTTP \${final_http_status}"
             echo "| Attempts exhausted | \${max_attempts}/\${max_attempts} |"
             echo '| Not deployed | \`firestore:rules\`, \`firestore:indexes\`, \`hosting\`, \`functions\` |'
@@ -216,6 +218,12 @@ concurrency:
             'Firestore Rules API (firebaserules.googleapis.com)',
             'Firestore API'
         ))).toThrow('Production Firestore retry-exhaustion API surface');
+        expect(() => validateProductionDeployCommand(validDeployCommand.replace(
+            `grep -Eio 'HTTP Error:[[:space:]]*(409|429|500|502|503|504)|(^|[^[:digit:]])(409|429|500|502|503|504)([^[:digit:]]|$)' "$deploy_log" \\
+              | grep -Eo '(409|429|500|502|503|504)'`,
+            `grep -Eio 'HTTP Error:[[:space:]]*(429|500|502|503|504)|(^|[^[:digit:]])(429|500|502|503|504)([^[:digit:]]|$)' "$deploy_log" \\
+              | grep -Eo '(429|500|502|503|504)'`
+        ))).toThrow('Production Firestore retry-exhaustion HTTP status extraction');
         expect(() => validateProductionDeployCommand(validDeployCommand.replace(
             'final_error_class="HTTP ${final_http_status}"',
             'final_error_class="transient failure"'


### PR DESCRIPTION
Closes #4143

## What changed
- Added a credential-safe job summary for exhausted Firestore retries.
- Reports the Google API surface, final HTTP class, attempt count, blocked surfaces, and recovery link.
- Documented the protected manual retry procedure and fail-closed behavior.

## Root Cause
The bounded retry helper returned only a stderr message after its final transient Firestore failure. Operators had no durable summary of the failure classification, deployment blast radius, or safe recovery path.

## Prevention / Learning
Bounded production retry loops should emit structured, allowlisted operational summaries that identify the exhausted policy, blocked downstream surfaces, fail-closed state, and protected recovery procedure. Adjacent workflow validators should enforce this contract.

## Regression Tests
- `npx vitest run tests/unit/validate-firebase-rules-ci.test.js --reporter=verbose`
- `node scripts/validate-firebase-rules-ci.mjs`
- `git diff --check`

## Recurrence Risk
Low. Focused validation now fails if any required retry-exhaustion summary field or recovery link is removed.