### PR TITLE
Require reciprocal links for cancellation notices

### DIFF
--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -88,6 +88,8 @@ vi.mock('./adapters/legacyScheduleDb', () => ({
   submitRsvpForPlayer: vi.fn(),
   broadcastLiveEvent: vi.fn(),
   updateGame: vi.fn(),
+  postChatMessage: vi.fn(),
+  postSharedGameCancellationNotification: vi.fn(),
   updatePracticeAttendance: vi.fn(),
   updateTeam: vi.fn(),
   upsertPracticePacketCompletion: vi.fn()
@@ -215,14 +217,14 @@ vi.mock('./appDataCache', () => ({
   getParentScheduleSummaryCacheKey: (userId: string) => `app-schedule-summary:${userId}`
 }));
 
-import { addGame, addPractice, broadcastLiveEvent, buildSingleLegacyTournamentGameDocument, buildLegacyTournamentGameDocument, buildLegacyTournamentGameDocuments, claimOpenOfficiatingSlot, clearOccurrenceOverride, releaseAssignmentClaim, respondToOfficiatingAssignment, updateEvent, updateGame, updateOccurrence, getAssignmentClaims, getGame, getGames, getMyRsvps, getPlayers, getPracticeSession, getPracticeSessions, getRsvpBreakdownByPlayer, getRsvpSummaries, getRsvps, getStaffTeams, getTeam, getTeams, listRideOffersForEvent, submitRsvp, submitRsvpForPlayer, updatePracticeAttendance, getDoc, getDocs } from './adapters/legacyScheduleDb';
+import { addGame, addPractice, broadcastLiveEvent, buildSingleLegacyTournamentGameDocument, buildLegacyTournamentGameDocument, buildLegacyTournamentGameDocuments, claimOpenOfficiatingSlot, clearOccurrenceOverride, releaseAssignmentClaim, respondToOfficiatingAssignment, updateEvent, updateGame, updateOccurrence, getAssignmentClaims, getGame, getGames, getMyRsvps, getPlayers, getPracticeSession, getPracticeSessions, getRsvpBreakdownByPlayer, getRsvpSummaries, getRsvps, getStaffTeams, getTeam, getTeams, listRideOffersForEvent, postChatMessage, postSharedGameCancellationNotification, submitRsvp, submitRsvpForPlayer, updatePracticeAttendance, getDoc, getDocs } from './adapters/legacyScheduleDb';
 import { getNativeAuthIdToken } from './authService';
 import { expandRecurrence, fetchAndParseCalendar, isTeamActive, mergeAssignmentsWithClaims } from './adapters/legacyScheduleHelpers';
 import { getCachedAppData, invalidateCachedAppData, loadCachedAppData } from './appDataCache';
 import { mapScheduleEventRecord } from './firestore/mappers';
 import { loadProfileDocument } from './profileService';
 import { getScheduleTournamentInfo } from './scheduleLogic';
-import { adjustGameScore, buildPlayerScoringLiveEvent, buildSingleGameTournamentLegacySchedulePayload, claimOfficialAssignmentItem, createScheduledGameForApp, createScheduledPracticeForApp, createScheduledTournamentBlockForApp, createStaffRsvpAvailabilityLoader, flushPendingLivePublishOperations, hydrateParentScheduleDetails, hydrateParentScheduleRsvps, loadOfficialAssignments, loadParentSchedule, loadParentScheduleChildren, loadParentScheduleEventDetail, loadParentScheduleScope, loadScheduledPracticeSeriesForEdit, loadStaffPracticeAttendance, loadStaffScheduleRsvpBreakdown, publishLiveScoreUpdateEvent, recordPlayerGameStat, recordPlayerScoringStat, releaseParentScheduleAssignmentClaim, resolveCachedParentScheduleEvents, resolveLiveGameClockSnapshot, resolveParentGameRoute, respondToOfficialAssignmentItem, revertScheduledPracticeOccurrenceForApp, saveScheduledGameLineupDraftForApp, saveStaffPracticeAttendance, submitParentScheduleRsvp, submitParentScheduleRsvpForChildren, submitStaffScheduleRsvpOverride, TournamentBlockPartialSaveError, undoRecordedPlayerGameStat, updateLiveGameClockState, updateScheduledPracticeForApp } from './scheduleService';
+import { adjustGameScore, buildPlayerScoringLiveEvent, buildSingleGameTournamentLegacySchedulePayload, cancelScheduledGameForApp, claimOfficialAssignmentItem, createScheduledGameForApp, createScheduledPracticeForApp, createScheduledTournamentBlockForApp, createStaffRsvpAvailabilityLoader, flushPendingLivePublishOperations, hydrateParentScheduleDetails, hydrateParentScheduleRsvps, loadOfficialAssignments, loadParentSchedule, loadParentScheduleChildren, loadParentScheduleEventDetail, loadParentScheduleScope, loadScheduledPracticeSeriesForEdit, loadStaffPracticeAttendance, loadStaffScheduleRsvpBreakdown, publishLiveScoreUpdateEvent, recordPlayerGameStat, recordPlayerScoringStat, releaseParentScheduleAssignmentClaim, resolveCachedParentScheduleEvents, resolveLiveGameClockSnapshot, resolveParentGameRoute, respondToOfficialAssignmentItem, revertScheduledPracticeOccurrenceForApp, saveScheduledGameLineupDraftForApp, saveStaffPracticeAttendance, submitParentScheduleRsvp, submitParentScheduleRsvpForChildren, submitStaffScheduleRsvpOverride, TournamentBlockPartialSaveError, undoRecordedPlayerGameStat, updateLiveGameClockState, updateScheduledPracticeForApp } from './scheduleService';
 
 function playerSnapshot(id: string, data: Record<string, unknown> | null) {
   return {
@@ -4198,6 +4200,43 @@ describe('resolveCachedParentScheduleEvents (#2649)', () => {
   it('returns empty on a cache miss', () => {
     vi.mocked(getCachedAppData).mockReturnValue(null);
     expect(resolveCachedParentScheduleEvents('u1', 't1', 'e1')).toEqual([]);
+  });
+});
+
+describe('cancelScheduledGameForApp', () => {
+  const user = { uid: 'coach-1', displayName: 'Coach', email: 'coach@example.com', roles: [] } as any;
+  const event = {
+    teamId: 'team-1',
+    id: 'game-1',
+    type: 'game',
+    isDbGame: true,
+    isCancelled: false,
+    canUpdateScore: true,
+    opponent: 'Wolves',
+    date: new Date('2026-06-04T18:00:00.000Z')
+  } as any;
+
+  beforeEach(() => {
+    (globalThis as any).window = { location: { protocol: 'https:' }, setTimeout, clearTimeout } as any;
+    vi.clearAllMocks();
+  });
+
+  it('does not request a counterpart notice for a linked opponent without reciprocal shared-game metadata', async () => {
+    await cancelScheduledGameForApp({ ...event, opponentTeamId: 'team-2' }, user);
+
+    expect(vi.mocked(updateGame)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(postChatMessage)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(postSharedGameCancellationNotification)).not.toHaveBeenCalled();
+  });
+
+  it('requests a counterpart notice for reciprocal shared-game metadata', async () => {
+    await cancelScheduledGameForApp({ ...event, sharedScheduleOpponentTeamId: 'team-2' }, user);
+
+    expect(vi.mocked(postSharedGameCancellationNotification)).toHaveBeenCalledWith(expect.objectContaining({
+      teamId: 'team-1',
+      gameId: 'game-1',
+      counterpartTeamId: 'team-2'
+    }));
   });
 });
 

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -6322,7 +6322,7 @@ export async function cancelScheduledGameForApp(event: ParentScheduleEvent, user
   const notificationFailures: string[] = [];
   const senderName = user.displayName || user.email;
   const senderEmail = user.email;
-  const counterpartTeamId = compactString(event.opponentTeamId || event.sharedScheduleOpponentTeamId) || null;
+  const counterpartTeamId = compactString(event.sharedScheduleOpponentTeamId) || null;
 
   try {
     await postChatMessage(event.teamId, {

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -3110,6 +3110,32 @@ describe('ScheduleEventDetail assignments', () => {
     });
   });
 
+  it('does not promise both chat notifications for a linked opponent without reciprocal shared-game metadata', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        canUpdateScore: true,
+        opponentTeamId: 'team-2',
+        sharedScheduleOpponentTeamId: null
+      })],
+      children: []
+    });
+    scheduleServiceMocks.cancelScheduledGameForApp.mockResolvedValue({ notificationError: null });
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Cancel game' })).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel game' }));
+
+    expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('notifies the team in chat'));
+    expect(confirmSpy).not.toHaveBeenCalledWith(expect.stringContaining('both team chats'));
+    await waitFor(() => {
+      expect(screen.getByText('Game cancelled and team chat notified.')).toBeTruthy();
+    });
+  });
+
   it('passes the recurring practice occurrence through cancellation without falling back to the series', async () => {
     const recurringOccurrence = buildEvent({
       eventKey: 'team-1::practice-master__2026-06-04::player-1::2026-06-04T18:00:00.000Z::practice',

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -1612,7 +1612,7 @@ function GameHubSection({ auth, event, childEvents, requestedPanel, onPanelChang
   const isRecurringPracticeOccurrence = Boolean(isPractice && event.id.includes('__'));
   const canCancelPracticeOccurrence = Boolean(isRecurringPracticeOccurrence && event.isDbGame && !event.isCancelled && event.isTeamAdmin && auth.user);
   const canPublishLineup = Boolean(!isPractice && event.isDbGame && event.isTeamStaff);
-  const notifiesCounterpartTeam = Boolean(event.opponentTeamId || event.sharedScheduleOpponentTeamId);
+  const notifiesCounterpartTeam = Boolean(event.sharedScheduleOpponentTeamId);
   const hubDestinations = isPractice ? buildPracticeHubDestinations(event) : buildGameHubDestinations(event);
   const standardTrackerHref = `/schedule/${encodeURIComponent(event.teamId)}/${encodeURIComponent(event.id)}/track`;
   const availablePanelIds = useMemo(() => {

--- a/functions/index.js
+++ b/functions/index.js
@@ -11477,27 +11477,26 @@ exports.postSharedGameCancellationNotification = functions.https.onCall(async (d
   }
   await assertSensitiveEmailVerified(context, 'post-shared-game-cancellation');
 
-  const teamId = normalizeText(data?.teamId, 160);
-  const gameId = normalizeText(data?.gameId, 160);
-  const counterpartTeamId = normalizeText(data?.counterpartTeamId, 160);
-
-  if (!teamId || !gameId || !counterpartTeamId) {
-    throw new functions.https.HttpsError('invalid-argument', 'teamId, gameId, and counterpartTeamId are required.');
+  let teamId;
+  let gameId;
+  let counterpartTeamId;
+  try {
+    teamId = normalizeFirestoreId(data?.teamId, 'teamId');
+    gameId = normalizeFirestoreId(data?.gameId, 'gameId');
+    counterpartTeamId = normalizeFirestoreId(data?.counterpartTeamId, 'counterpartTeamId');
+  } catch (error) {
+    throw new functions.https.HttpsError('invalid-argument', error.message);
   }
 
   const callerEmail = String(context.auth.token?.email || '').trim().toLowerCase();
-  const [sourceTeamSnap, counterpartTeamSnap, sourceGameSnap, userSnap] = await Promise.all([
+  const [sourceTeamSnap, sourceGameSnap, userSnap] = await Promise.all([
     firestore.doc(`teams/${teamId}`).get(),
-    firestore.doc(`teams/${counterpartTeamId}`).get(),
     firestore.doc(`teams/${teamId}/games/${gameId}`).get(),
     firestore.doc(`users/${context.auth.uid}`).get()
   ]);
 
   if (!sourceTeamSnap.exists) {
     throw new functions.https.HttpsError('not-found', 'Source team not found.');
-  }
-  if (!counterpartTeamSnap.exists) {
-    throw new functions.https.HttpsError('not-found', 'Counterpart team not found.');
   }
   if (!sourceGameSnap.exists) {
     throw new functions.https.HttpsError('not-found', 'Source game not found.');
@@ -11509,14 +11508,66 @@ exports.postSharedGameCancellationNotification = functions.https.onCall(async (d
     throw new functions.https.HttpsError('permission-denied', 'Only team coaches and admins can notify the linked team chat.');
   }
 
-  const counterpartTeam = counterpartTeamSnap.data() || {};
   const sourceGame = sourceGameSnap.data() || {};
-  const linkedCounterpartTeamId = String(sourceGame.sharedScheduleOpponentTeamId || sourceGame.opponentTeamId || '').trim();
-  if (!linkedCounterpartTeamId || linkedCounterpartTeamId !== counterpartTeamId) {
+  let linkedCounterpartTeamId;
+  let linkedCounterpartGameId;
+  try {
+    linkedCounterpartTeamId = normalizeFirestoreId(
+      sourceGame.sharedScheduleOpponentTeamId,
+      'sharedScheduleOpponentTeamId'
+    );
+    linkedCounterpartGameId = normalizeFirestoreId(
+      sourceGame.sharedScheduleOpponentGameId,
+      'sharedScheduleOpponentGameId'
+    );
+  } catch (error) {
+    throw new functions.https.HttpsError('failed-precondition', 'Game does not have a valid reciprocal shared-game link.');
+  }
+  if (linkedCounterpartTeamId !== counterpartTeamId) {
     throw new functions.https.HttpsError('failed-precondition', 'Game is not linked to the requested counterpart team.');
   }
   if (String(sourceGame.status || '').trim().toLowerCase() !== 'cancelled') {
     throw new functions.https.HttpsError('failed-precondition', 'Cancel the game before notifying the linked team chat.');
+  }
+
+  const sharedScheduleId = String(sourceGame.sharedScheduleId || '').trim();
+  if (!sharedScheduleId) {
+    throw new functions.https.HttpsError('failed-precondition', 'Game does not have a valid reciprocal shared-game link.');
+  }
+
+  const [counterpartTeamSnap, counterpartGameSnap] = await Promise.all([
+    firestore.doc(`teams/${counterpartTeamId}`).get(),
+    firestore.doc(`teams/${counterpartTeamId}/games/${linkedCounterpartGameId}`).get()
+  ]);
+  if (!counterpartTeamSnap.exists) {
+    throw new functions.https.HttpsError('not-found', 'Counterpart team not found.');
+  }
+  if (!counterpartGameSnap.exists) {
+    throw new functions.https.HttpsError('failed-precondition', 'Reciprocal counterpart game not found.');
+  }
+
+  const counterpartTeam = counterpartTeamSnap.data() || {};
+  const counterpartGame = counterpartGameSnap.data() || {};
+  let reciprocalTeamId;
+  let reciprocalGameId;
+  try {
+    reciprocalTeamId = normalizeFirestoreId(
+      counterpartGame.sharedScheduleOpponentTeamId,
+      'counterpart sharedScheduleOpponentTeamId'
+    );
+    reciprocalGameId = normalizeFirestoreId(
+      counterpartGame.sharedScheduleOpponentGameId,
+      'counterpart sharedScheduleOpponentGameId'
+    );
+  } catch (error) {
+    throw new functions.https.HttpsError('failed-precondition', 'Counterpart game does not have a valid reciprocal shared-game link.');
+  }
+  if (
+    reciprocalTeamId !== teamId
+    || reciprocalGameId !== gameId
+    || String(counterpartGame.sharedScheduleId || '').trim() !== sharedScheduleId
+  ) {
+    throw new functions.https.HttpsError('failed-precondition', 'Counterpart game does not reciprocally match the source game.');
   }
 
   const text = buildSharedGameCancellationCounterpartMessage({

--- a/functions/test/post-shared-game-cancellation-notification.test.js
+++ b/functions/test/post-shared-game-cancellation-notification.test.js
@@ -145,6 +145,9 @@ function makeFunctionsStub() {
     firestore: {
       document: () => triggerChain
     },
+    auth: {
+      user: () => triggerChain
+    },
     pubsub: {
       schedule: () => triggerChain
     },
@@ -187,50 +190,94 @@ function loadCallable(seed = {}) {
   return { firestore, callable: mod.postSharedGameCancellationNotification };
 }
 
-test('postSharedGameCancellationNotification writes a server-authored counterpart message', async () => {
-  const { firestore, callable } = loadCallable({
-    'teams/team-1': {
+const sourceTeamPath = 'teams/team-1';
+const sourceGamePath = 'teams/team-1/games/game-1';
+const counterpartTeamPath = 'teams/team-2';
+const counterpartGamePath = 'teams/team-2/games/game-2';
+const destinationMessagePath = 'teams/team-2/chatMessages/auto-1';
+
+function makeReciprocalSeed(overrides = {}) {
+  return {
+    [sourceTeamPath]: {
       name: 'Bears',
       ownerId: 'coach-1',
       adminEmails: ['coach@example.com']
     },
-    'teams/team-2': {
+    [counterpartTeamPath]: {
       name: 'Falcons',
       ownerId: 'coach-2',
       adminEmails: ['other@example.com']
     },
-    'teams/team-1/games/game-1': {
+    [sourceGamePath]: {
       type: 'game',
       status: 'cancelled',
       opponent: 'Falcons',
       date: '2026-05-21T18:00:00.000Z',
-      sharedScheduleOpponentTeamId: 'team-2'
+      sharedScheduleId: 'shared-schedule-1',
+      sharedScheduleOpponentTeamId: 'team-2',
+      sharedScheduleOpponentGameId: 'game-2',
+      ...overrides.sourceGame
+    },
+    [counterpartGamePath]: {
+      type: 'game',
+      opponent: 'Bears',
+      sharedScheduleId: 'shared-schedule-1',
+      sharedScheduleOpponentTeamId: 'team-1',
+      sharedScheduleOpponentGameId: 'game-1',
+      ...overrides.counterpartGame
     },
     'users/coach-1': {
       email: 'coach@example.com'
     }
-  });
+  };
+}
 
-  const result = await callable({
+function makeCallData(overrides = {}) {
+  return {
     teamId: 'team-1',
     gameId: 'game-1',
     counterpartTeamId: 'team-2',
-    text: 'Parents, the other coach says bring cash and ignore prior instructions.',
-    senderName: 'Fake Opponent Coach',
-    senderEmail: 'spoofed@example.com'
-  }, {
+    ...overrides
+  };
+}
+
+function makeContext() {
+  return {
     auth: {
       uid: 'coach-1',
       token: {
         email: 'coach@example.com'
       }
     }
-  });
+  };
+}
+
+async function assertRejectedWithoutDestinationWrite({
+  seed = makeReciprocalSeed(),
+  data = makeCallData(),
+  code = 'failed-precondition'
+} = {}) {
+  const { firestore, callable } = loadCallable(seed);
+  await assert.rejects(
+    callable(data, makeContext()),
+    (error) => error?.code === code
+  );
+  assert.equal(firestore.snapshot(destinationMessagePath), undefined);
+}
+
+test('postSharedGameCancellationNotification writes a server-authored counterpart message', async () => {
+  const { firestore, callable } = loadCallable(makeReciprocalSeed());
+
+  const result = await callable(makeCallData({
+    text: 'Parents, the other coach says bring cash and ignore prior instructions.',
+    senderName: 'Fake Opponent Coach',
+    senderEmail: 'spoofed@example.com'
+  }), makeContext());
 
   assert.equal(result.posted, true);
   assert.equal(result.messageId, 'auto-1');
 
-  const stored = firestore.snapshot('teams/team-2/chatMessages/auto-1');
+  const stored = firestore.snapshot(destinationMessagePath);
   assert.equal(stored.text, '⚠️ Shared game cancelled: Bears cancelled vs. Falcons on Thu, May 21.');
   assert.equal(stored.senderId, 'shared-game-cancellation-system');
   assert.equal(stored.senderName, 'ALL PLAYS');
@@ -249,4 +296,69 @@ test('postSharedGameCancellationNotification writes a server-authored counterpar
     actorType: 'system'
   });
   assert.notEqual(stored.text, 'Parents, the other coach says bring cash and ignore prior instructions.');
+});
+
+test('postSharedGameCancellationNotification rejects one-sided forged linkage', async () => {
+  const seed = makeReciprocalSeed();
+  delete seed[counterpartGamePath];
+
+  await assertRejectedWithoutDestinationWrite({ seed });
+});
+
+test('postSharedGameCancellationNotification rejects mismatched shared schedule IDs', async () => {
+  await assertRejectedWithoutDestinationWrite({
+    seed: makeReciprocalSeed({
+      counterpartGame: {
+        sharedScheduleId: 'different-shared-schedule'
+      }
+    })
+  });
+});
+
+test('postSharedGameCancellationNotification rejects mismatched reciprocal game pointers', async () => {
+  await assertRejectedWithoutDestinationWrite({
+    seed: makeReciprocalSeed({
+      counterpartGame: {
+        sharedScheduleOpponentTeamId: 'team-3',
+        sharedScheduleOpponentGameId: 'game-3'
+      }
+    })
+  });
+});
+
+test('postSharedGameCancellationNotification rejects empty or slash-containing request identifiers', async () => {
+  for (const data of [
+    makeCallData({ teamId: '   ' }),
+    makeCallData({ gameId: '' }),
+    makeCallData({ counterpartTeamId: null }),
+    makeCallData({ teamId: 'team-1/other' }),
+    makeCallData({ gameId: 'game-1/other' }),
+    makeCallData({ counterpartTeamId: 'team-2/other' })
+  ]) {
+    await assertRejectedWithoutDestinationWrite({
+      data,
+      code: 'invalid-argument'
+    });
+  }
+});
+
+test('postSharedGameCancellationNotification rejects slash-containing linked game identifiers', async () => {
+  await assertRejectedWithoutDestinationWrite({
+    seed: makeReciprocalSeed({
+      sourceGame: {
+        sharedScheduleOpponentGameId: 'game-2/other'
+      }
+    })
+  });
+});
+
+test('postSharedGameCancellationNotification does not authorize an opponentTeamId fallback', async () => {
+  await assertRejectedWithoutDestinationWrite({
+    seed: makeReciprocalSeed({
+      sourceGame: {
+        sharedScheduleOpponentTeamId: '',
+        opponentTeamId: 'team-2'
+      }
+    })
+  });
 });

--- a/tests/unit/app-schedule-event-detail-cancel.test.js
+++ b/tests/unit/app-schedule-event-detail-cancel.test.js
@@ -16,7 +16,7 @@ describe('React app schedule event detail cancellation action', () => {
         expect(source).toContain('cancelScheduledGameForApp');
         expect(source).toContain("const canCancelGame = Boolean(!isPractice && event.isDbGame && !event.isCancelled && event.canUpdateScore && auth.user);");
         expect(source).toContain('Cancel game');
-        expect(source).toContain("const notifiesCounterpartTeam = Boolean(event.opponentTeamId || event.sharedScheduleOpponentTeamId);");
+        expect(source).toContain("const notifiesCounterpartTeam = Boolean(event.sharedScheduleOpponentTeamId);");
         expect(source).toContain("This marks the game cancelled and notifies ${notifiesCounterpartTeam ? 'both team chats' : 'the team in chat'}.`);");
         expect(source).toContain("{ ...event, status: 'cancelled', isCancelled: true, availabilityLocked: true }");
         expect(source).toContain('Game cancelled, but team chat notification failed:');

--- a/tests/unit/app-schedule-score-update.test.js
+++ b/tests/unit/app-schedule-score-update.test.js
@@ -422,6 +422,7 @@ describe('React app schedule score updates', () => {
             location: 'Main Gym',
             opponent: 'Falcons',
             opponentTeamId: 'team-2',
+            sharedScheduleOpponentTeamId: 'team-2',
             counterpartTitle: 'vs. Bears',
             childId: 'player-1',
             childName: 'Pat',


### PR DESCRIPTION
Closes #4178

## What changed
- Validate all team and game path identifiers with `normalizeFirestoreId`.
- Remove the `opponentTeamId` authorization fallback.
- Load the referenced counterpart game and require matching reciprocal team/game pointers and a shared non-empty `sharedScheduleId`.
- Reject invalid or forged linkage before creating a destination chat message.

## Root Cause
The callable authorized the source-team admin but trusted caller-editable source-game metadata as sufficient authority for an Admin SDK write into another team's chat. It never verified a reciprocal destination game.

## Prevention / Learning
Privileged cross-tenant writes must validate every path identifier and verify an authoritative reciprocal relationship on the destination side before bypassing that tenant's normal authorization boundary.

## Regression Tests
- Valid reciprocal linkage creates exactly one server-authored notice.
- One-sided linkage, mismatched schedule IDs, and mismatched reciprocal pointers are rejected without a destination write.
- Empty and slash-containing identifiers are rejected.
- `opponentTeamId` alone cannot authorize notification delivery.
- `node --check functions/index.js`
- `npx vitest run functions/test/post-shared-game-cancellation-notification.test.js --reporter=verbose` (7 passed)
- `git diff --check`

## Recurrence Risk
Low. The destination write now requires independently loaded reciprocal metadata, and focused tests cover the known forgery paths.