### PR TITLE
Track Firestore deployment state

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -88,6 +88,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      deployments: read
     outputs:
       admin_user_search_backfill_needed: ${{ steps.firestore_config.outputs.admin_user_search_backfill_needed }}
       firestore_changed: ${{ steps.firestore_config.outputs.changed }}
@@ -152,6 +153,7 @@ jobs:
             baseline_branch="master"
           fi
           last_success_sha=""
+          firestore_success_sha=""
           lookup_succeeded="false"
           lookup_max_attempts=3
           for ((lookup_attempt = 1; lookup_attempt <= lookup_max_attempts; lookup_attempt += 1)); do
@@ -177,6 +179,49 @@ jobs:
             exit 0
           fi
 
+          component_lookup_succeeded="false"
+          component_lookup_max_attempts=3
+          for ((lookup_attempt = 1; lookup_attempt <= component_lookup_max_attempts; lookup_attempt += 1)); do
+            deployments_json=""
+            if deployments_json="$(gh api --method GET "repos/${GITHUB_REPOSITORY}/deployments" \
+              -f environment=production-firestore \
+              -F per_page=20)"; then
+              component_lookup_succeeded="true"
+              while IFS=$'\t' read -r deployment_id deployment_sha; do
+                [[ "$deployment_id" =~ ^[0-9]+$ ]] || continue
+                [[ "$deployment_sha" =~ ^[0-9a-f]{40}$ ]] || continue
+                deployment_state=""
+                if ! deployment_state="$(gh api --method GET \
+                  "repos/${GITHUB_REPOSITORY}/deployments/${deployment_id}/statuses" \
+                  -F per_page=1 \
+                  --jq '.[0].state // ""')"; then
+                  component_lookup_succeeded="false"
+                  break
+                fi
+                if [[ "$deployment_state" == "success" ]]; then
+                  firestore_success_sha="$deployment_sha"
+                  break
+                fi
+              done < <(jq -r '.[] | [.id, .sha] | @tsv' <<< "$deployments_json")
+              if [[ "$component_lookup_succeeded" == "true" ]]; then
+                break
+              fi
+            fi
+
+            if (( lookup_attempt < component_lookup_max_attempts )); then
+              sleep $((5 * lookup_attempt))
+            fi
+          done
+
+          if [[ "$component_lookup_succeeded" != "true" ]]; then
+            echo "::warning::The Firestore component deployment lookup failed; falling back to the last complete production deployment."
+          elif [[ -z "$firestore_success_sha" ]]; then
+            echo "::notice::No Firestore component deployment marker exists yet; using the last complete production deployment as the migration baseline."
+          fi
+          if [[ ! "$firestore_success_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            firestore_success_sha="$last_success_sha"
+          fi
+
           if [[ ! "$last_success_sha" =~ ^[0-9a-f]{40}$ ]]; then
             echo "::warning::No valid successful production deploy baseline was found; forcing authorization rules-first ordering."
             echo "admin_user_search_backfill_needed=true" >> "$GITHUB_OUTPUT"
@@ -195,7 +240,11 @@ jobs:
             else
               echo "admin_user_search_backfill_needed=true" >> "$GITHUB_OUTPUT"
             fi
-            if git diff --quiet "$last_success_sha" "$GITHUB_SHA" -- firestore.rules firestore.indexes.json; then
+            if [[ ! "$firestore_success_sha" =~ ^[0-9a-f]{40}$ ]] \
+              || ! git cat-file -e "${firestore_success_sha}^{commit}" 2>/dev/null; then
+              echo "::warning::The Firestore component deployment commit is unavailable locally; forcing authorization rules-first ordering."
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+            elif git diff --quiet "$firestore_success_sha" "$GITHUB_SHA" -- firestore.rules firestore.indexes.json; then
               echo "changed=false" >> "$GITHUB_OUTPUT"
             else
               echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -262,6 +311,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      deployments: write
       id-token: write
 
     steps:
@@ -405,6 +455,7 @@ jobs:
         env:
           ADMIN_USER_SEARCH_BACKFILL_NEEDED: ${{ needs.prepare-deploy.outputs.admin_user_search_backfill_needed }}
           FIRESTORE_CONFIG_CHANGED: ${{ needs.prepare-deploy.outputs.firestore_changed }}
+          GH_TOKEN: ${{ github.token }}
           GOOGLE_OAUTH_ACCESS_TOKEN: ${{ steps.google_auth_production.outputs.access_token }}
         run: |
           set -euo pipefail
@@ -418,7 +469,7 @@ jobs:
             local max_attempts="${3:-3}"
             local base_delay_seconds="${4:-15}"
             local acknowledge_failure_policy="${5:-false}"
-            local attempt deploy_log deploy_status retry_delay_seconds
+            local attempt deploy_log deploy_plain_log deploy_status retry_delay_seconds retry_jitter_seconds
             local api_surface final_error_class final_http_status
             local -a deploy_args=(
               --only "$deploy_targets"
@@ -450,6 +501,17 @@ jobs:
 
               if (( deploy_status == 0 )); then
                 return 0
+              fi
+
+              if [[ "$deploy_label" == "firestore" ]]; then
+                deploy_plain_log="${deploy_log}.plain"
+                sed -E 's/\x1B\[[0-9;]*[[:alpha:]]//g' "$deploy_log" > "$deploy_plain_log"
+                if grep -Fq "latest version of firestore.rules already up to date, skipping upload" "$deploy_plain_log" \
+                  && grep -Fq "deployed indexes in firestore.indexes.json successfully" "$deploy_plain_log" \
+                  && grep -Eq 'HTTP Error:[[:space:]]*409,[[:space:]]*Requested entity already exists' "$deploy_plain_log"; then
+                  echo "::notice::Firestore rules and indexes are already current; accepting the duplicate release 409 as success."
+                  return 0
+                fi
               fi
 
               if ! grep -Eiq "$transient_pattern" "$deploy_log"; then
@@ -498,12 +560,68 @@ jobs:
               fi
 
               retry_delay_seconds=$((base_delay_seconds * (2 ** (attempt - 1))))
+              retry_jitter_seconds=$((RANDOM % 16))
+              retry_delay_seconds=$((retry_delay_seconds + retry_jitter_seconds))
               if (( retry_delay_seconds > 120 )); then
                 retry_delay_seconds=120
               fi
               echo "Transient Firebase ${deploy_label} deploy failure; retrying in ${retry_delay_seconds} seconds (attempt $((attempt + 1))/${max_attempts})." >&2
               sleep "$retry_delay_seconds"
             done
+          }
+
+          record_component_deployment() {
+            local component_environment="$1"
+            local component_description="$2"
+            local attempt deployment_id deployment_status
+
+            for attempt in 1 2 3; do
+              deployment_id="$(
+                jq -n \
+                  --arg ref "$GITHUB_SHA" \
+                  --arg environment "$component_environment" \
+                  '{
+                    ref: $ref,
+                    environment: $environment,
+                    auto_merge: false,
+                    required_contexts: [],
+                    transient_environment: false,
+                    production_environment: true,
+                    description: "Component deployment marker"
+                  }' \
+                  | gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments" --input - --jq '.id'
+              )" || deployment_id=""
+
+              if [[ "$deployment_id" =~ ^[0-9]+$ ]]; then
+                deployment_status="$(
+                  jq -n \
+                    --arg description "$component_description" \
+                    --arg environment "$component_environment" \
+                    --arg log_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+                    '{
+                      state: "success",
+                      description: $description,
+                      environment: $environment,
+                      log_url: $log_url,
+                      auto_inactive: true
+                    }' \
+                    | gh api --method POST \
+                      "repos/${GITHUB_REPOSITORY}/deployments/${deployment_id}/statuses" \
+                      --input - \
+                      --jq '.state'
+                )" || deployment_status=""
+                if [[ "$deployment_status" == "success" ]]; then
+                  return 0
+                fi
+              fi
+
+              if (( attempt < 3 )); then
+                sleep $((5 * attempt))
+              fi
+            done
+
+            echo "Unable to record the ${component_environment} deployment marker." >&2
+            return 1
           }
 
           if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then
