### PR TITLE
Persist OAuth authorization codes across instances

### DIFF
--- a/docs/pr-notes/runs/issue-4159-fixer-20260724T025549Z/architecture.md
+++ b/docs/pr-notes/runs/issue-4159-fixer-20260724T025549Z/architecture.md
@@ -1,0 +1,37 @@
+# Current-State Read
+
+`createOAuthBroker()` owns a process-local authorization-code `Map`. Approval writes locally and exchange reads/deletes locally. Access and refresh grants already use injected memory and Firestore adapters with hashed identifiers, encrypted Firebase credential bindings, logical expiry, and TTL cleanup.
+
+# Proposed Design
+
+- Extend the existing store with `issueAuthorizationCode()` and `consumeAuthorizationCode()`.
+- Make approval async and persist before returning the code.
+- Consume before validating client, redirect, or PKCE to retain fail-closed burn-on-attempt behavior.
+- Memory: use shared `authorizationCodes` state, prune expired records, enforce the existing hard bound, and synchronously read/delete.
+- Firestore: use `code_<sha256(code)>`, encrypt the credential binding with authenticated immutable metadata, create with `exists=false`, and conditionally delete with `updateTime`.
+- Reuse existing Firestore configuration, isolated database, encryption key, IAM, and TTL. Add no dependency.
+
+# Files And Modules Touched
+
+- `services/chatgpt-mcp/src/oauth.js`
+- `services/chatgpt-mcp/src/oauthStore.js`
+- `services/chatgpt-mcp/src/server.js`
+- `tests/unit/chatgpt-mcp-oauth.test.js`
+- `services/chatgpt-mcp/README.md`
+
+# Data/State Impacts
+
+New code documents share the OAuth collection and retain `type`, `clientId`, `redirectUri`, `codeChallenge`, `expiresAt`, and `encryptedBinding`. Raw codes and Firebase refresh tokens are not persisted. No migration is required because existing codes are ephemeral.
+
+# Security/Permissions Impacts
+
+The isolated OAuth store remains the only service-identity boundary. Expiry is checked synchronously; TTL is cleanup only. Wrong validation fields burn the code. Store unavailability fails closed and does not fall back to memory in production.
+
+# Failure Modes And Mitigations
+
+- Conditional-delete conflicts mean another exchange won and map to `invalid_grant`.
+- Store outages propagate as server failures.
+- Corrupt records fail closed.
+- Grant issuance failure after consume leaves the code burned.
+- Rollout should drain old revisions promptly because old instances still issue local codes.
+- Rollback must retain the durable-store configuration and use a revision that supports durable code consumption.

--- a/docs/pr-notes/runs/issue-4159-fixer-20260724T025549Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-4159-fixer-20260724T025549Z/code-plan.md
@@ -1,0 +1,50 @@
+# Patch Plan
+
+1. Extend the existing OAuth store contract with durable code issue and atomic consume operations.
+2. Add shared, bounded authorization-code state to the memory adapter.
+3. Add hashed, encrypted, expiring authorization-code documents and conditional consume to the Firestore adapter.
+4. Remove the broker-local code map, make approval async, and consume before validation.
+5. Await approval in the HTTP route.
+6. Add focused cross-instance, race, invalid-grant, persistence, and retention tests.
+7. Document durable authorization-code controls.
+
+# Code Changes Applied
+
+No code was applied by the analysis role. The main fixer lane owns all edits.
+
+# Validation Run
+
+Planned focused validation: `npx vitest run tests/unit/chatgpt-mcp-oauth.test.js --reporter=verbose`.
+
+# Residual Risks
+
+- Firestore TTL is asynchronous, so the durable bound is time-based.
+- A grant-issuance failure after consume requires the user to restart authorization.
+- Type-specific authenticated metadata must preserve compatibility for existing access and refresh grants.
+- The REST fake models conditional semantics but does not replace an emulator or deployed canary.
+
+# Commit Message Draft
+
+`Persist OAuth authorization codes across instances (#4159)`
+
+# Synthesized Execution Plan
+
+## Acceptance Criteria
+
+Cross-instance exchange succeeds; concurrent consume has one winner; invalid binding fields and expiry return `invalid_grant`; credential binding remains encrypted and correct.
+
+## Architecture Decisions
+
+Reuse the existing OAuth store, use hashed code document IDs, authenticate all code metadata in encryption, consume with a Firestore `updateTime` precondition, and retain existing optional client/redirect request behavior.
+
+## QA Plan
+
+Write tests first for independent brokers, races, validation failures, persistence shape, and bounded memory behavior. Keep the focused OAuth suite as the local gate.
+
+## Implementation Plan
+
+Make the smallest changes in `oauthStore.js`, `oauth.js`, `server.js`, the focused unit test, and README. Do not change dependencies or out-of-scope token behavior.
+
+## Risks And Rollback
+
+The main rollout risk is mixed old/new revisions. Drain old revisions promptly. Roll back only to a durable-code-capable revision or temporarily constrain traffic to one instance as an explicit degraded control.

