### PR TITLE
Preserve verified teams in partial schedule scope

### DIFF
--- a/apps/app/src/lib/adapters/legacyScheduleDb.test.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.test.ts
@@ -344,9 +344,51 @@ describe('legacyScheduleDb staff team reads', () => {
         });
     });
 
+    it('keeps the in-app-created owner team when the admin-email query is denied', async () => {
+        vi.mocked(getDocs)
+            .mockResolvedValueOnce({ docs: [snapshot('team-vipers', { name: 'Vipers', ownerId: 'user-1' })] } as never)
+            .mockRejectedValueOnce(new Error('adminEmails denied'))
+            .mockResolvedValueOnce({ docs: [] } as never)
+            .mockResolvedValueOnce({ docs: [] } as never);
+
+        await expect(getStaffTeams({
+            userId: 'user-1',
+            email: 'paul@allplays.ai',
+            coachTeamIds: []
+        })).resolves.toEqual({
+            teams: [
+                { id: 'team-vipers', name: 'Vipers', ownerId: 'user-1' }
+            ],
+            isPartial: true
+        });
+    });
+
+    it('keeps admin teams when the owner-id query is denied', async () => {
+        vi.mocked(getDocs)
+            .mockRejectedValueOnce(new Error('ownerId denied'))
+            .mockResolvedValueOnce({ docs: [snapshot('team-admin', { name: 'Admin' })] } as never)
+            .mockResolvedValueOnce({ docs: [] } as never)
+            .mockResolvedValueOnce({ docs: [] } as never);
+
+        await expect(getStaffTeams({
+            userId: 'user-1',
+            email: 'staff@example.com',
+            coachTeamIds: []
+        })).resolves.toEqual({
+            teams: [
+                { id: 'team-admin', name: 'Admin' }
+            ],
+            isPartial: true
+        });
+    });
+
     it('propagates owner and admin query failures so native callers can use the REST fallback', async () => {
         const queryError = new Error('web sdk unavailable');
-        vi.mocked(getDocs).mockRejectedValueOnce(queryError);
+        vi.mocked(getDocs)
+            .mockRejectedValueOnce(queryError)
+            .mockRejectedValueOnce(queryError)
+            .mockRejectedValueOnce(queryError)
+            .mockRejectedValueOnce(queryError);
 
         await expect(getStaffTeams({ userId: 'coach-1', email: 'coach@example.com', coachTeamIds: [] })).rejects.toThrow('web sdk unavailable');
 

--- a/apps/app/src/lib/adapters/legacyScheduleDb.test.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.test.ts
@@ -304,6 +304,18 @@ describe('legacyScheduleDb staff team reads', () => {
         expect(getDoc).not.toHaveBeenCalled();
     });
 
+    it('propagates an owner-id failure for blank-email users so native callers can use the REST fallback', async () => {
+        const queryError = new Error('web sdk unavailable');
+        vi.mocked(getDocs).mockRejectedValueOnce(queryError);
+
+        await expect(getStaffTeams({ userId: 'parent-1', email: '   ', coachTeamIds: [] })).rejects.toThrow('web sdk unavailable');
+
+        expect(getDocs).toHaveBeenCalledTimes(1);
+        expect(where).toHaveBeenCalledTimes(1);
+        expect(where).toHaveBeenCalledWith('ownerId', '==', 'parent-1');
+        expect(getDoc).not.toHaveBeenCalled();
+    });
+
     it('keeps UID and admin teams when the normalized legacy owner query is denied', async () => {
         vi.mocked(getDocs)
             .mockResolvedValueOnce({ docs: [snapshot('team-owner', { name: 'Owner' })] } as never)

--- a/apps/app/src/lib/adapters/legacyScheduleDb.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.ts
@@ -182,13 +182,15 @@ export async function getStaffTeams({ userId, email, coachTeamIds = [], includeA
     const ownerEmailCandidates = [...new Set([staffEmail, normalizedEmail].filter(Boolean))];
     const uniqueCoachTeamIds = [...new Set(coachTeamIds.map((teamId) => String(teamId || '').trim()).filter(Boolean))];
     const emptySnapshot = { docs: [] };
-    const [ownedSnapshot, adminSnapshot, legacyOwnerSnapshotResults, coachSnapshotResults] = await Promise.all([
-        userId
-            ? legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('ownerId', '==', userId)))
-            : Promise.resolve(emptySnapshot),
-        normalizedEmail
-            ? legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('adminEmails', 'array-contains', normalizedEmail)))
-            : Promise.resolve(emptySnapshot),
+    const [coreStaffSnapshotResults, legacyOwnerSnapshotResults, coachSnapshotResults] = await Promise.all([
+        Promise.allSettled([
+            userId
+                ? legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('ownerId', '==', userId)))
+                : Promise.resolve(emptySnapshot),
+            normalizedEmail
+                ? legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('adminEmails', 'array-contains', normalizedEmail)))
+                : Promise.resolve(emptySnapshot)
+        ]),
         Promise.allSettled([
             normalizedEmail
                 ? legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('ownerEmailLower', '==', normalizedEmail)))
@@ -202,6 +204,13 @@ export async function getStaffTeams({ userId, email, coachTeamIds = [], includeA
         )))
     ]);
 
