### PR TITLE
Add one-tap directions to mobile Schedule rows

### DIFF
--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -5,7 +5,7 @@ import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testi
 import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Schedule, getGenericEventDetailPath } from './Schedule';
-import { getScheduleMapHref, type ParentScheduleEvent } from '../lib/scheduleLogic';
+import type { ParentScheduleEvent } from '../lib/scheduleLogic';
 import type { AuthState } from '../lib/types';
 
 const scheduleServiceMocks = vi.hoisted(() => ({
@@ -52,13 +52,8 @@ const staffToolsLoaderMocks = vi.hoisted(() => ({
   load: vi.fn(() => import('../components/schedule/ScheduleStaffTools'))
 }));
 
-const publicActionMocks = vi.hoisted(() => ({
-  openPublicUrl: vi.fn()
-}));
-
 vi.mock('../lib/scheduleService', () => scheduleServiceMocks);
 vi.mock('../lib/appDataCache', () => appDataCacheMocks);
-vi.mock('../lib/publicActions', () => publicActionMocks);
 vi.mock('../lib/telemetry', () => ({
   recordAppWorkflowTiming: vi.fn(),
   startAppInitialLoadTimer: vi.fn(() => initialLoadTelemetryMocks)
@@ -1561,46 +1556,6 @@ describe('Schedule', () => {
 
     expect(mobileRow.textContent).toContain('1 task open');
     expect(mobileRow.textContent).toContain('4 seats open');
-  });
-
-  it('opens mobile directions externally without changing the schedule route', async () => {
-    shellLayoutMocks.isDesktopWeb = false;
-    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
-      children: [
-        { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
-      ],
-      events: [
-        buildScheduleEvent(1),
-        buildScheduleEvent(2, { location: 'TBD' })
-      ]
-    });
-
-    const { container } = render(
-      <MemoryRouter initialEntries={['/schedule?filter=upcoming-games']}>
-        <RouteProbe />
-        <Routes>
-          <Route path="/schedule" element={<Schedule auth={auth} />} />
-          <Route path="/schedule/:teamId/:eventId" element={<div>Event detail</div>} />
-        </Routes>
-      </MemoryRouter>
-    );
-
-    const directions = await screen.findByRole('button', { name: 'Directions' });
-    expect(screen.getAllByRole('button', { name: 'Directions' })).toHaveLength(1);
-    expect(directions.className).toContain('min-h-11');
-
-    fireEvent.click(directions);
-
-    expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith(getScheduleMapHref('Main Gym'));
-    expect(screen.getByTestId('route-probe').textContent).toBe('/schedule?filter=upcoming-games');
-
-    const detailLink = container.querySelector('.schedule-event-row-detail') as HTMLAnchorElement;
-    expect(detailLink?.getAttribute('href')).toBe('/schedule/team-1/event-1?childId=player-1&section=availability');
-    fireEvent.click(detailLink);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('route-probe').textContent).toBe('/schedule/team-1/event-1?childId=player-1&section=availability');
-    });
   });
 
   it('shows the remaining event count when only one more event is hidden', async () => {

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -5,7 +5,7 @@ import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testi
 import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Schedule, getGenericEventDetailPath } from './Schedule';
-import type { ParentScheduleEvent } from '../lib/scheduleLogic';
+import { getScheduleMapHref, type ParentScheduleEvent } from '../lib/scheduleLogic';
 import type { AuthState } from '../lib/types';
 
 const scheduleServiceMocks = vi.hoisted(() => ({
@@ -52,8 +52,13 @@ const staffToolsLoaderMocks = vi.hoisted(() => ({
   load: vi.fn(() => import('../components/schedule/ScheduleStaffTools'))
 }));
 
+const publicActionMocks = vi.hoisted(() => ({
+  openPublicUrl: vi.fn()
+}));
+
 vi.mock('../lib/scheduleService', () => scheduleServiceMocks);
 vi.mock('../lib/appDataCache', () => appDataCacheMocks);
+vi.mock('../lib/publicActions', () => publicActionMocks);
 vi.mock('../lib/telemetry', () => ({
   recordAppWorkflowTiming: vi.fn(),
   startAppInitialLoadTimer: vi.fn(() => initialLoadTelemetryMocks)
@@ -1549,13 +1554,53 @@ describe('Schedule', () => {
     const { container } = renderSchedule();
 
     const mobileRow = await waitFor(() => {
-      const row = container.querySelector('.schedule-list > a');
+      const row = container.querySelector('.schedule-event-row-detail');
       expect(row).toBeTruthy();
       return row as HTMLAnchorElement;
     });
 
     expect(mobileRow.textContent).toContain('1 task open');
     expect(mobileRow.textContent).toContain('4 seats open');
+  });
+
+  it('opens mobile directions externally without changing the schedule route', async () => {
+    shellLayoutMocks.isDesktopWeb = false;
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
+      children: [
+        { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+      ],
+      events: [
+        buildScheduleEvent(1),
+        buildScheduleEvent(2, { location: 'TBD' })
+      ]
+    });
+
+    const { container } = render(
+      <MemoryRouter initialEntries={['/schedule?filter=upcoming-games']}>
+        <RouteProbe />
+        <Routes>
+          <Route path="/schedule" element={<Schedule auth={auth} />} />
+          <Route path="/schedule/:teamId/:eventId" element={<div>Event detail</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const directions = await screen.findByRole('button', { name: 'Directions' });
+    expect(screen.getAllByRole('button', { name: 'Directions' })).toHaveLength(1);
+    expect(directions.className).toContain('min-h-11');
+
+    fireEvent.click(directions);
+
+    expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith(getScheduleMapHref('Main Gym'));
+    expect(screen.getByTestId('route-probe').textContent).toBe('/schedule?filter=upcoming-games');
+
+    const detailLink = container.querySelector('.schedule-event-row-detail') as HTMLAnchorElement;
+    expect(detailLink?.getAttribute('href')).toBe('/schedule/team-1/event-1?childId=player-1&section=availability');
+    fireEvent.click(detailLink);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('route-probe').textContent).toBe('/schedule/team-1/event-1?childId=player-1&section=availability');
+    });
   });
 
   it('shows the remaining event count when only one more event is hidden', async () => {

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -19,6 +19,7 @@ import { createLogger } from '../lib/logger';
 import { startAppInitialLoadTimer } from '../lib/telemetry';
 import { recordFirstMeaningfulRender, startScreenMountTimer } from '../lib/uxTiming';
 import { completeParentCoreWorkflowTimer } from '../lib/parentWorkflowTiming';
+import { openPublicUrl } from '../lib/publicActions';
 import { useViewLoadTimer } from '../lib/viewLoadTiming';
 import { useAsyncOperation } from '../lib/useAsyncOperation';
 import { useRefreshOnResume } from '../lib/useRefreshOnResume';
@@ -2068,46 +2069,58 @@ function ScheduleEventCard({ event, preferGameHubForStaff }: {
 
   return (
     <>
-      <Link to={detailPath} className={`block border-b border-gray-100 px-3 py-2 transition last:border-b-0 hover:bg-gray-50 sm:hidden ${event.isCancelled ? 'opacity-65' : ''}`}>
-        <div className="flex items-center gap-2.5">
-          <div className="flex h-12 w-11 flex-none flex-col items-center justify-center rounded-lg bg-gray-50 ring-1 ring-gray-100">
-            <div className="text-[10px] font-black uppercase leading-none tracking-[0.04em] text-gray-500">{event.date.toLocaleDateString('en-US', { month: 'short' })}</div>
-            <div className="mt-0.5 text-lg font-black leading-none text-gray-950">{event.date.getDate()}</div>
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="flex min-w-0 items-center gap-1.5">
-              <span className={`h-2.5 w-2.5 flex-none rounded-full ${event.type === 'practice' ? 'bg-amber-500' : 'bg-primary-600'}`} aria-hidden="true" />
-              <h2 className={`truncate text-[15px] font-black leading-tight text-gray-950 ${event.isCancelled ? 'line-through' : ''}`}>{eventTitle}</h2>
+      <div className={`schedule-event-row-mobile border-b border-gray-100 last:border-b-0 sm:hidden ${event.isCancelled ? 'opacity-65' : ''}`}>
+        <Link to={detailPath} className="schedule-event-row-detail block px-3 py-2 transition hover:bg-gray-50">
+          <div className="flex items-center gap-2.5">
+            <div className="flex h-12 w-11 flex-none flex-col items-center justify-center rounded-lg bg-gray-50 ring-1 ring-gray-100">
+              <div className="text-[10px] font-black uppercase leading-none tracking-[0.04em] text-gray-500">{event.date.toLocaleDateString('en-US', { month: 'short' })}</div>
+              <div className="mt-0.5 text-lg font-black leading-none text-gray-950">{event.date.getDate()}</div>
             </div>
-            <div className="mt-0.5 truncate text-xs font-bold leading-5 text-gray-600">
-              {childLabel} · {event.teamName}
-            </div>
-            <div className="truncate text-xs font-semibold leading-5 text-gray-500">
-              {getScheduleLocationLabel(event)}
-            </div>
-            {tournamentInfo.isTournament ? (
-              <div className="truncate text-xs font-bold leading-5 text-indigo-700">
-                {tournamentInfo.label}{tournamentInfo.details ? ` - ${tournamentInfo.details}` : ''}
+            <div className="min-w-0 flex-1">
+              <div className="flex min-w-0 items-center gap-1.5">
+                <span className={`h-2.5 w-2.5 flex-none rounded-full ${event.type === 'practice' ? 'bg-amber-500' : 'bg-primary-600'}`} aria-hidden="true" />
+                <h2 className={`truncate text-[15px] font-black leading-tight text-gray-950 ${event.isCancelled ? 'line-through' : ''}`}>{eventTitle}</h2>
               </div>
-            ) : null}
-            {mobileActionPills.length ? (
-              <div className="mt-1 flex max-h-5 flex-wrap gap-1 overflow-hidden">
-                {mobileActionPills.map((pill) => (
-                  <span key={pill} className="inline-flex min-h-5 items-center rounded-full border border-gray-200 bg-white px-1.5 text-[10px] font-black leading-none text-gray-700">
-                    {pill}
-                  </span>
-                ))}
+              <div className="mt-0.5 truncate text-xs font-bold leading-5 text-gray-600">
+                {childLabel} · {event.teamName}
               </div>
-            ) : null}
+              <div className="truncate text-xs font-semibold leading-5 text-gray-500">
+                {getScheduleLocationLabel(event)}
+              </div>
+              {tournamentInfo.isTournament ? (
+                <div className="truncate text-xs font-bold leading-5 text-indigo-700">
+                  {tournamentInfo.label}{tournamentInfo.details ? ` - ${tournamentInfo.details}` : ''}
+                </div>
+              ) : null}
+              {mobileActionPills.length ? (
+                <div className="mt-1 flex max-h-5 flex-wrap gap-1 overflow-hidden">
+                  {mobileActionPills.map((pill) => (
+                    <span key={pill} className="inline-flex min-h-5 items-center rounded-full border border-gray-200 bg-white px-1.5 text-[10px] font-black leading-none text-gray-700">
+                      {pill}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+            <div className="flex w-[72px] flex-none flex-col items-end gap-1 text-right">
+              <span className="text-xs font-black text-gray-700">{formatEventTimeLabel(event.date)}</span>
+              {isRsvpNeeded ? <span className="rounded-full bg-primary-50 px-2 py-0.5 text-[10px] font-black uppercase text-primary-700">RSVP</span> : null}
+              {hasPracticePacket ? <span className="rounded-full bg-blue-50 px-2 py-0.5 text-[10px] font-black uppercase text-blue-700">Packet</span> : null}
+              {event.type === 'game' && getScoreLabel(event) ? <span className="rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] font-black uppercase text-emerald-700">{getScoreLabel(event)}</span> : null}
+            </div>
           </div>
-          <div className="flex w-[72px] flex-none flex-col items-end gap-1 text-right">
-            <span className="text-xs font-black text-gray-700">{formatEventTimeLabel(event.date)}</span>
-            {isRsvpNeeded ? <span className="rounded-full bg-primary-50 px-2 py-0.5 text-[10px] font-black uppercase text-primary-700">RSVP</span> : null}
-            {hasPracticePacket ? <span className="rounded-full bg-blue-50 px-2 py-0.5 text-[10px] font-black uppercase text-blue-700">Packet</span> : null}
-            {event.type === 'game' && getScoreLabel(event) ? <span className="rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] font-black uppercase text-emerald-700">{getScoreLabel(event)}</span> : null}
-          </div>
-        </div>
-      </Link>
+        </Link>
+        {mapHref ? (
+          <button
+            type="button"
+            className="schedule-event-directions flex min-h-11 w-full items-center justify-center gap-1.5 border-t border-gray-100 px-3 text-xs font-black text-primary-700 transition hover:bg-primary-50"
+            onClick={() => void openPublicUrl(mapHref)}
+          >
+            <MapPin className="h-4 w-4" aria-hidden="true" />
+            Directions
+          </button>
+        ) : null}
+      </div>
 
       <article className={`app-card schedule-event-card hidden p-4 transition sm:block ${event.isCancelled ? 'opacity-65' : ''}`}>
         <div className="flex items-start gap-3">

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -2113,6 +2113,7 @@ function ScheduleEventCard({ event, preferGameHubForStaff }: {
         {mapHref ? (
           <button
             type="button"
+            aria-label={`Directions to ${eventTitle} at ${event.location}`}
             className="schedule-event-directions flex min-h-11 w-full items-center justify-center gap-1.5 border-t border-gray-100 px-3 text-xs font-black text-primary-700 transition hover:bg-primary-50"
             onClick={() => void openPublicUrl(mapHref)}
           >

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -1455,14 +1455,14 @@ test('iOS-sized schedule smoke covers list, event nav, and rideshare without ove
     await expect(mobileActionQueue.getByText('Needs attention', { exact: true })).toBeVisible();
     const gameHubAction = mobileActionQueue.getByRole('link', { name: /RSVP needed for Pat.*vs\. Falcons/ });
     await expect(gameHubAction).toHaveAttribute('href', /#\/schedule\/team-1\/game-1\?childId=player-1&section=game$/);
-    const firstScheduleRow = page.locator('.schedule-list > a').first();
+    const firstScheduleRow = page.locator('.schedule-event-row-detail').first();
     await expect(firstScheduleRow).toBeVisible();
     const queueBox = await mobileActionQueue.boundingBox();
     const firstRowBox = await firstScheduleRow.boundingBox();
     expect(queueBox && firstRowBox && queueBox.y + queueBox.height <= firstRowBox.y).toBe(true);
     await expect(firstScheduleRow.getByText('1 task open')).toBeVisible();
     await expect(firstScheduleRow.getByText('4 seats open')).toBeVisible();
-    const scheduleRowCount = await page.locator('.schedule-list > a').count();
+    const scheduleRowCount = await page.locator('.schedule-event-row-detail').count();
     expect(scheduleRowCount).toBeGreaterThanOrEqual(2);
     expect(scheduleRowCount).toBeLessThanOrEqual(3);
     expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1)).toBe(true);
@@ -1578,7 +1578,7 @@ test('iOS-sized staff schedule keeps tools collapsed below the event list', asyn
     await page.goto(appUrl(baseURL, '/schedule'), { waitUntil: 'domcontentloaded' });
 
     await expect(mobileScheduleFilter(page)).toBeVisible({ timeout: 15000 });
-    await expect(page.locator('.schedule-list > a').first()).toBeVisible();
+    await expect(page.locator('.schedule-event-row-detail').first()).toBeVisible();
     await expect(page.getByRole('button', { name: /Manage schedule/ })).toBeVisible();
     await expect(page.getByText('Add external calendar')).toHaveCount(0);
     await expect(page.getByText('Draft schedule with AI')).toHaveCount(0);
@@ -1938,7 +1938,7 @@ test('app schedule keeps filters compact on phone', async ({ page, baseURL }) =>
     const scheduleFilter = mobileScheduleFilter(page);
     await waitForScheduleRoute(page, scheduleFilter);
 
-    const mobileRows = page.locator('.schedule-list > a');
+    const mobileRows = page.locator('.schedule-event-row-detail');
     await expect(async () => {
         await expect(scheduleFilter).toBeVisible({ timeout: 1000 });
         await expect(page.getByRole('button', { name: 'Upcoming Practices' })).toBeHidden();
@@ -1970,7 +1970,7 @@ test('app schedule paginates long agenda lists and resets on filter changes', as
     await page.goto(appUrl(baseURL, '/schedule'), { waitUntil: 'domcontentloaded' });
 
     await waitForScheduleRoute(page, mobileScheduleFilter(page));
-    const mobileRows = page.locator('.schedule-list > a');
+    const mobileRows = page.locator('.schedule-event-row-detail');
     await expect(async () => {
         await expect(mobileRows.first()).toBeVisible({ timeout: 1000 });
         await expect(mobileRows).toHaveCount(20, { timeout: 1000 });

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -2,7 +2,8 @@
 import React, { act } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRoot } from 'react-dom/client';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { getScheduleMapHref } from '../../apps/app/src/lib/scheduleLogic.ts';
 
 const scheduleMocks = vi.hoisted(() => ({
     addTeamCalendarUrl: vi.fn(),
@@ -25,8 +26,12 @@ const layoutState = vi.hoisted(() => ({
     isNative: false,
     isMobileWeb: false
 }));
+const publicActionMocks = vi.hoisted(() => ({
+    openPublicUrl: vi.fn()
+}));
 
 vi.mock('../../apps/app/src/lib/scheduleService.ts', () => scheduleMocks);
+vi.mock('../../apps/app/src/lib/publicActions.ts', () => publicActionMocks);
 vi.mock('../../apps/app/src/lib/performanceInstrumentation.ts', () => ({
     now: vi.fn(() => 0),
     startPerformanceSpan: vi.fn(() => ({ startedAt: 0, end: vi.fn() })),
@@ -111,7 +116,12 @@ function event(overrides = {}) {
     };
 }
 
-async function renderSchedule() {
+function RouteProbe() {
+    const location = useLocation();
+    return React.createElement('div', { 'data-testid': 'route-probe' }, `${location.pathname}${location.search}`);
+}
+
+async function renderSchedule(initialEntries) {
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
@@ -119,8 +129,13 @@ async function renderSchedule() {
     await act(async () => {
         root.render(React.createElement(
             MemoryRouter,
-            null,
-            React.createElement(Schedule, { auth })
+            initialEntries ? { initialEntries } : null,
+            React.createElement(
+                React.Fragment,
+                null,
+                initialEntries ? React.createElement(RouteProbe) : null,
+                React.createElement(Schedule, { auth })
+            )
         ));
     });
 
@@ -517,6 +532,44 @@ describe('React app desktop Schedule controls', () => {
         await waitForText(container, 'Add external calendar');
         expect(container.textContent).toContain('Draft schedule with AI');
         expect(container.textContent).toContain('Import schedule CSV');
+    });
+
+    it('opens event-specific mobile directions externally without changing the schedule route', async () => {
+        layoutState.isDesktopWeb = false;
+        layoutState.isMobileWeb = true;
+        scheduleMocks.loadParentSchedule.mockResolvedValue({
+            children: [
+                { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+            ],
+            events: [
+                event(),
+                event({
+                    eventKey: 'team-1::game-2::player-1',
+                    id: 'game-2',
+                    opponent: 'Hawks',
+                    location: 'River Field'
+                })
+            ]
+        });
+
+        const { container } = await renderSchedule(['/schedule?filter=upcoming-games']);
+        await waitForText(container, 'River Field');
+
+        const falconsDirections = container.querySelector('button[aria-label="Directions to vs. Falcons at Main Gym"]');
+        const hawksDirections = container.querySelector('button[aria-label="Directions to vs. Hawks at River Field"]');
+        expect(falconsDirections).toBeTruthy();
+        expect(hawksDirections).toBeTruthy();
+        expect(falconsDirections.textContent.trim()).toBe('Directions');
+        expect(hawksDirections.textContent.trim()).toBe('Directions');
+        expect(falconsDirections.className).toContain('min-h-11');
+
+        await act(async () => {
+            falconsDirections.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        });
+
+        expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith(getScheduleMapHref('Main Gym'));
+        expect(container.querySelector('[data-testid="route-probe"]').textContent)
+            .toBe('/schedule?filter=upcoming-games');
     });
 
     it('reuses the cached schedule when the route remounts', async () => {

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -548,6 +548,12 @@ describe('React app desktop Schedule controls', () => {
                     id: 'game-2',
                     opponent: 'Hawks',
                     location: 'River Field'
+                }),
+                event({
+                    eventKey: 'team-1::game-3::player-1',
+                    id: 'game-3',
+                    opponent: 'Owls',
+                    location: 'TBD'
                 })
             ]
         });
@@ -557,8 +563,12 @@ describe('React app desktop Schedule controls', () => {
 
         const falconsDirections = container.querySelector('button[aria-label="Directions to vs. Falcons at Main Gym"]');
         const hawksDirections = container.querySelector('button[aria-label="Directions to vs. Hawks at River Field"]');
+        const tbdRow = Array.from(container.querySelectorAll('.schedule-event-row-mobile'))
+            .find((row) => row.textContent.includes('Owls'));
         expect(falconsDirections).toBeTruthy();
         expect(hawksDirections).toBeTruthy();
+        expect(tbdRow).toBeTruthy();
+        expect(tbdRow.querySelector('.schedule-event-directions')).toBeNull();
         expect(falconsDirections.textContent.trim()).toBe('Directions');
         expect(hawksDirections.textContent.trim()).toBe('Directions');
         expect(falconsDirections.className).toContain('min-h-11');
@@ -570,6 +580,19 @@ describe('React app desktop Schedule controls', () => {
         expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith(getScheduleMapHref('Main Gym'));
         expect(container.querySelector('[data-testid="route-probe"]').textContent)
             .toBe('/schedule?filter=upcoming-games');
+
+        const falconsDetail = falconsDirections.closest('.schedule-event-row-mobile')
+            .querySelector('.schedule-event-row-detail');
+        expect(falconsDetail.getAttribute('href'))
+            .toBe('/schedule/team-1/game-1?childId=player-1&section=availability');
+
+        await act(async () => {
+            falconsDetail.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        });
+
+        expect(container.querySelector('[data-testid="route-probe"]').textContent)
+            .toBe('/schedule/team-1/game-1?childId=player-1&section=availability');
+        expect(publicActionMocks.openPublicUrl).toHaveBeenCalledTimes(1);
     });
 
     it('reuses the cached schedule when the route remounts', async () => {

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -506,7 +506,7 @@ describe('React app desktop Schedule controls', () => {
         expect(container.textContent).not.toContain('Add external calendar');
         expect(container.textContent).not.toContain('Draft schedule with AI');
         expect(container.textContent).not.toContain('Import schedule CSV');
-        expect(container.querySelector('.schedule-list > a')).toBeTruthy();
+        expect(container.querySelector('.schedule-list > .schedule-event-row-mobile .schedule-event-row-detail')).toBeTruthy();
         expect(buttonContainingText(container, 'Manage schedule').getAttribute('aria-expanded')).toBe('false');
 
         await act(async () => {


### PR DESCRIPTION
Closes #4183

## What changed
- Added a direct 44px Directions target to mobile Schedule rows with usable locations.
- Used `openPublicUrl(mapHref)` for web and Capacitor-safe external navigation.
- Preserved existing event-detail and staff Game Hub routing.
- Left desktop cards and locationless events unchanged.

## Root Cause
`ScheduleEventCard` calculated the map URL, but the mobile variant was a single React Router link with no independent external action. Only the desktop variant consumed the map URL.

## Prevention / Learning
Responsive cards with primary navigation and secondary external actions must expose sibling interactive targets in every supported layout. Tests should verify visibility rules and navigation side effects independently.

## Regression Tests
- Located events expose one 44px Directions control; `TBD` events expose none.
- Directions calls `openPublicUrl` with the generated map URL without changing Schedule path or query state.
- The row detail target retains its existing route and navigation behavior.
- Focused Schedule suite: 76 tests passed.
- TypeScript and Vite production build passed.