### PR TITLE
Recognize legacy team owners in web schedules

### DIFF
--- a/apps/app/src/lib/adapters/legacyScheduleDb.test.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.test.ts
@@ -304,6 +304,46 @@ describe('legacyScheduleDb staff team reads', () => {
         expect(getDoc).not.toHaveBeenCalled();
     });
 
+    it('keeps UID and admin teams when the normalized legacy owner query is denied', async () => {
+        vi.mocked(getDocs)
+            .mockResolvedValueOnce({ docs: [snapshot('team-owner', { name: 'Owner' })] } as never)
+            .mockResolvedValueOnce({ docs: [snapshot('team-admin', { name: 'Admin' })] } as never)
+            .mockRejectedValueOnce(new Error('ownerEmailLower denied'))
+            .mockResolvedValueOnce({ docs: [] } as never);
+
+        await expect(getStaffTeams({
+            userId: 'user-1',
+            email: 'staff@example.com',
+            coachTeamIds: []
+        })).resolves.toEqual({
+            teams: [
+                { id: 'team-owner', name: 'Owner' },
+                { id: 'team-admin', name: 'Admin' }
+            ],
+            isPartial: true
+        });
+    });
+
+    it('keeps UID and admin teams when a legacy ownerEmail query is denied', async () => {
+        vi.mocked(getDocs)
+            .mockResolvedValueOnce({ docs: [snapshot('team-owner', { name: 'Owner' })] } as never)
+            .mockResolvedValueOnce({ docs: [snapshot('team-admin', { name: 'Admin' })] } as never)
+            .mockResolvedValueOnce({ docs: [] } as never)
+            .mockRejectedValueOnce(new Error('ownerEmail denied'));
+
+        await expect(getStaffTeams({
+            userId: 'user-1',
+            email: 'staff@example.com',
+            coachTeamIds: []
+        })).resolves.toEqual({
+            teams: [
+                { id: 'team-owner', name: 'Owner' },
+                { id: 'team-admin', name: 'Admin' }
+            ],
+            isPartial: true
+        });
+    });
+
     it('propagates owner and admin query failures so native callers can use the REST fallback', async () => {
         const queryError = new Error('web sdk unavailable');
         vi.mocked(getDocs).mockRejectedValueOnce(queryError);

--- a/apps/app/src/lib/adapters/legacyScheduleDb.test.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.test.ts
@@ -251,10 +251,13 @@ describe('legacyScheduleDb staff team reads', () => {
         vi.mocked(doc).mockImplementation((...parts: unknown[]) => ({ path: parts.filter((part) => typeof part === 'string').join('/') }) as never);
     });
 
-    it('merges owner, normalized admin email, and unique coach team reads without a catalog load', async () => {
+    it('merges owner id, legacy owner email, normalized admin email, and unique coach team reads without a catalog load', async () => {
         vi.mocked(getDocs)
             .mockResolvedValueOnce({ docs: [snapshot('team-owner', { name: 'Owner' }), snapshot('team-shared', { name: 'Owner copy' })] } as never)
-            .mockResolvedValueOnce({ docs: [snapshot('team-admin', { name: 'Admin' }), snapshot('team-shared', { name: 'Admin copy' })] } as never);
+            .mockResolvedValueOnce({ docs: [snapshot('team-admin', { name: 'Admin' }), snapshot('team-shared', { name: 'Admin copy' })] } as never)
+            .mockResolvedValueOnce({ docs: [snapshot('team-owner-email-lower', { name: 'Legacy normalized owner' })] } as never)
+            .mockResolvedValueOnce({ docs: [snapshot('team-owner-email', { name: 'Legacy owner' })] } as never)
+            .mockResolvedValueOnce({ docs: [snapshot('team-owner-email-normalized', { name: 'Legacy normalized owner copy' })] } as never);
         vi.mocked(getDoc)
             .mockResolvedValueOnce(snapshot('team-coach', { name: 'Coach' }) as never)
             .mockRejectedValueOnce(new Error('Missing or insufficient permissions.'));
@@ -270,13 +273,19 @@ describe('legacyScheduleDb staff team reads', () => {
                 { id: 'team-owner', name: 'Owner' },
                 { id: 'team-shared', name: 'Admin copy' },
                 { id: 'team-admin', name: 'Admin' },
+                { id: 'team-owner-email-lower', name: 'Legacy normalized owner' },
+                { id: 'team-owner-email', name: 'Legacy owner' },
+                { id: 'team-owner-email-normalized', name: 'Legacy normalized owner copy' },
                 { id: 'team-coach', name: 'Coach' }
             ],
             isPartial: true
         });
-        expect(getDocs).toHaveBeenCalledTimes(2);
+        expect(getDocs).toHaveBeenCalledTimes(5);
         expect(where).toHaveBeenCalledWith('ownerId', '==', 'user-1');
         expect(where).toHaveBeenCalledWith('adminEmails', 'array-contains', 'staff@example.com');
+        expect(where).toHaveBeenCalledWith('ownerEmailLower', '==', 'staff@example.com');
+        expect(where).toHaveBeenCalledWith('ownerEmail', '==', 'STAFF@EXAMPLE.COM');
+        expect(where).toHaveBeenCalledWith('ownerEmail', '==', 'staff@example.com');
         expect(getDoc).toHaveBeenCalledTimes(2);
         expect(legacyGetTeams).not.toHaveBeenCalled();
     });
@@ -301,7 +310,7 @@ describe('legacyScheduleDb staff team reads', () => {
 
         await expect(getStaffTeams({ userId: 'coach-1', email: 'coach@example.com', coachTeamIds: [] })).rejects.toThrow('web sdk unavailable');
 
-        expect(getDocs).toHaveBeenCalledTimes(2);
+        expect(getDocs).toHaveBeenCalledTimes(4);
         expect(getDoc).not.toHaveBeenCalled();
     });
 });

--- a/apps/app/src/lib/adapters/legacyScheduleDb.test.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.test.ts
@@ -251,13 +251,10 @@ describe('legacyScheduleDb staff team reads', () => {
         vi.mocked(doc).mockImplementation((...parts: unknown[]) => ({ path: parts.filter((part) => typeof part === 'string').join('/') }) as never);
     });
 
-    it('merges owner id, legacy owner email, normalized admin email, and unique coach team reads without a catalog load', async () => {
+    it('merges owner, normalized admin email, and unique coach team reads without a catalog load', async () => {
         vi.mocked(getDocs)
             .mockResolvedValueOnce({ docs: [snapshot('team-owner', { name: 'Owner' }), snapshot('team-shared', { name: 'Owner copy' })] } as never)
-            .mockResolvedValueOnce({ docs: [snapshot('team-admin', { name: 'Admin' }), snapshot('team-shared', { name: 'Admin copy' })] } as never)
-            .mockResolvedValueOnce({ docs: [snapshot('team-owner-email-lower', { name: 'Legacy normalized owner' })] } as never)
-            .mockResolvedValueOnce({ docs: [snapshot('team-owner-email', { name: 'Legacy owner' })] } as never)
-            .mockResolvedValueOnce({ docs: [snapshot('team-owner-email-normalized', { name: 'Legacy normalized owner copy' })] } as never);
+            .mockResolvedValueOnce({ docs: [snapshot('team-admin', { name: 'Admin' }), snapshot('team-shared', { name: 'Admin copy' })] } as never);
         vi.mocked(getDoc)
             .mockResolvedValueOnce(snapshot('team-coach', { name: 'Coach' }) as never)
             .mockRejectedValueOnce(new Error('Missing or insufficient permissions.'));
@@ -273,19 +270,13 @@ describe('legacyScheduleDb staff team reads', () => {
                 { id: 'team-owner', name: 'Owner' },
                 { id: 'team-shared', name: 'Admin copy' },
                 { id: 'team-admin', name: 'Admin' },
-                { id: 'team-owner-email-lower', name: 'Legacy normalized owner' },
-                { id: 'team-owner-email', name: 'Legacy owner' },
-                { id: 'team-owner-email-normalized', name: 'Legacy normalized owner copy' },
                 { id: 'team-coach', name: 'Coach' }
             ],
             isPartial: true
         });
-        expect(getDocs).toHaveBeenCalledTimes(5);
+        expect(getDocs).toHaveBeenCalledTimes(2);
         expect(where).toHaveBeenCalledWith('ownerId', '==', 'user-1');
         expect(where).toHaveBeenCalledWith('adminEmails', 'array-contains', 'staff@example.com');
-        expect(where).toHaveBeenCalledWith('ownerEmailLower', '==', 'staff@example.com');
-        expect(where).toHaveBeenCalledWith('ownerEmail', '==', 'STAFF@EXAMPLE.COM');
-        expect(where).toHaveBeenCalledWith('ownerEmail', '==', 'staff@example.com');
         expect(getDoc).toHaveBeenCalledTimes(2);
         expect(legacyGetTeams).not.toHaveBeenCalled();
     });
@@ -310,7 +301,7 @@ describe('legacyScheduleDb staff team reads', () => {
 
         await expect(getStaffTeams({ userId: 'coach-1', email: 'coach@example.com', coachTeamIds: [] })).rejects.toThrow('web sdk unavailable');
 
-        expect(getDocs).toHaveBeenCalledTimes(4);
+        expect(getDocs).toHaveBeenCalledTimes(2);
         expect(getDoc).not.toHaveBeenCalled();
     });
 });