+    const successfulCoreStaffSnapshots = coreStaffSnapshotResults.flatMap((result) => (
+        result.status === 'fulfilled' && result.value ? [result.value] : []
+    ));
+    if (!successfulCoreStaffSnapshots.length) {
+        const firstCoreFailure = coreStaffSnapshotResults.find((result) => result.status === 'rejected');
+        if (firstCoreFailure?.status === 'rejected') throw firstCoreFailure.reason;
+    }
     const legacyOwnerSnapshots = legacyOwnerSnapshotResults.flatMap((result) => (
         result.status === 'fulfilled' && result.value ? [result.value] : []
     ));
@@ -209,7 +218,7 @@ export async function getStaffTeams({ userId, email, coachTeamIds = [], includeA
         result.status === 'fulfilled' && result.value ? [result.value] : []
     ));
     const teamsById = new Map<string, Record<string, unknown>>();
-    [...ownedSnapshot.docs, ...adminSnapshot.docs, ...legacyOwnerSnapshots.flatMap((snapshot) => snapshot.docs), ...coachSnapshots]
+    [...successfulCoreStaffSnapshots.flatMap((snapshot) => snapshot.docs), ...legacyOwnerSnapshots.flatMap((snapshot) => snapshot.docs), ...coachSnapshots]
         .filter((snapshot): snapshot is NonNullable<typeof snapshot> => Boolean(snapshot && ('exists' in snapshot ? snapshot.exists() : true)))
         .forEach((snapshot) => {
             const id = String(snapshot.id || '').trim();
@@ -217,7 +226,8 @@ export async function getStaffTeams({ userId, email, coachTeamIds = [], includeA
         });
     return {
         teams: [...teamsById.values()],
-        isPartial: [...legacyOwnerSnapshotResults, ...coachSnapshotResults].some((result) => result.status === 'rejected')
+        isPartial: [...coreStaffSnapshotResults, ...legacyOwnerSnapshotResults, ...coachSnapshotResults]
+            .some((result) => result.status === 'rejected')
     };
 }
 

--- a/apps/app/src/lib/adapters/legacyScheduleDb.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.ts
@@ -182,15 +182,16 @@ export async function getStaffTeams({ userId, email, coachTeamIds = [], includeA
     const ownerEmailCandidates = [...new Set([staffEmail, normalizedEmail].filter(Boolean))];
     const uniqueCoachTeamIds = [...new Set(coachTeamIds.map((teamId) => String(teamId || '').trim()).filter(Boolean))];
     const emptySnapshot = { docs: [] };
+    const coreStaffQueries = [
+        ...(userId
+            ? [legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('ownerId', '==', userId)))]
+            : []),
+        ...(normalizedEmail
+            ? [legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('adminEmails', 'array-contains', normalizedEmail)))]
+            : [])
+    ];
     const [coreStaffSnapshotResults, legacyOwnerSnapshotResults, coachSnapshotResults] = await Promise.all([
-        Promise.allSettled([
-            userId
-                ? legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('ownerId', '==', userId)))
-                : Promise.resolve(emptySnapshot),
-            normalizedEmail
-                ? legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('adminEmails', 'array-contains', normalizedEmail)))
-                : Promise.resolve(emptySnapshot)
-        ]),
+        Promise.allSettled(coreStaffQueries),
         Promise.allSettled([
             normalizedEmail
                 ? legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('ownerEmailLower', '==', normalizedEmail)))

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -1042,6 +1042,35 @@ describe('Schedule', () => {
     });
   });
 
