### PR TITLE
Persist and rotate ChatGPT MCP OAuth grants

### DIFF
--- a/docs/pr-notes/runs/issue-4160-fixer-20260723T234408Z/architecture.md
+++ b/docs/pr-notes/runs/issue-4160-fixer-20260723T234408Z/architecture.md
@@ -1,0 +1,57 @@
+# Architecture
+
+## Current-State Read
+
+- `oauth.js` owns process-local access and refresh maps.
+- `server.js` constructs one broker per Node process.
+- Refresh consume-and-reissue is not atomic across instances.
+- Expiry is checked locally, with no durable cleanup policy.
+- Persisting the current plaintext Firebase binding would increase blast radius.
+
+## Proposed Design
+
+- Inject an asynchronous grant store into `createOAuthBroker`.
+- Add memory and Firestore REST implementations.
+- Address documents by grant type plus `SHA-256(token)`.
+- Encrypt Firebase refresh-token bindings with AES-256-GCM and bind authenticated
+  metadata to the grant type, token digest, client, and expiry.
+- Atomically create initial access/refresh records.
+- Rotate refresh grants with one Firestore commit that conditionally deletes the
+  predecessor by `updateTime` and creates both successors with `exists: false`.
+- Reject expiry synchronously and best-effort delete expired records. Configure
+  Firestore TTL on `expiresAt` for eventual cleanup.
+- Require durable store and encryption configuration in production. Retain memory
+  mode only outside production.
+- Preserve direct Firebase bearer handling and propagate store failures closed.
+
+## Files And Modules Touched
+
+- `services/chatgpt-mcp/src/oauthStore.js`
+- `services/chatgpt-mcp/src/oauth.js`
+- `services/chatgpt-mcp/src/server.js`
+- `services/chatgpt-mcp/README.md`
+- `tests/unit/chatgpt-mcp-oauth.test.js`
+
+## Data/State Impacts
+
+- Durable records contain hashed identifiers, encrypted credential envelopes,
+  type/client metadata, and Firestore timestamp expiry.
+- Access grants remain one hour. Refresh grants remain 30 days.
+- Existing process-local sessions are not migrated.
+
+## Security/Permissions Impacts
+
+- Cloud Run gains a dedicated service identity for the OAuth grant store.
+- The identity should be least privilege and preferably isolated in a dedicated
+  Firestore project/database.
+- Secret Manager access is limited to the runtime service account and audited.
+- No plaintext Firebase binding or raw broker token is persisted.
+
+## Failure Modes And Mitigations
+
+- Concurrent refresh replay: conditional atomic Firestore commit.
+- TTL lag: request-time expiry enforcement.
+- Store outage/decryption failure: fail closed without memory fallback.
+- Key replacement: controlled revocation unless dual-key migration is added.
+- Privileged identity blast radius: dedicated store and least-privilege IAM.
+- #4159 overlap: authorization codes remain unchanged in this slice.

--- a/docs/pr-notes/runs/issue-4160-fixer-20260723T234408Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-4160-fixer-20260723T234408Z/code-plan.md
@@ -1,0 +1,70 @@
+# Code Plan
+
+## Patch Plan
+
+1. Add focused async regression tests for shared-store access, restart-safe
+   refresh, atomic concurrent rotation, expiry cleanup, and encrypted records.
+2. Add a dependency-free OAuth grant store using Node `crypto`, `fetch`, and the
+   Cloud Run metadata service.
+3. Inject the store into the broker and convert grant issuance, exchange, and
+   access resolution to async.
+4. Configure durable Firestore mode in `server.js`; production fails startup
+   without complete durable/encryption configuration.
+5. Document Firestore, TTL, IAM, Secret Manager, key rotation, rollback, and
+   local memory mode.
+6. Run the focused OAuth test file, the adjacent MCP core test if needed,
+   `git diff --check`, and inspect the final diff.
+
+## Code Changes Applied
+
+None during role analysis. Only the main issue-fixer run edits files.
+
+## Validation Run
+
+- `npx vitest run tests/unit/chatgpt-mcp-oauth.test.js --reporter=verbose`
+- `npx vitest run tests/unit/chatgpt-mcp-core.test.js --reporter=verbose` when
+  server/broker identity wiring changes.
+- `git diff --check`
+
+## Residual Risks
+
+- Authorization codes remain process-local under #4159.
+- Firestore availability becomes part of OAuth availability.
+- Replacing the encryption key without migration revokes existing grants.
+- Deployed multi-instance behavior and IAM still require post-deploy verification.
+
+## Commit Message Draft
+
+`Persist ChatGPT OAuth grants across instances (#4160)`
+
+## Synthesis
+
+### Acceptance Criteria
+
+Cross-instance access, restart-safe refresh, single-winner atomic rotation,
+request-time expiry plus cleanup, encrypted Firebase bindings, and actionable
+deployment configuration.
+
+### Architecture Decisions
+
+Use a Firestore REST adapter to match the existing dependency-free service,
+hashed token document IDs, AES-256-GCM, Firestore conditional commits, and
+explicit memory mode only for local/test.
+
+### QA Plan
+
+Test the store contract with independent brokers and the Firestore adapter's
+encrypted write/conditional commit shape. Preserve existing OAuth regression
+coverage after converting the broker API to async.
+
+### Implementation Plan
+
+Tests first, then the store, broker async conversion, server configuration, and
+README. Keep authorization-code persistence outside this issue.
+
+### Risks And Rollback
+
+The main risks are Firestore availability, encryption-key loss, and incomplete
+IAM/TTL provisioning. Roll back to a prior revision only with the documented
+expectation that durable grants may require reconnect; never silently downgrade a
+production revision to process memory.

--- a/docs/pr-notes/runs/issue-4160-fixer-20260723T234408Z/qa.md
+++ b/docs/pr-notes/runs/issue-4160-fixer-20260723T234408Z/qa.md
@@ -1,0 +1,54 @@
+# QA
+
+## Risk Matrix
+
+- High: concurrent refresh rotation permits replay.
+- High: stored Firebase binding confidentiality and identity isolation.
+- High: cross-instance and restart persistence.
+- Medium: expiry/TTL timing and async server wiring.
+- Medium: store failure must fail closed.
+- Low: PKCE, metadata, registration, and direct Firebase bearer regressions.
+
+## Automated Tests To Add/Update
+
+- Two brokers sharing one store resolve access across instances.
+- A recreated broker exchanges a pre-restart refresh token.
+- Concurrent refresh exchanges yield one success and one `invalid_grant`.
+- Expired access/refresh records are rejected before physical TTL deletion and
+  cleanup is requested.
+- Persisted records exclude plaintext Firebase bindings and raw broker tokens.
+- Tampered/wrong-key ciphertext fails closed.
+- Existing code exchange, PKCE burn, client mismatch, expiry, and metadata tests
+  remain green after asynchronous conversion.
+
+## Manual Test Plan
+
+- Deploy two non-production instances and issue on A, authorize `/mcp` on B.
+- Restart the revision and exchange a previously issued refresh token.
+- Race two refresh requests and observe one 200 plus one `invalid_grant`.
+- Inspect stored records/logs for absence of plaintext credentials and tokens.
+- Verify parent and coach/admin accounts remain rules-scoped.
+
+## Negative Tests
+
+- Unknown, expired, rotated, malformed, and empty refresh tokens.
+- Unknown and expired access grants.
+- Concurrent rotation and failed successor writes.
+- Wrong key, tampered envelope, corrupt record, store timeout, and permission
+  failure.
+- No production memory fallback.
+
+## Release Gates
+
+- Focused OAuth/store tests pass.
+- MCP core tests remain green if server identity wiring changes.
+- README documents store, IAM, TTL, encryption, rotation, and rollback.
+- PR evidence includes root cause, prevention, regression tests, and recurrence
+  risk.
+
+## Post-Deploy Checks
+
+- Repeat cross-instance, restart, and refresh-race tests.
+- Monitor invalid-grant rate, transaction conflicts, store latency/errors,
+  decrypt failures, `/mcp` 401s, and Cloud Run 5xx without logging secrets.
+- Verify immediate logical expiry and later datastore cleanup.

--- a/docs/pr-notes/runs/issue-4160-fixer-20260723T234408Z/requirements.md
+++ b/docs/pr-notes/runs/issue-4160-fixer-20260723T234408Z/requirements.md
@@ -1,0 +1,65 @@
+# Requirements
+
+## Problem Statement
+
+Broker-issued access and refresh grants live in process-local `Map` objects. An
+unexpired grant therefore stops working after a Cloud Run restart or when a
+request reaches another instance. Refresh rotation is also a local read/delete
+sequence, so two instances can accept the same refresh token.
+
+## User Segments Impacted
+
+- Coaches and parents lose connector access during scaling, deploys, or restarts.
+- Program administrators inherit repeated reconnect and support toil.
+- Operators cannot safely enable multi-instance production without durable,
+  protected, and auditable grant state.
+
+## Acceptance Criteria
+
+1. An access token issued by broker A resolves through broker B sharing the
+   durable store until expiry.
+2. A refresh token survives broker recreation and can be exchanged after restart.
+3. Concurrent refresh exchanges produce exactly one success, invalidate the
+   predecessor atomically, and issue one valid successor pair.
+4. Grants at or beyond expiry are rejected even if TTL deletion is delayed.
+5. Expired records are cleaned up opportunistically and/or by datastore TTL.
+6. The Firebase refresh-token binding is never stored in plaintext.
+7. Missing or unusable production protection configuration fails closed.
+8. Existing PKCE, token lifetimes, refresh rotation, and direct Firebase bearer
+   behavior remain compatible.
+9. Deployment documentation covers the store, TTL, IAM, encryption secret, key
+   rotation, rollback, and production fallback policy.
+10. Regression tests cover cross-instance access, restart exchange, atomic
+    rotation, expiry cleanup, ciphertext-at-rest, and configuration failure.
+
+## Non-Goals
+
+- ChatGPT connector UX changes.
+- Unrelated authentication migration.
+- New MCP tools.
+- Authorization-code durability, which remains tracked by #4159.
+- Broad MCP service refactoring.
+
+## Edge Cases
+
+- Two instances rotate the same refresh token concurrently.
+- A successor write fails after reading the predecessor.
+- Firestore TTL deletion is delayed.
+- Ciphertext is malformed, tampered with, or decrypted with the wrong key.
+- Store/IAM failure must not downgrade to direct Firebase credential handling.
+- Raw broker tokens, Firebase tokens, and encryption keys must not enter logs.
+
+## Open Questions Resolved
+
+- Durable store: Firestore through the service identity and REST API.
+- Credential protection: AES-256-GCM using a base64-encoded 32-byte key supplied
+  from Secret Manager.
+- Lookup keys: SHA-256 digests of opaque broker tokens, never raw tokens.
+- Failure model: durable production mode fails closed; memory mode is local/test
+  only.
+
+## Failing Invariant / Root Cause
+
+An unexpired broker grant must be valid independent of process identity. The
+broker instead owns local access/refresh maps, and refresh rotation has no shared
+transaction boundary.

