### PR TITLE
Make cache-bust guard tests assert version consistency, not frozen numbers

### DIFF
--- a/tests/unit/admin-invite-signup-cache-busting.test.js
+++ b/tests/unit/admin-invite-signup-cache-busting.test.js
@@ -66,33 +66,39 @@ function moduleVersionMap(moduleName, files) {
 // failure mode that actually ships a cache bug. Pinning exact numbers instead
 // turned every concurrent version bump into a false failure on rebase.
 describe('admin invite signup cache busting', () => {
-    // Single-version modules: every deployed consumer must import the exact same
-    // `?v=`. These are small/infrequently-bumped, so a split means a genuinely
-    // stale consumer.
-    it('keeps every deployed consumer of a single-version module on one agreed version', () => {
+    // Single-version modules: every deployed consumer must import the same fresh
+    // `?v=`. These are small/infrequently-bumped, so a split or a version below
+    // the known-good floor means a genuinely stale consumer.
+    it('keeps every deployed consumer of a single-version module on one fresh agreed version', () => {
         const deployed = collectVersionedSourceFiles(process.cwd());
-        const singleVersionModules = [
-            'auth.js',
-            'utils.js',
-            'signup-flow.js',
-            'admin-invite.js',
-            'accept-invite-flow.js'
-        ];
+        // These are freshness floors, not exact pins: a coordinated bump from
+        // master remains valid, while leaving every consumer on a known-stale
+        // pre-fix version still fails even though those consumers agree.
+        const minimumVersions = {
+            'auth.js': 129,
+            'utils.js': 18,
+            'signup-flow.js': 12,
+            'admin-invite.js': 6,
+            'accept-invite-flow.js': 11
+        };
 
-        const splits = {};
-        for (const moduleName of singleVersionModules) {
+        const violations = {};
+        for (const [moduleName, minimumVersion] of Object.entries(minimumVersions)) {
             const byVersion = moduleVersionMap(moduleName, deployed);
             const versions = Object.keys(byVersion);
-            if (versions.length > 1) {
-                splits[moduleName] = Object.fromEntries(
-                    versions.map((v) => [v, [...byVersion[v]].sort()])
-                );
+            if (versions.length !== 1 || Number(versions[0]) < minimumVersion) {
+                violations[moduleName] = {
+                    minimumVersion,
+                    consumersByVersion: Object.fromEntries(
+                        versions.map((v) => [v, [...byVersion[v]].sort()])
+                    )
+                };
             }
         }
 
         expect(
-            splits,
-            `Single-version modules imported at multiple versions (stale consumers): ${JSON.stringify(splits, null, 2)}`
+            violations,
+            `Single-version modules are missing, split, or stale: ${JSON.stringify(violations, null, 2)}`
         ).toEqual({});
     });
 
@@ -103,12 +109,17 @@ describe('admin invite signup cache busting', () => {
     // normal rollout stays within the window, and a truly stale consumer (many
     // versions behind) still fails. No frozen number, so rebases don't spiral.
     it('keeps db.js consumers within a bounded rollout window', () => {
+        const MIN_DB_VERSION = 117;
         const MAX_DB_VERSION_SPREAD = 2;
         const deployed = collectVersionedSourceFiles(process.cwd());
         const byVersion = moduleVersionMap('db.js', deployed);
         const versions = Object.keys(byVersion).map(Number);
 
         expect(versions.length, 'db.js is not imported anywhere').toBeGreaterThan(0);
+        expect(
+            Math.min(...versions),
+            `db.js consumers must use v${MIN_DB_VERSION} or newer`
+        ).toBeGreaterThanOrEqual(MIN_DB_VERSION);
 
         const spread = Math.max(...versions) - Math.min(...versions);
         const detail = Object.fromEntries(

--- a/tests/unit/admin-invite-signup-cache-busting.test.js
+++ b/tests/unit/admin-invite-signup-cache-busting.test.js
@@ -42,76 +42,149 @@ function collectVersionedSourceFiles(dir, root = dir) {
     return files;
 }
 
-describe('admin invite signup cache busting', () => {
-    it('pins fresh module versions for the admin invite signup path', () => {
-        const authSource = readFileSync(resolve(process.cwd(), 'js/auth.js'), 'utf8');
+// Map the distinct `?v=` versions a shared module is imported at across the given
+// deployed files, to the files using each version: { "129": ["login.html", ...] }.
+// More than one key means consumers disagree — the real cache-busting bug.
+function moduleVersionMap(moduleName, files) {
+    const escaped = moduleName.replace(/[.]/g, '\\.');
+    const re = new RegExp(`(?<![\\w-])${escaped}\\?v=(\\d+)\\b`, 'g');
+    const byVersion = {};
+    for (const relativePath of files) {
+        const source = readFileSync(resolve(process.cwd(), relativePath), 'utf8');
+        for (const match of source.matchAll(re)) {
+            (byVersion[match[1]] ||= new Set()).add(relativePath);
+        }
+    }
+    return byVersion;
+}
 
-        expect(authSource).toContain("import { executeEmailPasswordSignup } from './signup-flow.js?v=12';");
-        expect(authSource).not.toContain("./signup-flow.js?v=7");
-        expect(authSource).toContain("import { redeemAdminInviteAcceptance, redeemAdminInviteAtomically } from './admin-invite.js?v=6';");
-        expect(authSource).toContain("from './db.js?v=117';");
-        expect(authSource).not.toContain("from './db.js?v=112';");
-        expect(authSource).toContain("from './accept-invite-flow.js?v=11';");
+// The invariant these tests protect is *consistency*, not a frozen number: every
+// deployed consumer of a shared module must import it at the same `?v=` version,
+// so nobody loads a stale cached copy. Asserting derived agreement (rather than
+// "must equal v129") keeps the guard green when a rebase carries a coordinated
+// bump from master, while still failing on a genuinely stale consumer — the
+// failure mode that actually ships a cache bug. Pinning exact numbers instead
+// turned every concurrent version bump into a false failure on rebase.
+describe('admin invite signup cache busting', () => {
+    // Single-version modules: every deployed consumer must import the exact same
+    // `?v=`. These are small/infrequently-bumped, so a split means a genuinely
+    // stale consumer.
+    it('keeps every deployed consumer of a single-version module on one agreed version', () => {
+        const deployed = collectVersionedSourceFiles(process.cwd());
+        const singleVersionModules = [
+            'auth.js',
+            'utils.js',
+            'signup-flow.js',
+            'admin-invite.js',
+            'accept-invite-flow.js'
+        ];
+
+        const splits = {};
+        for (const moduleName of singleVersionModules) {
+            const byVersion = moduleVersionMap(moduleName, deployed);
+            const versions = Object.keys(byVersion);
+            if (versions.length > 1) {
+                splits[moduleName] = Object.fromEntries(
+                    versions.map((v) => [v, [...byVersion[v]].sort()])
+                );
+            }
+        }
+
+        expect(
+            splits,
+            `Single-version modules imported at multiple versions (stale consumers): ${JSON.stringify(splits, null, 2)}`
+        ).toEqual({});
     });
 
-    it('pins fresh invite acceptance module versions for admin invite redemption', () => {
+    // db.js is imported by ~40 files and bumped often, so it rolls forward across
+    // a couple of adjacent versions rather than flipping atomically. Enforce a
+    // bounded window (all consumers within MAX_DB_VERSION_SPREAD of each other)
+    // instead of exact agreement: a coordinated bump keeps the spread at 0, a
+    // normal rollout stays within the window, and a truly stale consumer (many
+    // versions behind) still fails. No frozen number, so rebases don't spiral.
+    it('keeps db.js consumers within a bounded rollout window', () => {
+        const MAX_DB_VERSION_SPREAD = 2;
+        const deployed = collectVersionedSourceFiles(process.cwd());
+        const byVersion = moduleVersionMap('db.js', deployed);
+        const versions = Object.keys(byVersion).map(Number);
+
+        expect(versions.length, 'db.js is not imported anywhere').toBeGreaterThan(0);
+
+        const spread = Math.max(...versions) - Math.min(...versions);
+        const detail = Object.fromEntries(
+            Object.entries(byVersion).map(([v, files]) => [v, [...files].sort()])
+        );
+        expect(
+            spread,
+            `db.js consumers span too many versions (spread ${spread} > ${MAX_DB_VERSION_SPREAD}) — likely a stale consumer: ${JSON.stringify(detail, null, 2)}`
+        ).toBeLessThanOrEqual(MAX_DB_VERSION_SPREAD);
+    });
+
+    it('wires the admin invite signup path to cache-busted modules', () => {
+        const authSource = readFileSync(resolve(process.cwd(), 'js/auth.js'), 'utf8');
+
+        // Structural wiring must be present and cache-busted; the exact version is
+        // covered by the consistency test above, not frozen here.
+        expect(authSource).toContain("import { executeEmailPasswordSignup } from './signup-flow.js?v=");
+        expect(authSource).toContain("import { redeemAdminInviteAcceptance, redeemAdminInviteAtomically } from './admin-invite.js?v=");
+        expect(authSource).toContain("from './db.js?v=");
+        expect(authSource).toContain("from './accept-invite-flow.js?v=");
+    });
+
+    it('wires admin invite redemption to cache-busted modules', () => {
         const acceptInviteSource = readFileSync(resolve(process.cwd(), 'accept-invite.html'), 'utf8');
 
         expect(acceptInviteSource).toContain(
-            "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemCoParentInvite, redeemFriendInvite, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=117';"
+            "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemCoParentInvite, redeemFriendInvite, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v="
         );
         expect(acceptInviteSource).toContain(
-            "import { redeemAdminInviteAtomically } from './js/admin-invite.js?v=6';"
+            "import { redeemAdminInviteAtomically } from './js/admin-invite.js?v="
         );
         expect(acceptInviteSource).toContain(
-            "import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from './js/accept-invite-flow.js?v=11';"
+            "import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from './js/accept-invite-flow.js?v="
         );
     });
 
-    it('bumps auth module consumers after signup flow changes', () => {
-        const authConsumers = {
-            'login.html': 'auth.js?v=129',
-            'accept-invite.html': 'auth.js?v=129',
-            'edit-team.html': 'auth.js?v=129',
-            'js/admin.js': 'auth.js?v=129',
-            'js/live-game.js': 'auth.js?v=129',
-            'js/live-tracker.js': 'auth.js?v=129',
-            'js/track-basketball.js': 'auth.js?v=129'
-        };
+    it('keeps the core auth.js consumers wired and version-aligned', () => {
+        const consumers = [
+            'login.html',
+            'accept-invite.html',
+            'edit-team.html',
+            'js/admin.js',
+            'js/live-game.js',
+            'js/live-tracker.js',
+            'js/track-basketball.js'
+        ];
 
-        for (const [relativePath, expectedVersion] of Object.entries(authConsumers)) {
+        const versions = new Set();
+        for (const relativePath of consumers) {
             const source = readFileSync(resolve(process.cwd(), relativePath), 'utf8');
-            expect(source).toContain(expectedVersion);
+            const match = source.match(/(?<![\w-])auth\.js\?v=(\d+)\b/);
+            expect(match, `${relativePath} does not import a cache-busted auth.js`).not.toBeNull();
+            versions.add(match[1]);
         }
+        expect(
+            [...versions],
+            `Listed auth.js consumers disagree on version: ${[...versions]}`
+        ).toHaveLength(1);
 
         const editTeamSource = readFileSync(resolve(process.cwd(), 'edit-team.html'), 'utf8');
-        expect(editTeamSource).toContain("import { checkAuth, sendInviteEmail } from './js/auth.js?v=129';");
-        expect(editTeamSource).not.toContain("import { checkAuth, sendInviteEmail } from './js/auth.js?v=55';");
+        expect(editTeamSource).toContain("import { checkAuth, sendInviteEmail } from './js/auth.js?v=");
     });
 
     it('bumps the shared header logout import with auth.js consumers', () => {
         const utilsSource = readFileSync(resolve(process.cwd(), 'js/utils.js'), 'utf8');
-        const logoutImportMatches = utilsSource.match(/const \{ logout \} = await import\('\.\/auth\.js\?v=129'\);/g) || [];
+        const logoutImports = [
+            ...utilsSource.matchAll(/const \{ logout \} = await import\('\.\/auth\.js\?v=(\d+)'\);/g)
+        ];
 
-        expect(logoutImportMatches).toHaveLength(1);
-        expect(utilsSource).not.toContain("const { logout } = await import('./auth.js?v=55');");
-        expect(utilsSource).not.toContain("const { logout } = await import('./auth.js?v=42');");
-    });
+        expect(logoutImports).toHaveLength(1);
 
-    it('pins every deployed auth and db consumer to the App Check-aware module keys', () => {
-        const deployedSources = collectVersionedSourceFiles(process.cwd());
-        const authConsumers = deployedSources.flatMap((relativePath) => {
-            const source = readFileSync(resolve(process.cwd(), relativePath), 'utf8');
-            const authImports = source.match(/(?<![\w-])auth\.js\?v=\d+\b/g) || [];
-            return authImports.map((importPath) => `${relativePath}: ${importPath}`);
-        });
-        const staleConsumers = deployedSources.flatMap((relativePath) => {
-            const source = readFileSync(resolve(process.cwd(), relativePath), 'utf8');
-            const staleImports = source.match(/(?:(?<![\w-])auth\.js\?v=(?!129\b)\d+|(?<![\w-])db\.js\?v=(?!11[7-9]\b)\d+|(?<![\w-])utils\.js\?v=(?!18\b)\d+)\b/g) || [];
-            return staleImports.map((importPath) => `${relativePath}: ${importPath}`);
-        });
-
-        expect(authConsumers.length).toBeGreaterThan(50);
-        expect(staleConsumers).toEqual([]);
+        // The dynamic logout import must agree with the auth.js version the rest of
+        // the app imports statically — derived, not frozen.
+        const deployed = collectVersionedSourceFiles(process.cwd());
+        const authVersions = Object.keys(moduleVersionMap('auth.js', deployed));
+        expect(authVersions).toHaveLength(1);
+        expect(logoutImports[0][1]).toBe(authVersions[0]);
     });
 });

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -27,10 +27,11 @@ describe('team media page wiring', () => {
     it('loads the team media module and cache-busted db dependency', () => {
         const page = fs.readFileSync(path.join(repoRoot, 'team-media.html'), 'utf8');
         const source = fs.readFileSync(path.join(repoRoot, 'js/team-media.js'), 'utf8');
+        const teamMediaVersion = page.match(/src="js\/team-media\.js\?v=(\d+)"/)?.[1];
 
-        // Cache-busting must be present and wired; the exact version is enforced by
-        // the consistency checks, not frozen here (frozen numbers break on rebase).
-        expect(page).toContain('src="js/team-media.js?v=');
+        // Keep a freshness floor without freezing future coordinated cache-bust bumps.
+        expect(teamMediaVersion, 'team-media.html has no cache-busted team-media.js entry point').toMatch(/^\d+$/);
+        expect(Number(teamMediaVersion), 'team-media.js must use v19 or newer').toBeGreaterThanOrEqual(19);
         expect(page).toContain('Add album');
         expect(page).toContain('Upload files');
         expect(page).toContain('Save video link');

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -28,13 +28,15 @@ describe('team media page wiring', () => {
         const page = fs.readFileSync(path.join(repoRoot, 'team-media.html'), 'utf8');
         const source = fs.readFileSync(path.join(repoRoot, 'js/team-media.js'), 'utf8');
 
-        expect(page).toContain('src="js/team-media.js?v=19"');
+        // Cache-busting must be present and wired; the exact version is enforced by
+        // the consistency checks, not frozen here (frozen numbers break on rebase).
+        expect(page).toContain('src="js/team-media.js?v=');
         expect(page).toContain('Add album');
         expect(page).toContain('Upload files');
         expect(page).toContain('Save video link');
-        expect(source).toContain("from './db.js?v=117'");
+        expect(source).toContain("from './db.js?v=");
         expect(source).toContain('normalizeTeamMediaVideoDraft');
-        expect(source).toContain("import { checkAuth } from './auth.js?v=129';");
+        expect(source).toContain("import { checkAuth } from './auth.js?v=");
         expect(source).toContain('checkAuth(async (user) => {');
         expect(source).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');
         expect(source).toContain('Team media permissions are not enabled');
@@ -51,7 +53,8 @@ describe('team media page wiring', () => {
         const source = fs.readFileSync(path.join(repoRoot, 'js/team-media.js'), 'utf8');
         const dbImportVersion = source.match(/from '\.\/db\.js\?v=(\d+)'/)?.[1];
 
-        expect(dbImportVersion).toBe('117');
+        // A cache-busted db.js import must exist; its exact value is derived, not frozen.
+        expect(dbImportVersion, 'js/team-media.js has no cache-busted db.js import').toMatch(/^\d+$/);
 
         for (const testFile of [
             'tests/unit/team-media-item-rename.test.js',
@@ -59,7 +62,16 @@ describe('team media page wiring', () => {
         ]) {
             const testSource = fs.readFileSync(path.join(repoRoot, testFile), 'utf8');
             expect(testSource).toContain(`vi.mock('../../js/db.js?v=${dbImportVersion}'`);
-            expect(testSource).not.toContain("vi.mock('../../js/db.js?v=84'");
+            // No db.js mock in the test may reference a version other than the runtime
+            // import — that is the alignment this test protects, without hardcoding a
+            // known-stale number.
+            const mockedVersions = [...testSource.matchAll(/vi\.mock\('\.\.\/\.\.\/js\/db\.js\?v=(\d+)'/g)].map((m) => m[1]);
+            for (const mockedVersion of mockedVersions) {
+                expect(
+                    mockedVersion,
+                    `${testFile} mocks db.js?v=${mockedVersion} but js/team-media.js imports v=${dbImportVersion}`
+                ).toBe(dbImportVersion);
+            }
         }
     });
 


### PR DESCRIPTION
## Why

The cache-busting unit tests pinned exact current versions (`auth.js?v=129`, `db.js?v=117`, an explicit `toBe('117')`, stale-version denylists). Every concurrent version bump on master turned a rebase into a guaranteed `unit-tests` failure — a PR rebases, fails the frozen assertion, gets a cache-bust fix, rebases again, and never converges on an active master. This is the #4058-class death-spiral that traps big PRs for hours.

## What changed

Replace the frozen assertions with the invariant they were really protecting — **consistency**:

- **Single-version modules** (auth.js, utils.js, signup-flow.js, admin-invite.js, accept-invite-flow.js): every deployed consumer must import the same *derived* version. A split = a genuinely stale consumer.
- **db.js** (imported by ~40 files, rolled forward gradually): consumers must stay within a bounded window (spread ≤ 2), matching the existing 117–119 tolerance, instead of exact agreement.
- **Structural wiring** assertions still verify the named imports exist and are cache-busted (`?v=` present) — just without the frozen number.
- **team-media db mock alignment** is derived from the runtime import instead of hardcoding `v=117` / denylisting `v=84`.

## Verification

- Passes on master (13/13 in the two files).
- Injecting a stale `auth.js?v=55` consumer still fails 3 assertions — **detection preserved**.
- A coordinated bump keeps all consumers in agreement → no rebase spiral.
- Full local unit run: no new failures vs baseline.

## Manual test

```bash
npx vitest run tests/unit/admin-invite-signup-cache-busting.test.js tests/unit/team-media-wiring.test.js
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)