### PR TITLE
Fix production search backfill auth

### DIFF
--- a/_migration/backfill-admin-user-search-index.js
+++ b/_migration/backfill-admin-user-search-index.js
@@ -9,7 +9,8 @@ const require = createRequire(import.meta.url);
 const { buildAdminUserSearchHashes } = require('../functions/admin-user-search-index-core.cjs');
 const APPLY = process.argv.includes('--apply');
 const FIRESTORE_BATCH_LIMIT = 500;
-const FIREBASE_PROJECT_ID = 'game-flow-c6311';
+const FIRESTORE_REST_BATCH_LIMIT = 20;
+const FIREBASE_PROJECT_ID = process.env.FIREBASE_PROJECT_ID || 'game-flow-c6311';
 const FIRESTORE_DATABASE_PATH =
     `projects/${FIREBASE_PROJECT_ID}/databases/(default)`;
 const FIRESTORE_API_BASE =
@@ -62,9 +63,11 @@ async function runAccessTokenBackfill(accessToken) {
         }
     });
     const writes = [];
+    let documentCount = 0;
     for (const result of results) {
         const document = result.document;
         if (!document?.name) continue;
+        documentCount += 1;
         const userId = document.name.slice(document.name.lastIndexOf('/') + 1);
         const fields = document.fields || {};
         const hashes = buildAdminUserSearchHashes({
@@ -90,10 +93,16 @@ async function runAccessTokenBackfill(accessToken) {
         });
     }
 
-    for (let start = 0; start < writes.length; start += FIRESTORE_BATCH_LIMIT) {
+    for (let start = 0; start < writes.length; start += FIRESTORE_REST_BATCH_LIMIT) {
+        const batchWrites = writes.slice(start, start + FIRESTORE_REST_BATCH_LIMIT);
         const result = await firestoreRestRequest(accessToken, '/documents:batchWrite', {
-            writes: writes.slice(start, start + FIRESTORE_BATCH_LIMIT)
+            writes: batchWrites
         });
+        if (!Array.isArray(result.status) || result.status.length !== batchWrites.length) {
+            throw new Error(
+                `Firestore REST batch write returned ${result.status?.length ?? 0} status entries for ${batchWrites.length} writes`
+            );
+        }
         const failedWrite = result.status?.find((status) => Number(status.code || 0) !== 0);
         if (failedWrite) {
             throw new Error(
@@ -101,7 +110,7 @@ async function runAccessTokenBackfill(accessToken) {
             );
         }
     }
-    console.log(`[backfill-admin-user-search-index] Done. ${APPLY ? `Wrote ${writes.length}` : `Would write ${results.filter((result) => result.document).length}`} index document(s).`);
+    console.log(`[backfill-admin-user-search-index] Done. ${APPLY ? `Wrote ${writes.length}` : `Would write ${documentCount}`} index document(s).`);
 }
 
 async function main() {

--- a/_migration/backfill-admin-user-search-index.js
+++ b/_migration/backfill-admin-user-search-index.js
@@ -10,20 +10,12 @@ const { buildAdminUserSearchHashes } = require('../functions/admin-user-search-i
 const APPLY = process.argv.includes('--apply');
 const FIRESTORE_BATCH_LIMIT = 500;
 const FIREBASE_PROJECT_ID = 'game-flow-c6311';
+const FIRESTORE_DATABASE_PATH =
+    `projects/${FIREBASE_PROJECT_ID}/databases/(default)`;
+const FIRESTORE_API_BASE =
+    `https://firestore.googleapis.com/v1/${FIRESTORE_DATABASE_PATH}`;
 
 function getAdminAppOptions() {
-    if (process.env.GOOGLE_OAUTH_ACCESS_TOKEN) {
-        const accessToken = process.env.GOOGLE_OAUTH_ACCESS_TOKEN;
-        return {
-            credential: {
-                getAccessToken: async () => ({
-                    access_token: accessToken,
-                    expires_in: 3600
-                })
-            },
-            projectId: FIREBASE_PROJECT_ID
-        };
-    }
     if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
         return {
             credential: applicationDefault(),
@@ -40,7 +32,83 @@ function getAdminAppOptions() {
     };
 }
 
+async function firestoreRestRequest(accessToken, path, body) {
+    const response = await fetch(`${FIRESTORE_API_BASE}${path}`, {
+        method: 'POST',
+        headers: {
+            authorization: `Bearer ${accessToken}`,
+            'content-type': 'application/json'
+        },
+        body: JSON.stringify(body)
+    });
+    if (!response.ok) {
+        const detail = await response.text();
+        throw new Error(`Firestore REST ${response.status}: ${detail.slice(0, 500)}`);
+    }
+    return response.json();
+}
+
+async function runAccessTokenBackfill(accessToken) {
+    const results = await firestoreRestRequest(accessToken, '/documents:runQuery', {
+        structuredQuery: {
+            from: [{ collectionId: 'users' }],
+            select: {
+                fields: [
+                    { fieldPath: 'email' },
+                    { fieldPath: 'fullName' },
+                    { fieldPath: 'phone' }
+                ]
+            }
+        }
+    });
+    const writes = [];
+    for (const result of results) {
+        const document = result.document;
+        if (!document?.name) continue;
+        const userId = document.name.slice(document.name.lastIndexOf('/') + 1);
+        const fields = document.fields || {};
+        const hashes = buildAdminUserSearchHashes({
+            email: fields.email?.stringValue,
+            fullName: fields.fullName?.stringValue,
+            phone: fields.phone?.stringValue
+        });
+        console.log(`[backfill-admin-user-search-index] ${APPLY ? 'Queue' : 'Would index'} ${userId} (${hashes.length} hashes)`);
+        if (!APPLY) continue;
+        writes.push({
+            update: {
+                name: `${FIRESTORE_DATABASE_PATH}/documents/adminUserSearch/${userId}`,
+                fields: {
+                    userId: { stringValue: userId },
+                    hashes: {
+                        arrayValue: {
+                            values: hashes.map((hash) => ({ stringValue: hash }))
+                        }
+                    },
+                    updatedAt: { timestampValue: new Date().toISOString() }
+                }
+            }
+        });
+    }
+
+    for (let start = 0; start < writes.length; start += FIRESTORE_BATCH_LIMIT) {
+        const result = await firestoreRestRequest(accessToken, '/documents:batchWrite', {
+            writes: writes.slice(start, start + FIRESTORE_BATCH_LIMIT)
+        });
+        const failedWrite = result.status?.find((status) => Number(status.code || 0) !== 0);
+        if (failedWrite) {
+            throw new Error(
+                `Firestore REST batch write failed (${failedWrite.code}): ${failedWrite.message || 'unknown error'}`
+            );
+        }
+    }
+    console.log(`[backfill-admin-user-search-index] Done. ${APPLY ? `Wrote ${writes.length}` : `Would write ${results.filter((result) => result.document).length}`} index document(s).`);
+}
+
 async function main() {
+    if (process.env.GOOGLE_OAUTH_ACCESS_TOKEN) {
+        await runAccessTokenBackfill(process.env.GOOGLE_OAUTH_ACCESS_TOKEN);
+        return;
+    }
     if (!getApps().length) initializeApp(getAdminAppOptions());
 
     const db = getFirestore();

--- a/_migration/backfill-admin-user-search-index.js
+++ b/_migration/backfill-admin-user-search-index.js
@@ -103,7 +103,7 @@ async function runAccessTokenBackfill(accessToken) {
                 `Firestore REST batch write returned ${result.status?.length ?? 0} status entries for ${batchWrites.length} writes`
             );
         }
-        const failedWrite = result.status?.find((status) => Number(status.code || 0) !== 0);
+        const failedWrite = result.status.find((status) => Number(status.code || 0) !== 0);
         if (failedWrite) {
             throw new Error(
                 `Firestore REST batch write failed (${failedWrite.code}): ${failedWrite.message || 'unknown error'}`

--- a/_migration/backfill-admin-user-search-index.js
+++ b/_migration/backfill-admin-user-search-index.js
@@ -2,6 +2,7 @@
 
 import { createRequire } from 'node:module';
 import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
 import { applicationDefault, cert, getApps, initializeApp } from 'firebase-admin/app';
 import { FieldValue, getFirestore } from 'firebase-admin/firestore';
 
@@ -49,7 +50,7 @@ async function firestoreRestRequest(accessToken, path, body) {
     return response.json();
 }
 
-async function runAccessTokenBackfill(accessToken) {
+export async function runAccessTokenBackfill(accessToken, { apply = APPLY } = {}) {
     const results = await firestoreRestRequest(accessToken, '/documents:runQuery', {
         structuredQuery: {
             from: [{ collectionId: 'users' }],
@@ -75,8 +76,8 @@ async function runAccessTokenBackfill(accessToken) {
             fullName: fields.fullName?.stringValue,
             phone: fields.phone?.stringValue
         });
-        console.log(`[backfill-admin-user-search-index] ${APPLY ? 'Queue' : 'Would index'} ${userId} (${hashes.length} hashes)`);
-        if (!APPLY) continue;
+        console.log(`[backfill-admin-user-search-index] ${apply ? 'Queue' : 'Would index'} ${userId} (${hashes.length} hashes)`);
+        if (!apply) continue;
         writes.push({
             update: {
                 name: `${FIRESTORE_DATABASE_PATH}/documents/adminUserSearch/${userId}`,
@@ -110,7 +111,7 @@ async function runAccessTokenBackfill(accessToken) {
             );
         }
     }
-    console.log(`[backfill-admin-user-search-index] Done. ${APPLY ? `Wrote ${writes.length}` : `Would write ${documentCount}`} index document(s).`);
+    console.log(`[backfill-admin-user-search-index] Done. ${apply ? `Wrote ${writes.length}` : `Would write ${documentCount}`} index document(s).`);
 }
 
 async function main() {
@@ -152,7 +153,9 @@ async function main() {
     console.log(`[backfill-admin-user-search-index] Done. ${APPLY ? `Wrote ${written}` : `Would write ${snapshot.size}`} index document(s).`);
 }
 
-main().catch((error) => {
-    console.error('[backfill-admin-user-search-index] Failed:', error);
-    process.exitCode = 1;
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main().catch((error) => {
+        console.error('[backfill-admin-user-search-index] Failed:', error);
+        process.exitCode = 1;
+    });
+}

--- a/tests/unit/admin-user-search-db.test.js
+++ b/tests/unit/admin-user-search-db.test.js
@@ -247,6 +247,8 @@ describe('bounded admin user search queries', () => {
         expect(migration).toContain('process.env.FIREBASE_PROJECT_ID');
         expect(migration).toContain('!Array.isArray(result.status)');
         expect(migration).toContain('result.status.length !== batchWrites.length');
+        expect(migration.indexOf('!Array.isArray(result.status)'))
+            .toBeLessThan(migration.indexOf('result.status.find('));
         expect(migration).toContain('documentCount += 1;');
         expect(migration).not.toContain('results.filter((result) => result.document).length');
         expect(migration).toContain("new URL('./serviceAccountKey.json', import.meta.url)");

--- a/tests/unit/admin-user-search-db.test.js
+++ b/tests/unit/admin-user-search-db.test.js
@@ -243,6 +243,12 @@ describe('bounded admin user search queries', () => {
         expect(migration).toContain("'/documents:runQuery'");
         expect(migration).toContain("'/documents:batchWrite'");
         expect(migration).not.toContain('getAccessToken: async');
+        expect(migration).toContain('const FIRESTORE_REST_BATCH_LIMIT = 20;');
+        expect(migration).toContain('process.env.FIREBASE_PROJECT_ID');
+        expect(migration).toContain('!Array.isArray(result.status)');
+        expect(migration).toContain('result.status.length !== batchWrites.length');
+        expect(migration).toContain('documentCount += 1;');
+        expect(migration).not.toContain('results.filter((result) => result.document).length');
         expect(migration).toContain("new URL('./serviceAccountKey.json', import.meta.url)");
     });
 });

--- a/tests/unit/admin-user-search-db.test.js
+++ b/tests/unit/admin-user-search-db.test.js
@@ -240,6 +240,9 @@ describe('bounded admin user search queries', () => {
         expect(migration).toContain('process.env.GOOGLE_OAUTH_ACCESS_TOKEN');
         expect(migration).toContain('process.env.GOOGLE_APPLICATION_CREDENTIALS');
         expect(migration).toContain('applicationDefault()');
+        expect(migration).toContain("'/documents:runQuery'");
+        expect(migration).toContain("'/documents:batchWrite'");
+        expect(migration).not.toContain('getAccessToken: async');
         expect(migration).toContain("new URL('./serviceAccountKey.json', import.meta.url)");
     });
 });

--- a/tests/unit/backfill-admin-user-search-index.test.js
+++ b/tests/unit/backfill-admin-user-search-index.test.js
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { runAccessTokenBackfill } from '../../_migration/backfill-admin-user-search-index.js';
+
+function jsonResponse(body, { ok = true, status = 200, text = '' } = {}) {
+    return {
+        ok,
+        status,
+        json: vi.fn().mockResolvedValue(body),
+        text: vi.fn().mockResolvedValue(text)
+    };
+}
+
+function queryDocument(index) {
+    return {
+        document: {
+            name: `projects/test-project/databases/(default)/documents/users/user-${index}`,
+            fields: {
+                email: { stringValue: `User-${index}@Example.com` },
+                fullName: { stringValue: `User ${index}` },
+                phone: { stringValue: `555000${String(index).padStart(4, '0')}` }
+            }
+        }
+    };
+}
+
+describe('admin user search REST backfill', () => {
+    let logSpy;
+
+    beforeEach(() => {
+        logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it('decodes query documents without writing during a dry run', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(jsonResponse([
+            queryDocument(1),
+            { readTime: '2026-07-25T00:00:00Z' }
+        ]));
+        vi.stubGlobal('fetch', fetchMock);
+
+        await runAccessTokenBackfill('token', { apply: false });
+
+        expect(fetchMock).toHaveBeenCalledOnce();
+        expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({
+            structuredQuery: {
+                from: [{ collectionId: 'users' }]
+            }
+        });
+        expect(logSpy).toHaveBeenCalledWith(
+            expect.stringContaining('Would index user-1')
+        );
+        expect(logSpy).toHaveBeenLastCalledWith(
+            '[backfill-admin-user-search-index] Done. Would write 1 index document(s).'
+        );
+    });
+
+    it('chunks apply writes into requests of at most 20 documents', async () => {
+        const documents = Array.from({ length: 21 }, (_, index) => queryDocument(index));
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce(jsonResponse(documents))
+            .mockResolvedValueOnce(jsonResponse({
+                status: Array.from({ length: 20 }, () => ({}))
+            }))
+            .mockResolvedValueOnce(jsonResponse({ status: [{}] }));
+        vi.stubGlobal('fetch', fetchMock);
+
+        await runAccessTokenBackfill('token', { apply: true });
+
+        const firstBatch = JSON.parse(fetchMock.mock.calls[1][1].body).writes;
+        const secondBatch = JSON.parse(fetchMock.mock.calls[2][1].body).writes;
+        expect(firstBatch).toHaveLength(20);
+        expect(secondBatch).toHaveLength(1);
+        expect(firstBatch[0]).toMatchObject({
+            update: {
+                fields: {
+                    userId: { stringValue: 'user-0' },
+                    hashes: {
+                        arrayValue: {
+                            values: expect.arrayContaining([
+                                { stringValue: '1wahw2d' }
+                            ])
+                        }
+                    }
+                }
+            }
+        });
+        expect(logSpy).toHaveBeenLastCalledWith(
+            '[backfill-admin-user-search-index] Done. Wrote 21 index document(s).'
+        );
+    });
+
+    it('reports Firestore HTTP errors', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+            jsonResponse(null, { ok: false, status: 403, text: 'permission denied' })
+        ));
+
+        await expect(runAccessTokenBackfill('token', { apply: true }))
+            .rejects.toThrow('Firestore REST 403: permission denied');
+    });
+
+    it.each([
+        ['missing', {}],
+        ['short', { status: [] }]
+    ])('rejects %s batch status arrays', async (_label, batchResponse) => {
+        vi.stubGlobal('fetch', vi.fn()
+            .mockResolvedValueOnce(jsonResponse([queryDocument(1)]))
+            .mockResolvedValueOnce(jsonResponse(batchResponse)));
+
+        await expect(runAccessTokenBackfill('token', { apply: true }))
+            .rejects.toThrow('returned 0 status entries for 1 writes');
+    });
+
+    it('rejects nonzero per-write statuses', async () => {
+        vi.stubGlobal('fetch', vi.fn()
+            .mockResolvedValueOnce(jsonResponse([queryDocument(1)]))
+            .mockResolvedValueOnce(jsonResponse({
+                status: [{ code: 7, message: 'permission denied' }]
+            })));
+
+        await expect(runAccessTokenBackfill('token', { apply: true }))
+            .rejects.toThrow('batch write failed (7): permission denied');
+    });
+});


### PR DESCRIPTION
## What changed

- use the workflow OAuth access token through the documented Firestore REST API
- retain Firebase Admin application-default/service-account paths for local and manual runs
- fail the backfill when an individual REST batch write reports an error

## Why

The app and Functions deployed from #4177, but the post-deploy admin search backfill failed because Firebase Admin Firestore rejects the custom access-token credential. Firestore REST directly supports the workflow OAuth token.

## Validation

- `node --check _migration/backfill-admin-user-search-index.js`
- `npx vitest run tests/unit/admin-user-search-db.test.js` (9/9)
- production app bundle already verified live with the corrected calendar field parser