--- a/apps/app/src/lib/adapters/legacyScheduleDb.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.ts
@@ -182,29 +182,34 @@ export async function getStaffTeams({ userId, email, coachTeamIds = [], includeA
     const ownerEmailCandidates = [...new Set([staffEmail, normalizedEmail].filter(Boolean))];
     const uniqueCoachTeamIds = [...new Set(coachTeamIds.map((teamId) => String(teamId || '').trim()).filter(Boolean))];
     const emptySnapshot = { docs: [] };
-    const [ownedSnapshot, adminSnapshot, ownerEmailLowerSnapshot, ownerEmailSnapshots, coachSnapshotResults] = await Promise.all([
+    const [ownedSnapshot, adminSnapshot, legacyOwnerSnapshotResults, coachSnapshotResults] = await Promise.all([
         userId
             ? legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('ownerId', '==', userId)))
             : Promise.resolve(emptySnapshot),
         normalizedEmail
             ? legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('adminEmails', 'array-contains', normalizedEmail)))
             : Promise.resolve(emptySnapshot),
-        normalizedEmail
-            ? legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('ownerEmailLower', '==', normalizedEmail)))
-            : Promise.resolve(emptySnapshot),
-        Promise.all(ownerEmailCandidates.map((ownerEmail) => (
+        Promise.allSettled([
+            normalizedEmail
+                ? legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('ownerEmailLower', '==', normalizedEmail)))
+                : Promise.resolve(emptySnapshot),
+            ...ownerEmailCandidates.map((ownerEmail) => (
             legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('ownerEmail', '==', ownerEmail)))
-        ))),
+            ))
+        ]),
         Promise.allSettled(uniqueCoachTeamIds.map((teamId) => (
             legacyFirebaseGetDoc(legacyFirebaseDoc(legacyFirebaseDb, 'teams', teamId))
         )))
     ]);
 
