### PR TITLE
Enable Vipers schedule management

### DIFF
--- a/apps/app/src/components/schedule/loadScheduleStaffTools.test.ts
+++ b/apps/app/src/components/schedule/loadScheduleStaffTools.test.ts
@@ -1,7 +1,13 @@
-import { describe, expect, it, vi } from 'vitest';
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { shouldAttemptLazyChunkReload } from '../../lib/lazyPage';
 import { createScheduleStaffToolsLoader, type ScheduleStaffToolsModule } from './loadScheduleStaffTools';
 
 describe('loadScheduleStaffTools', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
   it('caches the dynamic import across repeated open requests', async () => {
     const module = { default: vi.fn() } as unknown as ScheduleStaffToolsModule;
     const importer = vi.fn(async () => module);
@@ -45,5 +51,16 @@ describe('loadScheduleStaffTools', () => {
     await expect(load()).rejects.toThrow('Temporary import failure');
     await expect(load()).resolves.toBe(module);
     expect(importer).toHaveBeenCalledTimes(2);
+  });
+
+  it('releases the stale-chunk reload guard after a successful import', async () => {
+    const chunkError = new TypeError('Failed to fetch dynamically imported module: /ScheduleStaffTools-old.js');
+    window.sessionStorage.setItem('allplays:lazy-chunk-reload-attempted', '1');
+    const module = { default: vi.fn() } as unknown as ScheduleStaffToolsModule;
+    const load = createScheduleStaffToolsLoader(vi.fn(async () => module));
+
+    await expect(load()).resolves.toBe(module);
+
+    expect(shouldAttemptLazyChunkReload(chunkError)).toBe(true);
   });
 });

--- a/apps/app/src/components/schedule/loadScheduleStaffTools.test.ts
+++ b/apps/app/src/components/schedule/loadScheduleStaffTools.test.ts
@@ -34,4 +34,16 @@ describe('loadScheduleStaffTools', () => {
     expect(nestedRequest).toBe(firstRequest);
     expect(importer).toHaveBeenCalledTimes(1);
   });
+
+  it('allows a retry after a non-chunk import failure', async () => {
+    const module = { default: vi.fn() } as unknown as ScheduleStaffToolsModule;
+    const importer = vi.fn()
+      .mockRejectedValueOnce(new Error('Temporary import failure'))
+      .mockResolvedValueOnce(module);
+    const load = createScheduleStaffToolsLoader(importer);
+
+    await expect(load()).rejects.toThrow('Temporary import failure');
+    await expect(load()).resolves.toBe(module);
+    expect(importer).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/app/src/components/schedule/loadScheduleStaffTools.ts
+++ b/apps/app/src/components/schedule/loadScheduleStaffTools.ts
@@ -1,5 +1,5 @@
 import type { ComponentType } from 'react';
-import { handleLazyPageLoadError } from '../../lib/lazyPage';
+import { clearLazyChunkReloadAttempt, handleLazyPageLoadError } from '../../lib/lazyPage';
 import type { ScheduleStaffToolsProps } from './ScheduleStaffTools';
 
 export type ScheduleStaffToolsModule = {
@@ -14,6 +14,10 @@ export function createScheduleStaffToolsLoader(importer: ScheduleStaffToolsImpor
     if (!modulePromise) {
       modulePromise = Promise.resolve()
         .then(importer)
+        .then((module) => {
+          clearLazyChunkReloadAttempt();
+          return module;
+        })
         .catch((error) => {
           modulePromise = null;
           return handleLazyPageLoadError(error) as Promise<ScheduleStaffToolsModule>;

--- a/apps/app/src/components/schedule/loadScheduleStaffTools.ts
+++ b/apps/app/src/components/schedule/loadScheduleStaffTools.ts
@@ -1,4 +1,5 @@
 import type { ComponentType } from 'react';
+import { handleLazyPageLoadError } from '../../lib/lazyPage';
 import type { ScheduleStaffToolsProps } from './ScheduleStaffTools';
 
 export type ScheduleStaffToolsModule = {
@@ -10,7 +11,14 @@ type ScheduleStaffToolsImporter = () => Promise<ScheduleStaffToolsModule>;
 export function createScheduleStaffToolsLoader(importer: ScheduleStaffToolsImporter) {
   let modulePromise: Promise<ScheduleStaffToolsModule> | null = null;
   return () => {
-    if (!modulePromise) modulePromise = Promise.resolve().then(importer);
+    if (!modulePromise) {
+      modulePromise = Promise.resolve()
+        .then(importer)
+        .catch((error) => {
+          modulePromise = null;
+          return handleLazyPageLoadError(error) as Promise<ScheduleStaffToolsModule>;
+        });
+    }
     return modulePromise;
   };
 }

--- a/apps/app/src/lib/lazyPage.ts
+++ b/apps/app/src/lib/lazyPage.ts
@@ -31,17 +31,21 @@ export function handleLazyPageLoadError(error: unknown): Promise<{ default: Comp
   return new Promise(() => {});
 }
 
+export function clearLazyChunkReloadAttempt() {
+  try {
+    window.sessionStorage?.removeItem(lazyChunkReloadKey);
+  } catch {
+    // Session storage is best-effort only.
+  }
+}
+
 export function lazyNamedPage<TModule extends Record<string, unknown>, TExport extends keyof TModule>(
   loadModule: () => Promise<TModule>,
   exportName: TExport
 ) {
   return lazy(() => loadModule()
     .then((module) => {
-      try {
-        window.sessionStorage?.removeItem(lazyChunkReloadKey);
-      } catch {
-        // Session storage is best-effort only.
-      }
+      clearLazyChunkReloadAttempt();
       return { default: module[exportName] as ComponentType<any> };
     })
     .catch(handleLazyPageLoadError));

--- a/apps/app/src/lib/scheduleLogic.ts
+++ b/apps/app/src/lib/scheduleLogic.ts
@@ -1119,7 +1119,8 @@ export function filterParentScheduleEvents(
 
 export function getParentScheduleTeamOptions(
   events: ParentScheduleEvent[],
-  children: Array<{ teamId?: string; teamName?: string }> = []
+  children: Array<{ teamId?: string; teamName?: string }> = [],
+  staffTeams: Array<{ teamId?: string; teamName?: string }> = []
 ): ParentScheduleTeamOption[] {
   const byTeam = new Map<string, ParentScheduleTeamOption>();
   const playerIdsByTeam = new Map<string, Set<string>>();
@@ -1146,6 +1147,10 @@ export function getParentScheduleTeamOptions(
     if (option && playerId) {
       playerIdsByTeam.get(option.teamId)?.add(playerId);
     }
+  });
+
+  staffTeams.forEach((team) => {
+    ensureTeam(team.teamId || '', team.teamName);
   });
 
   events.forEach((event) => {

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -784,6 +784,10 @@ describe('Schedule', () => {
     const teamFilter = await screen.findByLabelText('Team filter');
     expect(within(teamFilter).getByRole('option', { name: 'Jr KC Current' })).toBeTruthy();
     expect(within(teamFilter).getByRole('option', { name: 'Vipers' })).toBeTruthy();
+
+    fireEvent.change(teamFilter, { target: { value: 'team-owned' } });
+
+    expect(await screen.findByText(/Calendar feeds and imports for Vipers/)).toBeTruthy();
   });
 
   it('routes generic staff card opens to the game hub helper on mobile', () => {
@@ -1727,6 +1731,25 @@ describe('Schedule', () => {
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Unable to load schedule tools');
     expect(screen.queryByText('Loading schedule tools…')).toBeNull();
+  });
+
+  it('retries schedule staff tools after a transient load failure', async () => {
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce(buildStaffScheduleResult());
+    const RecoveredScheduleTools = () => <div>Recovered schedule tools</div>;
+    staffToolsLoaderMocks.load
+      .mockRejectedValueOnce(new Error('Temporary schedule tools failure'))
+      .mockResolvedValueOnce({
+        default: RecoveredScheduleTools,
+        ScheduleStaffTools: RecoveredScheduleTools
+      });
+
+    renderSchedule();
+
+    fireEvent.click(await screen.findByRole('button', { name: /manage schedule/i }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry schedule tools' }));
+
+    expect(await screen.findByText('Recovered schedule tools')).toBeTruthy();
+    expect(staffToolsLoaderMocks.load).toHaveBeenCalledTimes(2);
   });
 
   it('defers tracker config loading on mobile until staff tools are opened and caches the result', async () => {

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -764,6 +764,28 @@ describe('Schedule', () => {
     });
   });
 
+  it('shows a zero-event staff team in the schedule team filter', async () => {
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
+      children: [{
+        playerId: 'player-1',
+        playerName: 'Madison Snider',
+        teamId: 'team-parent',
+        teamName: 'Jr KC Current'
+      }],
+      events: [buildScheduleEvent(1, {
+        teamId: 'team-parent',
+        teamName: 'Jr KC Current'
+      })],
+      staffTeams: [{ teamId: 'team-owned', teamName: 'Vipers' }]
+    });
+
+    renderSchedule();
+
+    const teamFilter = await screen.findByLabelText('Team filter');
+    expect(within(teamFilter).getByRole('option', { name: 'Jr KC Current' })).toBeTruthy();
+    expect(within(teamFilter).getByRole('option', { name: 'Vipers' })).toBeTruthy();
+  });
+
   it('routes generic staff card opens to the game hub helper on mobile', () => {
     expect(getGenericEventDetailPath(buildScheduleEvent(1, {
       isTeamStaff: true,

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -779,14 +779,12 @@ describe('Schedule', () => {
       staffTeams: [{ teamId: 'team-owned', teamName: 'Vipers' }]
     });
 
-    renderSchedule();
+    renderSchedule('/schedule?teamId=team-owned');
 
     const teamFilter = await screen.findByLabelText('Team filter');
     expect(within(teamFilter).getByRole('option', { name: 'Jr KC Current' })).toBeTruthy();
     expect(within(teamFilter).getByRole('option', { name: 'Vipers' })).toBeTruthy();
-
-    fireEvent.change(teamFilter, { target: { value: 'team-owned' } });
-
+    expect((teamFilter as HTMLSelectElement).value).toBe('team-owned');
     expect(await screen.findByText(/Calendar feeds and imports for Vipers/)).toBeTruthy();
   });
 

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -1127,9 +1127,11 @@ type DeferredScheduleStaffToolsProps = {
 function DeferredScheduleStaffTools(props: DeferredScheduleStaffToolsProps) {
   const [StaffTools, setStaffTools] = useState<ComponentType<DeferredScheduleStaffToolsProps> | null>(null);
   const [loadError, setLoadError] = useState(false);
+  const [loadAttempt, setLoadAttempt] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
+    setLoadError(false);
     void loadScheduleStaffTools()
       .then((module) => {
         if (!cancelled) setStaffTools(() => module.default);
@@ -1140,10 +1142,21 @@ function DeferredScheduleStaffTools(props: DeferredScheduleStaffToolsProps) {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [loadAttempt]);
 
   if (loadError) {
-    return <div role="alert" className="rounded-2xl border border-rose-200 bg-rose-50 p-3 text-sm font-bold text-rose-700">Unable to load schedule tools. Check your connection and refresh to try again.</div>;
+    return (
+      <div role="alert" className="rounded-2xl border border-rose-200 bg-rose-50 p-3 text-sm font-bold text-rose-700">
+        <p>Unable to load schedule tools. Check your connection and try again.</p>
+        <button
+          type="button"
+          className="mt-3 rounded-xl border border-rose-300 bg-white px-3 py-2 text-xs font-black text-rose-700"
+          onClick={() => setLoadAttempt((current) => current + 1)}
+        >
+          Retry schedule tools
+        </button>
+      </div>
+    );
   }
   if (!StaffTools) {
     return <div role="status" className="rounded-2xl border border-gray-200 bg-gray-50 p-3 text-sm font-bold text-gray-500">Loading schedule tools…</div>;

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -616,7 +616,10 @@ export function Schedule({ auth }: { auth: AuthState }) {
       setVisibleListCount((current) => current + listPageSize);
     }
   };
-  const teamOptions = useMemo(() => getParentScheduleTeamOptions(events, children), [children, events]);
+  const teamOptions = useMemo(
+    () => getParentScheduleTeamOptions(events, children, staffTeams),
+    [children, events, staffTeams]
+  );
   const selectedDayEntries = useMemo(() => {
     if (!selectedDay) return [];
     return calendarEntries.filter((event) =>

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -412,7 +412,12 @@ export function Schedule({ auth }: { auth: AuthState }) {
           if (selectedPlayerId && !result.children.some((child) => child.playerId === selectedPlayerId)) {
             setSelectedPlayerId('');
           }
-          if (selectedTeamId && !result.children.some((child) => child.teamId === selectedTeamId) && !result.events.some((event) => event.teamId === selectedTeamId)) {
+          if (
+            selectedTeamId
+            && !result.children.some((child) => child.teamId === selectedTeamId)
+            && !result.events.some((event) => event.teamId === selectedTeamId)
+            && !result.staffTeams?.some((team) => team.teamId === selectedTeamId)
+          ) {
             setSelectedTeamId('');
           }
           const firstUpcoming = filterParentScheduleEvents(result.events, { filter: 'upcoming-all' })[0];

--- a/tests/unit/app-schedule-logic.test.js
+++ b/tests/unit/app-schedule-logic.test.js
@@ -236,6 +236,16 @@ describe('React app parent schedule logic', () => {
             { teamId: 'team-1', playerCount: 1 },
             { teamId: 'team-2', playerCount: 1 }
         ]);
+        expect(getParentScheduleTeamOptions(events, [], [
+            { teamId: 'team-empty', teamName: 'Vipers' }
+        ])).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                teamId: 'team-empty',
+                teamName: 'Vipers',
+                playerCount: 0,
+                eventCount: 0
+            })
+        ]));
         expect(getPracticePacketRows(events, now).map((row) => `${row.event.id}:${row.status}`)).toEqual([
             'practice-1:ready',
             'practice-2:completed'


### PR DESCRIPTION
## What changed

- include owned/staff teams with no events or players in the Schedule team filter
- keep the selected owned team as the target for schedule management tools
- recover automatically from stale deferred chunk failures and provide an in-panel retry
- add regression coverage for the Vipers zero-event flow and loader retry

## Root cause

Schedule filter options were built only from linked players and events, while management access came from a separate staff-team list. A newly created empty team could therefore be visible inconsistently or resolve the tools to another team. The deferred tools loader also retained a rejected import promise, preventing recovery without a full reload.

## Validation

- `npm --prefix apps/app test -- --run src/pages/Schedule.test.tsx src/components/schedule/loadScheduleStaffTools.test.ts` (67 passed)
- `npx vitest run tests/unit/app-schedule-logic.test.js --reporter=verbose` (15 passed)
- `npm run app:build`
- `git diff --check`