### PR TITLE
Serialize expensive PR landing checks

### DIFF
--- a/.github/workflows/deploy-preview-trusted.yml
+++ b/.github/workflows/deploy-preview-trusted.yml
@@ -14,11 +14,59 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  prepare-preview:
+  classify-trigger:
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+    outputs:
+      preview_ready: ${{ steps.classify.outputs.preview_ready }}
+
+    steps:
+      - name: Classify artifact-producing and intentionally deferred runs
+        id: classify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          jobs_json="$RUNNER_TEMP/firebase-preview-source-jobs.json"
+          artifacts_json="$RUNNER_TEMP/firebase-preview-source-artifacts.json"
+          gh api --paginate "repos/$GITHUB_REPOSITORY/actions/runs/$WORKFLOW_RUN_ID/jobs?per_page=100" > "$jobs_json"
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$WORKFLOW_RUN_ID/artifacts?per_page=100" > "$artifacts_json"
+
+          bundle_count="$(jq '[.artifacts[]? | select(.name == "firebase-preview-hosting-bundle")] | length' "$artifacts_json")"
+          if [ "$bundle_count" -eq 1 ]; then
+            echo "preview_ready=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$bundle_count" -ne 0 ]; then
+            echo "Expected at most one preview bundle, found $bundle_count." >&2
+            exit 1
+          fi
+
+          regression_result="$(jq -r '[.jobs[]? | select(.name == "regression-guards") | .conclusion] | last // ""' "$jobs_json")"
+          build_result="$(jq -r '[.jobs[]? | select(.name == "build-preview-artifact") | .conclusion] | last // ""' "$jobs_json")"
+          if [ "$regression_result" = "skipped" ] && [ "$build_result" = "skipped" ]; then
+            echo "Preview source run was intentionally deferred; no trusted deploy is needed."
+            echo "preview_ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Successful preview source run had no bundle without an intentional two-job deferral." >&2
+          exit 1
+
+  prepare-preview:
+    needs: classify-trigger
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      needs.classify-trigger.outputs.preview_ready == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - synchronize
       - reopened
+      - labeled
       - unlabeled
       - closed
 
@@ -15,7 +16,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: preview-${{ github.event.pull_request.number }}
+  group: ${{ (github.event.action == 'labeled' || github.event.action == 'unlabeled') && github.event.label.name != 'external-claim' && format('preview-label-noop-{0}', github.run_id) || format('preview-{0}', github.event.pull_request.number) }}
   cancel-in-progress: true
 
 jobs:
@@ -24,7 +25,7 @@ jobs:
       github.event.action != 'closed' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       !contains(github.event.pull_request.labels.*.name, 'external-claim') &&
-      (github.event.action != 'unlabeled' || github.event.label.name == 'external-claim')
+      ((github.event.action != 'labeled' && github.event.action != 'unlabeled') || github.event.label.name == 'external-claim')
     runs-on: ubuntu-latest
 
     steps:
@@ -70,7 +71,7 @@ jobs:
       github.event.action != 'closed' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       !contains(github.event.pull_request.labels.*.name, 'external-claim') &&
-      (github.event.action != 'unlabeled' || github.event.label.name == 'external-claim')
+      ((github.event.action != 'labeled' && github.event.action != 'unlabeled') || github.event.label.name == 'external-claim')
     needs: [regression-guards]
     runs-on: ubuntu-latest
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - synchronize
       - reopened
+      - unlabeled
       - closed
 
 # Pull-request-controlled code runs here, so this workflow has no repository
