### PR TITLE
Render progressive Schedule results

### DIFF
--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -317,6 +317,75 @@ describe('Schedule', () => {
     });
   });
 
+  it('renders partial rows and filters while loading, then reconciles to the final schedule', async () => {
+    let emitPartial!: (result: {
+      children: Array<{ playerId: string; playerName: string; teamId: string; teamName: string }>;
+      events: ParentScheduleEvent[];
+      isPartial?: boolean;
+    }) => void;
+    let resolveSchedule!: (value: {
+      children: Array<{ playerId: string; playerName: string; teamId: string; teamName: string }>;
+      events: ParentScheduleEvent[];
+      isPartial?: boolean;
+    }) => void;
+    scheduleServiceMocks.loadParentSchedule.mockImplementationOnce((_user: unknown, options: {
+      onPartial: typeof emitPartial;
+    }) => {
+      emitPartial = options.onPartial;
+      return new Promise((resolve) => {
+        resolveSchedule = resolve;
+      });
+    });
+
+    renderSchedule();
+
+    expect(screen.getByRole('status', { name: 'Loading schedule' })).toBeTruthy();
+    await waitFor(() => expect(typeof emitPartial).toBe('function'));
+
+    act(() => {
+      emitPartial({
+        children: buildScopedScheduleResult('team-1', 'Bears', 1).children,
+        events: [],
+        isPartial: true
+      });
+    });
+
+    expect(screen.getByRole('status', { name: 'Loading schedule' })).toBeTruthy();
+    expect(screen.queryByText('No events in this filter')).toBeNull();
+
+    act(() => {
+      emitPartial({
+        ...buildScopedScheduleResult('team-1', 'Bears', 1),
+        isPartial: true
+      });
+    });
+
+    expect((await screen.findAllByText('vs. Rivals')).length).toBeGreaterThan(0);
+    expect(screen.getByRole('status', { name: 'Loading remaining schedule' })).toBeTruthy();
+    expect(screen.queryByRole('status', { name: 'Loading schedule' })).toBeNull();
+    expect(screen.queryByText('No events in this filter')).toBeNull();
+    expect((screen.getByLabelText('Team filter') as HTMLSelectElement).textContent).toContain('Bears');
+    expect(screen.getByRole('button', { name: 'Refresh schedule' })).toBeDisabled();
+
+    act(() => {
+      const finalResult = buildScopedScheduleResult('team-2', 'Wolves', 2);
+      resolveSchedule({
+        ...finalResult,
+        events: finalResult.events.map((event) => ({ ...event, opponent: 'Comets' })),
+        isPartial: false
+      });
+    });
+
+    expect((await screen.findAllByText('vs. Comets')).length).toBeGreaterThan(0);
+    await waitFor(() => {
+      expect(screen.queryByRole('status', { name: 'Loading remaining schedule' })).toBeNull();
+      expect(screen.queryAllByText('vs. Rivals')).toHaveLength(0);
+    });
+    expect((screen.getByLabelText('Team filter') as HTMLSelectElement).textContent).toContain('Wolves');
+    expect((screen.getByLabelText('Team filter') as HTMLSelectElement).textContent).not.toContain('Bears');
+    expect(screen.getByRole('button', { name: 'Refresh schedule' })).not.toBeDisabled();
+  });
+
   it.each([
     new TypeError('Failed to fetch'),
     new Error('Schedule unavailable.')

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -492,7 +492,13 @@ export function Schedule({ auth }: { auth: AuthState }) {
             return loadParentSchedule(auth.user, {
               hydrateDetails: false,
               expandStaffPlayers: false,
-              ...(parentScope && parentScope.isPartial !== true ? { parentScope } : {})
+              ...(parentScope && parentScope.isPartial !== true ? { parentScope } : {}),
+              onPartial: (partialResult) => {
+                if (activeUserIdRef.current !== requestedUserId) return;
+                if (scheduleRefreshVersionRef.current !== refreshVersion) return;
+                if (!partialResult.events.length && eventsRef.current.length) return;
+                applyScheduleResult(partialResult);
+              }
             });
           },
           {
@@ -910,7 +916,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
   };
 
   return (
-    <PullToRefresh onRefresh={() => refreshSchedule(true)} disabled={!auth.user?.uid}>
+    <PullToRefresh onRefresh={() => refreshSchedule(true)} disabled={!auth.user?.uid || scheduleReadLoading}>
     <div className="schedule-page space-y-4">
       <section className="schedule-header app-card p-3 sm:hidden">
         <div className="flex items-center justify-between gap-2">
@@ -1145,7 +1151,9 @@ export function Schedule({ auth }: { auth: AuthState }) {
             <ScheduleActionQueue events={visibleEvents} compact hideWhenEmpty preferGameHubForStaff />
           ) : null}
 
-          {scheduleReadLoading || isInitialScheduleLoad ? (
+          {scheduleReadLoading && events.length ? <ScheduleProgressLoading /> : null}
+
+          {(scheduleReadLoading || isInitialScheduleLoad) && !events.length ? (
             <LoadingSchedule />
           ) : view === 'calendar' ? (
             <CalendarSchedule
@@ -1840,6 +1848,20 @@ function ScheduleActionQueue({ events, compact = false, hideWhenEmpty = false, p
 
 function LoadingSchedule() {
   return <SchedulePageSkeleton />;
+}
+
+function ScheduleProgressLoading() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label="Loading remaining schedule"
+      className="flex items-center gap-2 rounded-xl border border-primary-100 bg-primary-50 px-3 py-2 text-xs font-bold text-primary-700"
+    >
+      <RefreshCw className="h-4 w-4 animate-spin" aria-hidden="true" />
+      Loading remaining teams…
+    </div>
+  );
 }
 
 function ScheduleList({ events, totalCount, visibleCount, pageSize, canShowMore, loadingMore, preferGameHubForStaff, onShowMore }: {

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -477,8 +477,16 @@ describe('React app desktop Schedule controls', () => {
         expect(scheduleMocks.addTeamCalendarUrl).toHaveBeenCalledWith('team-1', 'https://example.com/team.ics', auth.user);
         await waitForText(container, 'Calendar link saved and schedule refreshed.');
         expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledTimes(2);
-        expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(1, auth.user, { hydrateDetails: false, expandStaffPlayers: false });
-        expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(2, auth.user, { hydrateDetails: false, expandStaffPlayers: false });
+        expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(1, auth.user, {
+            hydrateDetails: false,
+            expandStaffPlayers: false,
+            onPartial: expect.any(Function)
+        });
+        expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(2, auth.user, {
+            hydrateDetails: false,
+            expandStaffPlayers: false,
+            onPartial: expect.any(Function)
+        });
     });
 
     it('keeps mobile staff schedule tools collapsed until explicitly opened', async () => {
@@ -593,8 +601,16 @@ describe('React app desktop Schedule controls', () => {
         expect(window.confirm).toHaveBeenCalledWith('Remove this external calendar link? Imported events from this feed will disappear after the schedule refreshes.');
         expect(scheduleMocks.removeTeamCalendarUrl).toHaveBeenCalledWith('team-1', 'https://example.com/stale.ics', auth.user);
         expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledTimes(2);
-        expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(1, auth.user, { hydrateDetails: false, expandStaffPlayers: false });
-        expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(2, auth.user, { hydrateDetails: false, expandStaffPlayers: false });
+        expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(1, auth.user, {
+            hydrateDetails: false,
+            expandStaffPlayers: false,
+            onPartial: expect.any(Function)
+        });
+        expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(2, auth.user, {
+            hydrateDetails: false,
+            expandStaffPlayers: false,
+            onPartial: expect.any(Function)
+        });
         await waitForText(container, 'Calendar link removed and schedule refreshed.');
     });
 
@@ -708,7 +724,11 @@ describe('React app desktop Schedule controls', () => {
             })
         }), auth.user);
         expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledTimes(3);
-        expect(scheduleMocks.loadParentSchedule).toHaveBeenLastCalledWith(auth.user, { hydrateDetails: false, expandStaffPlayers: false });
+        expect(scheduleMocks.loadParentSchedule).toHaveBeenLastCalledWith(auth.user, {
+            hydrateDetails: false,
+            expandStaffPlayers: false,
+            onPartial: expect.any(Function)
+        });
         await waitForText(container, 'Imported 2 schedule row(s) and refreshed the schedule.');
     });
 


### PR DESCRIPTION
Closes #4170

## What changed
- Consume guarded `loadParentSchedule.onPartial` emissions in Schedule UI state.
- Render completed-team rows and filters with a non-blocking loading indicator.
- Preserve the initial skeleton when partial emissions contain no events.
- Disable refresh and pull-to-refresh until loading completes.
- Reconcile with the authoritative final result while retaining the existing final-only cache gate.

## Root Cause
`loadParentSchedule` emitted completed-team results through `onPartial`, but Schedule never registered the callback and unconditionally rendered the full-page skeleton while the final promise remained pending.

## Prevention / Learning
When a service exposes progressive results, consumers must model loading-with-data separately from loading-without-data, guard callback writes by request and account identity, and keep partial emissions outside durable caches.

## Regression Tests
- Verifies empty partial shells retain the initial skeleton without an empty-state flash.
- Verifies partial rows, team filters, loading status, and disabled refresh actions.
- Verifies the final result replaces partial rows and filters and restores refresh actions.
- `npx vitest run src/pages/Schedule.test.tsx --reporter=dot` (75 passed)
- `npm run typecheck`

## Recurrence Risk
Low. Focused component coverage exercises the full progressive-to-final transition, and the existing cache contract rejects partial results.