### PR TITLE
Cache Playwright browser binaries in preview-smoke

### DIFF
--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -122,8 +122,32 @@ jobs:
             done
           done
 
+      - name: Resolve Playwright version
+        id: pw-version
+        run: |
+          set -euo pipefail
+          # Key the browser cache on the installed Playwright version so a version
+          # bump misses the cache and re-downloads, but same-version runs reuse it.
+          version="$(node -e "console.log(require('@playwright/test/package.json').version)" 2>/dev/null \
+            || node -e "console.log(require('playwright/package.json').version)")"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.pw-version.outputs.version }}
+
       - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
+        run: |
+          if [ "${{ steps.pw-cache.outputs.cache-hit }}" = "true" ]; then
+            # Browser binaries restored from cache; only (re)install the OS libs,
+            # which are not cached and are cheap.
+            npx playwright install-deps chromium
+          else
+            npx playwright install --with-deps chromium
+          fi
 
       - name: Run static-hosting smoke
         run: npx playwright test --config=playwright.smoke.config.js --grep-invert @visual --reporter=line


### PR DESCRIPTION
## Why
preview-smoke re-downloads Chromium on every run (`playwright install --with-deps chromium`, ~1-2 min). That fixed cost is paid by every app PR that runs the smoke.

## What
- Resolve the installed Playwright version and cache `~/.cache/ms-playwright` keyed on it (`actions/cache@v4`).
- On cache hit, only `playwright install-deps chromium` (OS libs, cheap) runs; on miss (version bump) it falls back to the full install.

No behavior change to the tests; purely setup-time. Complements the earlier path-filter (backend PRs skip the smoke entirely) and does not touch test parallelism (these smoke tests share backend fixtures, so forcing `fullyParallel` was deliberately avoided).

🤖 Generated with [Claude Code](https://claude.com/claude-code)