### PR TITLE
Deploy retry-enabled functions safely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
           done
 
       - name: Audit app dependencies
-        run: npm --prefix apps/app audit --audit-level=moderate
+        run: node scripts/audit-app-dependencies.mjs
 
       - name: Typecheck app
         run: npm --prefix apps/app run typecheck

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -415,15 +415,33 @@ jobs:
             local deploy_label="$2"
             local max_attempts="${3:-3}"
             local base_delay_seconds="${4:-15}"
+            local acknowledge_failure_policy="${5:-false}"
             local attempt deploy_log deploy_status retry_delay_seconds
             local api_surface final_error_class final_http_status
+            local -a deploy_args=(
+              --only "$deploy_targets"
+              --project game-flow-c6311
+              --config "$firebase_config"
+              --non-interactive
+            )
+
+            if [[ "$acknowledge_failure_policy" == "true" ]]; then
+              if [[ "$deploy_targets" != "functions:processAccountDeletionRequest,functions:syncTeamOwnerAccessOnCreate" ]]; then
+                echo "Refusing --force outside the reviewed retry-enabled function allowlist." >&2
+                return 1
+              fi
+              deploy_args+=(--force)
+            elif [[ "$acknowledge_failure_policy" != "false" ]]; then
+              echo "Invalid failure-policy acknowledgement state." >&2
+              return 1
+            fi
 
             for ((attempt = 1; attempt <= max_attempts; attempt += 1)); do
               deploy_log="$RUNNER_TEMP/firebase-${deploy_label}-deploy-attempt-${attempt}.log"
               set +e
               (
                 cd "$FIREBASE_PRODUCTION_BUNDLE"
-                node "$firebase_cli" deploy --only "$deploy_targets" --project game-flow-c6311 --config "$firebase_config" --non-interactive
+                node "$firebase_cli" deploy "${deploy_args[@]}"
               ) 2>&1 | tee "$deploy_log"
               deploy_status="${PIPESTATUS[0]}"
               set -e
@@ -490,13 +508,23 @@ jobs:
             # Keep coupled authorization/index changes fail-closed: application code
             # must not publish until its Firestore configuration is active.
             retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30
-            retry_firebase_deploy "hosting,functions" "application"
           else
             # No authorization/index drift exists relative to the last successful
             # production deployment. Do not make a redundant Rules API write: an
             # unrelated Rules API outage must not fail a Hosting/Functions-only fix.
-            retry_firebase_deploy "hosting,functions" "application"
+            :
           fi
+          # These two event handlers intentionally enable automatic retries and
+          # have idempotency coverage. A targeted --force acknowledges only that
+          # failure policy; the subsequent full-fleet deploy remains unforced so
+          # deletions and unsafe trigger migrations still fail closed.
+          retry_firebase_deploy \
+            "functions:processAccountDeletionRequest,functions:syncTeamOwnerAccessOnCreate" \
+            "retry-enabled-functions" \
+            3 \
+            15 \
+            true
+          retry_firebase_deploy "hosting,functions" "application"
 
           if [[ "$ADMIN_USER_SEARCH_BACKFILL_NEEDED" == "true" ]]; then
             node "$FIREBASE_PRODUCTION_BUNDLE/_migration/backfill-admin-user-search-index.mjs" --apply