+    const legacyOwnerSnapshots = legacyOwnerSnapshotResults.flatMap((result) => (
+        result.status === 'fulfilled' && result.value ? [result.value] : []
+    ));
     const coachSnapshots = coachSnapshotResults.flatMap((result) => (
         result.status === 'fulfilled' && result.value ? [result.value] : []
     ));
     const teamsById = new Map<string, Record<string, unknown>>();
-    [...ownedSnapshot.docs, ...adminSnapshot.docs, ...ownerEmailLowerSnapshot.docs, ...ownerEmailSnapshots.flatMap((snapshot) => snapshot.docs), ...coachSnapshots]
+    [...ownedSnapshot.docs, ...adminSnapshot.docs, ...legacyOwnerSnapshots.flatMap((snapshot) => snapshot.docs), ...coachSnapshots]
         .filter((snapshot): snapshot is NonNullable<typeof snapshot> => Boolean(snapshot && ('exists' in snapshot ? snapshot.exists() : true)))
         .forEach((snapshot) => {
             const id = String(snapshot.id || '').trim();
@@ -212,7 +217,7 @@ export async function getStaffTeams({ userId, email, coachTeamIds = [], includeA
         });
     return {
         teams: [...teamsById.values()],
-        isPartial: coachSnapshotResults.some((result) => result.status === 'rejected')
+        isPartial: [...legacyOwnerSnapshotResults, ...coachSnapshotResults].some((result) => result.status === 'rejected')
     };
 }
 

--- a/apps/app/src/lib/adapters/legacyScheduleDb.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.ts
@@ -177,16 +177,24 @@ export async function getStaffTeams({ userId, email, coachTeamIds = [], includeA
     }
 
     const teamsRef = legacyFirebaseCollection(legacyFirebaseDb, 'teams');
-    const normalizedEmail = String(email || '').trim().toLowerCase();
+    const staffEmail = String(email || '').trim();
+    const normalizedEmail = staffEmail.toLowerCase();
+    const ownerEmailCandidates = [...new Set([staffEmail, normalizedEmail].filter(Boolean))];
     const uniqueCoachTeamIds = [...new Set(coachTeamIds.map((teamId) => String(teamId || '').trim()).filter(Boolean))];
     const emptySnapshot = { docs: [] };
-    const [ownedSnapshot, adminSnapshot, coachSnapshotResults] = await Promise.all([
+    const [ownedSnapshot, adminSnapshot, ownerEmailLowerSnapshot, ownerEmailSnapshots, coachSnapshotResults] = await Promise.all([
         userId
             ? legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('ownerId', '==', userId)))
             : Promise.resolve(emptySnapshot),
         normalizedEmail
             ? legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('adminEmails', 'array-contains', normalizedEmail)))
             : Promise.resolve(emptySnapshot),
+        normalizedEmail
+            ? legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('ownerEmailLower', '==', normalizedEmail)))
+            : Promise.resolve(emptySnapshot),
+        Promise.all(ownerEmailCandidates.map((ownerEmail) => (
+            legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('ownerEmail', '==', ownerEmail)))
+        ))),
         Promise.allSettled(uniqueCoachTeamIds.map((teamId) => (
             legacyFirebaseGetDoc(legacyFirebaseDoc(legacyFirebaseDb, 'teams', teamId))
         )))
