### PR TITLE
Add fast PR closeout contracts

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -25,9 +25,10 @@ jobs:
       mobile: ${{ steps.filter.outputs.mobile }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Detect mobile-relevant changes
         id: filter
@@ -73,17 +74,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Record Android build start
+        run: date -u +%s > "$RUNNER_TEMP/android-build-start-epoch"
+
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: npm
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           distribution: temurin
           java-version: 21
@@ -127,31 +133,41 @@ jobs:
             rm -rf "$HOME/.gradle/caches/modules-2"
           }
 
-          run_with_retry() {
-            attempt=1
-            delay=20
-            until "$@"; do
-              if [ "$attempt" -ge 3 ]; then
-                return 1
-              fi
-              echo "Attempt $attempt failed. Retrying in ${delay}s..."
-              attempt=$((attempt + 1))
-              ./gradlew --stop || true
-              reset_gradle_dependency_cache
-              sleep "$delay"
-              delay=$((delay * 2))
-            done
-          }
+          if ./gradlew :app:assembleDebug --stacktrace; then
+            exit 0
+          fi
 
-          reset_gradle_dependency_cache
-          run_with_retry ./gradlew :app:assembleDebug --stacktrace --refresh-dependencies
+          delay=20
+          for attempt in 2 3; do
+            echo "Initial Android build failed. Clearing dependency state before retry $attempt in ${delay}s..."
+            ./gradlew --stop || true
+            reset_gradle_dependency_cache
+            sleep "$delay"
+            if ./gradlew :app:assembleDebug --stacktrace --refresh-dependencies; then
+              exit 0
+            fi
+            delay=$((delay * 2))
+          done
+          exit 1
 
       - name: Upload Android debug APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: allplays-android-debug
           path: android/app/build/outputs/apk/debug/*.apk
           retention-days: 7
+
+      - name: Report Android build timing
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ ! -s "$RUNNER_TEMP/android-build-start-epoch" ]; then
+            echo "Android build timing unavailable because setup failed before timing started." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          start_epoch="$(cat "$RUNNER_TEMP/android-build-start-epoch")"
+          end_epoch="$(date -u +%s)"
+          echo "Android build duration: $((end_epoch - start_epoch))s" >> "$GITHUB_STEP_SUMMARY"
 
   ios-simulator:
     needs: changes
@@ -159,11 +175,16 @@ jobs:
     runs-on: macos-15
 
     steps:
+      - name: Record iOS build start
+        run: date -u +%s > "$RUNNER_TEMP/ios-build-start-epoch"
+
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: npm
@@ -208,15 +229,14 @@ jobs:
           run_with_retry() {
             attempt=1
             delay=20
-            reset_swiftpm_package_state
             until "$@"; do
               if [ "$attempt" -ge 3 ]; then
                 return 1
               fi
               echo "Attempt $attempt failed. Retrying in ${delay}s..."
               attempt=$((attempt + 1))
-              sleep "$delay"
               reset_swiftpm_package_state
+              sleep "$delay"
               delay=$((delay * 2))
             done
           }
@@ -255,6 +275,18 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             build
 
+      - name: Report iOS build timing
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ ! -s "$RUNNER_TEMP/ios-build-start-epoch" ]; then
+            echo "iOS build timing unavailable because setup failed before timing started." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          start_epoch="$(cat "$RUNNER_TEMP/ios-build-start-epoch")"
+          end_epoch="$(date -u +%s)"
+          echo "iOS build duration: $((end_epoch - start_epoch))s" >> "$GITHUB_STEP_SUMMARY"
+
   # Single required status check with a stable name/context, regardless of
   # whether this PR's changes actually triggered a native build. Branch
   # protection requires this job (not the path-filtered android-debug/
@@ -268,24 +300,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check native build results
+        env:
+          ANDROID_RESULT: ${{ needs.android-debug.result }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          IOS_RESULT: ${{ needs.ios-simulator.result }}
+          SHOULD_BUILD_MOBILE: ${{ needs.changes.outputs.mobile }}
         run: |
-          if [ "${{ needs.changes.result }}" != "success" ]; then
-            echo "changes job did not complete successfully (${{ needs.changes.result }}) — failing closed instead of assuming no mobile-relevant changes."
+          if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "changes job did not complete successfully ($CHANGES_RESULT) — failing closed instead of assuming no mobile-relevant changes."
             exit 1
           fi
 
-          if [ "${{ needs.changes.outputs.mobile }}" != "true" ]; then
+          if [ "$SHOULD_BUILD_MOBILE" != "true" ]; then
             echo "No mobile-relevant changes — skipping native build requirement."
             exit 0
           fi
 
-          if [ "${{ needs.android-debug.result }}" != "success" ]; then
-            echo "android-debug build did not succeed (${{ needs.android-debug.result }})."
+          if [ "$ANDROID_RESULT" != "success" ]; then
+            echo "android-debug build did not succeed ($ANDROID_RESULT)."
             exit 1
           fi
 
-          if [ "${{ needs.ios-simulator.result }}" != "success" ]; then
-            echo "ios-simulator build did not succeed (${{ needs.ios-simulator.result }})."
+          if [ "$IOS_RESULT" != "success" ]; then
+            echo "ios-simulator build did not succeed ($IOS_RESULT)."
             exit 1
           fi
 

--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -22,9 +22,10 @@ jobs:
       web: ${{ steps.filter.outputs.web }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Detect preview-relevant changes
         id: filter
@@ -66,11 +67,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Record preview-smoke start
+        run: date -u +%s > "$RUNNER_TEMP/preview-smoke-start-epoch"
+
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: npm
@@ -141,7 +147,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: pw-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.pw-version.outputs.version }}
@@ -180,7 +186,7 @@ jobs:
 
       - name: Upload visual regression diffs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: preview-visual-regression-diffs
           path: test-results/
@@ -189,12 +195,32 @@ jobs:
 
       - name: Upload server log on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: preview-smoke-http-log
           path: |
             /tmp/allplays-preview-smoke.log
             /tmp/allplays-app-preview-smoke.log
+
+      - name: Report preview-smoke timing
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ ! -s "$RUNNER_TEMP/preview-smoke-start-epoch" ]; then
+            echo "preview-smoke timing unavailable because setup failed before timing started." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          start_epoch="$(cat "$RUNNER_TEMP/preview-smoke-start-epoch")"
+          end_epoch="$(date -u +%s)"
+          duration_seconds=$((end_epoch - start_epoch))
+          {
+            echo "### preview-smoke timing"
+            echo
+            echo "- Duration: ${duration_seconds}s"
+            echo "- Playwright browser cache hit: ${PLAYWRIGHT_CACHE_HIT:-unknown}"
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          PLAYWRIGHT_CACHE_HIT: ${{ steps.pw-cache.outputs.cache-hit }}
 
   # Required-check aggregate: always runs and reports the branch-protection status
   # named "preview-smoke". Passes when the heavy job succeeded OR was skipped as

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,15 @@ HTML test pages in the repo root (`test-foul-tracking.html`, `test-pr-changes.ht
 
 ## Commit & Pull Request Guidelines
 - Recent commit messages are short, imperative, and sentence-case (e.g., “Fix bugs found in code review”).
+- Automation may open a draft PR early for visibility, but it must not mark the
+  PR ready until the exact pushed head has passed the producer preflight: the
+  worktree is clean, required focused tests have passed, the PR scope/body are
+  complete, and no follow-up commit is still being written.
+- Treat “ready for review” as the controller handoff event. After marking a PR
+  ready, do not amend or force-push that head; push a new commit when a fix is
+  needed so CI and PaulBot can bind every decision to an observable SHA.
+- Report draft age separately from landing age. Landing latency starts at the
+  latest ready exact head, not when the early draft was opened.
 - PRs should include:
   - What changed and why (bullet summary).
   - Manual test steps executed, with affected pages (e.g., `edit-schedule.html`, `login.html`).

--- a/tests/unit/mobile-build-workflow.test.js
+++ b/tests/unit/mobile-build-workflow.test.js
@@ -68,10 +68,12 @@ describe('mobile-build CI workflow', () => {
 
     it('fails the required gate job when a mobile-relevant PR actually breaks native builds', () => {
         const gateSection = workflow.slice(workflow.indexOf('  mobile-build:'));
+        const gateRun = gateSection.slice(gateSection.indexOf('        run: |'));
         expect(gateSection).toContain('ANDROID_RESULT: ${{ needs.android-debug.result }}');
         expect(gateSection).toContain('IOS_RESULT: ${{ needs.ios-simulator.result }}');
         expect(gateSection).toContain('"$ANDROID_RESULT" != "success"');
         expect(gateSection).toContain('"$IOS_RESULT" != "success"');
+        expect(gateRun).not.toContain('${{ needs.');
         expect(gateSection).toContain('exit 1');
     });
 

--- a/tests/unit/mobile-build-workflow.test.js
+++ b/tests/unit/mobile-build-workflow.test.js
@@ -68,8 +68,10 @@ describe('mobile-build CI workflow', () => {
 
     it('fails the required gate job when a mobile-relevant PR actually breaks native builds', () => {
         const gateSection = workflow.slice(workflow.indexOf('  mobile-build:'));
-        expect(gateSection).toContain("needs.android-debug.result }}\" != \"success\"");
-        expect(gateSection).toContain("needs.ios-simulator.result }}\" != \"success\"");
+        expect(gateSection).toContain('ANDROID_RESULT: ${{ needs.android-debug.result }}');
+        expect(gateSection).toContain('IOS_RESULT: ${{ needs.ios-simulator.result }}');
+        expect(gateSection).toContain('"$ANDROID_RESULT" != "success"');
+        expect(gateSection).toContain('"$IOS_RESULT" != "success"');
         expect(gateSection).toContain('exit 1');
     });
 
@@ -81,8 +83,11 @@ describe('mobile-build CI workflow', () => {
         // success even though neither native build ran, exactly the gap this job
         // exists to close.
         const gateSection = workflow.slice(workflow.indexOf('  mobile-build:'));
-        const changesResultCheckIndex = gateSection.indexOf('needs.changes.result }}\" != \"success\"');
-        const mobileOutputCheckIndex = gateSection.indexOf('needs.changes.outputs.mobile }}\" != \"true\"');
+        expect(gateSection).toContain('CHANGES_RESULT: ${{ needs.changes.result }}');
+        expect(gateSection).toContain('SHOULD_BUILD_MOBILE: ${{ needs.changes.outputs.mobile }}');
+
+        const changesResultCheckIndex = gateSection.indexOf('"$CHANGES_RESULT" != "success"');
+        const mobileOutputCheckIndex = gateSection.indexOf('"$SHOULD_BUILD_MOBILE" != "true"');
 
         expect(changesResultCheckIndex).toBeGreaterThan(-1);
         expect(mobileOutputCheckIndex).toBeGreaterThan(-1);

--- a/tests/unit/pr-fast-closeout-workflow.test.js
+++ b/tests/unit/pr-fast-closeout-workflow.test.js
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const read = (path) => readFileSync(new URL(`../../${path}`, import.meta.url), 'utf8');
+const preview = read('.github/workflows/preview-smoke.yml');
+const mobile = read('.github/workflows/mobile-build.yml');
+const agents = read('AGENTS.md');
+
+function actionReferences(workflow) {
+    return [...workflow.matchAll(/^\s*uses:\s+([^\s#]+)/gm)].map((match) => match[1]);
+}
+
+describe('fast PR closeout workflow contracts', () => {
+    it('pins every action used by the touched required-check workflows', () => {
+        for (const workflow of [preview, mobile]) {
+            for (const action of actionReferences(workflow)) {
+                expect(action, `${action} should use an immutable action revision`)
+                    .toMatch(/@[0-9a-f]{40}$/);
+            }
+            expect(workflow).toContain('persist-credentials: false');
+        }
+    });
+
+    it('keeps destructive native dependency resets behind a failed first attempt', () => {
+        const androidBuild = mobile.slice(
+            mobile.indexOf('- name: Build Android debug APK'),
+            mobile.indexOf('- name: Upload Android debug APK')
+        );
+        expect(androidBuild.indexOf('if ./gradlew :app:assembleDebug --stacktrace'))
+            .toBeLessThan(androidBuild.lastIndexOf('reset_gradle_dependency_cache'));
+
+        const iosResolve = mobile.slice(
+            mobile.indexOf('- name: Resolve iOS package dependencies'),
+            mobile.indexOf('- name: Build iOS simulator app')
+        );
+        expect(iosResolve.indexOf('until "$@"'))
+            .toBeLessThan(iosResolve.lastIndexOf('reset_swiftpm_package_state'));
+    });
+
+    it('publishes timing summaries for the slow required-check jobs', () => {
+        expect(preview).toContain('### preview-smoke timing');
+        expect(preview).toContain('Playwright browser cache hit:');
+        expect(mobile).toContain('Android build duration:');
+        expect(mobile).toContain('iOS build duration:');
+    });
+
+    it('defines ready-for-review as an exact-head producer handoff', () => {
+        expect(agents).toContain('Treat “ready for review” as the controller handoff event.');
+        expect(agents).toContain('Landing latency starts at the');
+        expect(agents).toContain('latest ready exact head');
+    });
+});


### PR DESCRIPTION
## What changed

- define draft-to-ready as an exact-head producer handoff in `AGENTS.md`
- pin every action in the touched required-check workflows and disable checkout credential persistence
- keep normal Gradle and SwiftPM caches on the first attempt, clearing dependency state only before retries
- publish preview, Android, and iOS job timing in GitHub step summaries
- add workflow contract tests for the new latency and security invariants

## Why

PaulBot’s new exact-head closeout coordinator removes timer tail latency, but the repository side also needs an unambiguous ready event and CI that does not discard healthy dependency caches on every run. These changes preserve all current required checks and fail-closed aggregate jobs while making their elapsed time observable.

## Validation

- `npx vitest run tests/unit/pr-fast-closeout-workflow.test.js tests/unit/preview-smoke-workflow.test.js --reporter=verbose`
- parsed `.github/workflows/preview-smoke.yml` and `.github/workflows/mobile-build.yml` with the repository’s `yaml` package
- `git diff --check`

## Rollout note

The PaulBot watcher is already running in 24-hour shadow mode. It records this PR’s ready/head/check timing but has wakes and alerts disabled, so the existing timers and branch-protection checks remain the only landing path during shadow.