@@ -18,59 +19,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  unit-tests:
-    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout pull request merge
-        run: |
-          git init .
-          git remote add origin https://github.com/${{ github.repository }}.git
-          git fetch --no-tags --prune --depth=1 origin +refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge
-          git checkout --force refs/remotes/pull/${{ github.event.pull_request.number }}/merge
-
-      - name: Setup Node
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Setup Java
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
-        with:
-          distribution: temurin
-          java-version: 21
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Install Functions dependencies
-        run: npm ci --prefix functions
-
-      - name: Install app dependencies
-        run: |
-          npm config set fetch-retries 5
-          npm config set fetch-retry-factor 2
-          npm config set fetch-retry-mintimeout 10000
-          npm config set fetch-retry-maxtimeout 60000
-          for attempt in 1 2 3; do
-            npm ci --prefix apps/app && exit 0
-            if [ "$attempt" -eq 3 ]; then
-              exit 1
-            fi
-            echo "Transient npm install failure for apps/app. Retrying in 15 seconds..."
-            sleep 15
-          done
-
-      - name: Run unit tests
-        run: npm run test:unit:ci
-
-      - name: Run authentication email functions coverage
-        run: npm run test:functions:auth-email
-
   regression-guards:
-    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !contains(github.event.pull_request.labels.*.name, 'external-claim') &&
+      (github.event.action != 'unlabeled' || github.event.label.name == 'external-claim')
     runs-on: ubuntu-latest
 
     steps:
@@ -112,8 +66,12 @@ jobs:
           path: /tmp/allplays-preview-regression-guards.log
 
   build-preview-artifact:
-    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
-    needs: [unit-tests, regression-guards]
+    if: >-
+      github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !contains(github.event.pull_request.labels.*.name, 'external-claim') &&
+      (github.event.action != 'unlabeled' || github.event.label.name == 'external-claim')
+    needs: [regression-guards]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -292,7 +292,7 @@ jobs:
   mobile-build:
     name: ${{ github.event_name == 'pull_request' && (github.event.action == 'labeled' || github.event.action == 'unlabeled') && github.event.label.name != 'external-claim' && 'mobile-build-label-noop' || 'mobile-build' }}
     needs: [changes, android-debug, ios-simulator]
-    if: always()
+    if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Check native build results

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - synchronize
       - reopened
+      - labeled
       - unlabeled
   push:
     branches:
@@ -13,7 +14,10 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: mobile-build-${{ github.workflow }}-${{ github.ref }}
+  # Only external-claim label transitions share the integration-run group.
+  # Other label churn gets a unique no-op run so it cannot cancel or replace a
+  # required mobile-build check for this head.
+  group: ${{ github.event_name == 'pull_request' && (github.event.action == 'labeled' || github.event.action == 'unlabeled') && github.event.label.name != 'external-claim' && format('mobile-build-label-noop-{0}', github.run_id) || format('mobile-build-{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: true
 
 jobs:
@@ -59,8 +63,10 @@ jobs:
             exit 0
           fi
 
-          if [ "$EVENT_NAME" = "pull_request" ] && [ "$ACTION" = "unlabeled" ] && [ "$LABEL_NAME" != "external-claim" ]; then
-            echo "Unrelated label removal — not restarting native integration builds." >&2
+          if [ "$EVENT_NAME" = "pull_request" ] &&
+             { [ "$ACTION" = "labeled" ] || [ "$ACTION" = "unlabeled" ]; } &&
+             [ "$LABEL_NAME" != "external-claim" ]; then
+            echo "Unrelated label transition — not restarting native integration builds." >&2
             echo "landing=false" >> "$GITHUB_OUTPUT"
             echo "mobile=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -284,6 +290,7 @@ jobs:
   # waiting on a check that never runs, while a PR that does touch mobile
   # paths can't merge with a red native build (the gap this job closes).
   mobile-build:
+    name: ${{ github.event_name == 'pull_request' && (github.event.action == 'labeled' || github.event.action == 'unlabeled') && github.event.label.name != 'external-claim' && 'mobile-build-label-noop' || 'mobile-build' }}
     needs: [changes, android-debug, ios-simulator]
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -2,6 +2,11 @@ name: mobile-build
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - unlabeled
   push:
     branches:
       - master
@@ -15,6 +20,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
+      landing: ${{ steps.filter.outputs.landing }}
       mobile: ${{ steps.filter.outputs.mobile }}
     steps:
       - name: Checkout
@@ -25,7 +31,10 @@ jobs:
       - name: Detect mobile-relevant changes
         id: filter
         env:
+          ACTION: ${{ github.event.action }}
+          EXTERNAL_CLAIMED: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'external-claim') }}
           EVENT_NAME: ${{ github.event_name }}
