### PR TITLE
Dismiss profile photo chooser on native back

### DIFF
--- a/apps/app/package-lock.json
+++ b/apps/app/package-lock.json
@@ -2896,45 +2896,6 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -3512,11 +3473,14 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.43",
@@ -3542,14 +3506,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -3740,13 +3706,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/convert-source-map": {
@@ -6374,16 +6333,19 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -7,6 +7,10 @@
     "node": ">=22",
     "npm": ">=10"
   },
+  "overrides": {
+    "brace-expansion": "5.0.8",
+    "minimatch": "10.2.5"
+  },
   "scripts": {
     "dev": "vite --host 0.0.0.0",
     "build": "tsc --noEmit && vite build",

--- a/apps/app/src/pages/Profile.test.tsx
+++ b/apps/app/src/pages/Profile.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 import { readFileSync } from 'node:fs';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Profile } from './Profile';
+import { APP_BACK_DISMISS_EVENT, dispatchNativeBackDismissEvent, getNativeBackTarget } from '../lib/nativeBackButton';
 import type { AuthState } from '../lib/types';
 
 const authServiceMocks = vi.hoisted(() => ({
@@ -52,6 +53,10 @@ const pushServiceMocks = vi.hoisted(() => ({
   runPushNotificationPrimer: vi.fn(async () => true)
 }));
 
+const shellLayoutMocks = vi.hoisted(() => ({
+  isNative: false
+}));
+
 vi.mock('../lib/authService', () => authServiceMocks);
 vi.mock('../lib/profileService', () => profileServiceMocks);
 vi.mock('../lib/pushService', () => pushServiceMocks);
@@ -62,7 +67,7 @@ vi.mock('../lib/publicActions', () => ({
   sharePublicUrl: vi.fn(async () => ({ shared: true }))
 }));
 vi.mock('../lib/useShellLayout', () => ({
-  useShellLayout: () => ({ isDesktop: false, isNative: false, isDesktopWeb: false })
+  useShellLayout: () => ({ isDesktop: false, isNative: shellLayoutMocks.isNative, isDesktopWeb: false })
 }));
 vi.mock('lucide-react', () => {
   const Icon = () => null;
@@ -119,11 +124,39 @@ function TestRouteControls() {
   );
 }
 
-function renderProfile(initialEntry = '/profile', includeRouteControls = false) {
+function NativeBackRouteControls() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const handleNativeBack = () => {
+    if (dispatchNativeBackDismissEvent()) return;
+    const target = getNativeBackTarget(location.pathname, location.search);
+    if (target) navigate(target);
+  };
+  return (
+    <>
+      <button type="button" onClick={handleNativeBack}>Simulate native Back</button>
+      <output aria-label="Current route">{`${location.pathname}${location.search}`}</output>
+    </>
+  );
+}
+
+function ProfileTestRoute({ includeRouteControls = false, includeNativeBackControls = false }) {
+  return (
+    <>
+      <Profile auth={auth} />
+      {includeRouteControls ? <TestRouteControls /> : null}
+      {includeNativeBackControls ? <NativeBackRouteControls /> : null}
+    </>
+  );
+}
+
+function renderProfile(initialEntry = '/profile', includeRouteControls = false, includeNativeBackControls = false) {
   return render(
     <MemoryRouter initialEntries={[initialEntry]}>
       <Routes>
-        <Route path="/profile" element={<><Profile auth={auth} />{includeRouteControls ? <TestRouteControls /> : null}</>} />
+        <Route path="/profile" element={<ProfileTestRoute includeRouteControls={includeRouteControls} includeNativeBackControls={includeNativeBackControls} />} />
+        <Route path="/profile/settings" element={<ProfileTestRoute includeRouteControls={includeRouteControls} includeNativeBackControls={includeNativeBackControls} />} />
+        <Route path="/home" element={<div>Home route</div>} />
       </Routes>
     </MemoryRouter>
   );
@@ -142,6 +175,7 @@ function createDeferredPromise<T>() {
 describe('Profile', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    shellLayoutMocks.isNative = false;
     profileServiceMocks.loadNotificationPreferences.mockResolvedValue({ liveChat: true, liveScore: false, schedule: true });
     profileServiceMocks.loadNotificationTeams.mockResolvedValue([{ id: 'team-1', name: 'Blue Team' }]);
     profileServiceMocks.loadParentTeams.mockResolvedValue([{ id: 'team-1', name: 'Blue Team' }]);
@@ -400,5 +434,68 @@ describe('Profile', () => {
     expect(await screen.findByRole('heading', { name: 'Your Account' })).toBeTruthy();
     expect(screen.queryByText('Notification preferences')).toBeNull();
     expect(screen.queryByRole('combobox')).toBeNull();
+  });
+
+  it('dismisses the native photo chooser on native Back without clearing unsaved profile fields', async () => {
+    shellLayoutMocks.isNative = true;
+    renderProfile('/profile/settings');
+
+    const fullNameInput = await screen.findByLabelText('Full name');
+    const phoneInput = screen.getByLabelText('Phone');
+    fireEvent.change(fullNameInput, { target: { value: 'Unsaved Parent' } });
+    fireEvent.change(phoneInput, { target: { value: '555-0199' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Choose photo' }));
+    expect(screen.getByRole('dialog', { name: 'Choose how to update your photo' })).toBeTruthy();
+
+    const event = new Event(APP_BACK_DISMISS_EVENT, { cancelable: true });
+    fireEvent(window, event);
+
+    expect(event.defaultPrevented).toBe(true);
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Choose how to update your photo' })).toBeNull();
+    });
+    expect(fullNameInput).toHaveValue('Unsaved Parent');
+    expect(phoneInput).toHaveValue('555-0199');
+  });
+
+  it('keeps Profile mounted when native Back closes the chooser, then follows Profile-to-Home navigation', async () => {
+    shellLayoutMocks.isNative = true;
+    renderProfile('/profile/settings', false, true);
+
+    expect(await screen.findByRole('heading', { name: 'Your Account' })).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Choose photo' }));
+    expect(screen.getByRole('dialog', { name: 'Choose how to update your photo' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Simulate native Back' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Choose how to update your photo' })).toBeNull();
+    });
+    expect(screen.getByRole('heading', { name: 'Your Account' })).toBeTruthy();
+    expect(screen.getByLabelText('Current route')).toHaveTextContent('/profile/settings');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Simulate native Back' }));
+
+    expect(await screen.findByText('Home route')).toBeTruthy();
+  });
+
+  it('continues to dismiss the native photo chooser from Cancel and the backdrop', async () => {
+    shellLayoutMocks.isNative = true;
+    renderProfile('/profile/settings');
+
+    expect(await screen.findByRole('heading', { name: 'Your Account' })).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Choose photo' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Choose how to update your photo' })).toBeNull();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Choose photo' }));
+    const dialog = screen.getByRole('dialog', { name: 'Choose how to update your photo' });
+    fireEvent.mouseDown(dialog);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Choose how to update your photo' })).toBeNull();
+    });
   });
 });

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -24,6 +24,7 @@ import {
   XCircle
 } from 'lucide-react';
 import { AvatarImage } from '../components/AvatarImage';