+  it('keeps a verified in-app-created staff team from a partial scope response in the filter and editor', async () => {
+    scheduleServiceMocks.loadParentScheduleScope.mockResolvedValueOnce({
+      profile: {},
+      children: [],
+      staffTeams: [{ teamId: 'team-owned', teamName: 'Vipers' }],
+      isPartial: true
+    });
+    appDataCacheMocks.loadCachedAppData.mockResolvedValueOnce({
+      children: [],
+      events: [buildScheduleEvent(1, {
+        teamId: 'team-parent',
+        teamName: 'Jr KC Current',
+        isTeamStaff: true
+      })],
+      staffTeams: [{ teamId: 'team-parent', teamName: 'Jr KC Current' }]
+    });
+
+    renderSchedule('/schedule?teamId=team-owned');
+
+    const teamFilter = await screen.findByLabelText('Team filter');
+    expect(await within(teamFilter).findByRole('option', { name: 'Vipers' })).toBeTruthy();
+    expect((teamFilter as HTMLSelectElement).value).toBe('team-owned');
+
+    fireEvent.click(await screen.findByRole('button', { name: /manage schedule/i }));
+
+    expect(await screen.findByRole('heading', { name: 'Add game for Vipers' })).toBeTruthy();
+    expect((screen.getByLabelText('Team to manage') as HTMLSelectElement).value).toBe('team-owned');
+  });
+
   it('routes generic staff card opens to the game hub helper on mobile', () => {
     expect(getGenericEventDetailPath(buildScheduleEvent(1, {
       isTeamStaff: true,

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -139,6 +139,38 @@ function applyAuthoritativeScheduleScope(
     });
 }
 
+function mergePartialScheduleScope(
+  currentChildren: ParentScheduleChild[],
+  currentEvents: ParentScheduleEvent[],
+  currentStaffTeams: ParentScheduleStaffTeam[],
+  partialChildren: ParentScheduleChild[],
+  partialStaffTeams: ParentScheduleStaffTeam[]
+) {
+  const childrenByKey = new Map(
+    currentChildren.map((child) => [`${child.teamId}::${child.playerId}`, child])
+  );
+  partialChildren.forEach((child) => {
+    childrenByKey.set(`${child.teamId}::${child.playerId}`, child);
+  });
+
+  const staffTeamsById = new Map(currentStaffTeams.map((team) => [team.teamId, team]));
+  partialStaffTeams.forEach((team) => {
+    staffTeamsById.set(team.teamId, team);
+  });
+  const mergedStaffTeams = [...staffTeamsById.values()];
+  const discoveredStaffTeamIds = new Set(partialStaffTeams.map((team) => team.teamId));
+
+  return {
+    children: [...childrenByKey.values()],
+    events: currentEvents.map((event) => (
+      discoveredStaffTeamIds.has(event.teamId) && event.isTeamStaff !== true
+        ? { ...event, isTeamStaff: true }
+        : event
+    )),
+    staffTeams: mergedStaffTeams
+  };
+}
+
 export function Schedule({ auth }: { auth: AuthState }) {
   const [searchParams] = useSearchParams();
   const { isDesktopWeb } = useShellLayout();
@@ -398,12 +430,38 @@ export function Schedule({ auth }: { auth: AuthState }) {
     const refreshVersion = ++scheduleRefreshVersionRef.current;
     let refreshedChildren: ParentScheduleChild[] | null = null;
     let refreshedStaffTeams: ParentScheduleStaffTeam[] | null = null;
+    let partialScopeChildren: ParentScheduleChild[] = [];
+    let partialScopeStaffTeams: ParentScheduleStaffTeam[] = [];
     const parentScopePromise = loadParentScheduleScope(auth.user).catch(() => null);
     void parentScopePromise
       .then((parentScope) => {
-        if (!parentScope || parentScope.isPartial === true) return;
+        if (!parentScope) return;
         if (activeUserIdRef.current !== requestedUserId) return;
         if (scheduleRefreshVersionRef.current !== refreshVersion) return;
+        if (parentScope.isPartial === true) {
+          partialScopeChildren = parentScope.children ?? [];
+          partialScopeStaffTeams = parentScope.staffTeams ?? [];
+          const mergedScope = mergePartialScheduleScope(
+            childrenRef.current,
+            eventsRef.current,
+            [],
+            partialScopeChildren,
+            partialScopeStaffTeams
+          );
+          childrenRef.current = mergedScope.children;
+          setChildren(mergedScope.children);
+          setStaffTeams((currentStaffTeams) => (
+            mergePartialScheduleScope(
+              childrenRef.current,
+              eventsRef.current,
+              currentStaffTeams,
+              [],
+              partialScopeStaffTeams
+            ).staffTeams
+          ));
+          updateScheduleEvents(() => mergedScope.events);
+          return;
+        }
         refreshedChildren = parentScope.children ?? [];
         refreshedStaffTeams = parentScope.staffTeams ?? [];
         childrenRef.current = refreshedChildren;
@@ -450,7 +508,13 @@ export function Schedule({ auth }: { auth: AuthState }) {
           if (activeUserIdRef.current !== requestedUserId) return;
           if (scheduleRefreshVersionRef.current !== refreshVersion) return;
           const authoritativeResult = refreshedStaffTeams === null
-            ? result
+            ? mergePartialScheduleScope(
+                result.children,
+                result.events,
+                result.staffTeams ?? [],
+                partialScopeChildren,
+                partialScopeStaffTeams
+              )
             : {
                 ...result,
                 children: refreshedChildren!,


### PR DESCRIPTION
## What changed
- retain successful owner/admin team results when another staff-team lookup is denied
- merge verified teams from partial schedule-scope responses into cached schedule state
- keep the staff editor synchronized with the selected Vipers filter
- add regression coverage for an in-app-created Vipers team arriving alongside cached Jr KC Current data

## Root cause
Vipers was created correctly with Paul’s current UID and email. The schedule scope marked the overall result partial when any optional lookup failed, and the Schedule page discarded the entire partial response. That left the filter and staff editor using different cached team state, so the editor stayed on Jr KC Current.

## Validation
- `npx vitest run src/pages/Schedule.test.tsx src/lib/adapters/legacyScheduleDb.test.ts --reporter=dot` from `apps/app` (89 passed)
- `npx vitest run tests/unit/app-schedule-service-contracts.test.js --reporter=dot` (37 passed)
- `npm run app:build`
- `git diff --check`