--- a/services/chatgpt-mcp/README.md
+++ b/services/chatgpt-mcp/README.md
@@ -138,9 +138,9 @@ Enable TTL on the `expiresAt` field:
 
 ```bash
 gcloud firestore fields ttls update expiresAt \
-  --collection-group=chatgptMcpOAuthGrants \
+  --collection-group="$OAUTH_GRANT_STORE_COLLECTION" \
   --enable-ttl \
-  --database='(default)' \
+  --database="$OAUTH_GRANT_STORE_DATABASE_ID" \
   --project "$OAUTH_GRANT_STORE_PROJECT_ID"
 ```
 
@@ -150,13 +150,15 @@ rejects expired grants immediately and opportunistically deletes them.
 ## Deploy (Cloud Run)
 
 ```bash
+OAUTH_GRANT_KEY_VERSION=1 # Pin the numeric version created above.
+
 gcloud run deploy allplays-chatgpt-mcp \
   --source services/chatgpt-mcp \
   --project game-flow-c6311 \
   --region us-central1 \
   --service-account chatgpt-mcp@game-flow-c6311.iam.gserviceaccount.com \
   --set-env-vars OAUTH_GRANT_STORE=firestore,OAUTH_GRANT_STORE_PROJECT_ID=oauth-grant-project,OAUTH_GRANT_STORE_DATABASE_ID='(default)',OAUTH_GRANT_STORE_COLLECTION=chatgptMcpOAuthGrants \
-  --set-secrets OAUTH_GRANT_ENCRYPTION_KEY=chatgpt-mcp-oauth-grant-key:latest
+  --set-secrets "OAUTH_GRANT_ENCRYPTION_KEY=projects/$OAUTH_GRANT_STORE_PROJECT_ID/secrets/chatgpt-mcp-oauth-grant-key:$OAUTH_GRANT_KEY_VERSION"
 ```
 
 Before increasing the minimum or maximum instance count, verify cross-instance

--- a/services/chatgpt-mcp/README.md
+++ b/services/chatgpt-mcp/README.md
@@ -103,8 +103,8 @@ Required production variables:
 | Variable | Purpose |
 |---|---|
 | `OAUTH_GRANT_STORE=firestore` | Enables shared durable grants. Production rejects any other value. |
-| `OAUTH_GRANT_STORE_PROJECT_ID` | Project containing the isolated grant store. Defaults to `FIREBASE_PROJECT_ID`, but a dedicated project/database reduces blast radius. |
-| `OAUTH_GRANT_STORE_DATABASE_ID` | Firestore database ID. Defaults to `(default)`. |
+| `OAUTH_GRANT_STORE_PROJECT_ID` | Explicit project containing the isolated grant store. Required in production; it never defaults to the application project. |
+| `OAUTH_GRANT_STORE_DATABASE_ID` | Explicit Firestore database ID. Required in production. The application project's `(default)` database is rejected. |
 | `OAUTH_GRANT_STORE_COLLECTION` | Collection/collection-group name. Defaults to `chatgptMcpOAuthGrants`. |
 | `OAUTH_GRANT_ENCRYPTION_KEY` | Base64-encoded 32-byte AES key, supplied from Secret Manager. |
 
@@ -119,10 +119,20 @@ openssl rand -base64 32 | tr -d '\n' \
 ```
 
 Use a dedicated Cloud Run service account. Grant it `roles/datastore.user` only
-in the isolated grant-store project and `roles/secretmanager.secretAccessor`
-only on `chatgpt-mcp-oauth-grant-key`. Do not grant Editor, Owner, or application
-data administration roles. Firestore IAM is project/database scoped, not
-collection scoped, which is why a dedicated project or database is preferred.
+in an isolated grant-store project, or use an IAM condition that limits the role
+to a dedicated non-default database. For example:
+
+```bash
+gcloud projects add-iam-policy-binding "$OAUTH_GRANT_STORE_PROJECT_ID" \
+  --member="serviceAccount:$OAUTH_SERVICE_ACCOUNT" \
+  --role=roles/datastore.user \
+  --condition="expression=resource.name=='projects/$OAUTH_GRANT_STORE_PROJECT_ID/databases/$OAUTH_GRANT_STORE_DATABASE_ID',title=oauth-grant-database"
+```
+
+Grant `roles/secretmanager.secretAccessor` only on
+`chatgpt-mcp-oauth-grant-key`. Do not grant Editor, Owner, project-wide
+application data access, or application data administration roles. Firestore
+IAM cannot be collection-scoped.
 
 Enable TTL on the `expiresAt` field:
 

--- a/services/chatgpt-mcp/README.md
+++ b/services/chatgpt-mcp/README.md
@@ -129,6 +129,7 @@ Enable TTL on the `expiresAt` field:
 ```bash
 gcloud firestore fields ttls update expiresAt \
   --collection-group=chatgptMcpOAuthGrants \
+  --enable-ttl \
   --database='(default)' \
   --project "$OAUTH_GRANT_STORE_PROJECT_ID"
 ```

--- a/services/chatgpt-mcp/README.md
+++ b/services/chatgpt-mcp/README.md
@@ -8,13 +8,15 @@ Spec: `/spec/chatgpt-app-integration/` · Plan: `AllPlays_ChatGPT_App_Integratio
 
 ## How authorization works
 
-The service holds **no privileged credentials** (no service account, no Admin
-SDK). The connector's bearer token is the user's Firebase **refresh token**
-(or a short-lived ID token). Per request the service exchanges it for an ID
-token and calls the **Firestore REST API as that user**, so every read is
-authorized by the same `firestore.rules` that protect the AllPlays web and
-mobile clients. Cross-team access fails at the database, not just in service
-code (which also checks, as defense-in-depth).
+Application data access holds **no privileged credentials**. The connector's
+bearer token resolves to the user's Firebase refresh token (or a short-lived ID
+token). Per request the service exchanges it for an ID token and calls the
+Firestore REST API as that user, so every application read is authorized by the
+same `firestore.rules` that protect the AllPlays web and mobile clients.
+
+The production OAuth grant store is a separate control plane. Cloud Run's
+service identity may access only that Firestore store and its encryption secret;
+it never reads application data with service privileges.
 
 ## Run locally
 
@@ -31,6 +33,10 @@ npm start           # listens on :8787, endpoint POST /mcp
 exits at startup when either is missing. `CHATGPT_OAUTH_CLIENT_ID` identifies
 the trusted public ChatGPT client and defaults to `allplays-chatgpt-connector`;
 set the same value on every broker instance.
+
+Local development defaults to `OAUTH_GRANT_STORE=memory`. This mode is bounded
+but process-local. Production rejects memory mode and requires the durable
+configuration below.
 
 Get a bearer token (prints your refresh token):
 
@@ -73,9 +79,15 @@ dynamic client registration, authorization code + PKCE (S256 only), refresh
 grant, and opaque access tokens that map to the signed-in user's Firebase
 refresh token. Codes are single-use with a 10-minute TTL; access tokens last
 1 hour. The trusted ChatGPT client registration is configuration-backed and
-stable across instances. Authorization codes and tokens remain in-memory, so
-a restart logs everyone out; Firestore-backed grant storage is still required
-for complete multi-instance Cloud Run support.
+stable across instances. Access and refresh grants use Firestore in production,
+so they survive restarts and resolve across Cloud Run instances. Refresh-token
+consume-and-reissue is one conditional Firestore commit, so concurrent reuse has
+one winner. Authorization codes remain process-local under issue #4159.
+
+Raw broker tokens are not stored. Firestore document IDs contain SHA-256 token
+digests, and the Firebase refresh-token binding is encrypted with AES-256-GCM.
+The service checks `expiresAt` on every read or rotation; Firestore TTL provides
+eventual physical cleanup.
 
 Sign-in accepts AllPlays email/password (proxied to Firebase Identity Toolkit
 with the site referer; the password is never stored). Google sign-in is a
@@ -84,27 +96,93 @@ follow-up.
 For manual curl testing you can still bypass OAuth: a Firebase refresh token
 or ID token works directly as the MCP bearer.
 
