### PR TITLE
Include owned teams in My Teams summary

### DIFF
--- a/apps/app/src/lib/homeService.test.ts
+++ b/apps/app/src/lib/homeService.test.ts
@@ -136,6 +136,40 @@ describe('homeService Teams bootstrap reuse', () => {
         expect(summary.home.metrics.teams).toBe(2);
     });
 
+    it('refreshes a cached schedule summary when the fast scope contains staff teams', async () => {
+        const scheduleScope = {
+            profile: { coachOf: ['team-owned'] },
+            children: [{
+                teamId: 'team-parent',
+                teamName: 'Jr KC Current',
+                playerId: 'player-1',
+                playerName: 'Madison Snider'
+            }],
+            staffTeams: [{ teamId: 'team-owned', teamName: 'Vipers' }]
+        };
+        scheduleServiceMocks.loadParentSchedule
+            .mockResolvedValueOnce({
+                children: scheduleScope.children,
+                events: []
+            })
+            .mockImplementationOnce(async (_authUser, options) => ({
+                children: options?.parentScope?.children || [],
+                events: [],
+                staffTeams: options?.parentScope?.staffTeams || []
+            }));
+
+        await loadParentScheduleSummary(user, { force: true });
+        const refreshed = await loadParentScheduleSummary(user, { scheduleScope });
+
+        expect(scheduleServiceMocks.loadParentSchedule).toHaveBeenCalledTimes(2);
+        expect(scheduleServiceMocks.loadParentSchedule).toHaveBeenLastCalledWith(user, expect.objectContaining({
+            parentScope: scheduleScope
+        }));
+        expect(refreshed.staffTeams).toEqual([
+            { teamId: 'team-owned', teamName: 'Vipers' }
+        ]);
+    });
+
     it('does not cache partial parent schedule summaries as complete results', async () => {
         scheduleServiceMocks.loadParentSchedule
             .mockResolvedValueOnce({

--- a/apps/app/src/lib/homeService.test.ts
+++ b/apps/app/src/lib/homeService.test.ts
@@ -77,7 +77,8 @@ describe('homeService Teams bootstrap reuse', () => {
                 teamName: 'Fast Falcons',
                 playerId: 'player-1',
                 playerName: 'Avery Ace'
-            }]
+            }],
+            staffTeams: [{ teamId: 'team-owned', teamName: 'Vipers' }]
         };
         scheduleServiceMocks.loadParentScheduleScope.mockResolvedValue(scheduleScope);
         scheduleServiceMocks.loadParentSchedule.mockImplementation(async (_authUser, options) => ({
@@ -99,6 +100,40 @@ describe('homeService Teams bootstrap reuse', () => {
             parentScope: scheduleScope
         }));
         expect(window.localStorage.getItem('allplays:appDataCache:teams-summary-bootstrap%3Aparent-1')).toBeNull();
+    });
+
+    it('includes a newly created staff team before it has players, events, or chat', async () => {
+        scheduleServiceMocks.loadParentScheduleScope.mockResolvedValue({
+            profile: { coachOf: ['team-owned'] },
+            children: [{
+                teamId: 'team-parent',
+                teamName: 'Jr KC Current',
+                playerId: 'player-1',
+                playerName: 'Madison Snider'
+            }],
+            staffTeams: [{ teamId: 'team-owned', teamName: 'Vipers' }]
+        });
+        chatServiceMocks.loadChatInbox.mockResolvedValue({
+            teams: [{
+                id: 'team-parent',
+                name: 'Jr KC Current',
+                role: 'Parent',
+                unreadCount: 0
+            }]
+        });
+
+        const summary = await loadParentTeamsSummaryBootstrap(user, { force: true });
+
+        expect(summary.home.teams).toEqual(expect.arrayContaining([
+            expect.objectContaining({ teamId: 'team-parent', teamName: 'Jr KC Current' }),
+            expect.objectContaining({
+                teamId: 'team-owned',
+                teamName: 'Vipers',
+                role: 'Coach',
+                players: []
+            })
+        ]));
+        expect(summary.home.metrics.teams).toBe(2);
     });
 
     it('does not cache partial parent schedule summaries as complete results', async () => {

--- a/apps/app/src/lib/homeService.ts
+++ b/apps/app/src/lib/homeService.ts
@@ -149,7 +149,10 @@ export async function loadParentTeamsSummaryBootstrap(
         const model = buildParentHomeModel({
           children: scheduleScope.children,
           events: [],
-          inboxTeams: normalizeInboxTeams(chatInbox.teams || []),
+          inboxTeams: mergeTeamSummaries(
+            normalizeStaffTeams({ children: [], events: [], staffTeams: scheduleScope.staffTeams }),
+            normalizeInboxTeams(chatInbox.teams || [])
+          ),
           fees: []
         });
         timer.end({
@@ -299,4 +302,20 @@ function normalizeInboxTeams(teams: any[]): ParentHomeInboxTeam[] {
     archived: team.archived,
     status: team.status
   }));
+}
+
+function mergeTeamSummaries(
+  staffTeams: ParentHomeInboxTeam[],
+  inboxTeams: ParentHomeInboxTeam[]
+): ParentHomeInboxTeam[] {
+  const teamsById = new Map(staffTeams.map((team) => [team.id, team]));
+  inboxTeams.forEach((team) => {
+    const staffTeam = teamsById.get(team.id);
+    teamsById.set(team.id, {
+      ...staffTeam,
+      ...team,
+      role: staffTeam?.role || team.role
+    });
+  });
+  return [...teamsById.values()];
 }

--- a/apps/app/src/lib/homeService.ts
+++ b/apps/app/src/lib/homeService.ts
@@ -265,6 +265,7 @@ export async function loadParentScheduleSummary(
   options: ParentHomeSummaryOptions & { onPartial?: (schedule: ParentScheduleLoadResult) => void } = {}
 ): Promise<ParentScheduleLoadResult> {
   if (!user?.uid) return { children: [], events: [] };
+  const hasScopedStaffTeams = Boolean(options.scheduleScope?.staffTeams?.length);
   return loadCachedAppData(
     getParentScheduleSummaryCacheKey(user.uid),
     () => loadParentSchedule(user, {
@@ -275,7 +276,7 @@ export async function loadParentScheduleSummary(
     }),
     {
       ttlMs: homeSummaryTtlMs,
-      force: options.force,
+      force: options.force || hasScopedStaffTeams,
       shouldCache: (result) => result?.isPartial !== true
     }
   );

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -222,7 +222,7 @@ import { getCachedAppData, invalidateCachedAppData, loadCachedAppData } from './
 import { mapScheduleEventRecord } from './firestore/mappers';
 import { loadProfileDocument } from './profileService';
 import { getScheduleTournamentInfo } from './scheduleLogic';
-import { adjustGameScore, buildPlayerScoringLiveEvent, buildSingleGameTournamentLegacySchedulePayload, claimOfficialAssignmentItem, createScheduledGameForApp, createScheduledPracticeForApp, createScheduledTournamentBlockForApp, createStaffRsvpAvailabilityLoader, flushPendingLivePublishOperations, hydrateParentScheduleDetails, hydrateParentScheduleRsvps, loadOfficialAssignments, loadParentSchedule, loadParentScheduleChildren, loadParentScheduleEventDetail, loadScheduledPracticeSeriesForEdit, loadStaffPracticeAttendance, loadStaffScheduleRsvpBreakdown, publishLiveScoreUpdateEvent, recordPlayerGameStat, recordPlayerScoringStat, releaseParentScheduleAssignmentClaim, resolveCachedParentScheduleEvents, resolveLiveGameClockSnapshot, resolveParentGameRoute, respondToOfficialAssignmentItem, revertScheduledPracticeOccurrenceForApp, saveScheduledGameLineupDraftForApp, saveStaffPracticeAttendance, submitParentScheduleRsvp, submitParentScheduleRsvpForChildren, submitStaffScheduleRsvpOverride, TournamentBlockPartialSaveError, undoRecordedPlayerGameStat, updateLiveGameClockState, updateScheduledPracticeForApp } from './scheduleService';
+import { adjustGameScore, buildPlayerScoringLiveEvent, buildSingleGameTournamentLegacySchedulePayload, claimOfficialAssignmentItem, createScheduledGameForApp, createScheduledPracticeForApp, createScheduledTournamentBlockForApp, createStaffRsvpAvailabilityLoader, flushPendingLivePublishOperations, hydrateParentScheduleDetails, hydrateParentScheduleRsvps, loadOfficialAssignments, loadParentSchedule, loadParentScheduleChildren, loadParentScheduleEventDetail, loadParentScheduleScope, loadScheduledPracticeSeriesForEdit, loadStaffPracticeAttendance, loadStaffScheduleRsvpBreakdown, publishLiveScoreUpdateEvent, recordPlayerGameStat, recordPlayerScoringStat, releaseParentScheduleAssignmentClaim, resolveCachedParentScheduleEvents, resolveLiveGameClockSnapshot, resolveParentGameRoute, respondToOfficialAssignmentItem, revertScheduledPracticeOccurrenceForApp, saveScheduledGameLineupDraftForApp, saveStaffPracticeAttendance, submitParentScheduleRsvp, submitParentScheduleRsvpForChildren, submitStaffScheduleRsvpOverride, TournamentBlockPartialSaveError, undoRecordedPlayerGameStat, updateLiveGameClockState, updateScheduledPracticeForApp } from './scheduleService';
 
 function playerSnapshot(id: string, data: Record<string, unknown> | null) {
   return {
@@ -410,6 +410,30 @@ describe('parent schedule child scope', () => {
     expect(new Set(schedule.events.map((event) => event.teamId))).toEqual(new Set());
     expect(getTeam).not.toHaveBeenCalledWith('team-inactive');
     expect(getGames).toHaveBeenCalledTimes(3);
+  });
+
+  it('carries newly created staff teams through the reusable parent scope', async () => {
+    const coachUser = { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'], coachOf: ['team-owned'] } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: ['team-owned'] } as any);
+    vi.mocked(getStaffTeams).mockResolvedValue([
+      { id: 'team-owned', name: 'Vipers', ownerId: 'coach-1', active: true }
+    ] as any);
+    vi.mocked(getGames).mockResolvedValue([] as any);
+    vi.mocked(getPracticeSessions).mockResolvedValue([] as any);
+
+    const scope = await loadParentScheduleScope(coachUser);
+    const schedule = await loadParentSchedule(coachUser, {
+      hydrateDetails: false,
+      expandStaffPlayers: false,
+      parentScope: scope
+    });
+
+    expect(scope.staffTeams).toEqual([{ teamId: 'team-owned', teamName: 'Vipers' }]);
+    expect(schedule.staffTeams).toEqual([{ teamId: 'team-owned', teamName: 'Vipers' }]);
+    expect(getStaffTeams).toHaveBeenCalledTimes(1);
+    expect(getGames).toHaveBeenCalledWith('team-owned', expect.objectContaining({
+      startDate: expect.any(Date)
+    }));
   });
 });
 

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -374,6 +374,8 @@ export type ParentScheduleLoadResult = {
 export type ParentScheduleScope = {
   profile: Record<string, unknown>;
   children: ParentScheduleChild[];
+  /** Teams the user can manage, including newly created teams with no players or chat yet. */
+  staffTeams?: ParentScheduleStaffTeam[];
 };
 
 function hasResolvedParentProfile(profile: unknown): profile is Record<string, unknown> {
@@ -2782,14 +2784,24 @@ export async function loadParentScheduleScope(user: AuthUser | null): Promise<Pa
   if (!user?.uid) {
     return {
       profile: {},
-      children: []
+      children: [],
+      staffTeams: []
     };
   }
-  const profile = await loadProfileDocument(user.uid).catch(() => ({}));
+  const [profile, staffTeams] = await Promise.all([
+    loadProfileDocument(user.uid).catch(() => ({})),
+    loadStaffTeams(user).catch(() => [])
+  ]);
   const children = await resolveParentScheduleChildren(user, profile as Record<string, unknown>);
   return {
     profile: profile as Record<string, unknown>,
-    children
+    children,
+    staffTeams: staffTeams
+      .map((team: any) => {
+        const teamId = compactString(team?.id);
+        return teamId ? { teamId, teamName: compactString(team?.name) || teamId } : null;
+      })
+      .filter(Boolean) as ParentScheduleStaffTeam[]
   };
 }
 
@@ -4010,11 +4022,11 @@ async function buildParentScheduleTeamChildren(user: AuthUser, profile: Record<s
     byTeam.get(child.teamId)?.push(child);
   });
 
-  const staffTeams = await loadStaffTeams(user).catch(() => []);
+  const staffTeams = options.parentScope?.staffTeams || await loadStaffTeams(user).catch(() => []);
   await mapWithConcurrency(staffTeams, parentScheduleTeamConcurrency, async (team: any) => {
-    const teamId = compactString(team?.id);
+    const teamId = compactString(team?.id || team?.teamId);
     if (!teamId) return;
-    const teamName = compactString(team?.name) || teamId;
+    const teamName = compactString(team?.name || team?.teamName) || teamId;
     const existingPlayerIds = new Set((byTeam.get(teamId) || []).map((child) => child.playerId));
     if (!expandStaffPlayers) {
       if (!existingPlayerIds.size) {
@@ -4277,8 +4289,8 @@ export async function loadParentSchedule(user: AuthUser | null, options: ParentS
     });
     const staffTeamSummaries = staffTeams
       .map((team: any) => {
-        const teamId = compactString(team?.id);
-        return teamId ? { teamId, teamName: compactString(team?.name) || teamId } : null;
+        const teamId = compactString(team?.id || team?.teamId);
+        return teamId ? { teamId, teamName: compactString(team?.name || team?.teamName) || teamId } : null;
       })
       .filter(Boolean) as ParentScheduleStaffTeam[];
 


### PR DESCRIPTION
## What changed

- Carry owner/admin/coach teams in the reusable parent schedule scope.
- Merge those staff teams into the fast My Teams model even when they have no players, events, or chat.
- Reuse the resolved staff-team scope during schedule enrichment.
- Add regression coverage for a newly created empty team such as Vipers.

## Root cause

Home loaded staff/owner teams directly, while My Teams initially combined only linked players and chat teams. A newly created team with no roster or chat therefore appeared on Home but was omitted from My Teams.

## Validation

- `npm --prefix apps/app test -- --run src/lib/scheduleService.test.ts src/lib/homeService.test.ts src/pages/Teams.test.tsx` (141 passed)
- `npx vitest run tests/unit/app-home-service.test.js tests/unit/app-teams-integration.test.jsx --reporter=verbose` (20 passed)
- `npm run app:build`