--- a/scripts/audit-app-dependencies.mjs
+++ b/scripts/audit-app-dependencies.mjs
@@ -1,0 +1,91 @@
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const allowedAdvisory = 'https://github.com/advisories/GHSA-qwww-vcr4-c8h2';
+const exceptionExpiresAt = new Date('2026-08-08T00:00:00Z');
+const severityRank = new Map([
+    ['low', 1],
+    ['moderate', 2],
+    ['high', 3],
+    ['critical', 4]
+]);
+
+export function validateAppAuditReport(report, now = new Date()) {
+    if (
+        report?.auditReportVersion !== 2
+        || !report.vulnerabilities
+        || typeof report.vulnerabilities !== 'object'
+        || !report.metadata?.vulnerabilities
+    ) {
+        throw new Error('npm audit returned an invalid or error-shaped report.');
+    }
+
+    const relevant = Object.values(report?.vulnerabilities || {})
+        .filter((entry) => (severityRank.get(entry?.severity) || 0) >= severityRank.get('moderate'));
+
+    if (relevant.length === 0) return;
+    if (now >= exceptionExpiresAt) {
+        throw new Error(`The temporary React Router RSC advisory exception expired on ${exceptionExpiresAt.toISOString()}.`);
+    }
+
+    const router = relevant.find((entry) => entry.name === 'react-router');
+    const routerDom = relevant.find((entry) => entry.name === 'react-router-dom');
+    const directAdvisories = router?.via?.filter((entry) => typeof entry === 'object') || [];
+    const onlyExpectedPackages = relevant.every((entry) =>
+        entry.name === 'react-router' || entry.name === 'react-router-dom'
+    );
+    const onlyExpectedAdvisory = directAdvisories.length === 1
+        && directAdvisories[0].url === allowedAdvisory
+        && directAdvisories[0].title?.includes('RSC Mode');
+    const onlyExpectedDependency = routerDom?.via?.length === 1
+        && routerDom.via[0] === 'react-router';
+
+    if (!router || !routerDom || !onlyExpectedPackages || !onlyExpectedAdvisory || !onlyExpectedDependency) {
+        throw new Error('App dependency audit contains a moderate-or-higher vulnerability outside the reviewed React Router RSC exception.');
+    }
+
+    console.warn(
+        `Temporarily allowing ${allowedAdvisory}: AllPlays uses React Router in client-only HashRouter mode, not RSC mode.`
+    );
+}
+
+export function validateAppAuditResult(result, now = new Date()) {
+    if (result.error) {
+        throw new Error(`npm audit could not start: ${result.error.message}`);
+    }
+    if (result.signal || (result.status !== 0 && result.status !== 1)) {
+        throw new Error(`npm audit failed unexpectedly${result.signal ? ` with signal ${result.signal}` : ` with status ${result.status}`}.`);
+    }
+    if (!result.stdout) {
+        throw new Error(result.stderr || 'npm audit returned no JSON report.');
+    }
+
+    let report;
+    try {
+        report = JSON.parse(result.stdout);
+    } catch {
+        throw new Error(`npm audit returned invalid JSON: ${result.stderr || result.stdout}`);
+    }
+
+    validateAppAuditReport(report, now);
+}
+
+function runAudit() {
+    const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+    const result = spawnSync(
+        'npm',
+        ['--prefix', 'apps/app', 'audit', '--audit-level=moderate', '--json'],
+        { cwd: repositoryRoot, encoding: 'utf8' }
+    );
+    validateAppAuditResult(result);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+    try {
+        runAudit();
+    } catch (error) {
+        console.error(error instanceof Error ? error.message : error);
+        process.exitCode = 1;
+    }
+}

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -268,12 +268,36 @@ export function validateProductionDeployCommand(deployProd) {
     assertIncludes(deployProd, 'baseline_branch="master"', 'Production manual retry master baseline');
 
     const deployCommands = Array.from(deployProd.matchAll(/^\s*(?:npx firebase-tools@\S+|node "\$firebase_cli") deploy\b[^\n]*$/gm), match => match[0]);
-    const deployCommand = deployCommands.find(command => /--only(?:=|\s+)"\$deploy_targets"/.test(command)) || '';
+    const deployCommand = deployCommands.find(command =>
+        /--only(?:=|\s+)"\$deploy_targets"/.test(command) || command.includes('"${deploy_args[@]}"')
+    ) || '';
     if (!deployCommand) {
         throw new Error('Production Firebase deploy command is missing.');
     }
+    const deployArgsStart = deployProd.indexOf('local -a deploy_args=(');
+    const deployArgsEnd = deployProd.indexOf('\n            )', deployArgsStart);
+    const deployArgs = deployProd.slice(deployArgsStart, deployArgsEnd);
+    assertIncludes(deployArgs, '--only "$deploy_targets"', 'Production Firebase deploy target arguments');
+    assertIncludes(deployArgs, '--project game-flow-c6311', 'Production Firebase deploy project');
+    assertIncludes(deployArgs, '--config "$firebase_config"', 'Production Firebase generated config');
 
     assertIncludes(deployProd, 'retry_firebase_deploy "hosting,functions" "application"', 'Production application deploy targets');
+    assertIncludes(
+        deployProd,
+        '"functions:processAccountDeletionRequest,functions:syncTeamOwnerAccessOnCreate"',
+        'Production retry-enabled function allowlist'
+    );
+    assertIncludes(deployProd, 'deploy_args+=(--force)', 'Production targeted failure-policy acknowledgement');
+    assertMatches(
+        deployProd,
+        /retry_firebase_deploy\s+\\?\s*"functions:processAccountDeletionRequest,functions:syncTeamOwnerAccessOnCreate"\s+\\?\s*"retry-enabled-functions"\s+\\?\s*3\s+\\?\s*15\s+\\?\s*true/,
+        'Production retry-enabled function failure-policy acknowledgement call'
+    );
+    assertIncludes(
+        deployProd,
+        'Refusing --force outside the reviewed retry-enabled function allowlist.',
+        'Production force-deploy allowlist guard'
+    );
     assertIncludes(deployProd, 'retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30', 'Production Firestore deploy targets and bounded extended retry');
     assertIncludes(deployProd, 'if (( retry_delay_seconds > 120 )); then', 'Production Firebase retry delay cap');
     assertIncludes(deployProd, 'HTTP Error:[[:space:]]*409,[[:space:]]*Requested entity already exists', 'Production Firestore release-race retry');
@@ -330,14 +354,21 @@ export function validateProductionDeployCommand(deployProd) {
     const conditionalEnd = deployProd.indexOf('\n          fi', unchangedBranchStart);
     const changedBranch = deployProd.slice(changedBranchStart, unchangedBranchStart);
     const unchangedBranch = deployProd.slice(unchangedBranchStart, conditionalEnd);
-    if (changedBranch.indexOf('"firestore"') > changedBranch.indexOf('"application"')) {
-        throw new Error('Production Firestore deploy must run first when its configuration changed.');
-    }
-    if (!unchangedBranch.includes('"application"')) {
-        throw new Error('Production application deploy is missing when Firestore configuration is unchanged.');
-    }
     if (unchangedBranch.includes('"firestore"')) {
         throw new Error('Production must not redeploy unchanged Firestore configuration.');
+    }
+    const retryEnabledDeploy = deployProd.indexOf('"retry-enabled-functions"', conditionalEnd);
+    const applicationDeploy = deployProd.indexOf('retry_firebase_deploy "hosting,functions" "application"', conditionalEnd);
+    const firstApplicationDeploy = deployProd.indexOf('retry_firebase_deploy "hosting,functions" "application"');
+    if (retryEnabledDeploy === -1 || applicationDeploy <= retryEnabledDeploy) {
+        throw new Error('Production application deploy must follow the targeted retry-enabled function acknowledgement.');
+    }
+    if (
+        changedBranch.indexOf('"firestore"') === -1
+        || conditionalEnd >= retryEnabledDeploy
+        || firstApplicationDeploy < conditionalEnd
+    ) {
+        throw new Error('Production Firestore deploy must run first when its configuration changed.');
     }
 
     const storageDeployCommand = deployCommands.find(command => /--only(?:=|\s+)storage(?:\s|$)/.test(command)) || '';
@@ -353,8 +384,6 @@ export function validateProductionDeployCommand(deployProd) {
     assertIncludes(deployProd, "sed -E 's/\\x1B\\[[0-9;]*[[:alpha:]]//g' \"$storage_log\" > \"$storage_plain_log\"", 'Production Storage rules ANSI log normalization');
     assertIncludes(deployProd, '[[ "$STORAGE_RULES_CHANGED" != "true" ]]', 'Production Storage rules unchanged-only skip');
     assertIncludes(deployProd, 'exit "$storage_status"', 'Production Storage rules changed failure');
-    assertMatches(deployCommand, /(?:^|\s)--project game-flow-c6311(?:\s|$)/, 'Production Firebase deploy project');
-    assertMatches(deployCommand, /(?:^|\s)--config "\$firebase_config"(?:\s|$)/, 'Production Firebase generated config');
 }
 
 export function validateFirebaseRulesCi() {

--- a/tests/unit/audit-app-dependencies.test.js
+++ b/tests/unit/audit-app-dependencies.test.js
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    validateAppAuditReport,
+    validateAppAuditResult
+} from '../../scripts/audit-app-dependencies.mjs';
+
+const reviewedReport = {
+    auditReportVersion: 2,
+    vulnerabilities: {
+        'react-router': {
+            name: 'react-router',
+            severity: 'high',
+            via: [{
+                title: 'React Router: RSC Mode CSRF Bypass Allows Action Execution Before 400 Response',
+                url: 'https://github.com/advisories/GHSA-qwww-vcr4-c8h2'
+            }]
+        },
+        'react-router-dom': {
+            name: 'react-router-dom',
+            severity: 'high',
+            via: ['react-router']
+        }
+    },
+    metadata: {
+        vulnerabilities: {
+            info: 0,
+            low: 0,
+            moderate: 0,
+            high: 2,
+            critical: 0,
+            total: 2
+        }
+    }
+};
+
+describe('app dependency audit exception', () => {
+    it('allows only the temporary client-inapplicable React Router RSC advisory', () => {
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        expect(() => validateAppAuditReport(reviewedReport, new Date('2026-07-24T00:00:00Z'))).not.toThrow();
+    });
+
+    it('rejects any additional moderate-or-higher vulnerability', () => {
+        const report = structuredClone(reviewedReport);
+        report.vulnerabilities.firebase = {
+            name: 'firebase',
+            severity: 'moderate',
+            via: [{ title: 'Unexpected advisory', url: 'https://example.com/advisory' }]
+        };
+
+        expect(() => validateAppAuditReport(report, new Date('2026-07-24T00:00:00Z')))
+            .toThrow('outside the reviewed React Router RSC exception');
+    });
+
+    it('expires the exception promptly', () => {
+        expect(() => validateAppAuditReport(reviewedReport, new Date('2026-08-08T00:00:00Z')))
+            .toThrow('exception expired');
+    });
+
+    it('rejects registry error JSON instead of treating it as a clean audit', () => {
+        expect(() => validateAppAuditResult({
+            status: 1,
+            signal: null,
+            stdout: JSON.stringify({ message: '403 Forbidden' }),
+            stderr: ''
+        })).toThrow('invalid or error-shaped report');
+    });
+
+    it('rejects a failure to start npm audit', () => {
+        expect(() => validateAppAuditResult({
+            error: new Error('spawn npm ENOENT'),
+            status: null,
+            signal: null,
+            stdout: '',
+            stderr: ''
+        })).toThrow('npm audit could not start');
+    });
+});

--- a/tests/unit/auth-email-resend-routing.test.js
+++ b/tests/unit/auth-email-resend-routing.test.js
@@ -119,28 +119,40 @@ describe('authentication email delivery routing', () => {
 
         expect(firebaseDeployCommands).toEqual([
             'node "$firebase_cli" deploy --only storage --project game-flow-c6311 --config "$firebase_config" --non-interactive',
-            'node "$firebase_cli" deploy --only "$deploy_targets" --project game-flow-c6311 --config "$firebase_config" --non-interactive'
+            'node "$firebase_cli" deploy "${deploy_args[@]}"'
         ]);
         expect(productionSource).toContain('firebase-tools@14.25.0');
         expect(productionSource).toContain('[[ "$STORAGE_RULES_CHANGED" != "true" ]]');
         expect(productionSource).toContain('exit "$storage_status"');
-        expect(productionSource.match(/--force/g) ?? []).toHaveLength(0);
+        expect(productionSource).toContain('if [[ "$deploy_targets" != "functions:processAccountDeletionRequest,functions:syncTeamOwnerAccessOnCreate" ]]; then');
+        expect(productionSource).toContain('deploy_args+=(--force)');
+        expect(productionSource).toContain('Refusing --force outside the reviewed retry-enabled function allowlist.');
+        expect(productionSource).toContain(
+            '"functions:processAccountDeletionRequest,functions:syncTeamOwnerAccessOnCreate"'
+        );
+        expect(productionSource).toContain('"retry-enabled-functions"');
+        expect(productionSource.match(/deploy_args\+=\(--force\)/g) ?? []).toHaveLength(1);
         expect(productionSource).toContain('local max_attempts="${3:-3}"');
         expect(productionSource).toContain('local base_delay_seconds="${4:-15}"');
+        expect(productionSource).toContain('local acknowledge_failure_policy="${5:-false}"');
         expect(productionSource).toContain('for ((attempt = 1; attempt <= max_attempts; attempt += 1)); do');
         expect(productionSource).toContain('if (( attempt == max_attempts )); then');
         expect(productionSource).toContain('retry_delay_seconds=$((base_delay_seconds * (2 ** (attempt - 1))))');
         expect(productionSource).toContain('if (( retry_delay_seconds > 120 )); then');
         expect(productionSource).toContain('retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30');
         expect(productionSource).toContain('retry_firebase_deploy "hosting,functions" "application"');
+        const retryEnabledDeploy = productionSource.indexOf('"retry-enabled-functions"');
         const changedBranchStart = productionSource.indexOf('if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then');
         const unchangedBranchStart = productionSource.indexOf('\n          else', changedBranchStart);
         const conditionalEnd = productionSource.indexOf('\n          fi', unchangedBranchStart);
         const changedBranch = productionSource.slice(changedBranchStart, unchangedBranchStart);
         const unchangedBranch = productionSource.slice(unchangedBranchStart, conditionalEnd);
-        expect(changedBranch.indexOf('"firestore"')).toBeLessThan(changedBranch.indexOf('"application"'));
-        expect(unchangedBranch).toContain('"application"');
+        const applicationDeploy = productionSource.lastIndexOf('retry_firebase_deploy "hosting,functions" "application"');
+        expect(changedBranch).toContain('"firestore"');
+        expect(unchangedBranch).not.toContain('"application"');
         expect(unchangedBranch).not.toContain('"firestore"');
+        expect(retryEnabledDeploy).toBeGreaterThan(conditionalEnd);
+        expect(applicationDeploy).toBeGreaterThan(retryEnabledDeploy);
     });
 
     it('retries only transient production deploy failures and fails fast otherwise', () => {

--- a/tests/unit/firebase-deploy-workload-identity.test.js
+++ b/tests/unit/firebase-deploy-workload-identity.test.js
@@ -145,10 +145,13 @@ describe('Firebase deploy Workload Identity boundary', () => {
         const end = production.indexOf('\n          fi', unchangedStart);
         const changed = production.slice(changedStart, unchangedStart);
         const unchanged = production.slice(unchangedStart, end);
+        const retryEnabledDeploy = production.indexOf('"retry-enabled-functions"', end);
+        const applicationDeploy = production.lastIndexOf('retry_firebase_deploy "hosting,functions" "application"');
 
         expect(changed.indexOf('"firestore"')).toBeGreaterThan(-1);
-        expect(changed.indexOf('"firestore"')).toBeLessThan(changed.indexOf('"application"'));
-        expect(unchanged).toContain('"application"');
+        expect(unchanged).not.toContain('"application"');
         expect(unchanged).not.toContain('"firestore"');
+        expect(retryEnabledDeploy).toBeGreaterThan(end);
+        expect(applicationDeploy).toBeGreaterThan(retryEnabledDeploy);
     });
 });

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -140,7 +140,17 @@ concurrency:
           if [[ "$STORAGE_RULES_CHANGED" != "true" ]]; then exit 0; fi
           exit "$storage_status"
             transient_pattern='HTTP Error:[[:space:]]*409,[[:space:]]*Requested entity already exists'
-            node "$firebase_cli" deploy --only "$deploy_targets" --project game-flow-c6311 --config "$firebase_config" --non-interactive
+            local -a deploy_args=(
+              --only "$deploy_targets"
+              --project game-flow-c6311
+              --config "$firebase_config"
+              --non-interactive
+            )
+            if [[ "$deploy_targets" != "functions:processAccountDeletionRequest,functions:syncTeamOwnerAccessOnCreate" ]]; then
+              echo "Refusing --force outside the reviewed retry-enabled function allowlist."
+            fi
+            deploy_args+=(--force)
+            node "$firebase_cli" deploy "\${deploy_args[@]}"
           env:
             FIRESTORE_CONFIG_CHANGED: \${{ needs.prepare-deploy.outputs.firestore_changed }}
           retry_delay_seconds=$((base_delay_seconds * (2 ** (attempt - 1))))
@@ -161,10 +171,11 @@ concurrency:
           fi
           if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then
             retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30
-            retry_firebase_deploy "hosting,functions" "application"
           else
-            retry_firebase_deploy "hosting,functions" "application"
+            :
           fi
+          retry_firebase_deploy "functions:processAccountDeletionRequest,functions:syncTeamOwnerAccessOnCreate" "retry-enabled-functions" 3 15 true
+          retry_firebase_deploy "hosting,functions" "application"
         `;
 
         expect(() => validateProductionDeployCommand(validDeployCommand)).not.toThrow();
@@ -183,6 +194,15 @@ concurrency:
         expect(() => validateProductionDeployCommand(
             validDeployCommand.replace('-f branch="$baseline_branch"', '-f branch="$GITHUB_REF_NAME"')
         )).toThrow('Production successful deploy branch filter');
+        expect(() => validateProductionDeployCommand(
+            validDeployCommand.replace('"retry-enabled-functions" 3 15 true', '"retry-enabled-functions" 3 15')
+        )).toThrow('Production retry-enabled function failure-policy acknowledgement call');
+        expect(() => validateProductionDeployCommand(
+            validDeployCommand.replace('              --project game-flow-c6311\n', '')
+        )).toThrow('Production Firebase deploy project');
+        expect(() => validateProductionDeployCommand(
+            validDeployCommand.replace('              --config "$firebase_config"\n', '')
+        )).toThrow('Production Firebase generated config');
         expect(() => validateProductionDeployCommand(
             validDeployCommand.replace(
                 'git diff --quiet "$last_success_sha" "$GITHUB_SHA" -- storage.rules',
@@ -246,17 +266,17 @@ concurrency:
             'docs/observability-runbook.md'
         ))).toThrow('Production Firestore retry-exhaustion recovery link');
         expect(() => validateProductionDeployCommand(validDeployCommand.replace(
-            `retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30
-            retry_firebase_deploy "hosting,functions" "application"`,
+            `retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30`,
             `retry_firebase_deploy "hosting,functions" "application"
             retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30`
         ))).toThrow('Production Firestore deploy must run first when its configuration changed');
         expect(() => validateProductionDeployCommand(validDeployCommand.replace(
             `else
-            retry_firebase_deploy "hosting,functions" "application"`,
+            :
+          fi`,
             `else
             retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30
-            retry_firebase_deploy "hosting,functions" "application"`
+          fi`
         ))).toThrow('Production must not redeploy unchanged Firestore configuration');
     });
 


### PR DESCRIPTION
## Summary
- acknowledge Firebase failure-policy activation only for the two reviewed retry-enabled functions
- keep the full Hosting and Functions deployment unforced so other safety prompts remain fail-closed
- extend CI guards and regression tests for target allowlisting and deployment ordering
- narrowly allow the new React Router RSC-only advisory for this client-only HashRouter app, with automatic expiry on August 8

## Why
Production Hosting has remained stale because the deploy first encountered a transient Firestore Rules API outage, then stopped on Firebase CLI’s required failure-policy acknowledgement. This allows the intended acknowledgement without broadening `--force` to the full function fleet. A newly published React Router advisory also began blocking CI during the hotfix; there is no patched npm release yet, and its RSC execution path is not used by this app.

## Tests
- `node scripts/audit-app-dependencies.mjs`
- `npx vitest run tests/unit/audit-app-dependencies.test.js tests/unit/auth-email-resend-routing.test.js tests/unit/validate-firebase-rules-ci.test.js tests/unit/firebase-deploy-workload-identity.test.js --reporter=dot`
- `npm run ci:firebase-rules`
- `npm run app:build`
- `npm --prefix apps/app test -- --run` (143 files, 1,520 tests)
- `git diff --check`