-## Deploy (dev Cloud Run)
+## Durable grant-store configuration
+
+Required production variables:
+
+| Variable | Purpose |
+|---|---|
+| `OAUTH_GRANT_STORE=firestore` | Enables shared durable grants. Production rejects any other value. |
+| `OAUTH_GRANT_STORE_PROJECT_ID` | Project containing the isolated grant store. Defaults to `FIREBASE_PROJECT_ID`, but a dedicated project/database reduces blast radius. |
+| `OAUTH_GRANT_STORE_DATABASE_ID` | Firestore database ID. Defaults to `(default)`. |
+| `OAUTH_GRANT_STORE_COLLECTION` | Collection/collection-group name. Defaults to `chatgptMcpOAuthGrants`. |
+| `OAUTH_GRANT_ENCRYPTION_KEY` | Base64-encoded 32-byte AES key, supplied from Secret Manager. |
+
+Create the encryption secret without committing the key:
+
+```bash
+openssl rand -base64 32 | tr -d '\n' \
+  | gcloud secrets create chatgpt-mcp-oauth-grant-key \
+      --data-file=- \
+      --replication-policy=automatic \
+      --project "$OAUTH_GRANT_STORE_PROJECT_ID"
+```
+
+Use a dedicated Cloud Run service account. Grant it `roles/datastore.user` only
+in the isolated grant-store project and `roles/secretmanager.secretAccessor`
+only on `chatgpt-mcp-oauth-grant-key`. Do not grant Editor, Owner, or application
+data administration roles. Firestore IAM is project/database scoped, not
+collection scoped, which is why a dedicated project or database is preferred.
+
+Enable TTL on the `expiresAt` field:
+
+```bash
+gcloud firestore fields ttls update expiresAt \
+  --collection-group=chatgptMcpOAuthGrants \
+  --database='(default)' \
+  --project "$OAUTH_GRANT_STORE_PROJECT_ID"
+```
+
+TTL deletion is asynchronous and is not an authorization control. The service
+rejects expired grants immediately and opportunistically deletes them.
+
+## Deploy (Cloud Run)
 
 ```bash
 gcloud run deploy allplays-chatgpt-mcp \
   --source services/chatgpt-mcp \
   --project game-flow-c6311 \
-  --region us-central1
+  --region us-central1 \
+  --service-account chatgpt-mcp@game-flow-c6311.iam.gserviceaccount.com \
+  --set-env-vars OAUTH_GRANT_STORE=firestore,OAUTH_GRANT_STORE_PROJECT_ID=oauth-grant-project,OAUTH_GRANT_STORE_DATABASE_ID='(default)',OAUTH_GRANT_STORE_COLLECTION=chatgptMcpOAuthGrants \
+  --set-secrets OAUTH_GRANT_ENCRYPTION_KEY=chatgpt-mcp-oauth-grant-key:latest
 ```
 
-No secrets to provision — the service is stateless and credential-free. The
-production path replaces raw refresh tokens with an OAuth broker
-(authorization code + PKCE) that yields the same user-scoped credential.
+Before increasing the minimum or maximum instance count, verify cross-instance
+access-token resolution, refresh exchange after a revision restart, and a
+two-request refresh race with exactly one success.
+
+### Key rotation and rollback
+
+The current envelope version uses one active key. Replacing the secret value
+makes existing grants unreadable and intentionally forces every connector to
+reconnect. Treat key replacement as a controlled revocation:
+
+1. Announce the reconnect window and record the change.
+2. Add a new Secret Manager version and deploy a revision pinned to that version.
+3. Verify new grants, then disable the old version after the maximum 30-day
+   refresh lifetime or after explicitly accepting immediate revocation.
+
+Rollback must keep the same key version and durable-store configuration. Never
+roll a production revision back to `OAUTH_GRANT_STORE=memory`; that reintroduces
+instance-local grants and invalidates the multi-instance guarantee.
 
 ## Security model
 
 - Identity comes only from the bearer token; tool arguments are never trusted.
+- Opaque broker tokens are stored only as SHA-256 lookup digests.
+- Firebase refresh-token bindings are AES-256-GCM encrypted before persistence.
+- Firestore refresh rotation atomically consumes the predecessor and creates
+  both successor grants.
 - All Firestore access is user-credentialed — `firestore.rules` is the
-  enforcement point, identical to the parent UI.
+  enforcement point for application data, identical to the parent UI.
+- The Cloud Run service identity is limited to the isolated OAuth grant store
+  and encryption secret; audit both IAM access paths.
 - Responses are additionally field-whitelisted in `src/core.js`;
   `players/*/private/*` and `privatePlayerStats` are never requested.
 - A forged JWT yields no data: every Firestore call presents that same token
   and is rejected by the backend.
 
-Unit tests: `npx vitest run tests/unit/chatgpt-mcp-core.test.js` from the repo root.
+Focused OAuth tests:
+`npx vitest run tests/unit/chatgpt-mcp-oauth.test.js --reporter=verbose`
+from the repo root.

--- a/services/chatgpt-mcp/src/oauth.js
+++ b/services/chatgpt-mcp/src/oauth.js
@@ -7,10 +7,12 @@
 // resolve broker token → Firebase credential → rules-enforced Firestore
 // access, unchanged from the direct-bearer path.
 //
-// Storage is in-memory: fine for a single-instance dev deployment, replaced
-// by Firestore-backed storage before multi-instance Cloud Run (see spec).
+// Authorization codes remain process-local under issue #4159. Issued access
+// and refresh grants use an injected store so production instances share one
+// durable, atomic lifecycle boundary.
 
 import { createHash, randomBytes } from 'node:crypto';
+import { createMemoryOAuthGrantStore } from './oauthStore.js';
 
 const CODE_TTL_MS = 10 * 60 * 1000;
 const ACCESS_TOKEN_TTL_MS = 60 * 60 * 1000;