--- a/docs/pr-notes/runs/issue-4159-fixer-20260724T025549Z/qa.md
+++ b/docs/pr-notes/runs/issue-4159-fixer-20260724T025549Z/qa.md
@@ -1,0 +1,31 @@
+# Risk Matrix
+
+- High: cross-instance misses, double consumption, lost validation fields, credential crossover/leakage, expired or malformed record acceptance.
+- Medium: conflict/outage misclassification, unbounded retention, access/refresh regression.
+- Low: UI or sports-role behavior, which is out of scope.
+
+# Automated Tests To Add/Update
+
+- Create on broker/store A and exchange on independently constructed broker/store B.
+- Race two brokers and assert one success, one `invalid_grant`, and permanent replay rejection.
+- Cover expired, client mismatch, redirect mismatch, and wrong/missing PKCE verifier with fresh codes.
+- Prove a failed validation attempt burns the code.
+- Inspect Firestore persistence for hashed identifiers, encrypted credentials, retained binding fields, expiry, and conditional deletion.
+- Cover memory eviction, Firestore conflict, Firestore outage, corrupt record, and wrong key where the adjacent harness supports them.
+- Keep existing registration, access, refresh rotation, encryption, and production configuration tests green.
+
+# Manual Test Plan
+
+In isolated non-production infrastructure, authorize on instance A and exchange on B, then run a controlled two-instance race. Inspect Firestore for hashed code IDs, encrypted bindings, expiry, and TTL configuration.
+
+# Negative Tests
+
+Unknown, empty, consumed, expired, mismatched, tampered, and corrupt records issue no tokens. Conditional conflicts become `invalid_grant`; permissions, availability, and generic backend failures remain server errors.
+
+# Release Gates
+
+Run `npx vitest run tests/unit/chatgpt-mcp-oauth.test.js --reporter=verbose`. Tests must use independent brokers/store adapters, assert OAuth error codes, verify the conditional consume request, and prove no raw code or credential is persisted.
+
+# Post-Deploy Checks
+
+Canary cross-instance exchange and a controlled race. Monitor token endpoint errors, consume conflicts, authorization-to-token success, latency, expired-document growth, TTL cleanup, and isolated-database audit logs.

--- a/docs/pr-notes/runs/issue-4159-fixer-20260724T025549Z/requirements.md
+++ b/docs/pr-notes/runs/issue-4159-fixer-20260724T025549Z/requirements.md
@@ -1,0 +1,36 @@
+# Problem Statement
+
+OAuth authorization codes are stored in a broker-local `Map`. A code issued on one Cloud Run instance cannot be exchanged on another instance or after a restart. The durable boundary must retain PKCE, client, redirect URI, expiry, and the verified Firebase credential binding while preserving single use.
+
+# User Segments Impacted
+
+- Coaches, parents, and admins need reliable ChatGPT connector setup regardless of request routing.
+- Operators need restart-safe, replay-resistant, bounded authorization records without expanding the broker service identity's access to application data.
+
+# Acceptance Criteria
+
+1. A code created by broker A can be exchanged by broker B when both use the same durable store.
+2. The record retains client ID, exact redirect URI, S256 challenge, absolute expiry, and Firebase refresh-token binding.
+3. Two concurrent exchanges produce exactly one success and one `invalid_grant`; later replay also fails.
+4. The first exchange attempt consumes the code, including failed client, redirect, or PKCE validation.
+5. Unknown, expired, mismatched-client, mismatched-redirect, and failed-PKCE codes return `invalid_grant`.
+6. Expiry is enforced synchronously even when TTL cleanup is delayed.
+7. Memory storage remains cardinality-bounded; durable storage is time-bounded by the 10-minute lifetime and Firestore TTL.
+8. Raw codes are not used as document identifiers and credential bindings are encrypted at rest.
+9. Existing access-token, refresh-token, registration, direct-bearer, MCP tool, and UI behavior remains unchanged.
+
+# Non-Goals
+
+- Persisting broker access tokens or refresh tokens as part of this slice.
+- Changing MCP tools, UI, clients, redirects, grant types, PKCE methods, or application permissions.
+- Building a general-purpose OAuth storage framework.
+
+# Edge Cases
+
+- Cross-instance exchange, instance restart, simultaneous consume, exchange at exact expiry, invalid validation fields, corrupt storage, backend outage, random code collision, delayed TTL cleanup, and concurrent authorizations for different users.
+
+# Open Questions
+
+- Preserve the existing token-request contract: omitted client and redirect remain accepted, but supplied mismatches fail.
+- Treat the durable bound as short validity plus TTL rather than a contention-heavy distributed record-count cap.
+- Treat unusable/corrupt records as `invalid_grant`; propagate true store outages as server failures.