@@ -516,6 +634,14 @@ jobs:
             # unrelated Rules API outage must not fail a Hosting/Functions-only fix.
             :
           fi
+          # Record this component immediately. A later Hosting, Functions, or
+          # migration failure must not make the next run redeploy current rules.
+          if ! record_component_deployment \
+            "production-firestore" \
+            "Firestore rules and indexes are current at ${GITHUB_SHA}."; then
+            echo "::warning::Firestore is current, but its component marker could not be recorded. A future failed production retry may conservatively redeploy it."
+          fi
+
           # These two event handlers intentionally enable automatic retries and
           # have idempotency coverage. A targeted --force acknowledges only that
           # failure policy; the subsequent full-fleet deploy remains unforced so

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -300,7 +300,11 @@ export function validateProductionDeployCommand(deployProd) {
     );
     assertIncludes(deployProd, 'retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30', 'Production Firestore deploy targets and bounded extended retry');
     assertIncludes(deployProd, 'if (( retry_delay_seconds > 120 )); then', 'Production Firebase retry delay cap');
+    assertIncludes(deployProd, 'retry_jitter_seconds=$((RANDOM % 16))', 'Production Firebase retry jitter');
     assertIncludes(deployProd, 'HTTP Error:[[:space:]]*409,[[:space:]]*Requested entity already exists', 'Production Firestore release-race retry');
