### PR TITLE
Add bundle tooltip dismissal regression coverage

### DIFF
--- a/scripts/verify-app-bundle-visualizer.mjs
+++ b/scripts/verify-app-bundle-visualizer.mjs
@@ -60,6 +60,14 @@ try {
         throw new Error('Generated bundle visualizer hid its tooltip while the tooltip itself was hovered.');
     }
 
+    document.body.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    await wait(0);
+    if (!tooltip.classList.contains('tooltip-hidden')) {
+        throw new Error(
+            'Generated bundle visualizer tooltip remained visible after hovering outside the tooltip and module nodes.'
+        );
+    }
+
     includeInput.value = '**/react/**';
     includeInput.dispatchEvent(new Event('input', { bubbles: true }));
     includeInput.value = '**/react-dom/**';

--- a/tests/unit/app-bundle-visualizer-tooltip.test.js
+++ b/tests/unit/app-bundle-visualizer-tooltip.test.js
@@ -168,6 +168,10 @@ ${brokenTooltipHandler}
             await new Promise((resolve) => setTimeout(resolve, 0));
             expect(tooltip.className).not.toContain('tooltip-hidden');
 
+            document.body.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            expect(tooltip.className).toContain('tooltip-hidden');
+
             includeInput.value = '**/react/**';
             includeInput.dispatchEvent(new Event('input', { bubbles: true }));
             includeInput.value = '**/react-dom/**';
@@ -205,6 +209,8 @@ ${brokenTooltipHandler}
         expect(verifierSource).toContain("document.querySelector('.node')");
         expect(verifierSource).toContain("document.querySelector('.tooltip')");
         expect(verifierSource).toContain("document.querySelector('#module-filter-include')");
+        expect(verifierSource).toContain("document.body.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))");
+        expect(verifierSource).toContain('remained visible after hovering outside the tooltip and module nodes');
         expect(verifierSource).toContain("includeInput.value = '**/react-dom/**';");
         expect(verifierSource).toContain("document.querySelector('svg')?.textContent.includes('react-dom')");
     });


### PR DESCRIPTION
Closes #4179

## What changed
- Added behavioral coverage proving an outside `document.body` mouseover hides the bundle visualizer tooltip.
- Added the same dismissal assertion to the generated-artifact verifier.
- Added source-level coverage ensuring the verifier retains this check.

## Root Cause
Existing coverage tested tooltip display and retention for `.node` and `.tooltip` targets, but omitted the inverse branch for outside targets. A regression could therefore make tooltips permanently visible without failing tests or artifact verification.

## Prevention / Learning
For guarded UI event handlers, test both outcomes: allowed targets preserve state and outside targets dismiss or reset state. Mirror critical interaction assertions in generated-artifact verification when build-time patching is involved.

## Regression Tests
- `npm exec vitest run tests/unit/app-bundle-visualizer-tooltip.test.js --reporter=dot` (7 tests passed)
- `node scripts/verify-app-bundle-visualizer.mjs` (artifact verified with 699 rendered nodes)

## Recurrence Risk
Low. Both the patched fixture and generated artifact now exercise the previously uncovered dismissal branch.