+          LABEL_NAME: ${{ github.event.label.name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           BEFORE_SHA: ${{ github.event.before }}
@@ -35,9 +44,29 @@ jobs:
 
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             echo "Manual run — always building." >&2
+            echo "landing=true" >> "$GITHUB_OUTPUT"
             echo "mobile=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          # While another session owns the PR, keep the stable required
+          # mobile-build context cheap. Removing external-claim is the landing
+          # handoff and triggers this workflow again for the full native build.
+          if [ "$EVENT_NAME" = "pull_request" ] && [ "$EXTERNAL_CLAIMED" = "true" ]; then
+            echo "external-claim is active — deferring native integration builds." >&2
+            echo "landing=false" >> "$GITHUB_OUTPUT"
+            echo "mobile=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$EVENT_NAME" = "pull_request" ] && [ "$ACTION" = "unlabeled" ] && [ "$LABEL_NAME" != "external-claim" ]; then
+            echo "Unrelated label removal — not restarting native integration builds." >&2
+            echo "landing=false" >> "$GITHUB_OUTPUT"
+            echo "mobile=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "landing=true" >> "$GITHUB_OUTPUT"
 
           if [ "$EVENT_NAME" = "pull_request" ]; then
             CHANGED=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
@@ -264,6 +293,11 @@ jobs:
           if [ "${{ needs.changes.result }}" != "success" ]; then
             echo "changes job did not complete successfully (${{ needs.changes.result }}) — failing closed instead of assuming no mobile-relevant changes."
             exit 1
+          fi
+
+          if [ "${{ needs.changes.outputs.landing }}" != "true" ]; then
+            echo "Development ownership is still active — full native build deferred until external-claim is removed."
+            exit 0
           fi
 
           if [ "${{ needs.changes.outputs.mobile }}" != "true" ]; then

--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -6,10 +6,14 @@ on:
       - opened
       - synchronize
       - reopened
+      - labeled
       - unlabeled
 
 concurrency:
-  group: preview-smoke-${{ github.event.pull_request.number }}
+  # Unrelated label churn must neither cancel a landing smoke nor publish a
+  # replacement required context. external-claim transitions intentionally use
+  # the normal PR group so activating the lease cancels expensive work.
+  group: ${{ (github.event.action == 'labeled' || github.event.action == 'unlabeled') && github.event.label.name != 'external-claim' && format('preview-smoke-label-noop-{0}', github.run_id) || format('preview-smoke-{0}', github.event.pull_request.number) }}
   cancel-in-progress: true
 
 jobs:
@@ -45,8 +49,9 @@ jobs:
             exit 0
           fi
 
-          if [ "$ACTION" = "unlabeled" ] && [ "$LABEL_NAME" != "external-claim" ]; then
-            echo "Unrelated label removal — not restarting preview smoke." >&2
+          if { [ "$ACTION" = "labeled" ] || [ "$ACTION" = "unlabeled" ]; } &&
+             [ "$LABEL_NAME" != "external-claim" ]; then
+            echo "Unrelated label transition — not restarting preview smoke." >&2
             echo "landing=false" >> "$GITHUB_OUTPUT"
             echo "web=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -221,6 +226,7 @@ jobs:
   # not-applicable to this change (backend/native/docs-only); fails only on a real
   # failure. Mirrors the mobile-build aggregate so a skipped run never blocks merge.
   preview-smoke:
+    name: ${{ (github.event.action == 'labeled' || github.event.action == 'unlabeled') && github.event.label.name != 'external-claim' && 'preview-smoke-label-noop' || 'preview-smoke' }}
     needs: [changes, preview-smoke-run]
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -228,7 +228,7 @@ jobs:
   preview-smoke:
     name: ${{ (github.event.action == 'labeled' || github.event.action == 'unlabeled') && github.event.label.name != 'external-claim' && 'preview-smoke-label-noop' || 'preview-smoke' }}
     needs: [changes, preview-smoke-run]
-    if: always()
+    if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Report preview-smoke result

--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -2,6 +2,11 @@ name: preview-smoke
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - unlabeled
 
 concurrency:
   group: preview-smoke-${{ github.event.pull_request.number }}
@@ -12,6 +17,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     outputs:
+      landing: ${{ steps.filter.outputs.landing }}
       web: ${{ steps.filter.outputs.web }}
     steps:
       - name: Checkout
@@ -22,10 +28,31 @@ jobs:
       - name: Detect preview-relevant changes
         id: filter
         env:
+          ACTION: ${{ github.event.action }}
+          EXTERNAL_CLAIMED: ${{ contains(github.event.pull_request.labels.*.name, 'external-claim') }}
+          LABEL_NAME: ${{ github.event.label.name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
+
+          # external-claim is the active-development lease. Its removal is the
+          # handoff to the serialized landing worker and reruns the full smoke.
+          if [ "$EXTERNAL_CLAIMED" = "true" ]; then
+            echo "external-claim is active — deferring full preview smoke." >&2
+            echo "landing=false" >> "$GITHUB_OUTPUT"
+            echo "web=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$ACTION" = "unlabeled" ] && [ "$LABEL_NAME" != "external-claim" ]; then
+            echo "Unrelated label removal — not restarting preview smoke." >&2
+            echo "landing=false" >> "$GITHUB_OUTPUT"
+            echo "web=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "landing=true" >> "$GITHUB_OUTPUT"
 
           # Fail open: if we cannot compute a diff (new branch, missing base),
           # run the smoke so we never silently skip a real regression.
@@ -217,6 +244,11 @@ jobs:
           if [ "$CHANGES_RESULT" != "success" ]; then
             echo "Change detection did not succeed ($CHANGES_RESULT) — failing closed." >&2
             exit 1
+          fi
+
+          if [ "${{ needs.changes.outputs.landing }}" != "true" ]; then
+            echo "Development ownership is still active — full preview smoke deferred until external-claim is removed."
+            exit 0
           fi
 
           if [ "$SHOULD_RUN" = "false" ] && [ "$RUN_RESULT" = "skipped" ]; then

--- a/docs/landing-process.md
+++ b/docs/landing-process.md
@@ -1,0 +1,37 @@
+# AllPlays landing process
+
+AllPlays supports concurrent work by humans, Codex sessions, and PaulBot while
+serializing the expensive final integration step.
+
+## Ownership
+
+1. Add `external-claim` to an issue and its pull request before working from a
+   machine or agent session outside PaulBot.
+2. Keep the label while commits and review fixes are still being pushed.
+3. Remove `external-claim` only when the head is ready to freeze and land.
+4. PaulBot then applies `paulbot-automerge`, updates at most one landing branch
+   against `master`, completes the current-head review, waits for required
+   checks, and merges it.
+
+Do not push additional commits after handing a pull request to the landing
+worker. If more development is necessary, restore `external-claim` first.
+
+## CI stages
+
+- Fast PR checks (`unit-tests`, `cache-bust-guard`, `app-quality`, and focused
+  regression guards) provide feedback while development is active.
+- Native Android/iOS builds, full preview smoke, and preview artifact creation
+  are deferred while `external-claim` is present.
+- Removing `external-claim` triggers the full applicable integration checks.
+- Production deployment remains a post-merge `master` workflow.
+
+The stable aggregate contexts `mobile-build` and `preview-smoke` report a
+successful deferral while a claim is active. They rerun the real integration
+work on the same head when the claim is removed; `paulbot-review-gate` and the
+PaulBot mutation gate prevent a claimed PR from entering automated landing.
+
+## Pull request sizing
+
+Prefer pull requests below 500 changed lines and 20 changed files. Split larger
+features into independently testable slices. A larger PR should explain why it
+cannot be split and should not enter landing while another large PR is active.

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -454,7 +454,7 @@ export function validateFirebaseRulesCi() {
     validateFirebaseDeployWorkloadIdentity(deployProd, 'Production deploy');
     assertMatches(deployProd, /needs:\s*\[\s*unit-tests\s*,\s*regression-guards\s*\]/, 'Production deploy gate');
 
-    assertMatches(deployPreviewBuild, /needs:\s*\[\s*unit-tests\s*,\s*regression-guards\s*\]/, 'Preview artifact build gate');
+    assertMatches(deployPreviewBuild, /needs:\s*\[\s*regression-guards\s*\]/, 'Preview artifact build gate');
     validatePreviewDeployCommand(deployPreviewTrusted);
     validateFirebaseDeployWorkloadIdentity(deployPreviewTrusted, 'Trusted preview deploy');
     assertPreviewDeploySkipHandling(deployPreviewTrusted);

--- a/tests/unit/auth-email-resend-routing.test.js
+++ b/tests/unit/auth-email-resend-routing.test.js
@@ -95,11 +95,10 @@ describe('authentication email delivery routing', () => {
     it('runs extracted authentication email behavior tests in PR and production CI', () => {
         const packageSource = read('package.json');
         const ciSource = read('.github/workflows/ci.yml');
-        const previewSource = read('.github/workflows/deploy-preview.yml');
         const productionSource = read('.github/workflows/deploy-prod.yml');
 
         expect(packageSource).toContain('test:functions:auth-email');
-        for (const workflowSource of [ciSource, previewSource, productionSource]) {
+        for (const workflowSource of [ciSource, productionSource]) {
             expect(workflowSource).toContain('npm run test:functions:auth-email');
             const unitJobStart = workflowSource.indexOf('  unit-tests:');
             const unitTestCommand = workflowSource.indexOf('run: npm run test:unit:ci', unitJobStart);

--- a/tests/unit/mobile-build-workflow.test.js
+++ b/tests/unit/mobile-build-workflow.test.js
@@ -28,6 +28,19 @@ describe('mobile-build CI workflow', () => {
         expect(workflow).toContain('capacitor\\.config\\.json');
     });
 
+    it('defers native integration while external development owns the PR and reruns on handoff', () => {
+        const triggerSection = workflow.slice(workflow.indexOf('\non:'), workflow.indexOf('\nconcurrency:'));
+        const changesSection = workflow.slice(workflow.indexOf('  changes:'), workflow.indexOf('  android-debug:'));
+        const gateSection = workflow.slice(workflow.indexOf('  mobile-build:'));
+
+        expect(triggerSection).toContain('      - unlabeled');
+        expect(changesSection).toContain("contains(github.event.pull_request.labels.*.name, 'external-claim')");
+        expect(changesSection).toContain('[ "$EXTERNAL_CLAIMED" = "true" ]');
+        expect(changesSection).toContain('echo "landing=false" >> "$GITHUB_OUTPUT"');
+        expect(changesSection).toContain('[ "$LABEL_NAME" != "external-claim" ]');
+        expect(gateSection).toContain('needs.changes.outputs.landing');
+    });
+
     it('skips the native builds themselves for non-mobile changes but always runs the required mobile-build gate job', () => {
         const androidStart = workflow.indexOf('  android-debug:');
         const androidSection = workflow.slice(androidStart, workflow.indexOf('  ios-simulator:'));

--- a/tests/unit/mobile-build-workflow.test.js
+++ b/tests/unit/mobile-build-workflow.test.js
@@ -57,7 +57,14 @@ describe('mobile-build CI workflow', () => {
 
         const gateSection = workflow.slice(workflow.indexOf('  mobile-build:'));
         expect(gateSection).toContain('needs: [changes, android-debug, ios-simulator]');
-        expect(gateSection).toContain('if: always()');
+        expect(gateSection).toContain('if: ${{ always() && !cancelled() }}');
+    });
+
+    it('does not turn an intentional concurrency cancellation into a required-check failure', () => {
+        const gateSection = workflow.slice(workflow.indexOf('  mobile-build:'));
+
+        expect(gateSection).toContain('always()');
+        expect(gateSection).toContain('!cancelled()');
     });
 
     it('fails the required gate job when a mobile-relevant PR actually breaks native builds', () => {

--- a/tests/unit/mobile-build-workflow.test.js
+++ b/tests/unit/mobile-build-workflow.test.js
@@ -34,10 +34,13 @@ describe('mobile-build CI workflow', () => {
         const gateSection = workflow.slice(workflow.indexOf('  mobile-build:'));
 
         expect(triggerSection).toContain('      - unlabeled');
+        expect(triggerSection).toContain('      - labeled');
         expect(changesSection).toContain("contains(github.event.pull_request.labels.*.name, 'external-claim')");
         expect(changesSection).toContain('[ "$EXTERNAL_CLAIMED" = "true" ]');
         expect(changesSection).toContain('echo "landing=false" >> "$GITHUB_OUTPUT"');
-        expect(changesSection).toContain('[ "$LABEL_NAME" != "external-claim" ]');
+        expect(changesSection).toContain('[ "$ACTION" = "labeled" ] || [ "$ACTION" = "unlabeled" ]');
+        expect(workflow).toContain("format('mobile-build-label-noop-{0}', github.run_id)");
+        expect(gateSection).toContain("'mobile-build-label-noop' || 'mobile-build'");
         expect(gateSection).toContain('needs.changes.outputs.landing');
     });
 

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -186,13 +186,18 @@ describe('preview deployment workflow trust boundary', () => {
 
     it('cancels in-flight preview work when its pull request closes', () => {
         expect(pullRequestWorkflow).toContain('      - closed');
-        expect(pullRequestWorkflow).toContain('group: preview-${{ github.event.pull_request.number }}');
+        expect(pullRequestWorkflow).toContain("format('preview-{0}', github.event.pull_request.number)");
         expect(pullRequestWorkflow).toContain('cancel-in-progress: true');
         expect(pullRequestWorkflow).toContain('      - unlabeled');
+        expect(pullRequestWorkflow).toContain('      - labeled');
     });
 
     it('runs the credentialed deploy only from trusted default-branch code', () => {
         expect(trustedWorkflow).toContain('workflow_run:');
+        expect(trustedWorkflow).toContain('classify-trigger:');
+        expect(trustedWorkflow).toContain('preview_ready: ${{ steps.classify.outputs.preview_ready }}');
+        expect(trustedWorkflow).toContain('Successful preview source run had no bundle without an intentional two-job deferral.');
+        expect(trustedWorkflow).toContain("needs.classify-trigger.outputs.preview_ready == 'true'");
         expect(trustedWorkflow).toContain(
             'group: trusted-preview-pr-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.id }}'
         );

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -179,16 +179,16 @@ describe('preview deployment workflow trust boundary', () => {
         expect(pullRequestWorkflow).not.toMatch(/^\s+\w[\w-]*:\s+write\s*$/m);
         expect(pullRequestWorkflow).toContain('name: firebase-preview-hosting-bundle');
         expect(pullRequestWorkflow).toContain('include-hidden-files: true');
-        expect(pullRequestWorkflow).toMatch(/build-preview-artifact:[\s\S]*needs: \[unit-tests, regression-guards\]/);
+        expect(pullRequestWorkflow).toMatch(/build-preview-artifact:[\s\S]*needs: \[regression-guards\]/);
+        expect(pullRequestWorkflow).not.toContain('  unit-tests:');
+        expect(pullRequestWorkflow).toContain("!contains(github.event.pull_request.labels.*.name, 'external-claim')");
     });
 
     it('cancels in-flight preview work when its pull request closes', () => {
         expect(pullRequestWorkflow).toContain('      - closed');
         expect(pullRequestWorkflow).toContain('group: preview-${{ github.event.pull_request.number }}');
         expect(pullRequestWorkflow).toContain('cancel-in-progress: true');
-        expect(pullRequestWorkflow.match(
-            /if: github\.event\.action != 'closed' && github\.event\.pull_request\.head\.repo\.full_name == github\.repository/g
-        )).toHaveLength(3);
+        expect(pullRequestWorkflow).toContain('      - unlabeled');
     });
 
     it('runs the credentialed deploy only from trusted default-branch code', () => {

--- a/tests/unit/preview-smoke-workflow.test.js
+++ b/tests/unit/preview-smoke-workflow.test.js
@@ -13,10 +13,13 @@ describe('preview-smoke CI workflow', () => {
         const gateSection = workflow.slice(workflow.indexOf('  preview-smoke:'));
 
         expect(triggerSection).toContain('      - unlabeled');
+        expect(triggerSection).toContain('      - labeled');
         expect(changesSection).toContain("contains(github.event.pull_request.labels.*.name, 'external-claim')");
         expect(changesSection).toContain('[ "$EXTERNAL_CLAIMED" = "true" ]');
         expect(changesSection).toContain('echo "landing=false" >> "$GITHUB_OUTPUT"');
-        expect(changesSection).toContain('[ "$LABEL_NAME" != "external-claim" ]');
+        expect(changesSection).toContain('[ "$ACTION" = "labeled" ] || [ "$ACTION" = "unlabeled" ]');
+        expect(workflow).toContain("format('preview-smoke-label-noop-{0}', github.run_id)");
+        expect(gateSection).toContain("'preview-smoke-label-noop' || 'preview-smoke'");
         expect(gateSection).toContain('needs.changes.outputs.landing');
     });
 

--- a/tests/unit/preview-smoke-workflow.test.js
+++ b/tests/unit/preview-smoke-workflow.test.js
@@ -49,4 +49,10 @@ describe('preview-smoke CI workflow', () => {
         expect(intentionalSkipCheck).toBeGreaterThan(changesResultCheck);
         expect(gate).not.toContain('success|skipped');
     });
+
+    it('does not turn an intentional concurrency cancellation into a required-check failure', () => {
+        const gate = workflow.slice(workflow.indexOf('  preview-smoke:'));
+
+        expect(gate).toContain('if: ${{ always() && !cancelled() }}');
+    });
 });

--- a/tests/unit/preview-smoke-workflow.test.js
+++ b/tests/unit/preview-smoke-workflow.test.js
@@ -7,6 +7,19 @@ const workflow = readFileSync(
 );
 
 describe('preview-smoke CI workflow', () => {
+    it('defers the full smoke while external development owns the PR and reruns on handoff', () => {
+        const triggerSection = workflow.slice(workflow.indexOf('\non:'), workflow.indexOf('\nconcurrency:'));
+        const changesSection = workflow.slice(workflow.indexOf('  changes:'), workflow.indexOf('  preview-smoke-run:'));
+        const gateSection = workflow.slice(workflow.indexOf('  preview-smoke:'));
+
+        expect(triggerSection).toContain('      - unlabeled');
+        expect(changesSection).toContain("contains(github.event.pull_request.labels.*.name, 'external-claim')");
+        expect(changesSection).toContain('[ "$EXTERNAL_CLAIMED" = "true" ]');
+        expect(changesSection).toContain('echo "landing=false" >> "$GITHUB_OUTPUT"');
+        expect(changesSection).toContain('[ "$LABEL_NAME" != "external-claim" ]');
+        expect(gateSection).toContain('needs.changes.outputs.landing');
+    });
+
     it('runs smoke only when at least one changed path is not skippable', () => {
         const skippable = workflow.match(/SKIPPABLE='([^']+)'/)?.[1];
 


### PR DESCRIPTION
## What changed

- treat `external-claim` as the active-development lease for expensive CI
- defer Android, iOS, full preview smoke, and preview artifact generation while a claim is active
- rerun the full applicable integration checks when `external-claim` is removed
- remove the duplicate full unit-test job from preview artifact generation; `ci/unit-tests` remains the canonical required unit gate
- add regression coverage for the claimed and landing paths

## Why

Strict up-to-date protection and multiple concurrent agents were repeatedly rebuilding and reviewing unstable PR heads. PaulBot now serializes refreshed landing heads to one; this repository change separates fast development feedback from the expensive landing checks.

## Validation

- `npm test` — 4,848 passed, 114 skipped
- `npm run ci:firebase-rules`
- `npm run app:build`
- focused workflow suite — 44 passed
- YAML parsed successfully for all changed workflows

The PR is initially claimed so the deferred path can be validated. A documentation-only follow-up commit will trigger `synchronize` under `external-claim`; then the claim will be removed to validate the full landing path.