+    assertIncludes(deployProd, 'latest version of firestore.rules already up to date, skipping upload', 'Production Firestore current-rules verification');
+    assertIncludes(deployProd, 'deployed indexes in firestore.indexes.json successfully', 'Production Firestore current-indexes verification');
+    assertIncludes(deployProd, 'accepting the duplicate release 409 as success', 'Production Firestore verified duplicate-release recovery');
     assertIncludes(deployProd, 'if [[ "$deploy_label" == "firestore" ]]; then', 'Production Firestore retry-exhaustion summary scope');
     assertIncludes(deployProd, 'Firestore Rules API (firebaserules.googleapis.com)', 'Production Firestore retry-exhaustion API surface');
     assertIncludes(
@@ -325,6 +329,8 @@ export function validateProductionDeployCommand(deployProd) {
     );
     assertIncludes(deployProd, 'Application deployment remains fail-closed, so Hosting and Functions were not deployed.', 'Production Firestore retry-exhaustion fail-closed guidance');
     assertIncludes(deployProd, 'actions: read', 'Production workflow-run read permission');
+    assertIncludes(deployProd, 'deployments: read', 'Production component deployment read permission');
+    assertIncludes(deployProd, 'deployments: write', 'Production component deployment write permission');
     assertIncludes(deployProd, 'GH_TOKEN: ${{ github.token }}', 'Production workflow-run authentication');
     assertIncludes(deployProd, 'actions/workflows/deploy-prod.yml/runs', 'Production successful deploy lookup');
     assertIncludes(deployProd, '-f branch="$baseline_branch"', 'Production successful deploy branch filter');
@@ -343,7 +349,13 @@ export function validateProductionDeployCommand(deployProd) {
     ) {
         throw new Error('Production successful deploy lookup failure must force authorization rules-first ordering.');
     }
-    assertIncludes(deployProd, 'git diff --quiet "$last_success_sha" "$GITHUB_SHA" -- firestore.rules firestore.indexes.json', 'Production Firestore change detection');
+    assertIncludes(deployProd, 'repos/${GITHUB_REPOSITORY}/deployments', 'Production Firestore component deployment lookup');
+    assertIncludes(deployProd, '-f environment=production-firestore', 'Production Firestore component environment filter');
+    assertIncludes(deployProd, 'firestore_success_sha="$deployment_sha"', 'Production Firestore component successful SHA');
+    assertIncludes(deployProd, 'git diff --quiet "$firestore_success_sha" "$GITHUB_SHA" -- firestore.rules firestore.indexes.json', 'Production Firestore component change detection');
+    assertIncludes(deployProd, 'record_component_deployment()', 'Production component deployment recorder');
+    assertIncludes(deployProd, '"production-firestore"', 'Production Firestore component marker');
+    assertIncludes(deployProd, 'state: "success"', 'Production Firestore component success status');
     if (deployProd.includes('git diff --quiet "${{ github.event.before }}" "${{ github.sha }}" -- firestore.rules firestore.indexes.json')) {
         throw new Error('Production Firestore changes must not use the immediately previous push as the deploy baseline.');
     }
@@ -358,6 +370,7 @@ export function validateProductionDeployCommand(deployProd) {
         throw new Error('Production must not redeploy unchanged Firestore configuration.');
     }
     const retryEnabledDeploy = deployProd.indexOf('"retry-enabled-functions"', conditionalEnd);
+    const componentMarker = deployProd.indexOf('record_component_deployment', conditionalEnd);
     const applicationDeploy = deployProd.indexOf('retry_firebase_deploy "hosting,functions" "application"', conditionalEnd);
     const firstApplicationDeploy = deployProd.indexOf('retry_firebase_deploy "hosting,functions" "application"');
     if (retryEnabledDeploy === -1 || applicationDeploy <= retryEnabledDeploy) {
@@ -366,9 +379,11 @@ export function validateProductionDeployCommand(deployProd) {
     if (
         changedBranch.indexOf('"firestore"') === -1
         || conditionalEnd >= retryEnabledDeploy
+        || componentMarker === -1
+        || componentMarker >= retryEnabledDeploy
         || firstApplicationDeploy < conditionalEnd
     ) {
-        throw new Error('Production Firestore deploy must run first when its configuration changed.');
+        throw new Error('Production Firestore deploy and component marker must run first when its configuration changed.');
     }
 
     const storageDeployCommand = deployCommands.find(command => /--only(?:=|\s+)storage(?:\s|$)/.test(command)) || '';

--- a/tests/unit/firebase-deploy-workload-identity.test.js
+++ b/tests/unit/firebase-deploy-workload-identity.test.js
@@ -146,11 +146,17 @@ describe('Firebase deploy Workload Identity boundary', () => {
         const changed = production.slice(changedStart, unchangedStart);
         const unchanged = production.slice(unchangedStart, end);
         const retryEnabledDeploy = production.indexOf('"retry-enabled-functions"', end);
+        const componentMarker = production.indexOf('record_component_deployment', end);
         const applicationDeploy = production.lastIndexOf('retry_firebase_deploy "hosting,functions" "application"');
 
         expect(changed.indexOf('"firestore"')).toBeGreaterThan(-1);
         expect(unchanged).not.toContain('"application"');
         expect(unchanged).not.toContain('"firestore"');
+        expect(production).toContain('deployments: read');
+        expect(production).toContain('deployments: write');
+        expect(production).toContain('firestore_success_sha="$deployment_sha"');
+        expect(componentMarker).toBeGreaterThan(end);
+        expect(componentMarker).toBeLessThan(retryEnabledDeploy);
         expect(retryEnabledDeploy).toBeGreaterThan(end);
         expect(applicationDeploy).toBeGreaterThan(retryEnabledDeploy);
     });

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -103,6 +103,8 @@ concurrency:
           fetch-depth: 0
       permissions:
         actions: read
+        deployments: read
+        deployments: write
       outputs:
         storage_changed: \${{ steps.firestore_config.outputs.storage_changed }}
       - name: Detect Firebase rules changes
@@ -129,7 +131,9 @@ concurrency:
             echo "storage_changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          git diff --quiet "$last_success_sha" "$GITHUB_SHA" -- firestore.rules firestore.indexes.json
+          gh api --method GET "repos/\${GITHUB_REPOSITORY}/deployments" -f environment=production-firestore
+          firestore_success_sha="$deployment_sha"
+          git diff --quiet "$firestore_success_sha" "$GITHUB_SHA" -- firestore.rules firestore.indexes.json
           git diff --quiet "$last_success_sha" "$GITHUB_SHA" -- storage.rules
       - name: Deploy Firebase Storage rules when available
         env:
@@ -154,10 +158,14 @@ concurrency:
           env:
             FIRESTORE_CONFIG_CHANGED: \${{ needs.prepare-deploy.outputs.firestore_changed }}
           retry_delay_seconds=$((base_delay_seconds * (2 ** (attempt - 1))))
+          retry_jitter_seconds=$((RANDOM % 16))
           if (( retry_delay_seconds > 120 )); then
             retry_delay_seconds=120
           fi
           if [[ "$deploy_label" == "firestore" ]]; then
+            echo "latest version of firestore.rules already up to date, skipping upload"
+            echo "deployed indexes in firestore.indexes.json successfully"
+            echo "accepting the duplicate release 409 as success"
             api_surface="Firestore Rules API (firebaserules.googleapis.com)"
             grep -Eio 'HTTP Error:[[:space:]]*(409|429|500|502|503|504)|(^|[^[:digit:]])(409|429|500|502|503|504)([^[:digit:]]|$)' "$deploy_log" \\
               | grep -Eo '(409|429|500|502|503|504)'
@@ -174,6 +182,10 @@ concurrency:
           else
             :
           fi
+          record_component_deployment() {
+            echo 'state: "success"'
+          }
+          record_component_deployment "production-firestore"
           retry_firebase_deploy "functions:processAccountDeletionRequest,functions:syncTeamOwnerAccessOnCreate" "retry-enabled-functions" 3 15 true
           retry_firebase_deploy "hosting,functions" "application"
         `;
@@ -216,9 +228,9 @@ concurrency:
             'Production Storage rules ANSI log normalization'
         );
         expect(() => validateProductionDeployCommand(validDeployCommand.replace(
-            'git diff --quiet "$last_success_sha" "$GITHUB_SHA" -- firestore.rules firestore.indexes.json',
+            'git diff --quiet "$firestore_success_sha" "$GITHUB_SHA" -- firestore.rules firestore.indexes.json',
             'git diff --quiet "\${{ github.event.before }}" "\${{ github.sha }}" -- firestore.rules firestore.indexes.json'
-        ))).toThrow('Production Firestore change detection is missing');
+        ))).toThrow('Production Firestore component change detection is missing');
         expect(() => validateProductionDeployCommand(validDeployCommand.replace(
             'if last_success_sha="$(gh api',
             'last_success_sha="$(gh api'
@@ -269,7 +281,7 @@ concurrency:
             `retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30`,
             `retry_firebase_deploy "hosting,functions" "application"
             retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30`
-        ))).toThrow('Production Firestore deploy must run first when its configuration changed');
+        ))).toThrow('Production Firestore deploy and component marker must run first when its configuration changed');
         expect(() => validateProductionDeployCommand(validDeployCommand.replace(
             `else
             :


### PR DESCRIPTION
## What changed

- Record a successful production-firestore component deployment immediately after rules and indexes are confirmed current.
- Compare future Firestore changes against that component marker instead of the last completely successful production workflow.
- Accept the exact duplicate-release 409 only when the deploy log independently confirms both rules and indexes are already current.
- Add jitter to transient Firebase deploy retries and preserve conservative fallbacks when marker APIs are unavailable.
- Extend production deploy policy and Workload Identity regression coverage.

## Why

A later migration failure left Firestore successfully deployed but the overall workflow failed. The next run therefore redeployed unchanged Firestore configuration and was blocked for 13 minutes by a transient Rules API outage. Component state prevents that redundant dependency.

## Validation

- Focused Workload Identity and Firebase deploy-policy tests: passed.
- Firebase rules CI policy validation: passed.
- Full unit suite: 4,879 tests passed.
- Local Storage emulator phase could not run because Java is not installed on this Mac; CI installs Java before running it.
- Git diff check: passed.