### PR TITLE
Fix multi-team schedule scoping

### DIFF
--- a/apps/app/src/components/AppShell.test.tsx
+++ b/apps/app/src/components/AppShell.test.tsx
@@ -285,6 +285,23 @@ describe('AppShell', () => {
     expect(within(moreNav).getByRole('link', { name: /Discover/ })).toHaveAttribute('href', '/discover');
   });
 
+  it('keeps Schedule scoped to the team currently open in My Teams', () => {
+    useShellLayoutMock.mockReturnValue({ isDesktopWeb: false });
+    render(
+      <MemoryRouter initialEntries={['/teams/team-vipers']}>
+        <Routes>
+          <Route path="/teams/:teamId" element={<AppShell auth={signedInAuth}><div>Vipers</div></AppShell>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const primaryNav = screen.getByRole('navigation', { name: 'Primary navigation' });
+    expect(within(primaryNav).getByRole('link', { name: 'Schedule' })).toHaveAttribute(
+      'href',
+      '/schedule?teamId=team-vipers'
+    );
+  });
+
   it('routes the mobile My Teams nav directly to the team page when the user has one team', () => {
     useShellLayoutMock.mockReturnValue({ isDesktopWeb: false });
     const oneTeamAuth: AuthState = {

--- a/apps/app/src/components/AppShell.test.tsx
+++ b/apps/app/src/components/AppShell.test.tsx
@@ -302,6 +302,23 @@ describe('AppShell', () => {
     );
   });
 
+  it('keeps Schedule scoped across nested team management pages', () => {
+    useShellLayoutMock.mockReturnValue({ isDesktopWeb: false });
+    render(
+      <MemoryRouter initialEntries={['/teams/team-vipers/settings']}>
+        <Routes>
+          <Route path="/teams/:teamId/settings" element={<AppShell auth={signedInAuth}><div>Vipers settings</div></AppShell>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const primaryNav = screen.getByRole('navigation', { name: 'Primary navigation' });
+    expect(within(primaryNav).getByRole('link', { name: 'Schedule' })).toHaveAttribute(
+      'href',
+      '/schedule?teamId=team-vipers'
+    );
+  });
+
   it('routes the mobile My Teams nav directly to the team page when the user has one team', () => {
     useShellLayoutMock.mockReturnValue({ isDesktopWeb: false });
     const oneTeamAuth: AuthState = {

--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -309,8 +309,12 @@ export function AppShell({ auth, children }: AppShellProps) {
       ? 'Signed in'
       : 'Explore ALL PLAYS';
   const teamNavPath = getSingleTeamNavPath(auth.user);
-  const activeNavItems = hasSignedInSession ? withTeamNavPath(mobilePrimaryNavItems, teamNavPath) : publicNavItems;
-  const activeDesktopNavItems = hasSignedInSession ? withTeamNavPath(desktopNavItems, teamNavPath) : publicNavItems;
+  const activeNavItems = hasSignedInSession
+    ? withTeamContextSchedulePath(withTeamNavPath(mobilePrimaryNavItems, teamNavPath), location.pathname)
+    : publicNavItems;
+  const activeDesktopNavItems = hasSignedInSession
+    ? withTeamContextSchedulePath(withTeamNavPath(desktopNavItems, teamNavPath), location.pathname)
+    : publicNavItems;
   const moreNavActive = hasSignedInSession && mobileMoreNavItems.some((item) => isRouteActive(location.pathname, item.path));
   const commonAddWorkflows = commonAddWorkflowIds
     .map((id) => addWorkflows.find((workflow) => workflow.id === id))
@@ -931,6 +935,15 @@ function legacyUrl(path: string) {
 function withTeamNavPath(items: NavItem[], teamNavPath: string): NavItem[] {
   if (!teamNavPath) return items;
   return items.map((item) => item.path === '/teams' ? { ...item, path: teamNavPath } : item);
+}
+
+function withTeamContextSchedulePath(items: NavItem[], pathname: string): NavItem[] {
+  const match = String(pathname || '').match(/^\/teams\/([^/]+)$/);
+  const teamId = match?.[1] || '';
+  if (!teamId || teamId === 'browse' || teamId === 'new') return items;
+  return items.map((item) => item.path === '/schedule'
+    ? { ...item, path: `/schedule?teamId=${teamId}` }
+    : item);
 }
 
 function getSingleTeamNavPath(user: AuthUser | null) {

--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -938,7 +938,7 @@ function withTeamNavPath(items: NavItem[], teamNavPath: string): NavItem[] {
 }
 
 function withTeamContextSchedulePath(items: NavItem[], pathname: string): NavItem[] {
-  const match = String(pathname || '').match(/^\/teams\/([^/]+)$/);
+  const match = String(pathname || '').match(/^\/teams\/([^/]+)(?:\/|$)/);
   const teamId = match?.[1] || '';
   if (!teamId || teamId === 'browse' || teamId === 'new') return items;
   return items.map((item) => item.path === '/schedule'

--- a/apps/app/src/components/schedule/ScheduleStaffTools.tsx
+++ b/apps/app/src/components/schedule/ScheduleStaffTools.tsx
@@ -139,18 +139,19 @@ export function ScheduleStaffTools({
   const trackerConfigRequestPromiseRef = useRef<Partial<Record<string, Promise<ScheduleStatTrackerConfigOption[]>>>>({});
   const [selectedStaffManageTeamId, setSelectedStaffManageTeamId] = useState('');
   const selectedCalendarTeam = useMemo(() => {
+    const explicitlySelectedManageableTeam = selectedStaffManageTeamId
+      ? manageableTeamOptions.find((team) => team.teamId === selectedStaffManageTeamId) || null
+      : null;
+    if (explicitlySelectedManageableTeam) return explicitlySelectedManageableTeam;
     const pageSelectedManageableTeam = selectedTeamId
       ? manageableTeamOptions.find((team) => team.teamId === selectedTeamId) || null
       : null;
     if (pageSelectedManageableTeam) return pageSelectedManageableTeam;
-    if (selectedStaffManageTeamId) {
-      return manageableTeamOptions.find((team) => team.teamId === selectedStaffManageTeamId) || null;
-    }
     return manageableTeamOptions.length === 1 ? manageableTeamOptions[0] : null;
   }, [manageableTeamOptions, selectedStaffManageTeamId, selectedTeamId]);
   const activeTrackerConfigTeamIdRef = useRef<string | null>(null);
   activeTrackerConfigTeamIdRef.current = selectedCalendarTeam?.teamId || null;
-  const shouldShowManageScheduleTeamPicker = !selectedCalendarTeam && manageableTeamOptions.length > 1;
+  const shouldShowManageScheduleTeamPicker = manageableTeamOptions.length > 1;
   const previousSelectedTeamIdRef = useRef(selectedCalendarTeam?.teamId);
 
   useEffect(() => {
@@ -158,6 +159,12 @@ export function ScheduleStaffTools({
       setSelectedStaffManageTeamId('');
     }
   }, [manageableTeamOptions, selectedStaffManageTeamId]);
+
+  useEffect(() => {
+    if (selectedTeamId && manageableTeamOptions.some((team) => team.teamId === selectedTeamId)) {
+      setSelectedStaffManageTeamId(selectedTeamId);
+    }
+  }, [manageableTeamOptions, selectedTeamId]);
 
   useEffect(() => {
     if (previousSelectedTeamIdRef.current && previousSelectedTeamIdRef.current !== selectedCalendarTeam?.teamId) {
@@ -226,31 +233,41 @@ export function ScheduleStaffTools({
   };
 
   const renderScheduleStaffToolsContent = () => {
-    if (shouldShowManageScheduleTeamPicker) {
+    const teamPicker = shouldShowManageScheduleTeamPicker ? (
+      <section className="app-card p-3 sm:p-4" aria-label="Choose team to manage">
+        <div className="app-label">Manage team</div>
+        <label className="mt-2 block text-xs font-bold uppercase tracking-wide text-gray-600">
+          Team to manage
+          <select
+            aria-label="Team to manage"
+            className="auth-input mt-1"
+            value={selectedCalendarTeam?.teamId || ''}
+            onChange={(event) => setSelectedStaffManageTeamId(event.target.value)}
+          >
+            <option value="">Select a team</option>
+            {manageableTeamOptions.map((team) => (
+              <option key={team.teamId} value={team.teamId}>{team.teamName}</option>
+            ))}
+          </select>
+        </label>
+      </section>
+    ) : null;
+
+    if (!selectedCalendarTeam) {
       return (
-        <section className="app-card p-3 sm:p-4" aria-label="Choose team to manage">
-          <div className="app-label">Choose team</div>
-          <h3 className="mt-1 text-base font-black text-gray-950">Choose the team to manage</h3>
-          <p className="mt-1 text-sm font-semibold leading-6 text-gray-600">Pick a team here to unlock game, practice, tournament, and import tools.</p>
-          <label className="mt-3 block text-xs font-bold uppercase tracking-wide text-gray-600">
-            Team to manage
-            <select
-              aria-label="Team to manage"
-              className="auth-input mt-1"
-              value={selectedStaffManageTeamId}
-              onChange={(event) => setSelectedStaffManageTeamId(event.target.value)}
-            >
-              <option value="">Select a team</option>
-              {manageableTeamOptions.map((team) => (
-                <option key={team.teamId} value={team.teamId}>{team.teamName}</option>
-              ))}
-            </select>
-          </label>
-        </section>
+        <>
+          {teamPicker}
+          <section className="app-card p-3 sm:p-4" aria-label="Choose team to manage">
+            <div className="app-label">Choose team</div>
+            <h3 className="mt-1 text-base font-black text-gray-950">Choose the team to manage</h3>
+            <p className="mt-1 text-sm font-semibold leading-6 text-gray-600">Pick a team here to unlock game, practice, tournament, and import tools.</p>
+          </section>
+        </>
       );
     }
-    return selectedCalendarTeam ? (
+    return (
       <>
+        {teamPicker}
         <ScheduleGameCreatePanel
           teamName={selectedCalendarTeam.teamName}
           form={gameForm}
@@ -364,7 +381,7 @@ export function ScheduleStaffTools({
           onClearCsv={handleCsvClear}
         />
       </>
-    ) : null;
+    );
   };
 
   useEffect(() => {

--- a/apps/app/src/components/schedule/ScheduleStaffTools.tsx
+++ b/apps/app/src/components/schedule/ScheduleStaffTools.tsx
@@ -153,6 +153,7 @@ export function ScheduleStaffTools({
   activeTrackerConfigTeamIdRef.current = selectedCalendarTeam?.teamId || null;
   const shouldShowManageScheduleTeamPicker = manageableTeamOptions.length > 1;
   const previousSelectedTeamIdRef = useRef(selectedCalendarTeam?.teamId);
+  const appliedPageSelectedTeamIdRef = useRef('');
 
   useEffect(() => {
     if (selectedStaffManageTeamId && !manageableTeamOptions.some((team) => team.teamId === selectedStaffManageTeamId)) {
@@ -161,8 +162,15 @@ export function ScheduleStaffTools({
   }, [manageableTeamOptions, selectedStaffManageTeamId]);
 
   useEffect(() => {
-    if (selectedTeamId && manageableTeamOptions.some((team) => team.teamId === selectedTeamId)) {
+    if (
+      selectedTeamId
+      && selectedTeamId !== appliedPageSelectedTeamIdRef.current
+      && manageableTeamOptions.some((team) => team.teamId === selectedTeamId)
+    ) {
       setSelectedStaffManageTeamId(selectedTeamId);
+      appliedPageSelectedTeamIdRef.current = selectedTeamId;
+    } else if (!selectedTeamId) {
+      appliedPageSelectedTeamIdRef.current = '';
     }
   }, [manageableTeamOptions, selectedTeamId]);
 

--- a/apps/app/src/lib/adapters/legacyScheduleDb.test.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.test.ts
@@ -265,12 +265,15 @@ describe('legacyScheduleDb staff team reads', () => {
             coachTeamIds: ['team-coach', 'team-coach', 'team-inaccessible']
         });
 
-        expect(teams).toEqual([
-            { id: 'team-owner', name: 'Owner' },
-            { id: 'team-shared', name: 'Admin copy' },
-            { id: 'team-admin', name: 'Admin' },
-            { id: 'team-coach', name: 'Coach' }
-        ]);
+        expect(teams).toEqual({
+            teams: [
+                { id: 'team-owner', name: 'Owner' },
+                { id: 'team-shared', name: 'Admin copy' },
+                { id: 'team-admin', name: 'Admin' },
+                { id: 'team-coach', name: 'Coach' }
+            ],
+            isPartial: true
+        });
         expect(getDocs).toHaveBeenCalledTimes(2);
         expect(where).toHaveBeenCalledWith('ownerId', '==', 'user-1');
         expect(where).toHaveBeenCalledWith('adminEmails', 'array-contains', 'staff@example.com');
@@ -281,7 +284,10 @@ describe('legacyScheduleDb staff team reads', () => {
     it('skips the admin-email query and direct reads when affiliations are empty', async () => {
         vi.mocked(getDocs).mockResolvedValueOnce({ docs: [] } as never);
 
-        await expect(getStaffTeams({ userId: 'parent-1', email: '   ', coachTeamIds: [] })).resolves.toEqual([]);
+        await expect(getStaffTeams({ userId: 'parent-1', email: '   ', coachTeamIds: [] })).resolves.toEqual({
+            teams: [],
+            isPartial: false
+        });
 
         expect(getDocs).toHaveBeenCalledTimes(1);
         expect(where).toHaveBeenCalledTimes(1);

--- a/apps/app/src/lib/adapters/legacyScheduleDb.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.ts
@@ -163,27 +163,38 @@ export type StaffTeamsQuery = {
     includeAll?: boolean;
 };
 
+export type StaffTeamsResult = {
+    teams: Record<string, unknown>[];
+    isPartial: boolean;
+};
+
 export async function getStaffTeams({ userId, email, coachTeamIds = [], includeAll = false }: StaffTeamsQuery) {
     if (includeAll) {
-        return await Promise.resolve(legacyGetTeams({ includePrivate: true }));
+        return {
+            teams: await Promise.resolve(legacyGetTeams({ includePrivate: true })),
+            isPartial: false
+        };
     }
 
     const teamsRef = legacyFirebaseCollection(legacyFirebaseDb, 'teams');
     const normalizedEmail = String(email || '').trim().toLowerCase();
     const uniqueCoachTeamIds = [...new Set(coachTeamIds.map((teamId) => String(teamId || '').trim()).filter(Boolean))];
     const emptySnapshot = { docs: [] };
-    const [ownedSnapshot, adminSnapshot, coachSnapshots] = await Promise.all([
+    const [ownedSnapshot, adminSnapshot, coachSnapshotResults] = await Promise.all([
         userId
             ? legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('ownerId', '==', userId)))
             : Promise.resolve(emptySnapshot),
         normalizedEmail
             ? legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('adminEmails', 'array-contains', normalizedEmail)))
             : Promise.resolve(emptySnapshot),
-        Promise.all(uniqueCoachTeamIds.map((teamId) => (
-            legacyFirebaseGetDoc(legacyFirebaseDoc(legacyFirebaseDb, 'teams', teamId)).catch(() => null)
+        Promise.allSettled(uniqueCoachTeamIds.map((teamId) => (
+            legacyFirebaseGetDoc(legacyFirebaseDoc(legacyFirebaseDb, 'teams', teamId))
         )))
     ]);
 
+    const coachSnapshots = coachSnapshotResults.flatMap((result) => (
+        result.status === 'fulfilled' && result.value ? [result.value] : []
+    ));
     const teamsById = new Map<string, Record<string, unknown>>();
     [...ownedSnapshot.docs, ...adminSnapshot.docs, ...coachSnapshots]
         .filter((snapshot): snapshot is NonNullable<typeof snapshot> => Boolean(snapshot && ('exists' in snapshot ? snapshot.exists() : true)))
@@ -191,7 +202,10 @@ export async function getStaffTeams({ userId, email, coachTeamIds = [], includeA
             const id = String(snapshot.id || '').trim();
             if (id) teamsById.set(id, { id, ...snapshot.data() });
         });
-    return [...teamsById.values()];
+    return {
+        teams: [...teamsById.values()],
+        isPartial: coachSnapshotResults.some((result) => result.status === 'rejected')
+    };
 }
 
 export class LegacyTournamentGameAdapterValidationError extends Error {

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -467,6 +467,21 @@ describe('parent schedule child scope', () => {
     expect(scope.staffTeams).toEqual([{ teamId: 'team-owned', teamName: 'Vipers' }]);
   });
 
+  it('keeps repeated direct schedule refreshes partial when staff discovery fails', async () => {
+    const coachUser = { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'], coachOf: ['team-owned'] } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: ['team-owned'] } as any);
+    vi.mocked(getStaffTeams)
+      .mockRejectedValueOnce(new Error('network unavailable'))
+      .mockRejectedValueOnce(new Error('network unavailable'));
+
+    const firstRefresh = await loadParentSchedule(coachUser, { hydrateDetails: false, expandStaffPlayers: false });
+    const secondRefresh = await loadParentSchedule(coachUser, { hydrateDetails: false, expandStaffPlayers: false });
+
+    expect(firstRefresh).toMatchObject({ staffTeams: [], isPartial: true });
+    expect(secondRefresh).toMatchObject({ staffTeams: [], isPartial: true });
+    expect(getStaffTeams).toHaveBeenCalledTimes(2);
+  });
+
   it('marks native staff scope partial when one REST fallback read fails', async () => {
     const previousWindow = (globalThis as any).window;
     const previousFetch = globalThis.fetch;

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -354,6 +354,26 @@ describe('parent schedule child scope', () => {
     expect(getPlayers).not.toHaveBeenCalled();
   });
 
+  it.each(['team', 'player'])('marks parent scope partial when a linked %s validation read fails', async (failedRead) => {
+    vi.mocked(loadProfileDocument).mockResolvedValue({
+      parentPlayerKeys: ['team-1::player-1']
+    } as any);
+    vi.mocked(getStaffTeams).mockResolvedValue({ teams: [], isPartial: false } as any);
+    vi.mocked(getTeam).mockImplementation(async () => {
+      if (failedRead === 'team') throw new Error('team lookup unavailable');
+      return { id: 'team-1', name: 'Bears', active: true } as any;
+    });
+    vi.mocked(getDoc).mockImplementation(async () => {
+      if (failedRead === 'player') throw new Error('player lookup unavailable');
+      return playerSnapshot('player-1', { name: 'Avery Lee', active: true }) as any;
+    });
+
+    const scope = await loadParentScheduleScope(parentUser);
+
+    expect(scope.children).toEqual([]);
+    expect(scope.isPartial).toBe(true);
+  });
+
   it('reloads profile scope during schedule enrichment when the fast scope is partial', async () => {
     vi.mocked(loadProfileDocument).mockResolvedValue({
       parentOf: [],

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -448,6 +448,47 @@ describe('parent schedule child scope', () => {
     expect(scope.isPartial).toBe(true);
     expect(scope.staffTeams).toEqual([]);
   });
+
+  it('marks native staff scope partial when one REST fallback read fails', async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousFetch = globalThis.fetch;
+    const coachUser = { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'], coachOf: ['team-owned'] } as any;
+    (globalThis as any).window = { location: { protocol: 'capacitor:' }, setTimeout, clearTimeout } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: ['team-owned'] } as any);
+    vi.mocked(getStaffTeams).mockRejectedValueOnce(new Error('native Firebase unavailable'));
+    vi.mocked(getNativeAuthIdToken).mockResolvedValue('native-token' as any);
+    (globalThis as any).fetch = vi.fn(async (_input: any, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(String(init.body)) : null;
+      if (body?.structuredQuery?.where?.fieldFilter?.field?.fieldPath === 'adminEmails') {
+        return {
+          ok: false,
+          status: 503,
+          json: async () => ({ error: { message: 'temporarily unavailable' } })
+        } as any;
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => body ? [] : ({
+          name: 'projects/allplays-test/databases/(default)/documents/teams/team-owned',
+          fields: {
+            name: { stringValue: 'Vipers' },
+            active: { booleanValue: true }
+          }
+        })
+      } as any;
+    });
+
+    try {
+      const scope = await loadParentScheduleScope(coachUser);
+
+      expect(scope.isPartial).toBe(true);
+      expect(scope.staffTeams).toEqual([{ teamId: 'team-owned', teamName: 'Vipers' }]);
+    } finally {
+      (globalThis as any).window = previousWindow;
+      globalThis.fetch = previousFetch;
+    }
+  });
 });
 
 describe('scheduled tournament writes', () => {

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -384,12 +384,15 @@ describe('parent schedule child scope', () => {
   it('uses scoped staff discovery and excludes inactive affiliated teams', async () => {
     const coachUser = { uid: 'coach-1', email: ' Coach@Example.com ', roles: ['coach'], coachOf: ['team-coach', 'team-coach'] } as any;
     vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [] } as any);
-    vi.mocked(getStaffTeams).mockResolvedValue([
-      { id: 'team-owner', name: 'Owner Team', ownerId: 'coach-1', active: true },
-      { id: 'team-admin', name: 'Admin Team', adminEmails: ['coach@example.com'], active: true },
-      { id: 'team-coach', name: 'Coach Team', active: true },
-      { id: 'team-inactive', name: 'Inactive Team', ownerId: 'coach-1', active: false }
-    ] as any);
+    vi.mocked(getStaffTeams).mockResolvedValue({
+      teams: [
+        { id: 'team-owner', name: 'Owner Team', ownerId: 'coach-1', active: true },
+        { id: 'team-admin', name: 'Admin Team', adminEmails: ['coach@example.com'], active: true },
+        { id: 'team-coach', name: 'Coach Team', active: true },
+        { id: 'team-inactive', name: 'Inactive Team', ownerId: 'coach-1', active: false }
+      ],
+      isPartial: false
+    } as any);
     vi.mocked(getTeam).mockImplementation(async (teamId: string) => ({
       'team-owner': { id: 'team-owner', name: 'Owner Team', ownerId: 'coach-1', active: true },
       'team-admin': { id: 'team-admin', name: 'Admin Team', adminEmails: ['coach@example.com'], active: true },
@@ -416,9 +419,10 @@ describe('parent schedule child scope', () => {
   it('carries newly created staff teams through the reusable parent scope', async () => {
     const coachUser = { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'], coachOf: ['team-owned'] } as any;
     vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: ['team-owned'] } as any);
-    vi.mocked(getStaffTeams).mockResolvedValue([
-      { id: 'team-owned', name: 'Vipers', ownerId: 'coach-1', active: true }
-    ] as any);
+    vi.mocked(getStaffTeams).mockResolvedValue({
+      teams: [{ id: 'team-owned', name: 'Vipers', ownerId: 'coach-1', active: true }],
+      isPartial: false
+    } as any);
     vi.mocked(getGames).mockResolvedValue([] as any);
     vi.mocked(getPracticeSessions).mockResolvedValue([] as any);
 
@@ -447,6 +451,20 @@ describe('parent schedule child scope', () => {
 
     expect(scope.isPartial).toBe(true);
     expect(scope.staffTeams).toEqual([]);
+  });
+
+  it('marks web staff scope partial when a coach-team document read is incomplete', async () => {
+    const coachUser = { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'], coachOf: ['team-owned', 'team-missing'] } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: coachUser.coachOf } as any);
+    vi.mocked(getStaffTeams).mockResolvedValueOnce({
+      teams: [{ id: 'team-owned', name: 'Vipers', ownerId: 'coach-1', active: true }],
+      isPartial: true
+    } as any);
+
+    const scope = await loadParentScheduleScope(coachUser);
+
+    expect(scope.isPartial).toBe(true);
+    expect(scope.staffTeams).toEqual([{ teamId: 'team-owned', teamName: 'Vipers' }]);
   });
 
   it('marks native staff scope partial when one REST fallback read fails', async () => {

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -354,7 +354,7 @@ describe('parent schedule child scope', () => {
     expect(getPlayers).not.toHaveBeenCalled();
   });
 
-  it('reloads profile scope during schedule enrichment when the fast scope profile is empty', async () => {
+  it('reloads profile scope during schedule enrichment when the fast scope is partial', async () => {
     vi.mocked(loadProfileDocument).mockResolvedValue({
       parentOf: [],
       parentPlayerKeys: ['team-1::player-1']
@@ -370,7 +370,8 @@ describe('parent schedule child scope', () => {
       expandStaffPlayers: false,
       parentScope: {
         profile: {},
-        children: []
+        children: [],
+        isPartial: true
       }
     });
 
@@ -429,11 +430,23 @@ describe('parent schedule child scope', () => {
     });
 
     expect(scope.staffTeams).toEqual([{ teamId: 'team-owned', teamName: 'Vipers' }]);
+    expect(scope.isPartial).toBe(false);
     expect(schedule.staffTeams).toEqual([{ teamId: 'team-owned', teamName: 'Vipers' }]);
     expect(getStaffTeams).toHaveBeenCalledTimes(1);
     expect(getGames).toHaveBeenCalledWith('team-owned', expect.objectContaining({
       startDate: expect.any(Date)
     }));
+  });
+
+  it('marks parent scope partial when the authoritative staff-team read fails', async () => {
+    const coachUser = { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'], coachOf: ['team-owned'] } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: ['team-owned'] } as any);
+    vi.mocked(getStaffTeams).mockRejectedValueOnce(new Error('network unavailable'));
+
+    const scope = await loadParentScheduleScope(coachUser);
+
+    expect(scope.isPartial).toBe(true);
+    expect(scope.staffTeams).toEqual([]);
   });
 });
 

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -376,11 +376,9 @@ export type ParentScheduleScope = {
   children: ParentScheduleChild[];
   /** Teams the user can manage, including newly created teams with no players or chat yet. */
   staffTeams?: ParentScheduleStaffTeam[];
+  /** True when any authoritative scope read failed and cached access should be preserved. */
+  isPartial?: boolean;
 };
-
-function hasResolvedParentProfile(profile: unknown): profile is Record<string, unknown> {
-  return Boolean(profile && typeof profile === 'object' && !Array.isArray(profile) && Object.keys(profile as Record<string, unknown>).length > 0);
-}
 
 export type ParentScheduleLoadOptions = {
   hydrateDetails?: boolean;
@@ -2788,14 +2786,22 @@ export async function loadParentScheduleScope(user: AuthUser | null): Promise<Pa
       staffTeams: []
     };
   }
+  let isPartial = false;
   const [profile, staffTeams] = await Promise.all([
-    loadProfileDocument(user.uid).catch(() => ({})),
-    loadStaffTeams(user).catch(() => [])
+    loadProfileDocument(user.uid).catch(() => {
+      isPartial = true;
+      return {};
+    }),
+    loadStaffTeams(user).catch(() => {
+      isPartial = true;
+      return [];
+    })
   ]);
   const children = await resolveParentScheduleChildren(user, profile as Record<string, unknown>);
   return {
     profile: profile as Record<string, unknown>,
     children,
+    isPartial,
     staffTeams: staffTeams
       .map((team: any) => {
         const teamId = compactString(team?.id);
@@ -4278,7 +4284,7 @@ export async function loadParentSchedule(user: AuthUser | null, options: ParentS
   const scheduleRangeByTeam = options.scheduleRangeByTeam || null;
 
   try {
-    const canReuseParentScope = hasResolvedParentProfile(options.parentScope?.profile);
+    const canReuseParentScope = Boolean(options.parentScope && options.parentScope.isPartial !== true);
     const profile = canReuseParentScope
       ? options.parentScope!.profile
       : await loadProfileDocument(user.uid);

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -1674,17 +1674,17 @@ async function loadStaffTeams(user: AuthUser): Promise<StaffTeamsLoadResult> {
     'staff teams',
     async () => {
       const coachTeamIds = Array.isArray(user.coachOf) ? user.coachOf.map(compactString).filter(Boolean) : [];
-      const visibleTeams = await getStaffTeams({
+      const staffTeamResult = await getStaffTeams({
         userId: user.uid,
         email: user.email,
         coachTeamIds,
         includeAll: (user as any).isAdmin === true
       });
       const teamsById = new Map<string, any>();
-      visibleTeams.filter(Boolean).forEach((team: any) => {
+      staffTeamResult.teams.filter(Boolean).forEach((team: any) => {
         if (team?.id && isTeamActive(team) && isTeamStaff(team, user)) teamsById.set(team.id, team);
       });
-      return { teams: [...teamsById.values()], isPartial: false };
+      return { teams: [...teamsById.values()], isPartial: staffTeamResult.isPartial };
     },
     async () => {
       const coachTeamIds = Array.isArray(user.coachOf) ? user.coachOf.map(compactString).filter(Boolean) : [];

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -1664,7 +1664,12 @@ function isTeamStaff(team: any, user: AuthUser | null) {
   return false;
 }
 
-async function loadStaffTeams(user: AuthUser) {
+type StaffTeamsLoadResult = {
+  teams: any[];
+  isPartial: boolean;
+};
+
+async function loadStaffTeams(user: AuthUser): Promise<StaffTeamsLoadResult> {
   return readWithNativeFallback(
     'staff teams',
     async () => {
@@ -1679,27 +1684,34 @@ async function loadStaffTeams(user: AuthUser) {
       visibleTeams.filter(Boolean).forEach((team: any) => {
         if (team?.id && isTeamActive(team) && isTeamStaff(team, user)) teamsById.set(team.id, team);
       });
-      return [...teamsById.values()];
+      return { teams: [...teamsById.values()], isPartial: false };
     },
     async () => {
       const coachTeamIds = Array.isArray(user.coachOf) ? user.coachOf.map(compactString).filter(Boolean) : [];
       const normalizedEmail = normalizeEmail(user.email);
       const ownerEmailCandidates = Array.from(new Set([compactString(user.email), normalizedEmail].filter(Boolean)));
       const ownerEmailLookups = ownerEmailCandidates.map((ownerEmail) =>
-        nativeRunQuery('teams', 'ownerEmail', 'EQUAL', ownerEmail).catch(() => [])
+        nativeRunQuery('teams', 'ownerEmail', 'EQUAL', ownerEmail)
       );
-      const [ownedTeams, adminTeams, ownerEmailLowerTeams, ...ownerEmailTeams] = await Promise.all([
-        nativeRunQuery('teams', 'ownerId', 'EQUAL', user.uid).catch(() => []),
-        normalizedEmail ? nativeRunQuery('teams', 'adminEmails', 'ARRAY_CONTAINS', normalizedEmail).catch(() => []) : Promise.resolve([]),
-        normalizedEmail ? nativeRunQuery('teams', 'ownerEmailLower', 'EQUAL', normalizedEmail).catch(() => []) : Promise.resolve([]),
+      const queryResults = await Promise.allSettled([
+        nativeRunQuery('teams', 'ownerId', 'EQUAL', user.uid),
+        ...(normalizedEmail ? [
+          nativeRunQuery('teams', 'adminEmails', 'ARRAY_CONTAINS', normalizedEmail),
+          nativeRunQuery('teams', 'ownerEmailLower', 'EQUAL', normalizedEmail)
+        ] : []),
         ...ownerEmailLookups
       ]);
-      const coachTeams = await Promise.all(coachTeamIds.map((teamId) => nativeGetDocument(`teams/${encodeURIComponent(teamId)}`).catch(() => null)));
+      const coachTeamResults = await Promise.allSettled(
+        coachTeamIds.map((teamId) => nativeGetDocument(`teams/${encodeURIComponent(teamId)}`))
+      );
+      const isPartial = [...queryResults, ...coachTeamResults].some((result) => result.status === 'rejected');
       const teamsById = new Map<string, any>();
-      [...ownedTeams, ...adminTeams, ...ownerEmailLowerTeams, ...ownerEmailTeams.flat(), ...coachTeams].forEach((team) => {
+      const queryTeams = queryResults.flatMap((result) => result.status === 'fulfilled' ? result.value : []);
+      const coachTeams = coachTeamResults.flatMap((result) => result.status === 'fulfilled' && result.value ? [result.value] : []);
+      [...queryTeams, ...coachTeams].forEach((team) => {
         if (team?.id && isTeamActive(team) && isTeamStaff(team, user)) teamsById.set(team.id, team);
       });
-      return [...teamsById.values()];
+      return { teams: [...teamsById.values()], isPartial };
     }
   );
 }
@@ -2787,22 +2799,23 @@ export async function loadParentScheduleScope(user: AuthUser | null): Promise<Pa
     };
   }
   let isPartial = false;
-  const [profile, staffTeams] = await Promise.all([
+  const [profile, staffTeamResult] = await Promise.all([
     loadProfileDocument(user.uid).catch(() => {
       isPartial = true;
       return {};
     }),
     loadStaffTeams(user).catch(() => {
       isPartial = true;
-      return [];
+      return { teams: [], isPartial: true };
     })
   ]);
+  if (staffTeamResult.isPartial) isPartial = true;
   const children = await resolveParentScheduleChildren(user, profile as Record<string, unknown>);
   return {
     profile: profile as Record<string, unknown>,
     children,
     isPartial,
-    staffTeams: staffTeams
+    staffTeams: staffTeamResult.teams
       .map((team: any) => {
         const teamId = compactString(team?.id);
         return teamId ? { teamId, teamName: compactString(team?.name) || teamId } : null;
@@ -4028,7 +4041,7 @@ async function buildParentScheduleTeamChildren(user: AuthUser, profile: Record<s
     byTeam.get(child.teamId)?.push(child);
   });
 
-  const staffTeams = options.parentScope?.staffTeams || await loadStaffTeams(user).catch(() => []);
+  const staffTeams = options.parentScope?.staffTeams || (await loadStaffTeams(user).catch(() => ({ teams: [], isPartial: true }))).teams;
   await mapWithConcurrency(staffTeams, parentScheduleTeamConcurrency, async (team: any) => {
     const teamId = compactString(team?.id || team?.teamId);
     if (!teamId) return;

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -2729,11 +2729,17 @@ function collectParentScopeLinks(user: AuthUser, profile: Record<string, unknown
   return [...linksByKey.values()];
 }
 
-async function resolveParentScheduleChildren(user: AuthUser, profile: Record<string, unknown>): Promise<ParentScheduleChild[]> {
+type ParentScheduleChildrenResult = {
+  children: ParentScheduleChild[];
+  isPartial: boolean;
+};
+
+async function resolveParentScheduleChildren(user: AuthUser, profile: Record<string, unknown>): Promise<ParentScheduleChildrenResult> {
   const links = collectParentScopeLinks(user, profile);
-  if (!links.length) return [];
+  if (!links.length) return { children: [], isPartial: false };
 
   const linksByTeam = new Map<string, ParentScopeLink[]>();
+  let isPartial = false;
   links.forEach((link) => {
     if (!linksByTeam.has(link.teamId)) linksByTeam.set(link.teamId, []);
     linksByTeam.get(link.teamId)?.push(link);
@@ -2741,14 +2747,17 @@ async function resolveParentScheduleChildren(user: AuthUser, profile: Record<str
 
   const batches = await mapWithConcurrency([...linksByTeam.entries()], parentScheduleTeamConcurrency, async ([teamId, teamLinks]) => {
     const rawTeam = await loadRawTeam(teamId).catch((error) => {
+      isPartial = true;
       logScheduleWarning('Unable to validate parent-linked team.', 'parent-team-scope-load', error, { teamId });
       return undefined;
     });
+    if (rawTeam === undefined) return [];
     if (rawTeam === null) return [];
     if (rawTeam && !isTeamActive(rawTeam as Record<string, any>)) return [];
 
     const linkedPlayers = await mapWithConcurrency(teamLinks, parentSchedulePlayerConcurrency, async (link) => {
       const player = await loadPlayer(teamId, link.playerId).catch((error) => {
+        isPartial = true;
         logScheduleWarning('Unable to validate parent-linked player.', 'parent-player-scope-load', error, {
           teamId,
           playerId: link.playerId
@@ -2781,13 +2790,14 @@ async function resolveParentScheduleChildren(user: AuthUser, profile: Record<str
       .filter(Boolean) as ParentScheduleChild[];
   });
 
-  return batches.flat();
+  return { children: batches.flat(), isPartial };
 }
 
 export async function loadParentScheduleChildren(user: AuthUser | null, options: { profile?: Record<string, unknown> } = {}): Promise<ParentScheduleChild[]> {
   if (!user?.uid) return [];
   const profile = options.profile || await loadProfileDocument(user.uid).catch(() => ({}));
-  return resolveParentScheduleChildren(user, profile as Record<string, unknown>);
+  const result = await resolveParentScheduleChildren(user, profile as Record<string, unknown>);
+  return result.children;
 }
 
 export async function loadParentScheduleScope(user: AuthUser | null): Promise<ParentScheduleScope> {
@@ -2810,10 +2820,11 @@ export async function loadParentScheduleScope(user: AuthUser | null): Promise<Pa
     })
   ]);
   if (staffTeamResult.isPartial) isPartial = true;
-  const children = await resolveParentScheduleChildren(user, profile as Record<string, unknown>);
+  const childResult = await resolveParentScheduleChildren(user, profile as Record<string, unknown>);
+  if (childResult.isPartial) isPartial = true;
   return {
     profile: profile as Record<string, unknown>,
-    children,
+    children: childResult.children,
     isPartial,
     staffTeams: staffTeamResult.teams
       .map((team: any) => {
@@ -4034,7 +4045,10 @@ export async function hydrateParentScheduleDetails(schedule: ParentScheduleLoadR
 
 async function buildParentScheduleTeamChildren(user: AuthUser, profile: Record<string, unknown>, options: ParentScheduleLoadOptions = {}) {
   const expandStaffPlayers = options.expandStaffPlayers !== false;
-  const children = options.parentScope?.children || await resolveParentScheduleChildren(user, profile as Record<string, unknown>);
+  const childResult: ParentScheduleChildrenResult = options.parentScope?.children
+    ? { children: options.parentScope.children, isPartial: options.parentScope.isPartial === true }
+    : await resolveParentScheduleChildren(user, profile as Record<string, unknown>);
+  const children = childResult.children;
   const byTeam = new Map<string, ParentScheduleChild[]>();
   children.forEach((child) => {
     if (!byTeam.has(child.teamId)) byTeam.set(child.teamId, []);
@@ -4077,7 +4091,7 @@ async function buildParentScheduleTeamChildren(user: AuthUser, profile: Record<s
     }
   });
 
-  return { children, byTeam, staffTeams, isStaffTeamScopePartial: staffTeamResult.isPartial };
+  return { children, byTeam, staffTeams, isParentScopePartial: childResult.isPartial || staffTeamResult.isPartial };
 }
 
 /**
@@ -4173,7 +4187,7 @@ export async function loadParentPlayerSchedule(user: AuthUser | null, options: P
 
   try {
     const profile = await loadProfileDocument(user.uid);
-    const children = await resolveParentScheduleChildren(user, profile as Record<string, unknown>);
+    const { children } = await resolveParentScheduleChildren(user, profile as Record<string, unknown>);
     let child = (requestedTeamId && requestedPlayerId)
       ? children.find((entry) => entry.teamId === requestedTeamId && entry.playerId === requestedPlayerId)
       : children.find((entry) => entry.playerId === requestedPlayerId);
@@ -4304,7 +4318,7 @@ export async function loadParentSchedule(user: AuthUser | null, options: ParentS
     const profile = canReuseParentScope
       ? options.parentScope!.profile
       : await loadProfileDocument(user.uid);
-    const { children, byTeam, staffTeams, isStaffTeamScopePartial } = await buildParentScheduleTeamChildren(user, profile as Record<string, unknown>, {
+    const { children, byTeam, staffTeams, isParentScopePartial } = await buildParentScheduleTeamChildren(user, profile as Record<string, unknown>, {
       ...options,
       expandStaffPlayers,
       parentScope: canReuseParentScope ? options.parentScope : undefined
@@ -4390,7 +4404,7 @@ export async function loadParentSchedule(user: AuthUser | null, options: ParentS
       ? await hydrateEventDetails(events, user)
       : [];
     finalizeSessionRsvpHydration(events, authoritativeEvents, user.uid);
-    const isPartial = isStaffTeamScopePartial || failedTeamLoads.length > 0;
+    const isPartial = isParentScopePartial || failedTeamLoads.length > 0;
     timer.end({
       hydrateDetails,
       expandStaffPlayers,

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -4041,7 +4041,10 @@ async function buildParentScheduleTeamChildren(user: AuthUser, profile: Record<s
     byTeam.get(child.teamId)?.push(child);
   });
 
-  const staffTeams = options.parentScope?.staffTeams || (await loadStaffTeams(user).catch(() => ({ teams: [], isPartial: true }))).teams;
+  const staffTeamResult: StaffTeamsLoadResult = options.parentScope?.staffTeams
+    ? { teams: options.parentScope.staffTeams, isPartial: options.parentScope.isPartial === true }
+    : await loadStaffTeams(user).catch(() => ({ teams: [], isPartial: true }));
+  const staffTeams = staffTeamResult.teams;
   await mapWithConcurrency(staffTeams, parentScheduleTeamConcurrency, async (team: any) => {
     const teamId = compactString(team?.id || team?.teamId);
     if (!teamId) return;
@@ -4074,7 +4077,7 @@ async function buildParentScheduleTeamChildren(user: AuthUser, profile: Record<s
     }
   });
 
-  return { children, byTeam, staffTeams };
+  return { children, byTeam, staffTeams, isStaffTeamScopePartial: staffTeamResult.isPartial };
 }
 
 /**
@@ -4301,7 +4304,7 @@ export async function loadParentSchedule(user: AuthUser | null, options: ParentS
     const profile = canReuseParentScope
       ? options.parentScope!.profile
       : await loadProfileDocument(user.uid);
-    const { children, byTeam, staffTeams } = await buildParentScheduleTeamChildren(user, profile as Record<string, unknown>, {
+    const { children, byTeam, staffTeams, isStaffTeamScopePartial } = await buildParentScheduleTeamChildren(user, profile as Record<string, unknown>, {
       ...options,
       expandStaffPlayers,
       parentScope: canReuseParentScope ? options.parentScope : undefined
@@ -4387,7 +4390,7 @@ export async function loadParentSchedule(user: AuthUser | null, options: ParentS
       ? await hydrateEventDetails(events, user)
       : [];
     finalizeSessionRsvpHydration(events, authoritativeEvents, user.uid);
-    const isPartial = failedTeamLoads.length > 0;
+    const isPartial = isStaffTeamScopePartial || failedTeamLoads.length > 0;
     timer.end({
       hydrateDetails,
       expandStaffPlayers,

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -255,6 +255,11 @@ function resolveAppSourcePath(relativePath: string) {
 describe('Schedule', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    appDataCacheMocks.getCachedAppData.mockReturnValue(null);
+    appDataCacheMocks.loadCachedAppData.mockImplementation(async (
+      _key: string,
+      loader: () => Promise<unknown>
+    ) => loader());
     scheduleServiceMocks.loadParentScheduleScope.mockResolvedValue({
       profile: {},
       children: [],
@@ -884,6 +889,81 @@ describe('Schedule', () => {
     expect((await screen.findByLabelText('Team filter') as HTMLSelectElement).value).toBe('team-owned');
     fireEvent.click(await screen.findByRole('button', { name: /manage schedule/i }));
     expect(await screen.findByRole('heading', { name: 'Add game for Vipers' })).toBeTruthy();
+  });
+
+  it('removes cached management access when fresh staff scope revokes the team', async () => {
+    scheduleServiceMocks.loadParentScheduleScope.mockResolvedValueOnce({
+      profile: {},
+      children: [],
+      staffTeams: [],
+      isPartial: false
+    });
+    appDataCacheMocks.loadCachedAppData.mockResolvedValueOnce({
+      children: [],
+      events: [buildScheduleEvent(1, {
+        teamId: 'team-owned',
+        teamName: 'Vipers',
+        isTeamStaff: true
+      })],
+      staffTeams: [{ teamId: 'team-owned', teamName: 'Vipers' }]
+    });
+
+    renderSchedule('/schedule?teamId=team-owned');
+
+    expect(await screen.findByLabelText('Team filter')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /manage schedule/i })).toBeNull();
+    });
+  });
+
+  it('ignores a delayed staff-scope response from the previous account', async () => {
+    let resolvePreviousScope!: (scope: {
+      profile: Record<string, unknown>;
+      children: [];
+      staffTeams: Array<{ teamId: string; teamName: string }>;
+      isPartial: false;
+    }) => void;
+    scheduleServiceMocks.loadParentScheduleScope
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolvePreviousScope = resolve;
+      }));
+    appDataCacheMocks.loadCachedAppData
+      .mockResolvedValue({ children: [], events: [], staffTeams: [] });
+
+    const previousAuth = {
+      ...auth,
+      user: { ...auth.user!, uid: 'previous-user' } as AuthState['user']
+    };
+    const nextAuth = {
+      ...auth,
+      user: { ...auth.user!, uid: 'next-user' } as AuthState['user']
+    };
+    const { rerender } = render(
+      <MemoryRouter initialEntries={['/schedule']}>
+        <Routes>
+          <Route path="/schedule" element={<Schedule auth={previousAuth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    rerender(
+      <MemoryRouter initialEntries={['/schedule']}>
+        <Routes>
+          <Route path="/schedule" element={<Schedule auth={nextAuth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    resolvePreviousScope({
+      profile: {},
+      children: [],
+      staffTeams: [{ teamId: 'team-owned', teamName: 'Vipers' }],
+      isPartial: false
+    });
+
+    const teamFilter = await screen.findByLabelText('Team filter');
+    await waitFor(() => {
+      expect(within(teamFilter).queryByRole('option', { name: 'Vipers' })).toBeNull();
+    });
   });
 
   it('routes generic staff card opens to the game hub helper on mobile', () => {
@@ -1901,10 +1981,10 @@ describe('Schedule', () => {
       .mockResolvedValueOnce(buildMultiTeamStaffScheduleResult());
     scheduleServiceMocks.createScheduledGameForApp.mockResolvedValueOnce('game-2');
 
-    renderSchedule();
+    renderSchedule('/schedule?teamId=team-1');
 
     fireEvent.click(await screen.findByRole('button', { name: /manage schedule/i }));
-    expect(await screen.findByRole('heading', { name: 'Choose the team to manage' })).toBeTruthy();
+    expect(await screen.findByRole('heading', { name: 'Add game for Bears' })).toBeTruthy();
 
     fireEvent.change(screen.getByLabelText('Team to manage'), { target: { value: 'team-2' } });
 
@@ -1922,6 +2002,10 @@ describe('Schedule', () => {
         opponent: 'Falcons',
         location: 'West Gym'
       }), auth.user);
+    });
+    await waitFor(() => {
+      expect(scheduleServiceMocks.loadParentSchedule).toHaveBeenCalledTimes(2);
+      expect(screen.getByRole('heading', { name: 'Add game for Wolves' })).toBeTruthy();
     });
   });
 

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -966,6 +966,45 @@ describe('Schedule', () => {
     });
   });
 
+  it('ignores an older overlapping staff-scope refresh for the same account', async () => {
+    let resolveOlderScope!: (scope: {
+      profile: Record<string, unknown>;
+      children: [];
+      staffTeams: Array<{ teamId: string; teamName: string }>;
+      isPartial: false;
+    }) => void;
+    scheduleServiceMocks.loadParentScheduleScope
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolveOlderScope = resolve;
+      }))
+      .mockResolvedValueOnce({
+        profile: {},
+        children: [],
+        staffTeams: [{ teamId: 'team-new', teamName: 'Vipers' }],
+        isPartial: false
+      });
+    appDataCacheMocks.loadCachedAppData
+      .mockResolvedValue({ children: [], events: [], staffTeams: [] });
+
+    renderSchedule();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Refresh schedule' }));
+    const teamFilter = await screen.findByLabelText('Team filter');
+    expect(await within(teamFilter).findByRole('option', { name: 'Vipers' })).toBeTruthy();
+
+    resolveOlderScope({
+      profile: {},
+      children: [],
+      staffTeams: [{ teamId: 'team-old', teamName: 'Bears' }],
+      isPartial: false
+    });
+
+    await waitFor(() => {
+      expect(within(teamFilter).queryByRole('option', { name: 'Bears' })).toBeNull();
+      expect(within(teamFilter).getByRole('option', { name: 'Vipers' })).toBeTruthy();
+    });
+  });
+
   it('routes generic staff card opens to the game hub helper on mobile', () => {
     expect(getGenericEventDetailPath(buildScheduleEvent(1, {
       isTeamStaff: true,

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -810,7 +810,12 @@ describe('Schedule', () => {
   it('shows a zero-event staff team in the schedule team filter', async () => {
     scheduleServiceMocks.loadParentScheduleScope.mockResolvedValueOnce({
       profile: {},
-      children: [],
+      children: [{
+        playerId: 'player-1',
+        playerName: 'Madison Snider',
+        teamId: 'team-parent',
+        teamName: 'Jr KC Current'
+      }],
       staffTeams: [{ teamId: 'team-owned', teamName: 'Vipers' }],
       isPartial: false
     });
@@ -891,7 +896,7 @@ describe('Schedule', () => {
     expect(await screen.findByRole('heading', { name: 'Add game for Vipers' })).toBeTruthy();
   });
 
-  it('removes cached management access when fresh staff scope revokes the team', async () => {
+  it('removes cached events, filters, and management access when fresh scope revokes the team', async () => {
     scheduleServiceMocks.loadParentScheduleScope.mockResolvedValueOnce({
       profile: {},
       children: [],
@@ -910,9 +915,11 @@ describe('Schedule', () => {
 
     renderSchedule('/schedule?teamId=team-owned');
 
-    expect(await screen.findByLabelText('Team filter')).toBeTruthy();
+    const teamFilter = await screen.findByLabelText('Team filter');
     await waitFor(() => {
       expect(screen.queryByRole('button', { name: /manage schedule/i })).toBeNull();
+      expect(within(teamFilter).queryByRole('option', { name: 'Vipers' })).toBeNull();
+      expect((teamFilter as HTMLSelectElement).value).toBe('');
     });
   });
 

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -896,6 +896,36 @@ describe('Schedule', () => {
     expect(await screen.findByRole('heading', { name: 'Add game for Vipers' })).toBeTruthy();
   });
 
+  it('preserves cached parent events when linked child validation is incomplete', async () => {
+    scheduleServiceMocks.loadParentScheduleScope.mockResolvedValueOnce({
+      profile: {},
+      children: [],
+      staffTeams: [],
+      isPartial: true
+    });
+    appDataCacheMocks.loadCachedAppData.mockResolvedValueOnce({
+      children: [{
+        playerId: 'player-1',
+        playerName: 'Madison Snider',
+        teamId: 'team-parent',
+        teamName: 'Jr KC Current'
+      }],
+      events: [buildScheduleEvent(1, {
+        teamId: 'team-parent',
+        teamName: 'Jr KC Current',
+        isTeamStaff: false
+      })],
+      staffTeams: []
+    });
+
+    renderSchedule('/schedule?teamId=team-parent');
+
+    const teamFilter = await screen.findByLabelText('Team filter');
+    expect(within(teamFilter).getByRole('option', { name: 'Jr KC Current' })).toBeTruthy();
+    expect((teamFilter as HTMLSelectElement).value).toBe('team-parent');
+    expect(await screen.findByText('Next up')).toBeTruthy();
+  });
+
   it('removes cached events, filters, and management access when fresh scope revokes the team', async () => {
     scheduleServiceMocks.loadParentScheduleScope.mockResolvedValueOnce({
       profile: {},

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -258,7 +258,8 @@ describe('Schedule', () => {
     scheduleServiceMocks.loadParentScheduleScope.mockResolvedValue({
       profile: {},
       children: [],
-      staffTeams: []
+      staffTeams: [],
+      isPartial: true
     });
     shellLayoutMocks.isDesktopWeb = false;
     Object.defineProperty(window, 'scrollTo', {
@@ -345,6 +346,30 @@ describe('Schedule', () => {
     expect(options.force).toBe(false);
     expect(options.shouldCache({ isPartial: true })).toBe(false);
     expect(options.shouldCache({ isPartial: false })).toBe(true);
+  });
+
+  it('reuses a complete staff scope when loading a fresh schedule summary', async () => {
+    const parentScope = {
+      profile: {},
+      children: [],
+      staffTeams: [{ teamId: 'team-owned', teamName: 'Vipers' }],
+      isPartial: false
+    };
+    scheduleServiceMocks.loadParentScheduleScope.mockResolvedValueOnce(parentScope);
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
+      children: [],
+      events: [],
+      staffTeams: parentScope.staffTeams
+    });
+
+    renderSchedule();
+
+    expect(await screen.findByText('No events in this filter')).toBeTruthy();
+    expect(scheduleServiceMocks.loadParentSchedule).toHaveBeenCalledWith(auth.user, expect.objectContaining({
+      hydrateDetails: false,
+      expandStaffPlayers: false,
+      parentScope
+    }));
   });
 
   it('progressively applies RSVP hydration after the fast schedule shell loads', async () => {
@@ -737,7 +762,8 @@ describe('Schedule', () => {
     scheduleServiceMocks.loadParentScheduleScope.mockResolvedValueOnce({
       profile: {},
       children: [],
-      staffTeams: [{ teamId: 'team-empty', teamName: 'Empty FC' }]
+      staffTeams: [{ teamId: 'team-empty', teamName: 'Empty FC' }],
+      isPartial: false
     });
     scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
       children: [],
@@ -780,7 +806,8 @@ describe('Schedule', () => {
     scheduleServiceMocks.loadParentScheduleScope.mockResolvedValueOnce({
       profile: {},
       children: [],
-      staffTeams: [{ teamId: 'team-owned', teamName: 'Vipers' }]
+      staffTeams: [{ teamId: 'team-owned', teamName: 'Vipers' }],
+      isPartial: false
     });
     scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
       children: [{
@@ -812,7 +839,8 @@ describe('Schedule', () => {
       staffTeams: [
         { teamId: 'team-parent', teamName: 'Jr KC Current' },
         { teamId: 'team-owned', teamName: 'Vipers' }
-      ]
+      ],
+      isPartial: false
     });
     appDataCacheMocks.loadCachedAppData.mockResolvedValueOnce({
       children: [{
@@ -835,6 +863,26 @@ describe('Schedule', () => {
     fireEvent.click(await screen.findByRole('button', { name: /manage schedule/i }));
 
     expect((await screen.findByLabelText('Team to manage') as HTMLSelectElement).value).toBe('team-owned');
+    expect(await screen.findByRole('heading', { name: 'Add game for Vipers' })).toBeTruthy();
+  });
+
+  it('preserves cached staff access when the fresh scope read is incomplete', async () => {
+    scheduleServiceMocks.loadParentScheduleScope.mockResolvedValueOnce({
+      profile: {},
+      children: [],
+      staffTeams: [],
+      isPartial: true
+    });
+    appDataCacheMocks.loadCachedAppData.mockResolvedValueOnce({
+      children: [],
+      events: [],
+      staffTeams: [{ teamId: 'team-owned', teamName: 'Vipers' }]
+    });
+
+    renderSchedule('/schedule?teamId=team-owned');
+
+    expect((await screen.findByLabelText('Team filter') as HTMLSelectElement).value).toBe('team-owned');
+    fireEvent.click(await screen.findByRole('button', { name: /manage schedule/i }));
     expect(await screen.findByRole('heading', { name: 'Add game for Vipers' })).toBeTruthy();
   });
 

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -18,6 +18,7 @@ const scheduleServiceMocks = vi.hoisted(() => ({
   finalizeScheduleImportBatch: vi.fn(),
   hydrateParentScheduleRsvps: vi.fn(async (schedule: unknown, _user?: unknown, _options?: unknown) => schedule),
   loadParentSchedule: vi.fn(),
+  loadParentScheduleScope: vi.fn(),
   loadScheduleStatTrackerConfigsForApp: vi.fn().mockResolvedValue([]),
   removeTeamCalendarUrl: vi.fn(),
   submitParentScheduleRsvp: vi.fn(),
@@ -254,6 +255,11 @@ function resolveAppSourcePath(relativePath: string) {
 describe('Schedule', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    scheduleServiceMocks.loadParentScheduleScope.mockResolvedValue({
+      profile: {},
+      children: [],
+      staffTeams: []
+    });
     shellLayoutMocks.isDesktopWeb = false;
     Object.defineProperty(window, 'scrollTo', {
       value: vi.fn(),
@@ -275,6 +281,7 @@ describe('Schedule', () => {
 
     expect(uxTimingMocks.recordFirstMeaningfulRender).not.toHaveBeenCalled();
 
+    await waitFor(() => expect(typeof resolveSchedule).toBe('function'));
     resolveSchedule({
       children: [
         { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
@@ -302,10 +309,10 @@ describe('Schedule', () => {
     await waitFor(() => {
       expect(screen.queryByRole('status', { name: 'Loading schedule' })).toBeNull();
     });
-    expect(scheduleServiceMocks.loadParentSchedule).toHaveBeenCalledWith(auth.user, {
+    expect(scheduleServiceMocks.loadParentSchedule).toHaveBeenCalledWith(auth.user, expect.objectContaining({
       hydrateDetails: false,
       expandStaffPlayers: false
-    });
+    }));
   });
 
   it('passes the full schedule cache contract into the summary loader', async () => {
@@ -727,6 +734,11 @@ describe('Schedule', () => {
   });
 
   it('clears zero-event staff teams when the schedule is replaced without staff team data', async () => {
+    scheduleServiceMocks.loadParentScheduleScope.mockResolvedValueOnce({
+      profile: {},
+      children: [],
+      staffTeams: [{ teamId: 'team-empty', teamName: 'Empty FC' }]
+    });
     scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
       children: [],
       events: [],
@@ -765,6 +777,11 @@ describe('Schedule', () => {
   });
 
   it('shows a zero-event staff team in the schedule team filter', async () => {
+    scheduleServiceMocks.loadParentScheduleScope.mockResolvedValueOnce({
+      profile: {},
+      children: [],
+      staffTeams: [{ teamId: 'team-owned', teamName: 'Vipers' }]
+    });
     scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
       children: [{
         playerId: 'player-1',
@@ -786,6 +803,39 @@ describe('Schedule', () => {
     expect(within(teamFilter).getByRole('option', { name: 'Vipers' })).toBeTruthy();
     expect((teamFilter as HTMLSelectElement).value).toBe('team-owned');
     expect(await screen.findByText(/Calendar feeds and imports for Vipers/)).toBeTruthy();
+  });
+
+  it('uses fresh staff scope when the cached event summary predates a newly created team', async () => {
+    scheduleServiceMocks.loadParentScheduleScope.mockResolvedValueOnce({
+      profile: {},
+      children: [],
+      staffTeams: [
+        { teamId: 'team-parent', teamName: 'Jr KC Current' },
+        { teamId: 'team-owned', teamName: 'Vipers' }
+      ]
+    });
+    appDataCacheMocks.loadCachedAppData.mockResolvedValueOnce({
+      children: [{
+        playerId: 'player-1',
+        playerName: 'Madison Snider',
+        teamId: 'team-parent',
+        teamName: 'Jr KC Current'
+      }],
+      events: [buildScheduleEvent(1, {
+        teamId: 'team-parent',
+        teamName: 'Jr KC Current',
+        isTeamStaff: true
+      })],
+      staffTeams: [{ teamId: 'team-parent', teamName: 'Jr KC Current' }]
+    });
+
+    renderSchedule('/schedule?teamId=team-owned');
+
+    expect((await screen.findByLabelText('Team filter') as HTMLSelectElement).value).toBe('team-owned');
+    fireEvent.click(await screen.findByRole('button', { name: /manage schedule/i }));
+
+    expect((await screen.findByLabelText('Team to manage') as HTMLSelectElement).value).toBe('team-owned');
+    expect(await screen.findByRole('heading', { name: 'Add game for Vipers' })).toBeTruthy();
   });
 
   it('routes generic staff card opens to the game hub helper on mobile', () => {

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -373,25 +373,17 @@ export function Schedule({ auth }: { auth: AuthState }) {
     const scheduleCacheTtlMs = 60 * 1000 * 5;
     const scheduleCacheOptions = { ttlMs: scheduleCacheTtlMs, force };
     const cached = getCachedAppData(cacheKey);
+    const parentScopePromise = loadParentScheduleScope(auth.user).catch(() => null);
 
     return runScheduleRead(
-      async () => {
-        const parentScopePromise = loadParentScheduleScope(auth.user).catch(() => null);
-        const result = await loadCachedAppData(
+      () => loadCachedAppData(
           cacheKey,
-          async () => {
-            const parentScope = await parentScopePromise;
-            return loadParentSchedule(auth.user, {
-              hydrateDetails: false,
-              expandStaffPlayers: false,
-              ...(parentScope ? { parentScope } : {})
-            });
-          },
+          () => loadParentSchedule(auth.user, { hydrateDetails: false, expandStaffPlayers: false }),
           {
             ...scheduleCacheOptions,
             shouldCache: (loadedResult) => loadedResult?.isPartial !== true
           }
-        );
+        ).then(async (result) => {
         const parentScope = await parentScopePromise;
         return {
           ...result,
@@ -400,7 +392,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
           // newly created team can be edited immediately.
           staffTeams: parentScope?.staffTeams ?? result.staffTeams ?? []
         };
-      },
+      }),
       {
         getErrorMessage: (loadError) => {
           return getScheduleLoadErrorMessage(toAppServiceError(loadError, 'Unable to load schedule.'), hasExistingSchedule);

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -375,8 +375,10 @@ export function Schedule({ auth }: { auth: AuthState }) {
     const cached = getCachedAppData(cacheKey);
     const requestedUserId = auth.user.uid;
     let refreshedStaffTeams: ParentScheduleStaffTeam[] | null = null;
-    void loadParentScheduleScope(auth.user)
+    const parentScopePromise = loadParentScheduleScope(auth.user).catch(() => null);
+    void parentScopePromise
       .then((parentScope) => {
+        if (!parentScope || parentScope.isPartial === true) return;
         refreshedStaffTeams = parentScope.staffTeams ?? [];
         if (auth.user?.uid === requestedUserId) {
           setStaffTeams(refreshedStaffTeams);
@@ -390,16 +392,19 @@ export function Schedule({ auth }: { auth: AuthState }) {
             setSelectedTeamId('');
           }
         }
-      })
-      .catch(() => {
-        // A cached schedule remains useful offline; keep its last known staff
-        // scope when the background access refresh is unavailable.
       });
 
     return runScheduleRead(
       () => loadCachedAppData(
           cacheKey,
-          () => loadParentSchedule(auth.user, { hydrateDetails: false, expandStaffPlayers: false }),
+          async () => {
+            const parentScope = await parentScopePromise;
+            return loadParentSchedule(auth.user, {
+              hydrateDetails: false,
+              expandStaffPlayers: false,
+              ...(parentScope && parentScope.isPartial !== true ? { parentScope } : {})
+            });
+          },
           {
             ...scheduleCacheOptions,
             shouldCache: (loadedResult) => loadedResult?.isPartial !== true

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -121,6 +121,17 @@ function getScheduleTimeRangeFromQuery(value: string | null): ScheduleTimeRange 
   return scheduleTimeRangeValues.includes(normalized as ScheduleTimeRange) ? normalized as ScheduleTimeRange : null;
 }
 
+function applyAuthoritativeStaffScope(
+  events: ParentScheduleEvent[],
+  staffTeams: ParentScheduleStaffTeam[]
+) {
+  const staffTeamIds = new Set(staffTeams.map((team) => team.teamId));
+  return events.map((event) => {
+    const isTeamStaff = staffTeamIds.has(event.teamId);
+    return event.isTeamStaff === isTeamStaff ? event : { ...event, isTeamStaff };
+  });
+}
+
 export function Schedule({ auth }: { auth: AuthState }) {
   const [searchParams] = useSearchParams();
   const { isDesktopWeb } = useShellLayout();
@@ -164,6 +175,8 @@ export function Schedule({ auth }: { auth: AuthState }) {
   const pastHistoryLoadedRef = useRef(false);
   const childrenRef = useRef<ParentScheduleChild[]>([]);
   const eventsRef = useRef<ParentScheduleEvent[]>([]);
+  const activeUserIdRef = useRef<string | null>(auth.user?.uid || null);
+  activeUserIdRef.current = auth.user?.uid || null;
   const rsvpHydrationVersionRef = useRef(0);
   const lastRsvpHydrationScopeRef = useRef('');
   const bulkRsvpQueryHandledRef = useRef(false);
@@ -379,18 +392,18 @@ export function Schedule({ auth }: { auth: AuthState }) {
     void parentScopePromise
       .then((parentScope) => {
         if (!parentScope || parentScope.isPartial === true) return;
+        if (activeUserIdRef.current !== requestedUserId) return;
         refreshedStaffTeams = parentScope.staffTeams ?? [];
-        if (auth.user?.uid === requestedUserId) {
-          setStaffTeams(refreshedStaffTeams);
-          if (
-            hasLoadedScheduleRef.current
-            && selectedTeamId
-            && !childrenRef.current.some((child) => child.teamId === selectedTeamId)
-            && !eventsRef.current.some((event) => event.teamId === selectedTeamId)
-            && !refreshedStaffTeams.some((team) => team.teamId === selectedTeamId)
-          ) {
-            setSelectedTeamId('');
-          }
+        setStaffTeams(refreshedStaffTeams);
+        updateScheduleEvents((currentEvents) => applyAuthoritativeStaffScope(currentEvents, refreshedStaffTeams!));
+        if (
+          hasLoadedScheduleRef.current
+          && selectedTeamId
+          && !childrenRef.current.some((child) => child.teamId === selectedTeamId)
+          && !eventsRef.current.some((event) => event.teamId === selectedTeamId)
+          && !refreshedStaffTeams.some((team) => team.teamId === selectedTeamId)
+        ) {
+          setSelectedTeamId('');
         }
       });
 
@@ -416,17 +429,19 @@ export function Schedule({ auth }: { auth: AuthState }) {
         },
         rethrow: false,
         onSuccess: (result) => {
+          if (activeUserIdRef.current !== requestedUserId) return;
+          const authoritativeResult = refreshedStaffTeams === null
+            ? result
+            : {
+                ...result,
+                events: applyAuthoritativeStaffScope(result.events, refreshedStaffTeams),
+                staffTeams: refreshedStaffTeams
+              };
           hasLoadedScheduleRef.current = true;
           setLoadedScheduleUserId(auth.user?.uid || null);
           setScheduleLoadError(null);
-          applyScheduleResult({
-            ...result,
-            // Team ownership and staff access can change while the event
-            // summary remains cacheable. Use a completed access refresh when
-            // available without holding up the cached Schedule shell.
-            staffTeams: refreshedStaffTeams ?? result.staffTeams ?? []
-          });
-          hydrateScheduleRsvpsInBackground(result);
+          applyScheduleResult(authoritativeResult);
+          hydrateScheduleRsvpsInBackground(authoritativeResult);
           completeParentCoreWorkflowTimer('schedule', {
             targetPage: 'schedule',
             teamId: selectedTeamId || '',
@@ -476,6 +491,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
           });
         },
         onError: (loadError) => {
+          if (activeUserIdRef.current !== requestedUserId) return;
           const mappedError = toAppServiceError(loadError, 'Unable to load schedule.');
           setScheduleLoadError(mappedError);
           if (!hasExistingSchedule) {

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -373,7 +373,28 @@ export function Schedule({ auth }: { auth: AuthState }) {
     const scheduleCacheTtlMs = 60 * 1000 * 5;
     const scheduleCacheOptions = { ttlMs: scheduleCacheTtlMs, force };
     const cached = getCachedAppData(cacheKey);
-    const parentScopePromise = loadParentScheduleScope(auth.user).catch(() => null);
+    const requestedUserId = auth.user.uid;
+    let refreshedStaffTeams: ParentScheduleStaffTeam[] | null = null;
+    void loadParentScheduleScope(auth.user)
+      .then((parentScope) => {
+        refreshedStaffTeams = parentScope.staffTeams ?? [];
+        if (auth.user?.uid === requestedUserId) {
+          setStaffTeams(refreshedStaffTeams);
+          if (
+            hasLoadedScheduleRef.current
+            && selectedTeamId
+            && !childrenRef.current.some((child) => child.teamId === selectedTeamId)
+            && !eventsRef.current.some((event) => event.teamId === selectedTeamId)
+            && !refreshedStaffTeams.some((team) => team.teamId === selectedTeamId)
+          ) {
+            setSelectedTeamId('');
+          }
+        }
+      })
+      .catch(() => {
+        // A cached schedule remains useful offline; keep its last known staff
+        // scope when the background access refresh is unavailable.
+      });
 
     return runScheduleRead(
       () => loadCachedAppData(
@@ -383,16 +404,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
             ...scheduleCacheOptions,
             shouldCache: (loadedResult) => loadedResult?.isPartial !== true
           }
-        ).then(async (result) => {
-        const parentScope = await parentScopePromise;
-        return {
-          ...result,
-          // Team ownership and staff access can change while the event summary
-          // remains cacheable. Keep management targets authoritative so a
-          // newly created team can be edited immediately.
-          staffTeams: parentScope?.staffTeams ?? result.staffTeams ?? []
-        };
-      }),
+        ),
       {
         getErrorMessage: (loadError) => {
           return getScheduleLoadErrorMessage(toAppServiceError(loadError, 'Unable to load schedule.'), hasExistingSchedule);
@@ -402,7 +414,13 @@ export function Schedule({ auth }: { auth: AuthState }) {
           hasLoadedScheduleRef.current = true;
           setLoadedScheduleUserId(auth.user?.uid || null);
           setScheduleLoadError(null);
-          applyScheduleResult(result);
+          applyScheduleResult({
+            ...result,
+            // Team ownership and staff access can change while the event
+            // summary remains cacheable. Use a completed access refresh when
+            // available without holding up the cached Schedule shell.
+            staffTeams: refreshedStaffTeams ?? result.staffTeams ?? []
+          });
           hydrateScheduleRsvpsInBackground(result);
           completeParentCoreWorkflowTimer('schedule', {
             targetPage: 'schedule',
@@ -425,9 +443,10 @@ export function Schedule({ auth }: { auth: AuthState }) {
           }
           if (
             selectedTeamId
+            && refreshedStaffTeams !== null
             && !result.children.some((child) => child.teamId === selectedTeamId)
             && !result.events.some((event) => event.teamId === selectedTeamId)
-            && !result.staffTeams?.some((team) => team.teamId === selectedTeamId)
+            && !refreshedStaffTeams.some((team) => team.teamId === selectedTeamId)
           ) {
             setSelectedTeamId('');
           }

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -121,15 +121,22 @@ function getScheduleTimeRangeFromQuery(value: string | null): ScheduleTimeRange 
   return scheduleTimeRangeValues.includes(normalized as ScheduleTimeRange) ? normalized as ScheduleTimeRange : null;
 }
 
-function applyAuthoritativeStaffScope(
+function applyAuthoritativeScheduleScope(
   events: ParentScheduleEvent[],
+  children: ParentScheduleChild[],
   staffTeams: ParentScheduleStaffTeam[]
 ) {
+  const accessibleTeamIds = new Set([
+    ...children.map((child) => child.teamId),
+    ...staffTeams.map((team) => team.teamId)
+  ]);
   const staffTeamIds = new Set(staffTeams.map((team) => team.teamId));
-  return events.map((event) => {
-    const isTeamStaff = staffTeamIds.has(event.teamId);
-    return event.isTeamStaff === isTeamStaff ? event : { ...event, isTeamStaff };
-  });
+  return events
+    .filter((event) => accessibleTeamIds.has(event.teamId))
+    .map((event) => {
+      const isTeamStaff = staffTeamIds.has(event.teamId);
+      return event.isTeamStaff === isTeamStaff ? event : { ...event, isTeamStaff };
+    });
 }
 
 export function Schedule({ auth }: { auth: AuthState }) {
@@ -389,6 +396,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
     const cached = getCachedAppData(cacheKey);
     const requestedUserId = auth.user.uid;
     const refreshVersion = ++scheduleRefreshVersionRef.current;
+    let refreshedChildren: ParentScheduleChild[] | null = null;
     let refreshedStaffTeams: ParentScheduleStaffTeam[] | null = null;
     const parentScopePromise = loadParentScheduleScope(auth.user).catch(() => null);
     void parentScopePromise
@@ -396,13 +404,20 @@ export function Schedule({ auth }: { auth: AuthState }) {
         if (!parentScope || parentScope.isPartial === true) return;
         if (activeUserIdRef.current !== requestedUserId) return;
         if (scheduleRefreshVersionRef.current !== refreshVersion) return;
+        refreshedChildren = parentScope.children ?? [];
         refreshedStaffTeams = parentScope.staffTeams ?? [];
+        childrenRef.current = refreshedChildren;
+        setChildren(refreshedChildren);
         setStaffTeams(refreshedStaffTeams);
-        updateScheduleEvents((currentEvents) => applyAuthoritativeStaffScope(currentEvents, refreshedStaffTeams!));
+        updateScheduleEvents((currentEvents) => applyAuthoritativeScheduleScope(
+          currentEvents,
+          refreshedChildren!,
+          refreshedStaffTeams!
+        ));
         if (
           hasLoadedScheduleRef.current
           && selectedTeamId
-          && !childrenRef.current.some((child) => child.teamId === selectedTeamId)
+          && !refreshedChildren.some((child) => child.teamId === selectedTeamId)
           && !eventsRef.current.some((event) => event.teamId === selectedTeamId)
           && !refreshedStaffTeams.some((team) => team.teamId === selectedTeamId)
         ) {
@@ -438,7 +453,8 @@ export function Schedule({ auth }: { auth: AuthState }) {
             ? result
             : {
                 ...result,
-                events: applyAuthoritativeStaffScope(result.events, refreshedStaffTeams),
+                children: refreshedChildren!,
+                events: applyAuthoritativeScheduleScope(result.events, refreshedChildren!, refreshedStaffTeams),
                 staffTeams: refreshedStaffTeams
               };
           hasLoadedScheduleRef.current = true;
@@ -462,14 +478,14 @@ export function Schedule({ auth }: { auth: AuthState }) {
             void ensurePastSchedulePageLoaded(true);
           }
 
-          if (selectedPlayerId && !result.children.some((child) => child.playerId === selectedPlayerId)) {
+          if (selectedPlayerId && !authoritativeResult.children.some((child) => child.playerId === selectedPlayerId)) {
             setSelectedPlayerId('');
           }
           if (
             selectedTeamId
             && refreshedStaffTeams !== null
-            && !result.children.some((child) => child.teamId === selectedTeamId)
-            && !result.events.some((event) => event.teamId === selectedTeamId)
+            && !authoritativeResult.children.some((child) => child.teamId === selectedTeamId)
+            && !authoritativeResult.events.some((event) => event.teamId === selectedTeamId)
             && !refreshedStaffTeams.some((team) => team.teamId === selectedTeamId)
           ) {
             setSelectedTeamId('');

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -176,6 +176,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
   const childrenRef = useRef<ParentScheduleChild[]>([]);
   const eventsRef = useRef<ParentScheduleEvent[]>([]);
   const activeUserIdRef = useRef<string | null>(auth.user?.uid || null);
+  const scheduleRefreshVersionRef = useRef(0);
   activeUserIdRef.current = auth.user?.uid || null;
   const rsvpHydrationVersionRef = useRef(0);
   const lastRsvpHydrationScopeRef = useRef('');
@@ -387,12 +388,14 @@ export function Schedule({ auth }: { auth: AuthState }) {
     const scheduleCacheOptions = { ttlMs: scheduleCacheTtlMs, force };
     const cached = getCachedAppData(cacheKey);
     const requestedUserId = auth.user.uid;
+    const refreshVersion = ++scheduleRefreshVersionRef.current;
     let refreshedStaffTeams: ParentScheduleStaffTeam[] | null = null;
     const parentScopePromise = loadParentScheduleScope(auth.user).catch(() => null);
     void parentScopePromise
       .then((parentScope) => {
         if (!parentScope || parentScope.isPartial === true) return;
         if (activeUserIdRef.current !== requestedUserId) return;
+        if (scheduleRefreshVersionRef.current !== refreshVersion) return;
         refreshedStaffTeams = parentScope.staffTeams ?? [];
         setStaffTeams(refreshedStaffTeams);
         updateScheduleEvents((currentEvents) => applyAuthoritativeStaffScope(currentEvents, refreshedStaffTeams!));
@@ -430,6 +433,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
         rethrow: false,
         onSuccess: (result) => {
           if (activeUserIdRef.current !== requestedUserId) return;
+          if (scheduleRefreshVersionRef.current !== refreshVersion) return;
           const authoritativeResult = refreshedStaffTeams === null
             ? result
             : {
@@ -492,6 +496,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
         },
         onError: (loadError) => {
           if (activeUserIdRef.current !== requestedUserId) return;
+          if (scheduleRefreshVersionRef.current !== refreshVersion) return;
           const mappedError = toAppServiceError(loadError, 'Unable to load schedule.');
           setScheduleLoadError(mappedError);
           if (!hasExistingSchedule) {

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -7,6 +7,7 @@ import { PullToRefresh } from '../components/PullToRefresh';
 import {
   hydrateParentScheduleRsvps,
   loadParentSchedule,
+  loadParentScheduleScope,
   submitParentScheduleRsvp,
   submitParentScheduleRsvpForChildren,
   type ParentScheduleChild,
@@ -374,14 +375,32 @@ export function Schedule({ auth }: { auth: AuthState }) {
     const cached = getCachedAppData(cacheKey);
 
     return runScheduleRead(
-      () => loadCachedAppData(
-        cacheKey,
-        () => loadParentSchedule(auth.user, { hydrateDetails: false, expandStaffPlayers: false }),
-        {
-          ...scheduleCacheOptions,
-          shouldCache: (result) => result?.isPartial !== true
-        }
-      ),
+      async () => {
+        const parentScopePromise = loadParentScheduleScope(auth.user).catch(() => null);
+        const result = await loadCachedAppData(
+          cacheKey,
+          async () => {
+            const parentScope = await parentScopePromise;
+            return loadParentSchedule(auth.user, {
+              hydrateDetails: false,
+              expandStaffPlayers: false,
+              ...(parentScope ? { parentScope } : {})
+            });
+          },
+          {
+            ...scheduleCacheOptions,
+            shouldCache: (loadedResult) => loadedResult?.isPartial !== true
+          }
+        );
+        const parentScope = await parentScopePromise;
+        return {
+          ...result,
+          // Team ownership and staff access can change while the event summary
+          // remains cacheable. Keep management targets authoritative so a
+          // newly created team can be edited immediately.
+          staffTeams: parentScope?.staffTeams ?? result.staffTeams ?? []
+        };
+      },
       {
         getErrorMessage: (loadError) => {
           return getScheduleLoadErrorMessage(toAppServiceError(loadError, 'Unable to load schedule.'), hasExistingSchedule);

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -538,6 +538,10 @@ async function mockHomePlayerModules(page) {
                     return { children, events: scheduleEvents(), isPartial: false };
                 }
 
+                export async function loadParentScheduleScope() {
+                    return { profile: {}, children, staffTeams: [] };
+                }
+
                 export async function hydrateParentScheduleRsvps(schedule, _user, options = {}) {
                     options.onProgress?.([...schedule.events]);
                     return schedule;

--- a/tests/smoke/app-performance-timers.spec.js
+++ b/tests/smoke/app-performance-timers.spec.js
@@ -167,6 +167,14 @@ async function mockScheduleAppModules(page) {
                     };
                 }
 
+                export async function loadParentScheduleScope() {
+                    return {
+                        profile: {},
+                        children: [{ teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Avery' }],
+                        staffTeams: [{ teamId: 'team-1', teamName: 'Bears' }]
+                    };
+                }
+
                 export async function hydrateParentScheduleRsvps(schedule, _user, options = {}) {
                     options.onProgress?.([...schedule.events]);
                     return schedule;

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -529,6 +529,9 @@ async function mockScheduleModules(page, options = {}) {
                     return {
                         profile: { uid: user?.uid || 'user-1' },
                         children: await loadParentScheduleChildren(),
+                        staffTeams: ${staffManageable
+                          ? "[{ teamId: 'team-1', teamName: 'Bears' }]"
+                          : '[]'},
                         isPartial: false
                     };
                 }

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -528,7 +528,8 @@ async function mockScheduleModules(page, options = {}) {
                 export async function loadParentScheduleScope(user) {
                     return {
                         profile: { uid: user?.uid || 'user-1' },
-                        children: await loadParentScheduleChildren()
+                        children: await loadParentScheduleChildren(),
+                        isPartial: false
                     };
                 }
 

--- a/tests/unit/app-schedule-async-operation-contract.test.js
+++ b/tests/unit/app-schedule-async-operation-contract.test.js
@@ -25,7 +25,9 @@ describe('Schedule async operation contract', () => {
         expect(scheduleSource).toContain('run: runPastHistoryRead');
         expect(refreshScheduleSource).toContain('return runScheduleRead(');
         expect(refreshScheduleSource).toContain('() => loadCachedAppData(');
-        expect(refreshScheduleSource).toContain('() => loadParentSchedule(auth.user, { hydrateDetails: false, expandStaffPlayers: false })');
+        expect(refreshScheduleSource).toContain('const parentScope = await parentScopePromise;');
+        expect(refreshScheduleSource).toContain('return loadParentSchedule(auth.user, {');
+        expect(refreshScheduleSource).toContain('...(parentScope && parentScope.isPartial !== true ? { parentScope } : {})');
         expect(refreshScheduleSource).toContain('{ ttlMs: scheduleCacheTtlMs, force }');
         expect(refreshScheduleSource).not.toContain('setLoading(');
     });

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -237,7 +237,8 @@ beforeEach(() => {
     scheduleMocks.loadParentScheduleScope.mockResolvedValue({
         profile: {},
         children: [],
-        staffTeams: []
+        staffTeams: [],
+        isPartial: true
     });
     scheduleMocks.loadScheduleStatTrackerConfigsForApp.mockResolvedValue([{ id: 'cfg-basketball', name: 'Basketball' }]);
     scheduleMocks.removeTeamCalendarUrl.mockResolvedValue({ removed: true, calendarUrls: [] });

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -13,6 +13,7 @@ const scheduleMocks = vi.hoisted(() => ({
     createScheduleImportPractice: vi.fn(),
     finalizeScheduleImportBatch: vi.fn(),
     loadParentSchedule: vi.fn(),
+    loadParentScheduleScope: vi.fn(),
     loadScheduleStatTrackerConfigsForApp: vi.fn(),
     removeTeamCalendarUrl: vi.fn(),
     generateScheduleAiImportRows: vi.fn(),
@@ -233,6 +234,11 @@ beforeEach(() => {
     scheduleMocks.createScheduleImportGame.mockResolvedValue('game-new');
     scheduleMocks.createScheduleImportPractice.mockResolvedValue('practice-new');
     scheduleMocks.finalizeScheduleImportBatch.mockResolvedValue(undefined);
+    scheduleMocks.loadParentScheduleScope.mockResolvedValue({
+        profile: {},
+        children: [],
+        staffTeams: []
+    });
     scheduleMocks.loadScheduleStatTrackerConfigsForApp.mockResolvedValue([{ id: 'cfg-basketball', name: 'Basketball' }]);
     scheduleMocks.removeTeamCalendarUrl.mockResolvedValue({ removed: true, calendarUrls: [] });
     scheduleMocks.generateScheduleAiImportRows.mockResolvedValue({ rows: [], errors: [] });

--- a/tests/unit/app-schedule-lazy-load.test.tsx
+++ b/tests/unit/app-schedule-lazy-load.test.tsx
@@ -37,7 +37,8 @@ describe('Schedule lazy-load guards', () => {
         expect(refreshSource).toContain("() => loadParentSchedule(auth.user, { hydrateDetails: false, expandStaffPlayers: false })");
         expect(refreshSource).toContain("getScheduleLoadErrorMessage(toAppServiceError(loadError, 'Unable to load schedule.'), hasExistingSchedule)");
         expect(refreshSource).toContain('onSuccess: (result) => {');
-        expect(refreshSource).toContain('applyScheduleResult(result);');
+        expect(refreshSource).toContain('applyScheduleResult({');
+        expect(refreshSource).toContain('staffTeams: refreshedStaffTeams ?? result.staffTeams ?? []');
         expect(refreshSource).toContain('cacheHit: Boolean(cached) && !force');
         expect(refreshSource).toContain('onError: (loadError) => {');
         expect(refreshSource).toContain("const mappedError = toAppServiceError(loadError, 'Unable to load schedule.');");

--- a/tests/unit/app-schedule-lazy-load.test.tsx
+++ b/tests/unit/app-schedule-lazy-load.test.tsx
@@ -39,7 +39,8 @@ describe('Schedule lazy-load guards', () => {
         expect(refreshSource).toContain('...(parentScope && parentScope.isPartial !== true ? { parentScope } : {})');
         expect(refreshSource).toContain("getScheduleLoadErrorMessage(toAppServiceError(loadError, 'Unable to load schedule.'), hasExistingSchedule)");
         expect(refreshSource).toContain('onSuccess: (result) => {');
-        expect(refreshSource).toContain('events: applyAuthoritativeStaffScope(result.events, refreshedStaffTeams)');
+        expect(refreshSource).toContain('children: refreshedChildren!');
+        expect(refreshSource).toContain('events: applyAuthoritativeScheduleScope(result.events, refreshedChildren!, refreshedStaffTeams)');
         expect(refreshSource).toContain('applyScheduleResult(authoritativeResult);');
         expect(refreshSource).toContain('cacheHit: Boolean(cached) && !force');
         expect(refreshSource).toContain('onError: (loadError) => {');

--- a/tests/unit/app-schedule-lazy-load.test.tsx
+++ b/tests/unit/app-schedule-lazy-load.test.tsx
@@ -34,7 +34,9 @@ describe('Schedule lazy-load guards', () => {
         expect(refreshSource).toContain('const cached = getCachedAppData(cacheKey);');
         expect(refreshSource).toContain('return runScheduleRead(');
         expect(refreshSource).toContain('() => loadCachedAppData(');
-        expect(refreshSource).toContain("() => loadParentSchedule(auth.user, { hydrateDetails: false, expandStaffPlayers: false })");
+        expect(refreshSource).toContain('const parentScope = await parentScopePromise;');
+        expect(refreshSource).toContain('return loadParentSchedule(auth.user, {');
+        expect(refreshSource).toContain('...(parentScope && parentScope.isPartial !== true ? { parentScope } : {})');
         expect(refreshSource).toContain("getScheduleLoadErrorMessage(toAppServiceError(loadError, 'Unable to load schedule.'), hasExistingSchedule)");
         expect(refreshSource).toContain('onSuccess: (result) => {');
         expect(refreshSource).toContain('applyScheduleResult({');

--- a/tests/unit/app-schedule-lazy-load.test.tsx
+++ b/tests/unit/app-schedule-lazy-load.test.tsx
@@ -39,8 +39,8 @@ describe('Schedule lazy-load guards', () => {
         expect(refreshSource).toContain('...(parentScope && parentScope.isPartial !== true ? { parentScope } : {})');
         expect(refreshSource).toContain("getScheduleLoadErrorMessage(toAppServiceError(loadError, 'Unable to load schedule.'), hasExistingSchedule)");
         expect(refreshSource).toContain('onSuccess: (result) => {');
-        expect(refreshSource).toContain('applyScheduleResult({');
-        expect(refreshSource).toContain('staffTeams: refreshedStaffTeams ?? result.staffTeams ?? []');
+        expect(refreshSource).toContain('events: applyAuthoritativeStaffScope(result.events, refreshedStaffTeams)');
+        expect(refreshSource).toContain('applyScheduleResult(authoritativeResult);');
         expect(refreshSource).toContain('cacheHit: Boolean(cached) && !force');
         expect(refreshSource).toContain('onError: (loadError) => {');
         expect(refreshSource).toContain("const mappedError = toAppServiceError(loadError, 'Unable to load schedule.');");


### PR DESCRIPTION
## What changed
- refresh staff-team access separately from the cached event summary
- keep the schedule editor synchronized with the selected team and expose a team switcher for multi-team coaches
- preserve the current team when Schedule is opened from a team page

## Root cause
The event summary cache also carried the staff-team list. After a team was created, the visible filter and management tools could resolve from different scopes, causing Vipers to display while edits still targeted Jr KC Current.

## Validation
- npm --prefix apps/app test -- --run src/pages/Schedule.test.tsx src/components/AppShell.test.tsx --reporter=dot (100 tests)
- npm run app:build