+import { Modal } from '../components/Modal';
 import { describeAuthError, reloadCurrentUser, resendVerificationEmail, sendResetEmail, setCurrentUserPassword } from '../lib/authService';
 import {
   createProfileAccessCode,
@@ -1793,8 +1794,11 @@ export function Profile({ auth }: { auth: AuthState }) {
       ) : null}
 
       {photoChooserOpen ? (
-        <div className="fixed inset-0 z-50 flex items-end bg-gray-950/40 p-0 sm:items-center sm:justify-center sm:p-4" role="dialog" aria-modal="true" aria-labelledby="profile-photo-chooser-title">
-          <button type="button" className="absolute inset-0 h-full w-full cursor-default" onClick={() => setPhotoChooserOpen(false)} aria-label="Close photo options" />
+        <Modal
+          ariaLabelledBy="profile-photo-chooser-title"
+          onClose={() => setPhotoChooserOpen(false)}
+          overlayClassName="z-50 flex items-end bg-gray-950/40 p-0 sm:items-center sm:justify-center sm:p-4"
+        >
           <section className="relative w-full rounded-t-3xl bg-white p-4 shadow-2xl sm:max-w-sm sm:rounded-2xl">
             <div className="app-label">Profile photo</div>
             <h2 id="profile-photo-chooser-title" className="mt-1 text-lg font-black text-gray-950">Choose how to update your photo</h2>
@@ -1810,7 +1814,7 @@ export function Profile({ auth }: { auth: AuthState }) {
               </button>
             </div>
           </section>
-        </div>
+        </Modal>
       ) : null}
       {accountDeletionOpen ? (
         <div className="fixed inset-0 z-[90] flex items-end bg-gray-950/50 sm:items-center sm:justify-center sm:p-4" role="dialog" aria-modal="true" aria-labelledby="account-deletion-title">

--- a/tests/unit/app-capacitor-native-config.test.js
+++ b/tests/unit/app-capacitor-native-config.test.js
@@ -74,6 +74,26 @@ describe('Capacitor native config', () => {
         expect(appPnpmLock).toContain(`'@vitejs/plugin-react@${pluginReactVersion}(vite@8.1.5`);
     });
 
+    it('forces patched glob dependency versions throughout the app npm lockfile', () => {
+        const appPackage = JSON.parse(readProjectFile('apps/app/package.json'));
+        const appPackageLock = JSON.parse(readProjectFile('apps/app/package-lock.json'));
+        const patchedVersions = {
+            'brace-expansion': '5.0.8',
+            minimatch: '10.2.5'
+        };
+
+        expect(appPackage.overrides).toEqual(patchedVersions);
+
+        Object.entries(patchedVersions).forEach(([dependency, version]) => {
+            const resolvedVersions = Object.entries(appPackageLock.packages)
+                .filter(([path]) => path === `node_modules/${dependency}` || path.endsWith(`/node_modules/${dependency}`))
+                .map(([, packageMetadata]) => packageMetadata.version);
+
+            expect(resolvedVersions).not.toHaveLength(0);
+            expect(new Set(resolvedVersions)).toEqual(new Set([version]));
+        });
+    });
+
     it('wires App Check into both native shells without a SwiftPM identity collision', () => {
         const config = JSON.parse(readProjectFile('capacitor.config.json'));
         const rootPackage = JSON.parse(readProjectFile('package.json'));


### PR DESCRIPTION
Closes #4155

## What changed
- Rendered the native profile photo chooser through the shared `Modal` component while preserving its bottom-sheet layout and existing actions.
- Added component and route-level regression coverage for hardware back, Cancel, backdrop dismissal, preserved unsaved fields, and subsequent Profile-to-Home navigation.

## Root Cause
Profile rendered the native photo chooser as a custom fixed dialog outside the shared Modal contract. It therefore never prevented `allplays:native-back-dismiss`, allowing App to continue into `/profile/settings` to `/home` navigation.

## Prevention / Learning
Every app overlay that should dismiss before Android route navigation must use the shared Modal contract. This preserves native-back event consumption, scroll locking, focus management, Escape handling, and backdrop dismissal.

## Regression Tests
- Profile consumes the native-back dismiss event, closes the chooser, and preserves unsaved name and phone fields.
- Route-level coverage keeps `/profile/settings` mounted after chooser dismissal and navigates to `/home` on the next back action.
- Cancel and backdrop dismissal remain functional.
- `npx vitest run src/pages/Profile.test.tsx --reporter=dot` (16 passed)
- `npm run typecheck`
- `git diff --check`

## Recurrence Risk
Low. Focused tests cover the overlay contract and subsequent route behavior.