@@ -196,7 +204,7 @@ export async function getStaffTeams({ userId, email, coachTeamIds = [], includeA
         result.status === 'fulfilled' && result.value ? [result.value] : []
     ));
     const teamsById = new Map<string, Record<string, unknown>>();
-    [...ownedSnapshot.docs, ...adminSnapshot.docs, ...coachSnapshots]
+    [...ownedSnapshot.docs, ...adminSnapshot.docs, ...ownerEmailLowerSnapshot.docs, ...ownerEmailSnapshots.flatMap((snapshot) => snapshot.docs), ...coachSnapshots]
         .filter((snapshot): snapshot is NonNullable<typeof snapshot> => Boolean(snapshot && ('exists' in snapshot ? snapshot.exists() : true)))
         .forEach((snapshot) => {
             const id = String(snapshot.id || '').trim();

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 
 const scheduleServiceSource = readFileSync(new URL('../../apps/app/src/lib/scheduleService.ts', import.meta.url), 'utf8');
+const legacyScheduleDbSource = readFileSync(new URL('../../apps/app/src/lib/adapters/legacyScheduleDb.ts', import.meta.url), 'utf8');
 
 function getScheduleServiceSlice(startMarker, endMarker) {
     const start = scheduleServiceSource.indexOf(startMarker);
@@ -456,6 +457,9 @@ describe('React app schedule service contract integration', () => {
         expect(staffTeamSource).toContain("nativeRunQuery('teams', 'ownerEmailLower', 'EQUAL', normalizedEmail)");
         expect(staffTeamSource).toContain("nativeRunQuery('teams', 'ownerEmail', 'EQUAL', ownerEmail)");
         expect(scheduleServiceSource).toContain('normalizeEmail(team.ownerEmailLower) === email || normalizeEmail(team.ownerEmail) === email');
+        expect(legacyScheduleDbSource).toContain("legacyFirebaseWhere('ownerEmailLower', '==', normalizedEmail)");
+        expect(legacyScheduleDbSource).toContain("legacyFirebaseWhere('ownerEmail', '==', ownerEmail)");
+        expect(legacyScheduleDbSource).toContain('ownerEmailSnapshots.flatMap((snapshot) => snapshot.docs)');
     });
 
     it('routes parent schedule event detail reads through typed schedule mappers', () => {

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -459,7 +459,8 @@ describe('React app schedule service contract integration', () => {
         expect(scheduleServiceSource).toContain('normalizeEmail(team.ownerEmailLower) === email || normalizeEmail(team.ownerEmail) === email');
         expect(legacyScheduleDbSource).toContain("legacyFirebaseWhere('ownerEmailLower', '==', normalizedEmail)");
         expect(legacyScheduleDbSource).toContain("legacyFirebaseWhere('ownerEmail', '==', ownerEmail)");
-        expect(legacyScheduleDbSource).toContain('ownerEmailSnapshots.flatMap((snapshot) => snapshot.docs)');
+        expect(legacyScheduleDbSource).toContain('Promise.allSettled([');
+        expect(legacyScheduleDbSource).toContain('legacyOwnerSnapshots.flatMap((snapshot) => snapshot.docs)');
     });
 
     it('routes parent schedule event detail reads through typed schedule mappers', () => {


### PR DESCRIPTION
## What changed

- Include legacy `ownerEmail` and `ownerEmailLower` matches in the browser schedule staff-team query.
- Preserve normalized and original-case email lookup compatibility.
- Add regression coverage proving legacy-owned teams are merged with UID-owned, admin, and coach teams.

## Why

Vipers was visible in My Teams and selectable in the schedule filter, but the web schedule staff lookup only recognized `ownerId` and `adminEmails`. Its legacy ownership metadata therefore excluded it from the manageable-team list, leaving the editor bound to Jr KC Current.

## Impact

Selecting Vipers now makes it the active team for game, practice, calendar, and import management in the browser/PWA.

## Validation

- `npx vitest run apps/app/src/lib/adapters/legacyScheduleDb.test.ts apps/app/src/lib/scheduleService.test.ts --reporter=dot` — 146 tests passed
- `npm run app:build` — passed
