### PR TITLE
Stabilize ChatGPT OAuth client registration

### DIFF
--- a/services/chatgpt-mcp/README.md
+++ b/services/chatgpt-mcp/README.md
@@ -23,11 +23,14 @@ cd services/chatgpt-mcp
 npm install
 FIREBASE_PROJECT_ID=your-project-id \
 FIREBASE_WEB_API_KEY=your-web-api-key \
+CHATGPT_OAUTH_CLIENT_ID=allplays-chatgpt-connector \
 npm start           # listens on :8787, endpoint POST /mcp
 ```
 
 `FIREBASE_PROJECT_ID` and `FIREBASE_WEB_API_KEY` are required; the service
-exits at startup when either is missing.
+exits at startup when either is missing. `CHATGPT_OAUTH_CLIENT_ID` identifies
+the trusted public ChatGPT client and defaults to `allplays-chatgpt-connector`;
+set the same value on every broker instance.
 
 Get a bearer token (prints your refresh token):
 
@@ -69,8 +72,10 @@ Ask: "What does my family have this weekend?" — ChatGPT should call
 dynamic client registration, authorization code + PKCE (S256 only), refresh
 grant, and opaque access tokens that map to the signed-in user's Firebase
 refresh token. Codes are single-use with a 10-minute TTL; access tokens last
-1 hour. Storage is in-memory — restart logs everyone out; Firestore-backed
-storage is a prerequisite for multi-instance Cloud Run.
+1 hour. The trusted ChatGPT client registration is configuration-backed and
+stable across instances. Authorization codes and tokens remain in-memory, so
+a restart logs everyone out; Firestore-backed grant storage is still required
+for complete multi-instance Cloud Run support.
 
 Sign-in accepts AllPlays email/password (proxied to Firebase Identity Toolkit
 with the site referer; the password is never stored). Google sign-in is a

--- a/services/chatgpt-mcp/src/oauth.js
+++ b/services/chatgpt-mcp/src/oauth.js
@@ -16,6 +16,7 @@ const CODE_TTL_MS = 10 * 60 * 1000;
 const ACCESS_TOKEN_TTL_MS = 60 * 60 * 1000;
 const REFRESH_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const MAX_STORED_GRANTS = 1000;
+const DEFAULT_TRUSTED_CLIENT_ID = 'allplays-chatgpt-connector';
 const TRUSTED_REDIRECT_URIS = new Set([
     'https://chatgpt.com/connector_platform_oauth_redirect'
 ]);
@@ -39,12 +40,19 @@ function isAllowedRedirectUri(uri) {
 export function createOAuthBroker({
     now = () => Date.now(),
     randomId = (bytes = 32) => randomBytes(bytes).toString('base64url'),
-    maxStoredGrants = MAX_STORED_GRANTS
+    maxStoredGrants = MAX_STORED_GRANTS,
+    trustedClientId = DEFAULT_TRUSTED_CLIENT_ID
 } = {}) {
     if (!Number.isInteger(maxStoredGrants) || maxStoredGrants < 1) {
         throw new Error('maxStoredGrants must be a positive integer.');
     }
-    let registeredClient = null;
+    if (typeof trustedClientId !== 'string' || !trustedClientId.trim()) {
+        throw new Error('trustedClientId must be a non-empty string.');
+    }
+    const registeredClient = {
+        clientId: trustedClientId.trim(),
+        redirectUris: [...TRUSTED_REDIRECT_URIS]
+    };
     const codes = new Map();
     const accessTokens = new Map();
     const refreshTokens = new Map();
@@ -63,22 +71,15 @@ export function createOAuthBroker({
         store.set(key, record);
     }
 
-    function registerClient({ redirect_uris: redirectUris, client_name: clientName } = {}) {
+    function registerClient({ redirect_uris: redirectUris } = {}) {
         if (!Array.isArray(redirectUris) || redirectUris.length === 0) {
             throw new OAuthError('invalid_request', 'redirect_uris is required.');
         }
         if (!redirectUris.every(isAllowedRedirectUri)) {
             throw new OAuthError('invalid_request', 'redirect_uris must use an approved ChatGPT callback.');
         }
-        // This broker only serves one trusted public client. Reusing its ID keeps
-        // unauthenticated dynamic registration from growing server memory.
-        if (!registeredClient) {
-            registeredClient = {
-                clientId: randomId(16),
-                redirectUris: [...new Set(redirectUris)],
-                clientName: typeof clientName === 'string' ? clientName : ''
-            };
-        }
+        // This broker only serves one trusted public client. Its configured ID
+        // is stable across instances.
         return {
             client_id: registeredClient.clientId,
             redirect_uris: registeredClient.redirectUris,
@@ -89,7 +90,7 @@ export function createOAuthBroker({
     }
 
     function validateAuthorizeRequest({ client_id: clientId, redirect_uri: redirectUri, response_type: responseType, code_challenge: codeChallenge, code_challenge_method: method }) {
-        if (!registeredClient || clientId !== registeredClient.clientId) {
+        if (clientId !== registeredClient.clientId) {
             throw new OAuthError('invalid_client', 'Unknown client_id.');
         }
         if (!registeredClient.redirectUris.includes(redirectUri)) {

--- a/services/chatgpt-mcp/src/server.js
+++ b/services/chatgpt-mcp/src/server.js
@@ -48,7 +48,9 @@ if (FALLBACK_BEARER) {
     console.warn('[chatgpt-mcp] DEV_FALLBACK_BEARER is set: unauthenticated requests act as that user. Dev/test only.');
 }
 
-const oauth = createOAuthBroker();
+const oauth = createOAuthBroker({
+    trustedClientId: process.env.CHATGPT_OAUTH_CLIENT_ID
+});
 const SIGNIN_REFERER = process.env.ALLPLAYS_REFERER || 'https://allplays.ai/';
 
 // Public base URL for OAuth metadata: env override, else derive from the

--- a/tests/unit/chatgpt-mcp-oauth.test.js
+++ b/tests/unit/chatgpt-mcp-oauth.test.js
@@ -33,6 +33,36 @@ describe('chatgpt-mcp oauth: registration', () => {
         expect(client.token_endpoint_auth_method).toBe('none');
     });
 
+    it('uses one configured client registration across broker instances', () => {
+        const options = { trustedClientId: 'configured-chatgpt-client' };
+        const firstBroker = createOAuthBroker({
+            ...options,
+            randomId: () => 'instance-one-random-id'
+        });
+        const secondBroker = createOAuthBroker({
+            ...options,
+            randomId: () => 'instance-two-random-id'
+        });
+
+        const firstRegistration = firstBroker.registerClient({ redirect_uris: [REDIRECT] });
+        const secondRegistration = secondBroker.registerClient({ redirect_uris: [REDIRECT] });
+
+        expect(firstRegistration.client_id).toBe('configured-chatgpt-client');
+        expect(secondRegistration.client_id).toBe(firstRegistration.client_id);
+
+        const freshBroker = createOAuthBroker(options);
+        expect(freshBroker.validateAuthorizeRequest({
+            client_id: firstRegistration.client_id,
+            redirect_uri: REDIRECT,
+            response_type: 'code',
+            code_challenge: s256Challenge(VERIFIER),
+            code_challenge_method: 'S256'
+        })).toMatchObject({
+            clientId: 'configured-chatgpt-client',
+            redirectUri: REDIRECT
+        });
+    });
+
     it('rejects untrusted redirect uris regardless of scheme', () => {
         const broker = createOAuthBroker();
         expect(() => broker.registerClient({ redirect_uris: ['https://evil.example/cb'] })).toThrow(OAuthError);


### PR DESCRIPTION
Closes #4158

## What changed
- Initialize the trusted ChatGPT OAuth client from `CHATGPT_OAUTH_CLIENT_ID`, with a stable default.
- Recognize the configured client on every broker instance without prior local registration.
- Document configuration and the remaining process-local grant limitation.

## Root Cause
The trusted client ID was randomly generated during the first registration and retained only in process memory. Other broker instances generated different IDs and rejected authorization requests as `invalid_client`.

## Prevention / Learning
Shared public OAuth registrations must use deterministic, startup-initialized configuration. Process-local randomness should be limited to ephemeral authorization codes and tokens.

## Regression Tests
- Added independent-broker coverage proving registration returns the same configured client ID despite different random generators.
- Added fresh-instance authorization validation using that client ID.
- Existing coverage confirms unapproved redirect URIs remain rejected.
- `npx vitest run tests/unit/chatgpt-mcp-oauth.test.js --reporter=verbose` passes 16 tests.
- `git diff --check` passes.

## Recurrence Risk
Low. Focused tests enforce stable cross-instance registration and authorization while retaining callback allowlist validation.