--- a/services/chatgpt-mcp/README.md
+++ b/services/chatgpt-mcp/README.md
@@ -80,14 +80,18 @@ grant, and opaque access tokens that map to the signed-in user's Firebase
 refresh token. Codes are single-use with a 10-minute TTL; access tokens last
 1 hour. The trusted ChatGPT client registration is configuration-backed and
 stable across instances. Access and refresh grants use Firestore in production,
-so they survive restarts and resolve across Cloud Run instances. Refresh-token
-consume-and-reissue is one conditional Firestore commit, so concurrent reuse has
-one winner. Authorization codes remain process-local under issue #4159.
+so they survive restarts and resolve across Cloud Run instances. Authorization
+codes use the same durable store, retain their PKCE/client/redirect/expiry
+binding, and are atomically consumed before token-exchange validation.
+Refresh-token consume-and-reissue and authorization-code consumption use
+conditional Firestore commits, so concurrent reuse has one winner.
 
-Raw broker tokens are not stored. Firestore document IDs contain SHA-256 token
-digests, and the Firebase refresh-token binding is encrypted with AES-256-GCM.
-The service checks `expiresAt` on every read or rotation; Firestore TTL provides
-eventual physical cleanup.
+Raw broker tokens and authorization codes are not stored. Firestore document IDs
+contain SHA-256 digests, and the Firebase refresh-token binding is encrypted
+with AES-256-GCM. Authorization-code client, redirect, PKCE, and expiry metadata
+is authenticated with that encryption envelope. The service checks `expiresAt`
+on every consume, read, or rotation; Firestore TTL provides eventual physical
+cleanup.
 
 Sign-in accepts AllPlays email/password (proxied to Firebase Identity Toolkit
 with the site referer; the password is never stored). Google sign-in is a
