### PR TITLE
Stop label churn from restarting CI

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -6,8 +6,6 @@ on:
       - opened
       - synchronize
       - reopened
-      - labeled
-      - unlabeled
       - closed
 
 # Pull-request-controlled code runs here, so this workflow has no repository
@@ -16,16 +14,14 @@ on:
 permissions: {}
 
 concurrency:
-  group: ${{ (github.event.action == 'labeled' || github.event.action == 'unlabeled') && github.event.label.name != 'external-claim' && format('preview-label-noop-{0}', github.run_id) || format('preview-{0}', github.event.pull_request.number) }}
+  group: preview-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   regression-guards:
     if: >-
       github.event.action != 'closed' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      !contains(github.event.pull_request.labels.*.name, 'external-claim') &&
-      ((github.event.action != 'labeled' && github.event.action != 'unlabeled') || github.event.label.name == 'external-claim')
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     steps:
@@ -69,9 +65,7 @@ jobs:
   build-preview-artifact:
     if: >-
       github.event.action != 'closed' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      !contains(github.event.pull_request.labels.*.name, 'external-claim') &&
-      ((github.event.action != 'labeled' && github.event.action != 'unlabeled') || github.event.label.name == 'external-claim')
+      github.event.pull_request.head.repo.full_name == github.repository
     needs: [regression-guards]
     runs-on: ubuntu-latest
 

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -6,25 +6,22 @@ on:
       - opened
       - synchronize
       - reopened
-      - labeled
-      - unlabeled
   push:
     branches:
       - master
   workflow_dispatch:
 
 concurrency:
-  # Only external-claim label transitions share the integration-run group.
-  # Other label churn gets a unique no-op run so it cannot cancel or replace a
-  # required mobile-build check for this head.
-  group: ${{ github.event_name == 'pull_request' && (github.event.action == 'labeled' || github.event.action == 'unlabeled') && github.event.label.name != 'external-claim' && format('mobile-build-label-noop-{0}', github.run_id) || format('mobile-build-{0}-{1}', github.workflow, github.ref) }}
+  group: mobile-build-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      landing: ${{ steps.filter.outputs.landing }}
       mobile: ${{ steps.filter.outputs.mobile }}
     steps:
       - name: Checkout
@@ -35,10 +32,7 @@ jobs:
       - name: Detect mobile-relevant changes
         id: filter
         env:
-          ACTION: ${{ github.event.action }}
-          EXTERNAL_CLAIMED: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'external-claim') }}
           EVENT_NAME: ${{ github.event_name }}