@@ -41,7 +43,8 @@ export function createOAuthBroker({
     now = () => Date.now(),
     randomId = (bytes = 32) => randomBytes(bytes).toString('base64url'),
     maxStoredGrants = MAX_STORED_GRANTS,
-    trustedClientId = DEFAULT_TRUSTED_CLIENT_ID
+    trustedClientId = DEFAULT_TRUSTED_CLIENT_ID,
+    grantStore = createMemoryOAuthGrantStore({ now, maxStoredGrants })
 } = {}) {
     if (!Number.isInteger(maxStoredGrants) || maxStoredGrants < 1) {
         throw new Error('maxStoredGrants must be a positive integer.');
@@ -49,13 +52,19 @@ export function createOAuthBroker({
     if (typeof trustedClientId !== 'string' || !trustedClientId.trim()) {
         throw new Error('trustedClientId must be a non-empty string.');
     }
+    if (
+        !grantStore
+        || typeof grantStore.issueGrantPair !== 'function'
+        || typeof grantStore.resolveAccessToken !== 'function'
+        || typeof grantStore.rotateRefreshToken !== 'function'
+    ) {
+        throw new Error('grantStore must implement the OAuth grant store contract.');
+    }
     const registeredClient = {
         clientId: trustedClientId.trim(),
         redirectUris: [...TRUSTED_REDIRECT_URIS]
     };
     const codes = new Map();
-    const accessTokens = new Map();
-    const refreshTokens = new Map();
 
     function pruneExpired(store) {
         for (const [key, record] of store) {
@@ -117,15 +126,7 @@ export function createOAuthBroker({
         return code;
     }
 
-    function issueTokens(firebaseRefreshToken, clientId) {
-        const accessToken = randomId(32);
-        const refreshToken = randomId(32);
-        setBounded(accessTokens, accessToken, { firebaseRefreshToken, expiresAt: now() + ACCESS_TOKEN_TTL_MS });
-        setBounded(refreshTokens, refreshToken, {
-            firebaseRefreshToken,
-            clientId,
-            expiresAt: now() + REFRESH_TOKEN_TTL_MS
-        });
+    function tokenResponse(accessToken, refreshToken) {
         return {
             access_token: accessToken,
             token_type: 'Bearer',
@@ -134,7 +135,22 @@ export function createOAuthBroker({
         };
     }
 
-    function exchange(params = {}) {
+    async function issueTokens(firebaseRefreshToken, clientId) {
+        const accessToken = randomId(32);
+        const refreshToken = randomId(32);
+        const issuedAt = now();
+        await grantStore.issueGrantPair({
+            accessToken,
+            refreshToken,
+            firebaseRefreshToken,
+            clientId,
+            accessExpiresAt: issuedAt + ACCESS_TOKEN_TTL_MS,
+            refreshExpiresAt: issuedAt + REFRESH_TOKEN_TTL_MS
+        });
+        return tokenResponse(accessToken, refreshToken);
+    }
+
+    async function exchange(params = {}) {
         const grantType = params.grant_type;
         if (grantType === 'authorization_code') {
             const record = codes.get(params.code);
@@ -154,20 +170,24 @@ export function createOAuthBroker({
             return issueTokens(record.firebaseRefreshToken, record.clientId);
         }
         if (grantType === 'refresh_token') {
-            pruneExpired(refreshTokens);
-            const record = refreshTokens.get(params.refresh_token);
-            if (!record) throw new OAuthError('invalid_grant', 'Unknown refresh token.');
-            refreshTokens.delete(params.refresh_token); // rotate on every use
-            return issueTokens(record.firebaseRefreshToken, record.clientId);
+            const accessToken = randomId(32);
+            const refreshToken = randomId(32);
+            const issuedAt = now();
+            const rotated = await grantStore.rotateRefreshToken({
+                refreshToken: params.refresh_token,
+                newAccessToken: accessToken,
+                newRefreshToken: refreshToken,
+                accessExpiresAt: issuedAt + ACCESS_TOKEN_TTL_MS,
+                refreshExpiresAt: issuedAt + REFRESH_TOKEN_TTL_MS
+            });
+            if (!rotated) throw new OAuthError('invalid_grant', 'Unknown refresh token.');
+            return tokenResponse(accessToken, refreshToken);
         }
         throw new OAuthError('invalid_request', 'Unsupported grant_type.');
     }
 
-    function resolveAccessToken(token) {
-        pruneExpired(accessTokens);
-        const record = accessTokens.get(token);
-        if (!record) return null;
-        return { firebaseRefreshToken: record.firebaseRefreshToken };
+    async function resolveAccessToken(token) {
+        return grantStore.resolveAccessToken(token);
     }
 
     return { registerClient, validateAuthorizeRequest, approveAuthorization, exchange, resolveAccessToken };

--- a/services/chatgpt-mcp/src/oauthStore.js
+++ b/services/chatgpt-mcp/src/oauthStore.js
@@ -111,7 +111,7 @@ export function createMemoryOAuthGrantStore({
 
 function decodeEncryptionKey(value) {
     const encoded = String(value || '').trim();
-    if (!/^[A-Za-z0-9+/]+={0,2}$/.test(encoded)) {
+    if (encoded.length !== 44 || !/^[A-Za-z0-9+/]{43}=$/.test(encoded)) {
         throw new Error('OAUTH_GRANT_ENCRYPTION_KEY must be a base64-encoded 32-byte key.');
     }
     const key = Buffer.from(encoded, 'base64');
@@ -386,7 +386,14 @@ export function createFirestoreOAuthGrantStore({
         }) {
             const current = await readGrant('refresh', refreshToken);
             if (!current) return false;
-            const grant = decryptGrant('refresh', current);
+            let grant;
+            try {
+                grant = decryptGrant('refresh', current);
+            } catch {
+                // Key replacement and corrupt records make this specific grant
+                // unusable; clients must reconnect instead of retrying it.
+                return false;
+            }
             if (grant.expiresAt <= now()) {
                 await deleteExpired('refresh', current.digest, current.document.updateTime);
                 return false;

--- a/services/chatgpt-mcp/src/oauthStore.js
+++ b/services/chatgpt-mcp/src/oauthStore.js
@@ -1,0 +1,422 @@
+// OAuth access/refresh grant persistence.
+//
+// Production grants live in Firestore under SHA-256 token identifiers. The
+// user's Firebase refresh-token binding is encrypted with AES-256-GCM before
+// it crosses the storage boundary. The in-memory adapter is intentionally
+// limited to local development and tests.
+
+import {
+    createCipheriv,
+    createDecipheriv,
+    createHash,
+    randomBytes
+} from 'node:crypto';
+import { decodeFields, encodeValue } from './firestoreRest.js';
+
+const DEFAULT_COLLECTION_ID = 'chatgptMcpOAuthGrants';
+const DEFAULT_DATABASE_ID = '(default)';
+const METADATA_TOKEN_URL = 'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token';
+
+function tokenDigest(token) {
+    return createHash('sha256').update(String(token), 'utf8').digest('hex');
+}
+
+function initializeMemoryState(state) {
+    if (!state.accessTokens) state.accessTokens = new Map();
+    if (!state.refreshTokens) state.refreshTokens = new Map();
+    return state;
+}
+
+function pruneExpired(store, now) {
+    for (const [key, record] of store) {
+        if (record.expiresAt <= now) store.delete(key);
+    }
+}
+
+function setBounded(store, key, record, now, maxStoredGrants) {
+    pruneExpired(store, now);
+    while (store.size >= maxStoredGrants) {
+        store.delete(store.keys().next().value);
+    }
+    store.set(key, record);
+}
+
+export function createMemoryOAuthGrantStore({
+    state = {},
+    now = () => Date.now(),
+    maxStoredGrants = 1000
+} = {}) {
+    if (!Number.isInteger(maxStoredGrants) || maxStoredGrants < 1) {
+        throw new Error('maxStoredGrants must be a positive integer.');
+    }
+    const stores = initializeMemoryState(state);
+
+    return {
+        async issueGrantPair({
+            accessToken,
+            refreshToken,
+            firebaseRefreshToken,
+            clientId,
+            accessExpiresAt,
+            refreshExpiresAt
+        }) {
+            const currentTime = now();
+            setBounded(stores.accessTokens, accessToken, {
+                firebaseRefreshToken,
+                clientId,
+                expiresAt: accessExpiresAt
+            }, currentTime, maxStoredGrants);
+            setBounded(stores.refreshTokens, refreshToken, {
+                firebaseRefreshToken,
+                clientId,
+                expiresAt: refreshExpiresAt
+            }, currentTime, maxStoredGrants);
+        },
+
+        async resolveAccessToken(token) {
+            pruneExpired(stores.accessTokens, now());
+            const record = stores.accessTokens.get(token);
+            return record ? { firebaseRefreshToken: record.firebaseRefreshToken } : null;
+        },
+
+        async rotateRefreshToken({
+            refreshToken,
+            newAccessToken,
+            newRefreshToken,
+            accessExpiresAt,
+            refreshExpiresAt
+        }) {
+            const currentTime = now();
+            pruneExpired(stores.refreshTokens, currentTime);
+            const record = stores.refreshTokens.get(refreshToken);
+            if (!record) return false;
+
+            // No await occurs between the read and delete, so concurrent calls
+            // against shared state have one consume winner.
+            stores.refreshTokens.delete(refreshToken);
+            setBounded(stores.accessTokens, newAccessToken, {
+                firebaseRefreshToken: record.firebaseRefreshToken,
+                clientId: record.clientId,
+                expiresAt: accessExpiresAt
+            }, currentTime, maxStoredGrants);
+            setBounded(stores.refreshTokens, newRefreshToken, {
+                firebaseRefreshToken: record.firebaseRefreshToken,
+                clientId: record.clientId,
+                expiresAt: refreshExpiresAt
+            }, currentTime, maxStoredGrants);
+            return true;
+        }
+    };
+}
+
+function decodeEncryptionKey(value) {
+    const encoded = String(value || '').trim();
+    if (!/^[A-Za-z0-9+/]+={0,2}$/.test(encoded)) {
+        throw new Error('OAUTH_GRANT_ENCRYPTION_KEY must be a base64-encoded 32-byte key.');
+    }
+    const key = Buffer.from(encoded, 'base64');
+    if (key.length !== 32 || key.toString('base64') !== encoded) {
+        throw new Error('OAUTH_GRANT_ENCRYPTION_KEY must be a base64-encoded 32-byte key.');
+    }
+    return key;
+}
+
+function authenticatedMetadata({ type, digest, clientId, expiresAt }) {
+    return Buffer.from(JSON.stringify({
+        type,
+        digest,
+        clientId: clientId || '',
+        expiresAt
+    }), 'utf8');
+}
+
+function encryptBinding(key, firebaseRefreshToken, metadata) {
+    const iv = randomBytes(12);
+    const cipher = createCipheriv('aes-256-gcm', key, iv);
+    cipher.setAAD(authenticatedMetadata(metadata));
+    const ciphertext = Buffer.concat([
+        cipher.update(firebaseRefreshToken, 'utf8'),
+        cipher.final()
+    ]);
+    return {
+        version: 1,
+        iv: iv.toString('base64'),
+        ciphertext: ciphertext.toString('base64'),
+        tag: cipher.getAuthTag().toString('base64')
+    };
+}
+
+function decryptBinding(key, envelope, metadata) {
+    if (envelope?.version !== 1 || !envelope.iv || !envelope.ciphertext || !envelope.tag) {
+        throw new Error('Stored OAuth grant has an invalid encrypted binding.');
+    }
+    const decipher = createDecipheriv(
+        'aes-256-gcm',
+        key,
+        Buffer.from(envelope.iv, 'base64')
+    );
+    decipher.setAAD(authenticatedMetadata(metadata));
+    decipher.setAuthTag(Buffer.from(envelope.tag, 'base64'));
+    return Buffer.concat([
+        decipher.update(Buffer.from(envelope.ciphertext, 'base64')),
+        decipher.final()
+    ]).toString('utf8');
+}
+
+function documentFields(record) {
+    return Object.fromEntries(
+        Object.entries(record).map(([field, value]) => [field, encodeValue(value)])
+    );
+}
+
+function grantRecord({ type, token, firebaseRefreshToken, clientId, expiresAt, encryptionKey }) {
+    const digest = tokenDigest(token);
+    const metadata = { type, digest, clientId, expiresAt };
+    return {
+        id: `${type}_${digest}`,
+        digest,
+        fields: {
+            type,
+            clientId,
+            expiresAt: new Date(expiresAt),
+            encryptedBinding: encryptBinding(encryptionKey, firebaseRefreshToken, metadata)
+        }
+    };
+}
+
+function createdDocumentWrite(documentName, record) {
+    return {
+        update: {
+            name: documentName,
+            fields: documentFields(record.fields)
+        },
+        currentDocument: { exists: false }
+    };
+}
+
+export function createMetadataAccessTokenProvider({
+    fetchImpl = fetch,
+    now = () => Date.now(),
+    metadataUrl = METADATA_TOKEN_URL
+} = {}) {
+    let cachedToken = null;
+    let refreshAt = 0;
+
+    return async () => {
+        if (cachedToken && now() < refreshAt) return cachedToken;
+        const response = await fetchImpl(metadataUrl, {
+            headers: { 'Metadata-Flavor': 'Google' }
+        });
+        if (!response.ok) {
+            throw new Error(`Cloud Run service-identity token request failed (${response.status}).`);
+        }
+        const body = await response.json();
+        if (!body.access_token || !Number.isFinite(Number(body.expires_in))) {
+            throw new Error('Cloud Run service-identity token response was invalid.');
+        }
+        cachedToken = body.access_token;
+        refreshAt = now() + Math.max(0, Number(body.expires_in) - 60) * 1000;
+        return cachedToken;
+    };
+}
+
+export function createFirestoreOAuthGrantStore({
+    projectId,
+    databaseId = DEFAULT_DATABASE_ID,
+    collectionId = DEFAULT_COLLECTION_ID,
+    encryptionKey,
+    accessTokenProvider,
+    fetchImpl = fetch,
+    now = () => Date.now()
+} = {}) {
+    if (!projectId || typeof projectId !== 'string') {
+        throw new Error('OAUTH_GRANT_STORE_PROJECT_ID must be set for Firestore grant storage.');
+    }
+    if (!databaseId || !collectionId) {
+        throw new Error('OAuth grant Firestore database and collection must be configured.');
+    }
+    if (typeof accessTokenProvider !== 'function') {
+        throw new Error('A Cloud Run service-identity access token provider is required.');
+    }
+    const key = decodeEncryptionKey(encryptionKey);
+    const documentsRoot = `projects/${projectId}/databases/${databaseId}/documents`;
+    const collectionRoot = `${documentsRoot}/${collectionId}`;
+    const apiRoot = `https://firestore.googleapis.com/v1/${documentsRoot}`;
+
+    function documentName(id) {
+        return `${collectionRoot}/${id}`;
+    }
+
+    function documentUrl(id) {
+        return `${apiRoot}/${collectionId}/${id}`;
+    }
+
+    async function request(url, options = {}) {
+        const serviceAccessToken = await accessTokenProvider();
+        return fetchImpl(url, {
+            ...options,
+            headers: {
+                Authorization: `Bearer ${serviceAccessToken}`,
+                'Content-Type': 'application/json',
+                ...(options.headers || {})
+            }
+        });
+    }
+
+    async function commit(writes) {
+        const response = await request(`${apiRoot}:commit`, {
+            method: 'POST',
+            body: JSON.stringify({ writes })
+        });
+        if (response.ok) return { ok: true };
+        const body = await response.json().catch(() => ({}));
+        const status = body?.error?.status;
+        if (
+            response.status === 409
+            || status === 'ABORTED'
+            || status === 'FAILED_PRECONDITION'
+            || status === 'ALREADY_EXISTS'
+        ) {
+            return { ok: false, conflict: true };
+        }
+        throw new Error(`OAuth grant Firestore commit failed (${response.status}).`);
+    }
+
+    async function readGrant(type, token) {
+        const digest = tokenDigest(token);
+        const response = await request(documentUrl(`${type}_${digest}`));
+        if (response.status === 404) return null;
+        if (!response.ok) {
+            throw new Error(`OAuth grant Firestore read failed (${response.status}).`);
+        }
+        const document = await response.json();
+        return {
+            digest,
+            document,
+            record: decodeFields(document.fields)
+        };
+    }
+
+    async function deleteExpired(type, digest, updateTime) {
+        const precondition = updateTime
+            ? `?currentDocument.updateTime=${encodeURIComponent(updateTime)}`
+            : '';
+        try {
+            await request(`${documentUrl(`${type}_${digest}`)}${precondition}`, {
+                method: 'DELETE'
+            });
+        } catch {
+            // Expiry is enforced before this best-effort cleanup. Firestore TTL
+            // remains the durable cleanup backstop.
+        }
+    }
+
+    function decryptGrant(type, result) {
+        const expiresAt = result.record.expiresAt instanceof Date
+            ? result.record.expiresAt.getTime()
+            : Number.NaN;
+        if (
+            result.record.type !== type
+            || !Number.isFinite(expiresAt)
+            || typeof result.record.clientId !== 'string'
+        ) {
+            throw new Error('Stored OAuth grant has an invalid schema.');
+        }
+        return {
+            clientId: result.record.clientId,
+            expiresAt,
+            firebaseRefreshToken: decryptBinding(key, result.record.encryptedBinding, {
+                type,
+                digest: result.digest,
+                clientId: result.record.clientId,
+                expiresAt
+            })
+        };
+    }
+
+    return {
+        async issueGrantPair({
+            accessToken,
+            refreshToken,
+            firebaseRefreshToken,
+            clientId,
+            accessExpiresAt,
+            refreshExpiresAt
+        }) {
+            const access = grantRecord({
+                type: 'access',
+                token: accessToken,
+                firebaseRefreshToken,
+                clientId,
+                expiresAt: accessExpiresAt,
+                encryptionKey: key
+            });
+            const refresh = grantRecord({
+                type: 'refresh',
+                token: refreshToken,
+                firebaseRefreshToken,
+                clientId,
+                expiresAt: refreshExpiresAt,
+                encryptionKey: key
+            });
+            const result = await commit([
+                createdDocumentWrite(documentName(access.id), access),
+                createdDocumentWrite(documentName(refresh.id), refresh)
+            ]);
+            if (!result.ok) throw new Error('OAuth grant token collision.');
+        },
+
+        async resolveAccessToken(token) {
+            const result = await readGrant('access', token);
+            if (!result) return null;
+            const grant = decryptGrant('access', result);
+            if (grant.expiresAt <= now()) {
+                await deleteExpired('access', result.digest, result.document.updateTime);
+                return null;
+            }
+            return { firebaseRefreshToken: grant.firebaseRefreshToken };
+        },
+
+        async rotateRefreshToken({
+            refreshToken,
+            newAccessToken,
+            newRefreshToken,
+            accessExpiresAt,
+            refreshExpiresAt
+        }) {
+            const current = await readGrant('refresh', refreshToken);
+            if (!current) return false;
+            const grant = decryptGrant('refresh', current);
+            if (grant.expiresAt <= now()) {
+                await deleteExpired('refresh', current.digest, current.document.updateTime);
+                return false;
+            }
+
+            const access = grantRecord({
+                type: 'access',
+                token: newAccessToken,
+                firebaseRefreshToken: grant.firebaseRefreshToken,
+                clientId: grant.clientId,
+                expiresAt: accessExpiresAt,
+                encryptionKey: key
+            });
+            const refresh = grantRecord({
+                type: 'refresh',
+                token: newRefreshToken,
+                firebaseRefreshToken: grant.firebaseRefreshToken,
+                clientId: grant.clientId,
+                expiresAt: refreshExpiresAt,
+                encryptionKey: key
+            });
+            const result = await commit([
+                {
+                    delete: documentName(`refresh_${current.digest}`),
+                    currentDocument: { updateTime: current.document.updateTime }
+                },
+                createdDocumentWrite(documentName(access.id), access),
+                createdDocumentWrite(documentName(refresh.id), refresh)
+            ]);
+            return result.ok;
+        }
+    };
+}

--- a/services/chatgpt-mcp/src/server.js
+++ b/services/chatgpt-mcp/src/server.js
@@ -61,10 +61,29 @@ if (IS_PRODUCTION && OAUTH_GRANT_STORE !== 'firestore') {
 if (!['memory', 'firestore'].includes(OAUTH_GRANT_STORE)) {
     throw new Error('OAUTH_GRANT_STORE must be "memory" or "firestore".');
 }
+const OAUTH_GRANT_STORE_PROJECT_ID = process.env.OAUTH_GRANT_STORE_PROJECT_ID
+    || (IS_PRODUCTION ? '' : PROJECT_ID);
+const OAUTH_GRANT_STORE_DATABASE_ID = process.env.OAUTH_GRANT_STORE_DATABASE_ID
+    || (IS_PRODUCTION ? '' : '(default)');
+if (IS_PRODUCTION && (!OAUTH_GRANT_STORE_PROJECT_ID || !OAUTH_GRANT_STORE_DATABASE_ID)) {
+    throw new Error(
+        'Production and Cloud Run require explicit OAUTH_GRANT_STORE_PROJECT_ID '
+        + 'and OAUTH_GRANT_STORE_DATABASE_ID values.'
+    );
+}
+if (
+    IS_PRODUCTION
+    && OAUTH_GRANT_STORE_PROJECT_ID === PROJECT_ID
+    && OAUTH_GRANT_STORE_DATABASE_ID === '(default)'
+) {
+    throw new Error(
+        'Production OAuth grants must use an isolated project or a non-default Firestore database.'
+    );
+}
 const oauthGrantStore = OAUTH_GRANT_STORE === 'firestore'
     ? createFirestoreOAuthGrantStore({
-        projectId: process.env.OAUTH_GRANT_STORE_PROJECT_ID || PROJECT_ID,
-        databaseId: process.env.OAUTH_GRANT_STORE_DATABASE_ID || '(default)',
+        projectId: OAUTH_GRANT_STORE_PROJECT_ID,
+        databaseId: OAUTH_GRANT_STORE_DATABASE_ID,
         collectionId: process.env.OAUTH_GRANT_STORE_COLLECTION || 'chatgptMcpOAuthGrants',
         encryptionKey: process.env.OAUTH_GRANT_ENCRYPTION_KEY,
         accessTokenProvider: createMetadataAccessTokenProvider()

--- a/services/chatgpt-mcp/src/server.js
+++ b/services/chatgpt-mcp/src/server.js
@@ -1,10 +1,9 @@
 // AllPlays ChatGPT MCP service — Streamable HTTP entry point.
 //
-// Credential-free by design: the service holds no service account. Each
-// request's bearer token (Firebase refresh token or ID token) is resolved to
-// the user's ID token, and all Firestore access happens AS THAT USER over the
-// REST API — the same security rules that protect the AllPlays web/app clients
-// authorize every read here.
+// Application reads remain user-credentialed: each request's Firebase token is
+// resolved to the user's ID token, and Firestore access happens AS THAT USER.
+// The Cloud Run service identity is used only for the isolated OAuth grant
+// store; it never performs application-data reads.
 //
 // Tool names mirror the in-app private AI registry (apps/app/src/lib/
 // privateAiService.ts) so the ChatGPT surface and the app assistant stay one
@@ -25,10 +24,16 @@ import {
 import { createIdentityResolver, extractBearerToken } from './identity.js';
 import { createUserDb } from './firestoreRest.js';
 import { createOAuthBroker, metadataFor, OAuthError } from './oauth.js';
+import {
+    createFirestoreOAuthGrantStore,
+    createMemoryOAuthGrantStore,
+    createMetadataAccessTokenProvider
+} from './oauthStore.js';
 
 const PORT = Number(process.env.PORT) || 8787;
 const PROJECT_ID = process.env.FIREBASE_PROJECT_ID;
 const WEB_API_KEY = process.env.FIREBASE_WEB_API_KEY;
+const IS_PRODUCTION = process.env.NODE_ENV === 'production' || Boolean(process.env.K_SERVICE);
 
 if (!PROJECT_ID || !WEB_API_KEY) {
     throw new Error('FIREBASE_PROJECT_ID and FIREBASE_WEB_API_KEY must be set.');
@@ -40,16 +45,34 @@ const resolveIdentity = createIdentityResolver({ apiKey: WEB_API_KEY });
 // an Authorization header authenticate as this token's user. Anyone who can
 // reach the endpoint gets that user's (rules-scoped) data — use only with a
 // test account behind a private tunnel, never in production.
-const FALLBACK_BEARER = process.env.NODE_ENV === 'production' ? '' : (process.env.DEV_FALLBACK_BEARER || '');
-if (process.env.NODE_ENV === 'production' && process.env.DEV_FALLBACK_BEARER) {
+const FALLBACK_BEARER = IS_PRODUCTION ? '' : (process.env.DEV_FALLBACK_BEARER || '');
+if (IS_PRODUCTION && process.env.DEV_FALLBACK_BEARER) {
     throw new Error('DEV_FALLBACK_BEARER must not be set in production.');
 }
 if (FALLBACK_BEARER) {
     console.warn('[chatgpt-mcp] DEV_FALLBACK_BEARER is set: unauthenticated requests act as that user. Dev/test only.');
 }
 
+const OAUTH_GRANT_STORE = process.env.OAUTH_GRANT_STORE
+    || (IS_PRODUCTION ? 'firestore' : 'memory');
+if (IS_PRODUCTION && OAUTH_GRANT_STORE !== 'firestore') {
+    throw new Error('Production and Cloud Run require OAUTH_GRANT_STORE=firestore.');
+}
+if (!['memory', 'firestore'].includes(OAUTH_GRANT_STORE)) {
+    throw new Error('OAUTH_GRANT_STORE must be "memory" or "firestore".');
+}
+const oauthGrantStore = OAUTH_GRANT_STORE === 'firestore'
+    ? createFirestoreOAuthGrantStore({
+        projectId: process.env.OAUTH_GRANT_STORE_PROJECT_ID || PROJECT_ID,
+        databaseId: process.env.OAUTH_GRANT_STORE_DATABASE_ID || '(default)',
+        collectionId: process.env.OAUTH_GRANT_STORE_COLLECTION || 'chatgptMcpOAuthGrants',
+        encryptionKey: process.env.OAUTH_GRANT_ENCRYPTION_KEY,
+        accessTokenProvider: createMetadataAccessTokenProvider()
+    })
+    : createMemoryOAuthGrantStore();
 const oauth = createOAuthBroker({
-    trustedClientId: process.env.CHATGPT_OAUTH_CLIENT_ID
+    trustedClientId: process.env.CHATGPT_OAUTH_CLIENT_ID,
+    grantStore: oauthGrantStore
 });
 const SIGNIN_REFERER = process.env.ALLPLAYS_REFERER || 'https://allplays.ai/';
 
@@ -255,13 +278,16 @@ app.post('/oauth/authorize', async (req, res) => {
     }
 });
 
-app.post('/oauth/token', (req, res) => {
+app.post('/oauth/token', async (req, res) => {
     try {
-        res.json(oauth.exchange(req.body || {}));
+        res.json(await oauth.exchange(req.body || {}));
     } catch (error) {
         const code = error instanceof OAuthError ? error.code : 'server_error';
         if (!(error instanceof OAuthError)) console.error('[chatgpt-mcp] token failure:', error);
-        res.status(400).json({ error: code, error_description: error.message });
+        res.status(error instanceof OAuthError ? 400 : 503).json({
+            error: code,
+            error_description: error instanceof OAuthError ? error.message : 'OAuth grant store unavailable.'
+        });
     }
 });
 
@@ -273,7 +299,7 @@ app.post('/mcp', async (req, res) => {
         // Broker-issued access tokens resolve to the user's Firebase refresh
         // token; direct Firebase refresh/ID tokens pass through unchanged.
         const bearer = extractBearerToken(authHeader);
-        const brokerGrant = bearer ? oauth.resolveAccessToken(bearer) : null;
+        const brokerGrant = bearer ? await oauth.resolveAccessToken(bearer) : null;
         if (brokerGrant) authHeader = `Bearer ${brokerGrant.firebaseRefreshToken}`;
         identity = await resolveIdentity(authHeader);
     } catch (error) {

--- a/tests/unit/chatgpt-mcp-oauth.test.js
+++ b/tests/unit/chatgpt-mcp-oauth.test.js
@@ -525,6 +525,16 @@ describe('chatgpt-mcp oauth: Firestore grant store', () => {
             firebaseRefreshToken: 'firebase-secret-binding'
         });
 
+        for (const document of documents.values()) {
+            if (document.fields.type.stringValue === 'refresh') {
+                document.fields.encryptedBinding.mapValue.fields.tag.stringValue = Buffer.alloc(16, 9).toString('base64');
+            }
+        }
+        await expect(broker.exchange({
+            grant_type: 'refresh_token',
+            refresh_token: second.refresh_token
+        })).rejects.toMatchObject({ code: 'invalid_grant' });
+
         const expiringCode = authorize(broker, clientId, 'firebase-expiring-binding');
         const expiring = await broker.exchange({
             grant_type: 'authorization_code',
@@ -547,11 +557,22 @@ describe('chatgpt-mcp oauth: Firestore grant store', () => {
     });
 
     it('fails closed when credential-protection configuration is invalid', () => {
+        const validKey = Buffer.alloc(32).toString('base64');
         expect(() => createFirestoreOAuthGrantStore({
             projectId: 'oauth-project',
             encryptionKey: Buffer.alloc(16).toString('base64'),
             accessTokenProvider: async () => 'service-access-token'
         })).toThrow(/32-byte/);
+        expect(() => createFirestoreOAuthGrantStore({
+            projectId: 'oauth-project',
+            encryptionKey: `${validKey}=`,
+            accessTokenProvider: async () => 'service-access-token'
+        })).toThrow(/32-byte/);
+        const storeSource = readFileSync(
+            new URL('../../services/chatgpt-mcp/src/oauthStore.js', import.meta.url),
+            'utf8'
+        );
+        expect(storeSource).toContain('encoded.length !== 44');
     });
 });
 
@@ -574,6 +595,7 @@ describe('chatgpt-mcp oauth: durable deployment configuration', () => {
         expect(readme).toContain('roles/datastore.user');
         expect(readme).toContain('roles/secretmanager.secretAccessor');
         expect(readme).toContain('gcloud firestore fields ttls update expiresAt');
+        expect(readme).toContain('--enable-ttl');
         expect(readme).toContain('Key rotation and rollback');
         expect(readme).toContain('Never');
         expect(readme).toContain('OAUTH_GRANT_STORE=memory');

--- a/tests/unit/chatgpt-mcp-oauth.test.js
+++ b/tests/unit/chatgpt-mcp-oauth.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createServer } from 'node:http';
+import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import {
     createOAuthBroker,
@@ -578,6 +579,50 @@ describe('chatgpt-mcp oauth: Firestore grant store', () => {
 
 describe('chatgpt-mcp oauth: durable deployment configuration', () => {
     it('fails production closed and documents store, TTL, IAM, encryption, and rollback', () => {
+        const serverModuleUrl = new URL(
+            '../../services/chatgpt-mcp/src/server.js',
+            import.meta.url
+        ).href;
+        const productionEnv = {
+            ...process.env,
+            NODE_ENV: 'production',
+            FIREBASE_PROJECT_ID: 'application-project',
+            FIREBASE_WEB_API_KEY: 'test-api-key',
+            OAUTH_GRANT_STORE: 'firestore',
+            OAUTH_GRANT_ENCRYPTION_KEY: Buffer.alloc(32).toString('base64')
+        };
+        delete productionEnv.K_SERVICE;
+        delete productionEnv.OAUTH_GRANT_STORE_PROJECT_ID;
+        delete productionEnv.OAUTH_GRANT_STORE_DATABASE_ID;
+        const importServer = (env) => spawnSync(
+            process.execPath,
+            ['--input-type=module', '--eval', `import(${JSON.stringify(serverModuleUrl)})`],
+            { encoding: 'utf8', env }
+        );
+
+        const implicitApplicationStore = importServer(productionEnv);
+        expect(implicitApplicationStore.status).not.toBe(0);
+        expect(implicitApplicationStore.stderr).toContain(
+            'require explicit OAUTH_GRANT_STORE_PROJECT_ID and OAUTH_GRANT_STORE_DATABASE_ID'
+        );
+
+        const explicitApplicationStore = importServer({
+            ...productionEnv,
+            OAUTH_GRANT_STORE_PROJECT_ID: 'application-project',
+            OAUTH_GRANT_STORE_DATABASE_ID: '(default)'
+        });
+        expect(explicitApplicationStore.status).not.toBe(0);
+        expect(explicitApplicationStore.stderr).toContain(
+            'must use an isolated project or a non-default Firestore database'
+        );
+
+        const isolatedStore = importServer({
+            ...productionEnv,
+            OAUTH_GRANT_STORE_PROJECT_ID: 'oauth-grant-project',
+            OAUTH_GRANT_STORE_DATABASE_ID: '(default)'
+        });
+        expect(isolatedStore.status).toBe(0);
+
         const serverSource = readFileSync(
             new URL('../../services/chatgpt-mcp/src/server.js', import.meta.url),
             'utf8'
@@ -593,6 +638,7 @@ describe('chatgpt-mcp oauth: durable deployment configuration', () => {
         expect(serverSource).toContain('Production and Cloud Run require OAUTH_GRANT_STORE=firestore.');
         expect(serverSource).toContain('process.env.OAUTH_GRANT_ENCRYPTION_KEY');
         expect(readme).toContain('roles/datastore.user');
+        expect(readme).toContain('resource.name==');
         expect(readme).toContain('roles/secretmanager.secretAccessor');
         expect(readme).toContain('gcloud firestore fields ttls update expiresAt');
         expect(readme).toContain('--enable-ttl');

--- a/tests/unit/chatgpt-mcp-oauth.test.js
+++ b/tests/unit/chatgpt-mcp-oauth.test.js
@@ -641,7 +641,14 @@ describe('chatgpt-mcp oauth: durable deployment configuration', () => {
         expect(readme).toContain('resource.name==');
         expect(readme).toContain('roles/secretmanager.secretAccessor');
         expect(readme).toContain('gcloud firestore fields ttls update expiresAt');
+        expect(readme).toContain('--collection-group="$OAUTH_GRANT_STORE_COLLECTION"');
         expect(readme).toContain('--enable-ttl');
+        expect(readme).toContain('--database="$OAUTH_GRANT_STORE_DATABASE_ID"');
+        expect(readme).toContain('OAUTH_GRANT_KEY_VERSION=1');
+        expect(readme).toContain(
+            'projects/$OAUTH_GRANT_STORE_PROJECT_ID/secrets/chatgpt-mcp-oauth-grant-key:$OAUTH_GRANT_KEY_VERSION'
+        );
+        expect(readme).not.toContain('chatgpt-mcp-oauth-grant-key:latest');
         expect(readme).toContain('Key rotation and rollback');
         expect(readme).toContain('Never');
         expect(readme).toContain('OAUTH_GRANT_STORE=memory');

--- a/tests/unit/chatgpt-mcp-oauth.test.js
+++ b/tests/unit/chatgpt-mcp-oauth.test.js
@@ -1,11 +1,16 @@
 import { describe, it, expect } from 'vitest';
 import { createServer } from 'node:http';
+import { readFileSync } from 'node:fs';
 import {
     createOAuthBroker,
     metadataFor,
     s256Challenge,
     OAuthError
 } from '../../services/chatgpt-mcp/src/oauth.js';
+import {
+    createFirestoreOAuthGrantStore,
+    createMemoryOAuthGrantStore
+} from '../../services/chatgpt-mcp/src/oauthStore.js';
 
 const REDIRECT = 'https://chatgpt.com/connector_platform_oauth_redirect';
 const VERIFIER = 'test-verifier-string-with-plenty-of-entropy-1234567890';
@@ -184,10 +189,10 @@ describe('chatgpt-mcp oauth: authorize validation', () => {
 });
 
 describe('chatgpt-mcp oauth: code exchange', () => {
-    it('exchanges a code with the right PKCE verifier for tokens bound to the Firebase credential', () => {
+    it('exchanges a code with the right PKCE verifier for tokens bound to the Firebase credential', async () => {
         const { broker, clientId } = registeredBroker();
         const code = authorize(broker, clientId, 'firebase-rt-42');
-        const tokens = broker.exchange({
+        const tokens = await broker.exchange({
             grant_type: 'authorization_code',
             code,
             code_verifier: VERIFIER,
@@ -196,78 +201,382 @@ describe('chatgpt-mcp oauth: code exchange', () => {
         });
         expect(tokens.token_type).toBe('Bearer');
         expect(tokens.expires_in).toBeGreaterThan(0);
-        expect(broker.resolveAccessToken(tokens.access_token)).toEqual({ firebaseRefreshToken: 'firebase-rt-42' });
+        await expect(broker.resolveAccessToken(tokens.access_token)).resolves.toEqual({
+            firebaseRefreshToken: 'firebase-rt-42'
+        });
     });
 
-    it('rejects a wrong PKCE verifier and burns the code', () => {
+    it('rejects a wrong PKCE verifier and burns the code', async () => {
         const { broker, clientId } = registeredBroker();
         const code = authorize(broker, clientId);
-        expect(() => broker.exchange({ grant_type: 'authorization_code', code, code_verifier: 'wrong' })).toThrow(/PKCE/);
+        await expect(broker.exchange({
+            grant_type: 'authorization_code',
+            code,
+            code_verifier: 'wrong'
+        })).rejects.toThrow(/PKCE/);
         // Code is single-use even after a failed attempt.
-        expect(() => broker.exchange({ grant_type: 'authorization_code', code, code_verifier: VERIFIER })).toThrow(/invalid or expired/);
+        await expect(broker.exchange({
+            grant_type: 'authorization_code',
+            code,
+            code_verifier: VERIFIER
+        })).rejects.toThrow(/invalid or expired/);
     });
 
-    it('rejects reuse of a successfully exchanged code', () => {
+    it('rejects reuse of a successfully exchanged code', async () => {
         const { broker, clientId } = registeredBroker();
         const code = authorize(broker, clientId);
-        broker.exchange({ grant_type: 'authorization_code', code, code_verifier: VERIFIER });
-        expect(() => broker.exchange({ grant_type: 'authorization_code', code, code_verifier: VERIFIER })).toThrow(OAuthError);
+        await broker.exchange({ grant_type: 'authorization_code', code, code_verifier: VERIFIER });
+        await expect(broker.exchange({
+            grant_type: 'authorization_code',
+            code,
+            code_verifier: VERIFIER
+        })).rejects.toThrow(OAuthError);
     });
 
-    it('rejects expired codes', () => {
+    it('rejects expired codes', async () => {
         let time = 0;
         const { broker, clientId } = registeredBroker({ now: () => time });
         const code = authorize(broker, clientId);
         time = 11 * 60 * 1000;
-        expect(() => broker.exchange({ grant_type: 'authorization_code', code, code_verifier: VERIFIER })).toThrow(/expired/);
+        await expect(broker.exchange({
+            grant_type: 'authorization_code',
+            code,
+            code_verifier: VERIFIER
+        })).rejects.toThrow(/expired/);
     });
 
-    it('rejects a mismatched client_id on exchange', () => {
+    it('rejects a mismatched client_id on exchange', async () => {
         const { broker, clientId } = registeredBroker();
         const code = authorize(broker, clientId);
-        expect(() => broker.exchange({ grant_type: 'authorization_code', code, code_verifier: VERIFIER, client_id: 'other' })).toThrow(/client_id/);
+        await expect(broker.exchange({
+            grant_type: 'authorization_code',
+            code,
+            code_verifier: VERIFIER,
+            client_id: 'other'
+        })).rejects.toThrow(/client_id/);
     });
 });
 
 describe('chatgpt-mcp oauth: refresh and access tokens', () => {
-    it('supports the refresh_token grant', () => {
+    it('supports the refresh_token grant', async () => {
         const { broker, clientId } = registeredBroker();
         const code = authorize(broker, clientId, 'firebase-rt-9');
-        const first = broker.exchange({ grant_type: 'authorization_code', code, code_verifier: VERIFIER });
-        const second = broker.exchange({ grant_type: 'refresh_token', refresh_token: first.refresh_token });
+        const first = await broker.exchange({ grant_type: 'authorization_code', code, code_verifier: VERIFIER });
+        const second = await broker.exchange({ grant_type: 'refresh_token', refresh_token: first.refresh_token });
         expect(second.access_token).not.toBe(first.access_token);
-        expect(broker.resolveAccessToken(second.access_token)).toEqual({ firebaseRefreshToken: 'firebase-rt-9' });
-        expect(() => broker.exchange({ grant_type: 'refresh_token', refresh_token: first.refresh_token })).toThrow(/Unknown/);
+        await expect(broker.resolveAccessToken(second.access_token)).resolves.toEqual({
+            firebaseRefreshToken: 'firebase-rt-9'
+        });
+        await expect(broker.exchange({
+            grant_type: 'refresh_token',
+            refresh_token: first.refresh_token
+        })).rejects.toThrow(/Unknown/);
     });
 
-    it('expires refresh tokens and bounds retained access grants', () => {
+    it('expires refresh tokens and bounds retained access grants', async () => {
         let time = 0;
         const { broker, clientId } = registeredBroker({ now: () => time, maxStoredGrants: 2 });
-        const issued = Array.from({ length: 3 }, (_, index) => {
+        const issued = [];
+        for (let index = 0; index < 3; index += 1) {
             const code = authorize(broker, clientId, `firebase-rt-${index}`);
-            return broker.exchange({ grant_type: 'authorization_code', code, code_verifier: VERIFIER });
-        });
+            issued.push(await broker.exchange({
+                grant_type: 'authorization_code',
+                code,
+                code_verifier: VERIFIER
+            }));
+        }
 
-        expect(broker.resolveAccessToken(issued[0].access_token)).toBeNull();
-        expect(broker.resolveAccessToken(issued[2].access_token)).toBeTruthy();
+        await expect(broker.resolveAccessToken(issued[0].access_token)).resolves.toBeNull();
+        await expect(broker.resolveAccessToken(issued[2].access_token)).resolves.toBeTruthy();
         time = 31 * 24 * 60 * 60 * 1000;
-        expect(() => broker.exchange({ grant_type: 'refresh_token', refresh_token: issued[2].refresh_token })).toThrow(/Unknown/);
+        await expect(broker.exchange({
+            grant_type: 'refresh_token',
+            refresh_token: issued[2].refresh_token
+        })).rejects.toThrow(/Unknown/);
     });
 
-    it('expires access tokens and returns null for unknown tokens', () => {
+    it('expires access tokens and returns null for unknown tokens', async () => {
         let time = 0;
         const { broker, clientId } = registeredBroker({ now: () => time });
         const code = authorize(broker, clientId);
-        const tokens = broker.exchange({ grant_type: 'authorization_code', code, code_verifier: VERIFIER });
-        expect(broker.resolveAccessToken(tokens.access_token)).toBeTruthy();
+        const tokens = await broker.exchange({ grant_type: 'authorization_code', code, code_verifier: VERIFIER });
+        await expect(broker.resolveAccessToken(tokens.access_token)).resolves.toBeTruthy();
         time = 2 * 60 * 60 * 1000;
-        expect(broker.resolveAccessToken(tokens.access_token)).toBeNull();
-        expect(broker.resolveAccessToken('unknown')).toBeNull();
+        await expect(broker.resolveAccessToken(tokens.access_token)).resolves.toBeNull();
+        await expect(broker.resolveAccessToken('unknown')).resolves.toBeNull();
     });
 
-    it('rejects unsupported grant types', () => {
+    it('rejects unsupported grant types', async () => {
         const { broker } = registeredBroker();
-        expect(() => broker.exchange({ grant_type: 'password' })).toThrow(/grant_type/);
+        await expect(broker.exchange({ grant_type: 'password' })).rejects.toThrow(/grant_type/);
+    });
+
+    it('resolves an access grant through another broker instance', async () => {
+        const state = {};
+        const first = registeredBroker({
+            grantStore: createMemoryOAuthGrantStore({ state })
+        });
+        const second = registeredBroker({
+            grantStore: createMemoryOAuthGrantStore({ state })
+        });
+        const code = authorize(first.broker, first.clientId, 'firebase-cross-instance');
+        const tokens = await first.broker.exchange({
+            grant_type: 'authorization_code',
+            code,
+            code_verifier: VERIFIER
+        });
+
+        await expect(second.broker.resolveAccessToken(tokens.access_token)).resolves.toEqual({
+            firebaseRefreshToken: 'firebase-cross-instance'
+        });
+    });
+
+    it('exchanges a pre-restart refresh grant through a recreated broker', async () => {
+        const state = {};
+        const beforeRestart = registeredBroker({
+            grantStore: createMemoryOAuthGrantStore({ state })
+        });
+        const code = authorize(beforeRestart.broker, beforeRestart.clientId, 'firebase-after-restart');
+        const first = await beforeRestart.broker.exchange({
+            grant_type: 'authorization_code',
+            code,
+            code_verifier: VERIFIER
+        });
+        const afterRestart = registeredBroker({
+            grantStore: createMemoryOAuthGrantStore({ state })
+        });
+
+        const rotated = await afterRestart.broker.exchange({
+            grant_type: 'refresh_token',
+            refresh_token: first.refresh_token
+        });
+        await expect(afterRestart.broker.resolveAccessToken(rotated.access_token)).resolves.toEqual({
+            firebaseRefreshToken: 'firebase-after-restart'
+        });
+    });
+
+    it('allows exactly one concurrent refresh rotation across brokers', async () => {
+        const state = {};
+        const firstBroker = registeredBroker({
+            grantStore: createMemoryOAuthGrantStore({ state })
+        });
+        const secondBroker = registeredBroker({
+            grantStore: createMemoryOAuthGrantStore({ state })
+        });
+        const code = authorize(firstBroker.broker, firstBroker.clientId, 'firebase-atomic');
+        const first = await firstBroker.broker.exchange({
+            grant_type: 'authorization_code',
+            code,
+            code_verifier: VERIFIER
+        });
+
+        const attempts = await Promise.allSettled([
+            firstBroker.broker.exchange({
+                grant_type: 'refresh_token',
+                refresh_token: first.refresh_token
+            }),
+            secondBroker.broker.exchange({
+                grant_type: 'refresh_token',
+                refresh_token: first.refresh_token
+            })
+        ]);
+
+        expect(attempts.filter(({ status }) => status === 'fulfilled')).toHaveLength(1);
+        expect(attempts.filter(({ status }) => status === 'rejected')).toHaveLength(1);
+        expect(attempts.find(({ status }) => status === 'rejected').reason).toMatchObject({
+            code: 'invalid_grant'
+        });
+        await expect(firstBroker.broker.exchange({
+            grant_type: 'refresh_token',
+            refresh_token: first.refresh_token
+        })).rejects.toThrow(/Unknown/);
+    });
+
+    it('removes expired durable records while preserving unexpired grants', async () => {
+        let time = 0;
+        const state = {};
+        const { broker, clientId } = registeredBroker({
+            now: () => time,
+            grantStore: createMemoryOAuthGrantStore({ state, now: () => time })
+        });
+        const code = authorize(broker, clientId, 'firebase-expiring');
+        const tokens = await broker.exchange({
+            grant_type: 'authorization_code',
+            code,
+            code_verifier: VERIFIER
+        });
+
+        expect(state.accessTokens.size).toBe(1);
+        expect(state.refreshTokens.size).toBe(1);
+        time = 2 * 60 * 60 * 1000;
+        await expect(broker.resolveAccessToken(tokens.access_token)).resolves.toBeNull();
+        expect(state.accessTokens.size).toBe(0);
+        expect(state.refreshTokens.size).toBe(1);
+    });
+});
+
+describe('chatgpt-mcp oauth: Firestore grant store', () => {
+    it('encrypts Firebase bindings and uses one conditional commit for refresh rotation', async () => {
+        const requests = [];
+        const documents = new Map();
+        let updateCounter = 0;
+        let time = 0;
+        const fetchImpl = async (url, options = {}) => {
+            const resourceName = String(url)
+                .split('?')[0]
+                .replace('https://firestore.googleapis.com/v1/', '');
+            const request = {
+                url: String(url),
+                method: options.method || 'GET',
+                body: options.body ? JSON.parse(options.body) : null
+            };
+            requests.push(request);
+
+            if (request.url.endsWith('/documents:commit')) {
+                for (const write of request.body.writes) {
+                    if (write.delete) {
+                        const current = documents.get(write.delete);
+                        if (!current || current.updateTime !== write.currentDocument?.updateTime) {
+                            return {
+                                ok: false,
+                                status: 409,
+                                json: async () => ({ error: { status: 'ABORTED' } })
+                            };
+                        }
+                        documents.delete(write.delete);
+                    } else {
+                        const name = write.update.name;
+                        if (write.currentDocument?.exists === false && documents.has(name)) {
+                            return {
+                                ok: false,
+                                status: 409,
+                                json: async () => ({ error: { status: 'ALREADY_EXISTS' } })
+                            };
+                        }
+                        updateCounter += 1;
+                        documents.set(name, {
+                            ...write.update,
+                            updateTime: `2026-07-23T00:00:0${updateCounter}Z`
+                        });
+                    }
+                }
+                return { ok: true, json: async () => ({ writeResults: [] }) };
+            }
+
+            if (request.method === 'DELETE') {
+                documents.delete(resourceName);
+                return { ok: true, json: async () => ({}) };
+            }
+
+            const document = documents.get(resourceName);
+            if (!document) return { ok: false, status: 404, json: async () => ({}) };
+            return { ok: true, json: async () => document };
+        };
+        const store = createFirestoreOAuthGrantStore({
+            projectId: 'oauth-project',
+            encryptionKey: Buffer.alloc(32, 7).toString('base64'),
+            accessTokenProvider: async () => 'service-access-token',
+            fetchImpl,
+            now: () => time
+        });
+        const { broker, clientId } = registeredBroker({ grantStore: store, now: () => time });
+        const { broker: secondBroker } = registeredBroker({ grantStore: store, now: () => time });
+        const code = authorize(broker, clientId, 'firebase-secret-binding');
+        const first = await broker.exchange({
+            grant_type: 'authorization_code',
+            code,
+            code_verifier: VERIFIER
+        });
+
+        const persisted = JSON.stringify([...documents.values()]);
+        expect(persisted).not.toContain('firebase-secret-binding');
+        expect(persisted).not.toContain(first.access_token);
+        expect(persisted).not.toContain(first.refresh_token);
+        await expect(broker.resolveAccessToken(first.access_token)).resolves.toEqual({
+            firebaseRefreshToken: 'firebase-secret-binding'
+        });
+
+        const rotations = await Promise.allSettled([
+            broker.exchange({
+                grant_type: 'refresh_token',
+                refresh_token: first.refresh_token
+            }),
+            secondBroker.exchange({
+                grant_type: 'refresh_token',
+                refresh_token: first.refresh_token
+            })
+        ]);
+        expect(rotations.filter(({ status }) => status === 'fulfilled')).toHaveLength(1);
+        expect(rotations.filter(({ status }) => status === 'rejected')).toHaveLength(1);
+        const second = rotations.find(({ status }) => status === 'fulfilled').value;
+        expect(second.refresh_token).not.toBe(first.refresh_token);
+        const rotationCommit = requests
+            .filter(({ url }) => url.endsWith('/documents:commit'))
+            .at(-1).body;
+        expect(rotationCommit.writes).toHaveLength(3);
+        expect(rotationCommit.writes[0]).toMatchObject({
+            delete: expect.stringContaining('/refresh_'),
+            currentDocument: { updateTime: expect.any(String) }
+        });
+        expect(rotationCommit.writes.slice(1).every((write) => (
+            write.currentDocument?.exists === false
+        ))).toBe(true);
+        await expect(broker.resolveAccessToken(second.access_token)).resolves.toEqual({
+            firebaseRefreshToken: 'firebase-secret-binding'
+        });
+
+        const expiringCode = authorize(broker, clientId, 'firebase-expiring-binding');
+        const expiring = await broker.exchange({
+            grant_type: 'authorization_code',
+            code: expiringCode,
+            code_verifier: VERIFIER
+        });
+        time = 2 * 60 * 60 * 1000;
+        await expect(broker.resolveAccessToken(expiring.access_token)).resolves.toBeNull();
+        expect(requests.some(({ method, url }) => (
+            method === 'DELETE' && url.includes('/access_')
+        ))).toBe(true);
+
+        time = 0;
+        for (const document of documents.values()) {
+            if (document.fields.type.stringValue === 'access') {
+                document.fields.encryptedBinding.mapValue.fields.tag.stringValue = Buffer.alloc(16, 9).toString('base64');
+            }
+        }
+        await expect(broker.resolveAccessToken(second.access_token)).rejects.toThrow();
+    });
+
+    it('fails closed when credential-protection configuration is invalid', () => {
+        expect(() => createFirestoreOAuthGrantStore({
+            projectId: 'oauth-project',
+            encryptionKey: Buffer.alloc(16).toString('base64'),
+            accessTokenProvider: async () => 'service-access-token'
+        })).toThrow(/32-byte/);
+    });
+});
+
+describe('chatgpt-mcp oauth: durable deployment configuration', () => {
+    it('fails production closed and documents store, TTL, IAM, encryption, and rollback', () => {
+        const serverSource = readFileSync(
+            new URL('../../services/chatgpt-mcp/src/server.js', import.meta.url),
+            'utf8'
+        );
+        const readme = readFileSync(
+            new URL('../../services/chatgpt-mcp/README.md', import.meta.url),
+            'utf8'
+        );
+
+        expect(serverSource).toContain(
+            "const IS_PRODUCTION = process.env.NODE_ENV === 'production' || Boolean(process.env.K_SERVICE);"
+        );
+        expect(serverSource).toContain('Production and Cloud Run require OAUTH_GRANT_STORE=firestore.');
+        expect(serverSource).toContain('process.env.OAUTH_GRANT_ENCRYPTION_KEY');
+        expect(readme).toContain('roles/datastore.user');
+        expect(readme).toContain('roles/secretmanager.secretAccessor');
+        expect(readme).toContain('gcloud firestore fields ttls update expiresAt');
+        expect(readme).toContain('Key rotation and rollback');
+        expect(readme).toContain('Never');
+        expect(readme).toContain('OAUTH_GRANT_STORE=memory');
     });
 });
 


### PR DESCRIPTION
Closes #4160

## What changed
- Persist access and refresh grants in Firestore using SHA-256 token identifiers.
- Encrypt Firebase refresh-token bindings with AES-256-GCM.
- Rotate refresh tokens through one conditional atomic commit.
- Enforce expiry immediately and support Firestore TTL cleanup.
- Fail closed on Cloud Run without durable-store and encryption configuration.
- Document IAM, Secret Manager, TTL, key rotation, and rollback requirements.

## Root Cause
The OAuth broker stored access and refresh grants in process-local Maps. Cloud Run instances could not share grants, restarts erased them, and refresh rotation lacked a cross-instance atomic consume boundary.

## Prevention / Learning
Bearer grants used by stateless multi-instance services require shared durable storage, hashed identifiers, protected credential bindings, request-time expiry enforcement, and transactional consume-and-reissue semantics before deployment.

## Regression Tests
- Cross-instance access-token resolution.
- Refresh exchange after broker recreation.
- Single-winner concurrent refresh rotation.
- Expiry rejection and cleanup.
- Encrypted-at-rest bindings and tamper rejection.
- Production configuration and deployment-documentation checks.
- Adjacent MCP core regression suite.

## Recurrence Risk
Medium. Unit coverage protects the code paths, but production IAM, TTL, Secret Manager configuration, and deployed multi-instance behavior still require rollout verification.