@@ -162,6 +166,7 @@ gcloud run deploy allplays-chatgpt-mcp \
 ```
 
 Before increasing the minimum or maximum instance count, verify cross-instance
+authorization-code exchange, concurrent single-use code consumption,
 access-token resolution, refresh exchange after a revision restart, and a
 two-request refresh race with exactly one success.
 

--- a/services/chatgpt-mcp/src/oauth.js
+++ b/services/chatgpt-mcp/src/oauth.js
@@ -7,9 +7,8 @@
 // resolve broker token → Firebase credential → rules-enforced Firestore
 // access, unchanged from the direct-bearer path.
 //
-// Authorization codes remain process-local under issue #4159. Issued access
-// and refresh grants use an injected store so production instances share one
-// durable, atomic lifecycle boundary.
+// Authorization codes and issued grants use an injected store so production
+// instances share one durable, atomic lifecycle boundary.
 
 import { createHash, randomBytes } from 'node:crypto';
 import { createMemoryOAuthGrantStore } from './oauthStore.js';
@@ -54,6 +53,8 @@ export function createOAuthBroker({
     }
     if (
         !grantStore
+        || typeof grantStore.issueAuthorizationCode !== 'function'
+        || typeof grantStore.consumeAuthorizationCode !== 'function'
         || typeof grantStore.issueGrantPair !== 'function'
         || typeof grantStore.resolveAccessToken !== 'function'
         || typeof grantStore.rotateRefreshToken !== 'function'
@@ -64,22 +65,6 @@ export function createOAuthBroker({
         clientId: trustedClientId.trim(),
         redirectUris: [...TRUSTED_REDIRECT_URIS]
     };
-    const codes = new Map();
-
-    function pruneExpired(store) {
-        for (const [key, record] of store) {
-            if (record.expiresAt <= now()) store.delete(key);
-        }
-    }
-
-    function setBounded(store, key, record) {
-        pruneExpired(store);
-        while (store.size >= maxStoredGrants) {
-            store.delete(store.keys().next().value);
-        }
-        store.set(key, record);
-    }
-
     function registerClient({ redirect_uris: redirectUris } = {}) {
         if (!Array.isArray(redirectUris) || redirectUris.length === 0) {
             throw new OAuthError('invalid_request', 'redirect_uris is required.');
@@ -111,7 +96,7 @@ export function createOAuthBroker({
         return { clientId, redirectUri, codeChallenge };
     }
 
-    function approveAuthorization({ clientId, redirectUri, codeChallenge, firebaseRefreshToken }) {
+    async function approveAuthorization({ clientId, redirectUri, codeChallenge, firebaseRefreshToken }) {
         if (!firebaseRefreshToken) throw new OAuthError('invalid_request', 'Sign-in did not produce a credential.');
         // Re-validate so a tampered approval form cannot bypass the checks.
         validateAuthorizeRequest({
@@ -122,7 +107,14 @@ export function createOAuthBroker({
             code_challenge_method: 'S256'
         });
         const code = randomId(32);
-        setBounded(codes, code, { clientId, redirectUri, codeChallenge, firebaseRefreshToken, expiresAt: now() + CODE_TTL_MS });
+        await grantStore.issueAuthorizationCode({
+            code,
+            clientId,
+            redirectUri,
+            codeChallenge,
+            firebaseRefreshToken,
+            expiresAt: now() + CODE_TTL_MS
+        });
         return code;
     }
 
@@ -153,8 +145,7 @@ export function createOAuthBroker({
     async function exchange(params = {}) {
         const grantType = params.grant_type;
         if (grantType === 'authorization_code') {
-            const record = codes.get(params.code);
-            codes.delete(params.code); // single-use, success or not
+            const record = await grantStore.consumeAuthorizationCode(params.code);
             if (!record || record.expiresAt <= now()) {
                 throw new OAuthError('invalid_grant', 'Authorization code is invalid or expired.');
             }

--- a/services/chatgpt-mcp/src/oauthStore.js
+++ b/services/chatgpt-mcp/src/oauthStore.js
@@ -1,4 +1,4 @@
-// OAuth access/refresh grant persistence.
+// OAuth authorization-code and access/refresh grant persistence.
 //
 // Production grants live in Firestore under SHA-256 token identifiers. The
 // user's Firebase refresh-token binding is encrypted with AES-256-GCM before
@@ -22,6 +22,7 @@ function tokenDigest(token) {
 }
 
 function initializeMemoryState(state) {
+    if (!state.authorizationCodes) state.authorizationCodes = new Map();
     if (!state.accessTokens) state.accessTokens = new Map();
     if (!state.refreshTokens) state.refreshTokens = new Map();
     return state;
@@ -52,6 +53,35 @@ export function createMemoryOAuthGrantStore({
     const stores = initializeMemoryState(state);
 
     return {
+        async issueAuthorizationCode({
+            code,
+            clientId,
+            redirectUri,
+            codeChallenge,
+            firebaseRefreshToken,
+            expiresAt
+        }) {
+            setBounded(stores.authorizationCodes, code, {
+                clientId,
+                redirectUri,
+                codeChallenge,
+                firebaseRefreshToken,
+                expiresAt
+            }, now(), maxStoredGrants);
+        },
+
+        async consumeAuthorizationCode(code) {
+            const currentTime = now();
+            pruneExpired(stores.authorizationCodes, currentTime);
+            const record = stores.authorizationCodes.get(code);
+            if (!record) return null;
+
+            // No await occurs between the read and delete, so concurrent calls
+            // against shared state have one consume winner.
+            stores.authorizationCodes.delete(code);
+            return { ...record };
+        },
+
         async issueGrantPair({
             accessToken,
             refreshToken,
@@ -121,13 +151,18 @@ function decodeEncryptionKey(value) {
     return key;
 }
 
-function authenticatedMetadata({ type, digest, clientId, expiresAt }) {
-    return Buffer.from(JSON.stringify({
+function authenticatedMetadata({ type, digest, clientId, expiresAt, redirectUri, codeChallenge }) {
+    const metadata = {
         type,
         digest,
         clientId: clientId || '',
         expiresAt
-    }), 'utf8');
+    };
+    if (type === 'code') {
+        metadata.redirectUri = redirectUri || '';
+        metadata.codeChallenge = codeChallenge || '';
+    }
+    return Buffer.from(JSON.stringify(metadata), 'utf8');
 }
 
 function encryptBinding(key, firebaseRefreshToken, metadata) {
@@ -178,6 +213,39 @@ function grantRecord({ type, token, firebaseRefreshToken, clientId, expiresAt, e
         fields: {
             type,
             clientId,
+            expiresAt: new Date(expiresAt),
+            encryptedBinding: encryptBinding(encryptionKey, firebaseRefreshToken, metadata)
+        }
+    };
+}
+
+function authorizationCodeRecord({
+    code,
+    clientId,
+    redirectUri,
+    codeChallenge,
+    firebaseRefreshToken,
+    expiresAt,
+    encryptionKey
+}) {
+    const type = 'code';
+    const digest = tokenDigest(code);
+    const metadata = {
+        type,
+        digest,
+        clientId,
+        redirectUri,
+        codeChallenge,
+        expiresAt
+    };
+    return {
+        id: `${type}_${digest}`,
+        digest,
+        fields: {
+            type,
+            clientId,
+            redirectUri,
+            codeChallenge,
             expiresAt: new Date(expiresAt),
             encryptedBinding: encryptBinding(encryptionKey, firebaseRefreshToken, metadata)
         }
@@ -334,7 +402,84 @@ export function createFirestoreOAuthGrantStore({
         };
     }
 
+    function decryptAuthorizationCode(result) {
+        const expiresAt = result.record.expiresAt instanceof Date
+            ? result.record.expiresAt.getTime()
+            : Number.NaN;
+        if (
+            result.record.type !== 'code'
+            || !Number.isFinite(expiresAt)
+            || typeof result.record.clientId !== 'string'
+            || typeof result.record.redirectUri !== 'string'
+            || typeof result.record.codeChallenge !== 'string'
+        ) {
+            throw new Error('Stored OAuth authorization code has an invalid schema.');
+        }
+        const metadata = {
+            type: 'code',
+            digest: result.digest,
+            clientId: result.record.clientId,
+            redirectUri: result.record.redirectUri,
+            codeChallenge: result.record.codeChallenge,
+            expiresAt
+        };
+        return {
+            clientId: result.record.clientId,
+            redirectUri: result.record.redirectUri,
+            codeChallenge: result.record.codeChallenge,
+            expiresAt,
+            firebaseRefreshToken: decryptBinding(
+                key,
+                result.record.encryptedBinding,
+                metadata
+            )
+        };
+    }
+
     return {
+        async issueAuthorizationCode({
+            code,
+            clientId,
+            redirectUri,
+            codeChallenge,
+            firebaseRefreshToken,
+            expiresAt
+        }) {
+            const record = authorizationCodeRecord({
+                code,
+                clientId,
+                redirectUri,
+                codeChallenge,
+                firebaseRefreshToken,
+                expiresAt,
+                encryptionKey: key
+            });
+            const result = await commit([
+                createdDocumentWrite(documentName(record.id), record)
+            ]);
+            if (!result.ok) throw new Error('OAuth authorization code collision.');
+        },
+
+        async consumeAuthorizationCode(code) {
+            const current = await readGrant('code', code);
+            if (!current) return null;
+            let record;
+            try {
+                record = decryptAuthorizationCode(current);
+            } catch {
+                return null;
+            }
+            if (record.expiresAt <= now()) {
+                await deleteExpired('code', current.digest, current.document.updateTime);
+                return null;
+            }
+            const result = await commit([{
+                delete: documentName(`code_${current.digest}`),
+                currentDocument: { updateTime: current.document.updateTime }
+            }]);
+            return result.ok ? record : null;
+        },
+
         async issueGrantPair({
             accessToken,
             refreshToken,

--- a/services/chatgpt-mcp/src/server.js
+++ b/services/chatgpt-mcp/src/server.js
@@ -274,7 +274,12 @@ app.post('/oauth/authorize', async (req, res) => {
         // do not persist an unverified refresh_token posted to this public route.
         const signedIn = await firebaseSignIn(String(params.email || ''), String(params.password || ''));
         const firebaseRefreshToken = signedIn.refreshToken;
-        const code = oauth.approveAuthorization({ clientId, redirectUri, codeChallenge, firebaseRefreshToken });
+        const code = await oauth.approveAuthorization({
+            clientId,
+            redirectUri,
+            codeChallenge,
+            firebaseRefreshToken
+        });
         const redirect = new URL(redirectUri);
         redirect.searchParams.set('code', code);
         if (params.state) redirect.searchParams.set('state', params.state);

--- a/tests/unit/chatgpt-mcp-oauth.test.js
+++ b/tests/unit/chatgpt-mcp-oauth.test.js
@@ -192,7 +192,7 @@ describe('chatgpt-mcp oauth: authorize validation', () => {
 describe('chatgpt-mcp oauth: code exchange', () => {
     it('exchanges a code with the right PKCE verifier for tokens bound to the Firebase credential', async () => {
         const { broker, clientId } = registeredBroker();
-        const code = authorize(broker, clientId, 'firebase-rt-42');
+        const code = await authorize(broker, clientId, 'firebase-rt-42');
         const tokens = await broker.exchange({
             grant_type: 'authorization_code',
             code,
@@ -209,23 +209,29 @@ describe('chatgpt-mcp oauth: code exchange', () => {
 
     it('rejects a wrong PKCE verifier and burns the code', async () => {
         const { broker, clientId } = registeredBroker();
-        const code = authorize(broker, clientId);
+        const code = await authorize(broker, clientId);
         await expect(broker.exchange({
             grant_type: 'authorization_code',
             code,
             code_verifier: 'wrong'
-        })).rejects.toThrow(/PKCE/);
+        })).rejects.toMatchObject({ code: 'invalid_grant' });
         // Code is single-use even after a failed attempt.
         await expect(broker.exchange({
             grant_type: 'authorization_code',
             code,
             code_verifier: VERIFIER
         })).rejects.toThrow(/invalid or expired/);
+
+        const missingVerifierCode = await authorize(broker, clientId);
+        await expect(broker.exchange({
+            grant_type: 'authorization_code',
+            code: missingVerifierCode
+        })).rejects.toMatchObject({ code: 'invalid_grant' });
     });
 
     it('rejects reuse of a successfully exchanged code', async () => {
         const { broker, clientId } = registeredBroker();
-        const code = authorize(broker, clientId);
+        const code = await authorize(broker, clientId);
         await broker.exchange({ grant_type: 'authorization_code', code, code_verifier: VERIFIER });
         await expect(broker.exchange({
             grant_type: 'authorization_code',
@@ -237,31 +243,125 @@ describe('chatgpt-mcp oauth: code exchange', () => {
     it('rejects expired codes', async () => {
         let time = 0;
         const { broker, clientId } = registeredBroker({ now: () => time });
-        const code = authorize(broker, clientId);
+        const code = await authorize(broker, clientId);
         time = 11 * 60 * 1000;
         await expect(broker.exchange({
             grant_type: 'authorization_code',
             code,
             code_verifier: VERIFIER
-        })).rejects.toThrow(/expired/);
+        })).rejects.toMatchObject({ code: 'invalid_grant' });
     });
 
     it('rejects a mismatched client_id on exchange', async () => {
         const { broker, clientId } = registeredBroker();
-        const code = authorize(broker, clientId);
+        const code = await authorize(broker, clientId);
         await expect(broker.exchange({
             grant_type: 'authorization_code',
             code,
             code_verifier: VERIFIER,
             client_id: 'other'
-        })).rejects.toThrow(/client_id/);
+        })).rejects.toMatchObject({ code: 'invalid_grant' });
+    });
+
+    it('exchanges a code through another broker instance using shared durable state', async () => {
+        const state = {};
+        const first = registeredBroker({
+            grantStore: createMemoryOAuthGrantStore({ state })
+        });
+        const second = registeredBroker({
+            grantStore: createMemoryOAuthGrantStore({ state })
+        });
+        const code = await authorize(first.broker, first.clientId, 'firebase-cross-instance-code');
+
+        const tokens = await second.broker.exchange({
+            grant_type: 'authorization_code',
+            code,
+            code_verifier: VERIFIER,
+            client_id: first.clientId,
+            redirect_uri: REDIRECT
+        });
+
+        await expect(second.broker.resolveAccessToken(tokens.access_token)).resolves.toEqual({
+            firebaseRefreshToken: 'firebase-cross-instance-code'
+        });
+    });
+
+    it('allows exactly one concurrent authorization-code exchange across brokers', async () => {
+        const state = {};
+        const first = registeredBroker({
+            grantStore: createMemoryOAuthGrantStore({ state })
+        });
+        const second = registeredBroker({
+            grantStore: createMemoryOAuthGrantStore({ state })
+        });
+        const code = await authorize(first.broker, first.clientId, 'firebase-code-race');
+        const params = {
+            grant_type: 'authorization_code',
+            code,
+            code_verifier: VERIFIER
+        };
+
+        const attempts = await Promise.allSettled([
+            first.broker.exchange(params),
+            second.broker.exchange(params)
+        ]);
+
+        expect(attempts.filter(({ status }) => status === 'fulfilled')).toHaveLength(1);
+        expect(attempts.filter(({ status }) => status === 'rejected')).toHaveLength(1);
+        expect(attempts.find(({ status }) => status === 'rejected').reason).toMatchObject({
+            code: 'invalid_grant'
+        });
+        await expect(first.broker.exchange(params)).rejects.toMatchObject({
+            code: 'invalid_grant'
+        });
+    });
+
+    it('returns invalid_grant for redirect mismatch and consumes the code', async () => {
+        const { broker, clientId } = registeredBroker();
+        const code = await authorize(broker, clientId);
+
+        await expect(broker.exchange({
+            grant_type: 'authorization_code',
+            code,
+            code_verifier: VERIFIER,
+            redirect_uri: 'https://example.invalid/callback'
+        })).rejects.toMatchObject({ code: 'invalid_grant' });
+        await expect(broker.exchange({
+            grant_type: 'authorization_code',
+            code,
+            code_verifier: VERIFIER
+        })).rejects.toMatchObject({ code: 'invalid_grant' });
+    });
+
+    it('bounds retained unconsumed authorization codes in memory', async () => {
+        const state = {};
+        let sequence = 0;
+        const { broker, clientId } = registeredBroker({
+            randomId: () => `opaque-${sequence += 1}`,
+            maxStoredGrants: 2,
+            grantStore: createMemoryOAuthGrantStore({
+                state,
+                maxStoredGrants: 2
+            })
+        });
+        const codes = [];
+        for (let index = 0; index < 3; index += 1) {
+            codes.push(await authorize(broker, clientId, `firebase-bounded-${index}`));
+        }
+
+        await expect(broker.exchange({
+            grant_type: 'authorization_code',
+            code: codes[0],
+            code_verifier: VERIFIER
+        })).rejects.toMatchObject({ code: 'invalid_grant' });
+        expect(state.authorizationCodes.size).toBe(2);
     });
 });
 
 describe('chatgpt-mcp oauth: refresh and access tokens', () => {
     it('supports the refresh_token grant', async () => {
         const { broker, clientId } = registeredBroker();
-        const code = authorize(broker, clientId, 'firebase-rt-9');
+        const code = await authorize(broker, clientId, 'firebase-rt-9');
         const first = await broker.exchange({ grant_type: 'authorization_code', code, code_verifier: VERIFIER });
         const second = await broker.exchange({ grant_type: 'refresh_token', refresh_token: first.refresh_token });
         expect(second.access_token).not.toBe(first.access_token);
@@ -279,7 +379,7 @@ describe('chatgpt-mcp oauth: refresh and access tokens', () => {
         const { broker, clientId } = registeredBroker({ now: () => time, maxStoredGrants: 2 });
         const issued = [];
         for (let index = 0; index < 3; index += 1) {
-            const code = authorize(broker, clientId, `firebase-rt-${index}`);
+            const code = await authorize(broker, clientId, `firebase-rt-${index}`);
             issued.push(await broker.exchange({
                 grant_type: 'authorization_code',
                 code,
@@ -299,7 +399,7 @@ describe('chatgpt-mcp oauth: refresh and access tokens', () => {
     it('expires access tokens and returns null for unknown tokens', async () => {
         let time = 0;
         const { broker, clientId } = registeredBroker({ now: () => time });
-        const code = authorize(broker, clientId);
+        const code = await authorize(broker, clientId);
         const tokens = await broker.exchange({ grant_type: 'authorization_code', code, code_verifier: VERIFIER });
         await expect(broker.resolveAccessToken(tokens.access_token)).resolves.toBeTruthy();
         time = 2 * 60 * 60 * 1000;
@@ -320,7 +420,7 @@ describe('chatgpt-mcp oauth: refresh and access tokens', () => {
         const second = registeredBroker({
             grantStore: createMemoryOAuthGrantStore({ state })
         });
-        const code = authorize(first.broker, first.clientId, 'firebase-cross-instance');
+        const code = await authorize(first.broker, first.clientId, 'firebase-cross-instance');
         const tokens = await first.broker.exchange({
             grant_type: 'authorization_code',
             code,
@@ -337,7 +437,7 @@ describe('chatgpt-mcp oauth: refresh and access tokens', () => {
         const beforeRestart = registeredBroker({
             grantStore: createMemoryOAuthGrantStore({ state })
         });
-        const code = authorize(beforeRestart.broker, beforeRestart.clientId, 'firebase-after-restart');
+        const code = await authorize(beforeRestart.broker, beforeRestart.clientId, 'firebase-after-restart');
         const first = await beforeRestart.broker.exchange({
             grant_type: 'authorization_code',
             code,
@@ -364,7 +464,7 @@ describe('chatgpt-mcp oauth: refresh and access tokens', () => {
         const secondBroker = registeredBroker({
             grantStore: createMemoryOAuthGrantStore({ state })
         });
-        const code = authorize(firstBroker.broker, firstBroker.clientId, 'firebase-atomic');
+        const code = await authorize(firstBroker.broker, firstBroker.clientId, 'firebase-atomic');
         const first = await firstBroker.broker.exchange({
             grant_type: 'authorization_code',
             code,
@@ -400,7 +500,7 @@ describe('chatgpt-mcp oauth: refresh and access tokens', () => {
             now: () => time,
             grantStore: createMemoryOAuthGrantStore({ state, now: () => time })
         });
-        const code = authorize(broker, clientId, 'firebase-expiring');
+        const code = await authorize(broker, clientId, 'firebase-expiring');
         const tokens = await broker.exchange({
             grant_type: 'authorization_code',
             code,
@@ -473,17 +573,36 @@ describe('chatgpt-mcp oauth: Firestore grant store', () => {
             if (!document) return { ok: false, status: 404, json: async () => ({}) };
             return { ok: true, json: async () => document };
         };
-        const store = createFirestoreOAuthGrantStore({
+        const storeOptions = {
             projectId: 'oauth-project',
             encryptionKey: Buffer.alloc(32, 7).toString('base64'),
             accessTokenProvider: async () => 'service-access-token',
             fetchImpl,
             now: () => time
-        });
+        };
+        const store = createFirestoreOAuthGrantStore(storeOptions);
+        const secondStore = createFirestoreOAuthGrantStore(storeOptions);
         const { broker, clientId } = registeredBroker({ grantStore: store, now: () => time });
-        const { broker: secondBroker } = registeredBroker({ grantStore: store, now: () => time });
-        const code = authorize(broker, clientId, 'firebase-secret-binding');
-        const first = await broker.exchange({
+        const { broker: secondBroker } = registeredBroker({
+            grantStore: secondStore,
+            now: () => time
+        });
+        const code = await authorize(broker, clientId, 'firebase-secret-binding');
+        const codeDocuments = [...documents.entries()].filter(([name]) => name.includes('/code_'));
+        expect(codeDocuments).toHaveLength(1);
+        expect(codeDocuments[0][0]).not.toContain(code);
+        expect(JSON.stringify(codeDocuments[0][1])).not.toContain(code);
+        expect(JSON.stringify(codeDocuments[0][1])).not.toContain('firebase-secret-binding');
+        expect(codeDocuments[0][1].fields).toMatchObject({
+            type: { stringValue: 'code' },
+            clientId: { stringValue: clientId },
+            redirectUri: { stringValue: REDIRECT },
+            codeChallenge: { stringValue: s256Challenge(VERIFIER) },
+            expiresAt: { timestampValue: expect.any(String) },
+            encryptedBinding: { mapValue: expect.any(Object) }
+        });
+
+        const first = await secondBroker.exchange({
             grant_type: 'authorization_code',
             code,
             code_verifier: VERIFIER
@@ -496,6 +615,48 @@ describe('chatgpt-mcp oauth: Firestore grant store', () => {
         await expect(broker.resolveAccessToken(first.access_token)).resolves.toEqual({
             firebaseRefreshToken: 'firebase-secret-binding'
         });
+
+        const racingCode = await authorize(broker, clientId, 'firebase-code-race');
+        const codeExchanges = await Promise.allSettled([
+            broker.exchange({
+                grant_type: 'authorization_code',
+                code: racingCode,
+                code_verifier: VERIFIER
+            }),
+            secondBroker.exchange({
+                grant_type: 'authorization_code',
+                code: racingCode,
+                code_verifier: VERIFIER
+            })
+        ]);
+        expect(codeExchanges.filter(({ status }) => status === 'fulfilled')).toHaveLength(1);
+        expect(codeExchanges.filter(({ status }) => status === 'rejected')).toHaveLength(1);
+        expect(codeExchanges.find(({ status }) => status === 'rejected').reason).toMatchObject({
+            code: 'invalid_grant'
+        });
+        const codeConsumeCommit = requests
+            .filter(({ url, body }) => (
+                url.endsWith('/documents:commit')
+                && body?.writes?.length === 1
+                && body.writes[0].delete?.includes('/code_')
+            ))
+            .at(-1).body;
+        expect(codeConsumeCommit.writes[0]).toMatchObject({
+            delete: expect.stringContaining('/code_'),
+            currentDocument: { updateTime: expect.any(String) }
+        });
+
+        const expiredCode = await authorize(broker, clientId, 'firebase-expired-code');
+        time = 11 * 60 * 1000;
+        await expect(secondBroker.exchange({
+            grant_type: 'authorization_code',
+            code: expiredCode,
+            code_verifier: VERIFIER
+        })).rejects.toMatchObject({ code: 'invalid_grant' });
+        expect(requests.some(({ method, url }) => (
+            method === 'DELETE' && url.includes('/code_')
+        ))).toBe(true);
+        time = 0;
 
         const rotations = await Promise.allSettled([
             broker.exchange({
@@ -536,7 +697,7 @@ describe('chatgpt-mcp oauth: Firestore grant store', () => {
             refresh_token: second.refresh_token
         })).rejects.toMatchObject({ code: 'invalid_grant' });
 
-        const expiringCode = authorize(broker, clientId, 'firebase-expiring-binding');
+        const expiringCode = await authorize(broker, clientId, 'firebase-expiring-binding');
         const expiring = await broker.exchange({
             grant_type: 'authorization_code',
             code: expiringCode,


### PR DESCRIPTION
Closes #4159

## What changed
- Persist authorization codes in the shared OAuth grant store.
- Encrypt Firebase credential bindings and store codes under hashed identifiers.
- Atomically consume Firestore records using update-time preconditions.
- Preserve bounded memory storage and Firestore TTL cleanup.
- Add cross-instance, concurrent-consume, expiry, binding, and PKCE regression coverage.

## Root Cause
Authorization codes lived in a process-local Map, so another Cloud Run instance or restarted process could not exchange them. Local deletion also provided no cross-instance atomic single-use boundary.

## Prevention / Learning
Every one-time credential issued by a stateless multi-instance service must persist its validation and identity-binding fields in the shared durable control plane and use atomic consumption before validation or token issuance.

## Regression Tests
- Cross-instance exchange through independent brokers and stores.
- Concurrent memory and Firestore exchanges with exactly one winner.
- Expired, client-mismatched, redirect-mismatched, wrong-PKCE, and missing-PKCE invalid_grant cases.
- Hashed identifiers, encrypted bindings, expiry metadata, bounded memory retention, and conditional Firestore deletion.
- `npx vitest run tests/unit/chatgpt-mcp-oauth.test.js --reporter=verbose` passed with 27 tests.

## Recurrence Risk
Low. Focused tests now cover the persistence boundary, atomic consume semantics, credential binding, expiry, and validation failures.