-          LABEL_NAME: ${{ github.event.label.name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           BEFORE_SHA: ${{ github.event.before }}
@@ -48,31 +42,9 @@ jobs:
 
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             echo "Manual run — always building." >&2
-            echo "landing=true" >> "$GITHUB_OUTPUT"
             echo "mobile=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-
-          # While another session owns the PR, keep the stable required
-          # mobile-build context cheap. Removing external-claim is the landing
-          # handoff and triggers this workflow again for the full native build.
-          if [ "$EVENT_NAME" = "pull_request" ] && [ "$EXTERNAL_CLAIMED" = "true" ]; then
-            echo "external-claim is active — deferring native integration builds." >&2
-            echo "landing=false" >> "$GITHUB_OUTPUT"
-            echo "mobile=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [ "$EVENT_NAME" = "pull_request" ] &&
-             { [ "$ACTION" = "labeled" ] || [ "$ACTION" = "unlabeled" ]; } &&
-             [ "$LABEL_NAME" != "external-claim" ]; then
-            echo "Unrelated label transition — not restarting native integration builds." >&2
-            echo "landing=false" >> "$GITHUB_OUTPUT"
-            echo "mobile=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "landing=true" >> "$GITHUB_OUTPUT"
 
           if [ "$EVENT_NAME" = "pull_request" ]; then
             CHANGED=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
@@ -117,7 +89,7 @@ jobs:
           java-version: 21
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
         with:
           packages: 'platform-tools'
 
@@ -290,7 +262,7 @@ jobs:
   # waiting on a check that never runs, while a PR that does touch mobile
   # paths can't merge with a red native build (the gap this job closes).
   mobile-build:
-    name: ${{ github.event_name == 'pull_request' && (github.event.action == 'labeled' || github.event.action == 'unlabeled') && github.event.label.name != 'external-claim' && 'mobile-build-label-noop' || 'mobile-build' }}
+    name: mobile-build
     needs: [changes, android-debug, ios-simulator]
     if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
@@ -300,11 +272,6 @@ jobs:
           if [ "${{ needs.changes.result }}" != "success" ]; then
             echo "changes job did not complete successfully (${{ needs.changes.result }}) — failing closed instead of assuming no mobile-relevant changes."
             exit 1
-          fi
-
-          if [ "${{ needs.changes.outputs.landing }}" != "true" ]; then
-            echo "Development ownership is still active — full native build deferred until external-claim is removed."
-            exit 0
           fi
 
           if [ "${{ needs.changes.outputs.mobile }}" != "true" ]; then

--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -6,22 +6,19 @@ on:
       - opened
       - synchronize
       - reopened
-      - labeled
-      - unlabeled
 
 concurrency:
-  # Unrelated label churn must neither cancel a landing smoke nor publish a
-  # replacement required context. external-claim transitions intentionally use
-  # the normal PR group so activating the lease cancels expensive work.
-  group: ${{ (github.event.action == 'labeled' || github.event.action == 'unlabeled') && github.event.label.name != 'external-claim' && format('preview-smoke-label-noop-{0}', github.run_id) || format('preview-smoke-{0}', github.event.pull_request.number) }}
+  group: preview-smoke-${{ github.event.pull_request.number }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   changes:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     outputs:
-      landing: ${{ steps.filter.outputs.landing }}
       web: ${{ steps.filter.outputs.web }}
     steps:
       - name: Checkout
@@ -32,32 +29,10 @@ jobs:
       - name: Detect preview-relevant changes
         id: filter
         env:
-          ACTION: ${{ github.event.action }}
-          EXTERNAL_CLAIMED: ${{ contains(github.event.pull_request.labels.*.name, 'external-claim') }}
-          LABEL_NAME: ${{ github.event.label.name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-
-          # external-claim is the active-development lease. Its removal is the
-          # handoff to the serialized landing worker and reruns the full smoke.
-          if [ "$EXTERNAL_CLAIMED" = "true" ]; then
-            echo "external-claim is active — deferring full preview smoke." >&2
-            echo "landing=false" >> "$GITHUB_OUTPUT"
-            echo "web=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if { [ "$ACTION" = "labeled" ] || [ "$ACTION" = "unlabeled" ]; } &&
-             [ "$LABEL_NAME" != "external-claim" ]; then
-            echo "Unrelated label transition — not restarting preview smoke." >&2
-            echo "landing=false" >> "$GITHUB_OUTPUT"
-            echo "web=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "landing=true" >> "$GITHUB_OUTPUT"
 
           # Fail open: if we cannot compute a diff (new branch, missing base),
           # run the smoke so we never silently skip a real regression.
@@ -226,7 +201,7 @@ jobs:
   # not-applicable to this change (backend/native/docs-only); fails only on a real
   # failure. Mirrors the mobile-build aggregate so a skipped run never blocks merge.
   preview-smoke:
-    name: ${{ (github.event.action == 'labeled' || github.event.action == 'unlabeled') && github.event.label.name != 'external-claim' && 'preview-smoke-label-noop' || 'preview-smoke' }}
+    name: preview-smoke
     needs: [changes, preview-smoke-run]
     if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
@@ -250,11 +225,6 @@ jobs:
           if [ "$CHANGES_RESULT" != "success" ]; then
             echo "Change detection did not succeed ($CHANGES_RESULT) — failing closed." >&2
             exit 1
-          fi
-
-          if [ "${{ needs.changes.outputs.landing }}" != "true" ]; then
-            echo "Development ownership is still active — full preview smoke deferred until external-claim is removed."
-            exit 0
           fi
 
           if [ "$SHOULD_RUN" = "false" ] && [ "$RUN_RESULT" = "skipped" ]; then

--- a/tests/unit/mobile-build-workflow.test.js
+++ b/tests/unit/mobile-build-workflow.test.js
@@ -28,20 +28,19 @@ describe('mobile-build CI workflow', () => {
         expect(workflow).toContain('capacitor\\.config\\.json');
     });
 
-    it('defers native integration while external development owns the PR and reruns on handoff', () => {
+    it('runs for code changes without creating duplicate runs for label churn', () => {
         const triggerSection = workflow.slice(workflow.indexOf('\non:'), workflow.indexOf('\nconcurrency:'));
         const changesSection = workflow.slice(workflow.indexOf('  changes:'), workflow.indexOf('  android-debug:'));
         const gateSection = workflow.slice(workflow.indexOf('  mobile-build:'));
 
-        expect(triggerSection).toContain('      - unlabeled');
-        expect(triggerSection).toContain('      - labeled');
-        expect(changesSection).toContain("contains(github.event.pull_request.labels.*.name, 'external-claim')");
-        expect(changesSection).toContain('[ "$EXTERNAL_CLAIMED" = "true" ]');
-        expect(changesSection).toContain('echo "landing=false" >> "$GITHUB_OUTPUT"');
-        expect(changesSection).toContain('[ "$ACTION" = "labeled" ] || [ "$ACTION" = "unlabeled" ]');
-        expect(workflow).toContain("format('mobile-build-label-noop-{0}', github.run_id)");
-        expect(gateSection).toContain("'mobile-build-label-noop' || 'mobile-build'");
-        expect(gateSection).toContain('needs.changes.outputs.landing');
+        expect(triggerSection).toContain('      - synchronize');
+        expect(triggerSection).not.toContain('      - unlabeled');
+        expect(triggerSection).not.toContain('      - labeled');
+        expect(workflow).toContain('group: mobile-build-${{ github.workflow }}-${{ github.ref }}');
+        expect(changesSection).not.toContain('external-claim');
+        expect(changesSection).not.toContain('LABEL_NAME');
+        expect(gateSection).toContain('name: mobile-build');
+        expect(gateSection).not.toContain('label-noop');
     });
 
     it('skips the native builds themselves for non-mobile changes but always runs the required mobile-build gate job', () => {
@@ -88,6 +87,18 @@ describe('mobile-build CI workflow', () => {
         expect(changesResultCheckIndex).toBeGreaterThan(-1);
         expect(mobileOutputCheckIndex).toBeGreaterThan(-1);
         expect(changesResultCheckIndex).toBeLessThan(mobileOutputCheckIndex);
+    });
+
+    it('pins third-party actions to immutable commit SHAs', () => {
+        const actionReferences = [...workflow.matchAll(/uses:\s+([^@\s]+)@([^\s#]+)/g)];
+        const thirdPartyReferences = actionReferences.filter(
+            ([, action]) => !action.startsWith('actions/') && !action.startsWith('github/')
+        );
+
+        expect(thirdPartyReferences.length).toBeGreaterThan(0);
+        for (const [, action, ref] of thirdPartyReferences) {
+            expect(ref, action).toMatch(/^[0-9a-f]{40}$/);
+        }
     });
 
     it('keeps every CI and release workflow on production App Check assets', () => {

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -181,15 +181,15 @@ describe('preview deployment workflow trust boundary', () => {
         expect(pullRequestWorkflow).toContain('include-hidden-files: true');
         expect(pullRequestWorkflow).toMatch(/build-preview-artifact:[\s\S]*needs: \[regression-guards\]/);
         expect(pullRequestWorkflow).not.toContain('  unit-tests:');
-        expect(pullRequestWorkflow).toContain("!contains(github.event.pull_request.labels.*.name, 'external-claim')");
+        expect(pullRequestWorkflow).not.toContain('external-claim');
     });
 
     it('cancels in-flight preview work when its pull request closes', () => {
         expect(pullRequestWorkflow).toContain('      - closed');
-        expect(pullRequestWorkflow).toContain("format('preview-{0}', github.event.pull_request.number)");
+        expect(pullRequestWorkflow).toContain('group: preview-${{ github.event.pull_request.number }}');
         expect(pullRequestWorkflow).toContain('cancel-in-progress: true');
-        expect(pullRequestWorkflow).toContain('      - unlabeled');
-        expect(pullRequestWorkflow).toContain('      - labeled');
+        expect(pullRequestWorkflow).not.toContain('      - unlabeled');
+        expect(pullRequestWorkflow).not.toContain('      - labeled');
     });
 
     it('runs the credentialed deploy only from trusted default-branch code', () => {

--- a/tests/unit/preview-smoke-workflow.test.js
+++ b/tests/unit/preview-smoke-workflow.test.js
@@ -7,20 +7,19 @@ const workflow = readFileSync(
 );
 
 describe('preview-smoke CI workflow', () => {
-    it('defers the full smoke while external development owns the PR and reruns on handoff', () => {
+    it('runs for code changes without creating duplicate runs for label churn', () => {
         const triggerSection = workflow.slice(workflow.indexOf('\non:'), workflow.indexOf('\nconcurrency:'));
         const changesSection = workflow.slice(workflow.indexOf('  changes:'), workflow.indexOf('  preview-smoke-run:'));
         const gateSection = workflow.slice(workflow.indexOf('  preview-smoke:'));
 
-        expect(triggerSection).toContain('      - unlabeled');
-        expect(triggerSection).toContain('      - labeled');
-        expect(changesSection).toContain("contains(github.event.pull_request.labels.*.name, 'external-claim')");
-        expect(changesSection).toContain('[ "$EXTERNAL_CLAIMED" = "true" ]');
-        expect(changesSection).toContain('echo "landing=false" >> "$GITHUB_OUTPUT"');
-        expect(changesSection).toContain('[ "$ACTION" = "labeled" ] || [ "$ACTION" = "unlabeled" ]');
-        expect(workflow).toContain("format('preview-smoke-label-noop-{0}', github.run_id)");
-        expect(gateSection).toContain("'preview-smoke-label-noop' || 'preview-smoke'");
-        expect(gateSection).toContain('needs.changes.outputs.landing');
+        expect(triggerSection).toContain('      - synchronize');
+        expect(triggerSection).not.toContain('      - unlabeled');
+        expect(triggerSection).not.toContain('      - labeled');
+        expect(workflow).toContain('group: preview-smoke-${{ github.event.pull_request.number }}');
+        expect(changesSection).not.toContain('external-claim');
+        expect(changesSection).not.toContain('LABEL_NAME');
+        expect(gateSection).toContain('name: preview-smoke');
+        expect(gateSection).not.toContain('label-noop');
     });
 
     it('runs smoke only when at least one changed path is not skippable', () => {


### PR DESCRIPTION
## What changed

- stop `labeled` and `unlabeled` events from launching deploy-preview, preview-smoke, and mobile-build
- run the normal required checks on PR open, reopen, and synchronize regardless of ownership labels
- keep stable per-PR concurrency groups so a newer code revision cancels only stale code work
- make preview-smoke and mobile-build tokens explicitly read-only
- pin the existing third-party Android setup action to its immutable v3 commit
- add regression coverage for trigger scope, stable required-check names, and action pinning

## Why

PaulBot adds and removes ownership and automation labels while landing a PR. Those metadata-only transitions were launching three extra workflow runs, cancelling useful in-flight work, and making the landing controller wait for replacement required checks. Code was not changing, but the PR repeatedly returned to a pending state.

This keeps ownership labels as controller metadata and makes CI respond only to code-head lifecycle events.

## Validation

- `npm test -- --reporter=dot` — 4,874 passed, 114 skipped
- focused workflow suite — 33 passed
- parsed all three edited workflow files with the repository's YAML parser
- `git diff --check`
