### PR TITLE
Support pasted images in AI import text boxes

### DIFF
--- a/apps/app/src/components/schedule/ScheduleStaffTools.tsx
+++ b/apps/app/src/components/schedule/ScheduleStaffTools.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from 'react';
 import { ClipboardCheck, Link as LinkIcon } from 'lucide-react';
 import { Modal } from '../../components/Modal';
+import { capturePastedImage } from '../../lib/clipboardImage';
 import {
   addTeamCalendarUrl,
   createScheduledGameForApp,
@@ -1216,7 +1217,7 @@ function ScheduleAiImportPanel({ teamName, text, imageName, previewRows, errors,
         <div className="min-w-0 flex-1">
           <div className="app-label">Staff schedule tools</div>
           <h2 className="mt-1 text-base font-black text-gray-950">Draft schedule with AI</h2>
-          <p className="mt-1 text-xs font-semibold leading-5 text-gray-500">Paste schedule text or upload one image for {teamName}. AI drafts game rows only; nothing is saved until you review and import.</p>
+          <p className="mt-1 text-xs font-semibold leading-5 text-gray-500">Paste schedule text or an image for {teamName}. AI drafts game rows only; nothing is saved until you review and import.</p>
         </div>
       </div>
 
@@ -1228,8 +1229,12 @@ function ScheduleAiImportPanel({ teamName, text, imageName, previewRows, errors,
             placeholder="Paste schedule lines, or add instructions like 'only home games' when uploading an image."
             value={text}
             onChange={(event) => onTextChange(event.target.value)}
+            onPaste={(event) => capturePastedImage(event, onImageChange)}
+            disabled={processing || importing}
             aria-label="Schedule text or AI instructions"
+            aria-describedby="schedule-ai-paste-help"
           />
+          <span id="schedule-ai-paste-help" className="mt-1 block text-[11px] font-semibold text-gray-500">Paste text normally, or paste a copied schedule screenshot here to attach it.</span>
         </label>
 
         <label className="block">
@@ -1240,9 +1245,10 @@ function ScheduleAiImportPanel({ teamName, text, imageName, previewRows, errors,
             accept="image/png,image/jpeg,image/webp,image/heic,image/heif"
             aria-label="Schedule image"
             onChange={(event) => onImageChange(event.target.files?.[0] || null)}
+            disabled={processing || importing}
           />
         </label>
-        {imageName ? <div className="text-xs font-bold text-gray-500">Loaded {imageName}</div> : null}
+        {imageName ? <div className="text-xs font-bold text-gray-500" role="status" aria-live="polite">Image ready: {imageName}</div> : null}
 
         {errors.length ? (
           <div className="rounded-xl border border-rose-200 bg-rose-50 p-3 text-xs font-bold text-rose-700" role="alert">

--- a/apps/app/src/lib/clipboardImage.test.ts
+++ b/apps/app/src/lib/clipboardImage.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { capturePastedImage, getClipboardImageFile } from './clipboardImage';
+
+describe('clipboardImage', () => {
+  it('extracts the first pasted image and captures the paste', () => {
+    const image = new File(['schedule'], 'schedule.png', { type: 'image/png' });
+    const preventDefault = vi.fn();
+    const onImage = vi.fn();
+
+    const captured = capturePastedImage(
+      {
+        clipboardData: {
+          items: [
+            { type: 'text/plain', getAsFile: () => null },
+            { type: 'image/png', getAsFile: () => image }
+          ]
+        },
+        preventDefault
+      },
+      onImage
+    );
+
+    expect(captured).toBe(true);
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(onImage).toHaveBeenCalledWith(image);
+  });
+
+  it('falls back to clipboard files when items are unavailable', () => {
+    const image = new File(['roster'], 'roster.webp', { type: 'image/webp' });
+
+    expect(getClipboardImageFile({ files: [image] })).toBe(image);
+  });
+
+  it('leaves plain-text paste untouched', () => {
+    const preventDefault = vi.fn();
+    const onImage = vi.fn();
+
+    const captured = capturePastedImage(
+      {
+        clipboardData: {
+          items: [{ type: 'text/plain', getAsFile: () => null }]
+        },
+        preventDefault
+      },
+      onImage
+    );
+
+    expect(captured).toBe(false);
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(onImage).not.toHaveBeenCalled();
+  });
+
+  it('wires both app AI import text boxes to the shared paste helper', () => {
+    const scheduleSource = readFileSync(path.resolve(process.cwd(), 'src/components/schedule/ScheduleStaffTools.tsx'), 'utf8');
+    const rosterSource = readFileSync(path.resolve(process.cwd(), 'src/pages/TeamDetail.tsx'), 'utf8');
+
+    expect(scheduleSource).toContain('onPaste={(event) => capturePastedImage(event, onImageChange)}');
+    expect(scheduleSource).toContain('paste a copied schedule screenshot here to attach it');
+    expect(rosterSource).toContain('onPaste={(event) => capturePastedImage(event, handleImageChange)}');
+    expect(rosterSource).toContain('paste a copied roster screenshot here to attach it');
+  });
+});

--- a/apps/app/src/lib/clipboardImage.ts
+++ b/apps/app/src/lib/clipboardImage.ts
@@ -1,0 +1,49 @@
+type ClipboardImageItem = {
+  type?: string;
+  getAsFile?: () => File | null;
+};
+
+type ClipboardImageData = {
+  items?: ArrayLike<ClipboardImageItem>;
+  files?: ArrayLike<File>;
+};
+
+type ClipboardImagePasteEvent = {
+  clipboardData?: ClipboardImageData;
+  preventDefault: () => void;
+};
+
+function isImageFile(file: File | null | undefined) {
+  return Boolean(
+    file &&
+    String(file.type || '')
+      .toLowerCase()
+      .startsWith('image/')
+  );
+}
+
+export function getClipboardImageFile(clipboardData?: ClipboardImageData | null): File | null {
+  const imageFromItems = Array.from(clipboardData?.items || [])
+    .map((item) => {
+      if (
+        !String(item?.type || '')
+          .toLowerCase()
+          .startsWith('image/')
+      )
+        return null;
+      return typeof item.getAsFile === 'function' ? item.getAsFile() : null;
+    })
+    .find(isImageFile);
+
+  if (imageFromItems) return imageFromItems;
+  return Array.from(clipboardData?.files || []).find(isImageFile) || null;
+}
+
+export function capturePastedImage(event: ClipboardImagePasteEvent, onImage: (file: File) => void): boolean {
+  const file = getClipboardImageFile(event.clipboardData);
+  if (!file) return false;
+
+  event.preventDefault();
+  onImage(file);
+  return true;
+}

--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -1257,6 +1257,44 @@ describe('TeamDetail', () => {
     expect(await screen.findByText('Imported 1 player: #14 Alex New.')).toBeTruthy();
   });
 
+  it('attaches an image pasted into the roster AI text box', async () => {
+    const managedModel = {
+      ...model,
+      canManageTeam: true
+    };
+    const image = new File(['roster'], 'roster.png', { type: 'image/png' });
+    teamDetailServiceMocks.loadParentTeamDetail.mockResolvedValue(managedModel);
+    rosterAiImportMocks.generateRosterAiImportRows.mockResolvedValue({
+      rows: [],
+      errors: ['AI did not find any players to import.']
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/teams/team-1?tab=roster']}>
+        <Routes>
+          <Route path="/teams/:teamId" element={<TeamDetail auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Bears' })).toBeTruthy();
+    fireEvent.click(await screen.findByRole('button', { name: 'Import roster' }));
+    fireEvent.paste(screen.getByRole('textbox', { name: 'Roster text or AI instructions' }), {
+      clipboardData: {
+        items: [{ type: 'image/png', getAsFile: () => image }]
+      }
+    });
+
+    expect(screen.getByText('Image ready: roster.png')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Generate preview' }));
+
+    await waitFor(() => expect(rosterAiImportMocks.generateRosterAiImportRows).toHaveBeenCalledWith({
+      text: '',
+      imageFile: image,
+      currentPlayers: [managedModel.players[0], managedModel.inactivePlayers[0]]
+    }));
+  });
+
   it('uses descriptive alt text for team and roster photos', async () => {
     teamDetailServiceMocks.loadParentTeamDetail.mockResolvedValue({
       ...model,

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -35,6 +35,7 @@ import {
 import { AvatarImage } from '../components/AvatarImage';
 import { TeamDetailPageSkeleton } from '../components/PageSkeletons';
 import { DetailLoadErrorState } from '../components/DetailLoadErrorState';
+import { capturePastedImage } from '../lib/clipboardImage';
 import { copyPublicText, openPublicUrl, sharePublicUrl } from '../lib/publicActions';
 import { isRetryableAppServiceError, toAppServiceError, type AppServiceError } from '../lib/appErrors';
 import { useAppAsyncOperation } from '../lib/useAsyncOperation';
@@ -1077,6 +1078,13 @@ function RosterAiImportCard({
     setErrors([]);
   }
 
+  function handleImageChange(file: File | null) {
+    setImageFile(file);
+    setImageName(file?.name || (file ? 'Pasted roster image' : ''));
+    setPreviewRows([]);
+    setErrors([]);
+  }
+
   async function generatePreview() {
     if (processing) return;
     setProcessing(true);
@@ -1167,7 +1175,7 @@ function RosterAiImportCard({
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <div className="text-sm font-black text-gray-950">Import roster with AI</div>
-          <div className="mt-1 text-xs font-semibold text-gray-600">Paste roster text or upload one photo, edit the preview, then create player records.</div>
+          <div className="mt-1 text-xs font-semibold text-gray-600">Paste roster text or an image, edit the preview, then create player records.</div>
         </div>
         {!open ? (
           <button type="button" className="secondary-button !min-h-10 text-xs" onClick={() => setOpen(true)}>
@@ -1190,9 +1198,12 @@ function RosterAiImportCard({
               placeholder="Paste roster rows, or add instructions like 'only varsity' when uploading a photo."
               value={text}
               onChange={(event) => setText(event.target.value)}
+              onPaste={(event) => capturePastedImage(event, handleImageChange)}
               disabled={processing || importing}
               aria-label="Roster text or AI instructions"
+              aria-describedby="roster-ai-paste-help"
             />
+            <span id="roster-ai-paste-help" className="mt-1 block text-[11px] font-semibold text-gray-500">Paste text normally, or paste a copied roster screenshot here to attach it.</span>
           </label>
           <label className="block">
             <span className="text-[11px] font-black uppercase tracking-[0.04em] text-violet-700">Roster photo</span>
@@ -1200,17 +1211,11 @@ function RosterAiImportCard({
               type="file"
               accept="image/png,image/jpeg,image/webp,image/heic,image/heif"
               className="mt-2 block w-full text-sm font-semibold text-gray-600 file:mr-4 file:rounded-xl file:border-0 file:bg-white file:px-3 file:py-2 file:text-sm file:font-black file:text-violet-700"
-              onChange={(event) => {
-                const file = event.target.files?.[0] || null;
-                setImageFile(file);
-                setImageName(file?.name || '');
-                setPreviewRows([]);
-                setErrors([]);
-              }}
+              onChange={(event) => handleImageChange(event.target.files?.[0] || null)}
               disabled={processing || importing}
               aria-label="Roster photo"
             />
-            {imageName ? <div className="mt-1 text-[11px] font-semibold text-gray-500"><ImageIcon className="mr-1 inline h-3 w-3" aria-hidden="true" />{imageName}</div> : null}
+            {imageName ? <div className="mt-1 text-[11px] font-semibold text-gray-500" role="status" aria-live="polite"><ImageIcon className="mr-1 inline h-3 w-3" aria-hidden="true" />Image ready: {imageName}</div> : null}
           </label>
 
           {errors.length ? (

--- a/edit-roster.html
+++ b/edit-roster.html
@@ -162,7 +162,7 @@
                     <div id="content-bulk-ai" class="p-6 hidden">
                         <div class="mb-3">
                             <h2 class="text-xl font-bold">Bulk AI Update</h2>
-                            <p class="text-sm text-gray-600">Upload a roster image and add text hints, or skip the image and paste raw roster text. Short instructions steer what gets imported.</p>
+                            <p class="text-sm text-gray-600">Upload or paste a roster image and add text hints, or skip the image and paste raw roster text. Short instructions steer what gets imported.</p>
                         </div>
 
                         <div class="space-y-4">
@@ -172,7 +172,7 @@
                                 </label>
                                 <input type="file" id="roster-image-input" accept="image/*"
                                     class="w-full text-sm text-gray-600 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100">
-                                <p class="text-xs text-gray-500 mt-1">Screenshot/photo works. Text below can further filter (e.g., “just varsity”).</p>
+                                <p class="text-xs text-gray-500 mt-1">Upload, paste (Ctrl/Cmd+V), or drop a screenshot/photo. You can paste directly into the text box below; text can further filter (e.g., “just varsity”).</p>
 
                                 <!-- Image preview -->
                                 <div id="roster-image-preview" class="hidden mt-3">
@@ -564,6 +564,7 @@
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { hasFullTeamAccess, normalizeTeamPermissions } from './js/team-access.js';
         import { formatRegistrationRosterImportResults, getRegistrationRosterPlayers, hasConfiguredRegistrationProviderMetadata, isExternallyLinkedRosterTeam, planRegistrationRosterImport } from './js/edit-roster-registration-import.js?v=3';
+        import { createBulkAiImageController } from './js/edit-schedule-ai-import.js?v=2';
         import { buildRegistrationReviewCsv, buildRegistrationReviewCsvFilename, getDefaultRegistrationReviewCsvColumnKeys, getRegistrationReviewCsvColumnDefinitions, matchesRegistrationReviewScreeningStatus, summarizeRegistrationReviewScreening } from './js/registration-review.js?v=6';
         import { buildRosterPrintHtml } from './js/roster-print.js?v=2';
         import { getApp } from './js/vendor/firebase-app.js';
@@ -2562,34 +2563,26 @@
         document.getElementById('download-roster-template-btn').addEventListener('click', downloadFullRosterTemplate);
         document.getElementById('import-csv-btn').addEventListener('click', () => handleRosterCsvImport());
 
-        // Image preview handler
-        document.getElementById('roster-image-input').addEventListener('change', (e) => {
-            const file = e.target.files[0];
-            if (file) {
-                const reader = new FileReader();
-                reader.onload = (event) => {
-                    document.getElementById('roster-image-preview-img').src = event.target.result;
-                    document.getElementById('roster-image-preview').classList.remove('hidden');
-                };
-                reader.readAsDataURL(file);
-            }
+        // Image upload, paste, drop, and preview handlers
+        const rosterAiImageController = createBulkAiImageController({
+            imageInput: document.getElementById('roster-image-input'),
+            preview: document.getElementById('roster-image-preview'),
+            previewImage: document.getElementById('roster-image-preview-img'),
+            removeButton: document.getElementById('remove-roster-image')
+        });
+        rosterAiImageController.bindBulkAiImageControls({
+            container: document.getElementById('content-bulk-ai'),
+            textInput: document.getElementById('bulk-text-input')
         });
 
-        // Remove image handler
         function resetBulkAiImageState() {
-            document.getElementById('roster-image-input').value = '';
-            document.getElementById('roster-image-preview').classList.add('hidden');
-            document.getElementById('roster-image-preview-img').src = '';
+            rosterAiImageController.clearBulkAiImage();
         }
 
         function resetBulkAiDraftState() {
             resetBulkAiImageState();
             document.getElementById('bulk-text-input').value = '';
         }
-
-        document.getElementById('remove-roster-image').addEventListener('click', () => {
-            resetBulkAiImageState();
-        });
 
         // Helper function to convert image file to base64 for Gemini
         async function fileToGenerativePart(file) {
@@ -2606,7 +2599,7 @@
         // Process with AI
         document.getElementById('process-ai-btn').addEventListener('click', async () => {
             const textInput = document.getElementById('bulk-text-input').value.trim();
-            const imageFile = document.getElementById('roster-image-input').files[0];
+            const imageFile = rosterAiImageController.getBulkAiImageFile();
 
             if (!textInput && !imageFile) {
                 alert('Please upload an image or paste roster text');

--- a/tests/smoke/edit-roster-bulk-ai-reset.spec.js
+++ b/tests/smoke/edit-roster-bulk-ai-reset.spec.js
@@ -284,7 +284,7 @@ test('bulk AI cancel clears stale image state before another run', async ({ page
     const fileCount = await page.evaluate(() => document.getElementById('roster-image-input').files.length);
     expect(fileCount).toBe(0);
     await expect(page.locator('#roster-image-preview')).toBeHidden();
-    await expect(page.locator('#roster-image-preview-img')).toHaveAttribute('src', '');
+    await expect(page.locator('#roster-image-preview-img')).not.toHaveAttribute('src');
 
     await page.click('#process-ai-btn');
     expect(dialogs.at(-1)).toBe('Please upload an image or paste roster text');

--- a/tests/unit/clipboard-image.test.ts
+++ b/tests/unit/clipboard-image.test.ts
@@ -1,7 +1,10 @@
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
-import { capturePastedImage, getClipboardImageFile } from './clipboardImage';
+import {
+  capturePastedImage,
+  getClipboardImageFile
+} from '../../apps/app/src/lib/clipboardImage';
 
 describe('clipboardImage', () => {
   it('extracts the first pasted image and captures the paste', () => {
@@ -53,8 +56,14 @@ describe('clipboardImage', () => {
   });
 
   it('wires both app AI import text boxes to the shared paste helper', () => {
-    const scheduleSource = readFileSync(path.resolve(process.cwd(), 'src/components/schedule/ScheduleStaffTools.tsx'), 'utf8');
-    const rosterSource = readFileSync(path.resolve(process.cwd(), 'src/pages/TeamDetail.tsx'), 'utf8');
+    const scheduleSource = readFileSync(
+      path.resolve(process.cwd(), 'apps/app/src/components/schedule/ScheduleStaffTools.tsx'),
+      'utf8'
+    );
+    const rosterSource = readFileSync(
+      path.resolve(process.cwd(), 'apps/app/src/pages/TeamDetail.tsx'),
+      'utf8'
+    );
 
     expect(scheduleSource).toContain('onPaste={(event) => capturePastedImage(event, onImageChange)}');
     expect(scheduleSource).toContain('paste a copied schedule screenshot here to attach it');

--- a/tests/unit/edit-roster-ai-image-clipboard.test.js
+++ b/tests/unit/edit-roster-ai-image-clipboard.test.js
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+describe('edit roster Bulk AI image clipboard support', () => {
+    it('wires the roster AI text box to the shared paste and drop controller', () => {
+        const source = readFileSync(path.join(repoRoot, 'edit-roster.html'), 'utf8');
+
+        expect(source).toContain("import { createBulkAiImageController } from './js/edit-schedule-ai-import.js?v=2';");
+        expect(source).toContain('Upload, paste (Ctrl/Cmd+V), or drop a screenshot/photo.');
+        expect(source).toContain("container: document.getElementById('content-bulk-ai')");
+        expect(source).toContain("textInput: document.getElementById('bulk-text-input')");
+        expect(source).toContain('rosterAiImageController.getBulkAiImageFile()');
+        expect(source).toContain('rosterAiImageController.clearBulkAiImage()');
+    });
+});

--- a/tests/unit/edit-roster-registration-import.test.js
+++ b/tests/unit/edit-roster-registration-import.test.js
@@ -498,7 +498,7 @@ describe('bulk AI roster update wiring', () => {
         expect(source).toContain('id="bulk-text-input"');
         expect(source).toContain("if (!textInput && !imageFile)");
         expect(source).toContain("alert('Please upload an image or paste roster text')");
-        expect(source).toContain("const imageFile = document.getElementById('roster-image-input').files[0];");
+        expect(source).toContain('const imageFile = rosterAiImageController.getBulkAiImageFile();');
         expect(source).toContain("Extract ALL players ${imageFile ? 'from the image' : 'from the text'}");
         expect(source).toContain('let promptParts = [promptText];');
         expect(source).toContain('if (imageFile) {');


### PR DESCRIPTION
## Summary

- allow pasted clipboard images in the schedule and roster AI import text boxes in the React app
- extend the legacy roster importer to match the legacy schedule's upload, paste, and drop behavior
- preserve normal text paste and announce image-ready state accessibly

## Why

The AI import pipelines already accepted uploaded image files, but the text boxes did not extract image items from clipboard paste events. The legacy roster flow also read only from its file input instead of using the shared image controller.

## Validation

- `npm test -- --reporter=dot --silent` — 4,922 passed, 114 skipped
- `npm run app:build`
- focused app clipboard and roster tests — 5 passed
- focused legacy clipboard/import tests — 28 passed
- targeted ESLint checks for the new clipboard helper and tests

Note: the repository-wide app lint currently reports existing warnings; the new helper files pass with zero warnings.