### PR TITLE
Pause basketball timer when opening Finish

### DIFF
--- a/js/track-basketball.js
+++ b/js/track-basketball.js
@@ -138,6 +138,7 @@ function setTab(tab) {
   els.panelFin.classList.toggle('hidden', tab !== 'finish');
 
   if (tab === 'finish') {
+    pauseTimer();
     renderFinish();
   }
 }
@@ -818,13 +819,17 @@ function isPointsColumn(colOrKey) {
   return u === 'PTS' || u === 'POINTS' || u === 'GOALS';
 }
 
+function pauseTimer() {
+  state.running = false;
+  els.startStop.textContent = 'Start';
+  els.startStop.classList.remove('bg-red-600', 'border-red-700');
+  els.startStop.classList.add('bg-emerald-600', 'border-emerald-700');
+  clearInterval(state.tick);
+}
+
 async function startStop() {
   if (state.running) {
-    state.running = false;
-    els.startStop.textContent = 'Start';
-    els.startStop.classList.remove('bg-red-600', 'border-red-700');
-    els.startStop.classList.add('bg-emerald-600', 'border-emerald-700');
-    clearInterval(state.tick);
+    pauseTimer();
   } else {
     // If no local activity yet, check for existing tracked data and offer to clear
     const hasLocalActivity = state.clock > 0 || state.home > 0 || state.away > 0 || (state.log && state.log.length > 0);

--- a/tests/unit/track-basketball-finish-timer.test.js
+++ b/tests/unit/track-basketball-finish-timer.test.js
@@ -1,0 +1,91 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+
+const source = readFileSync(new URL('../../js/track-basketball.js', import.meta.url), 'utf8');
+
+function extractFunction(name) {
+    const start = source.indexOf(`function ${name}`);
+    if (start === -1) {
+        throw new Error(`Function ${name} not found`);
+    }
+
+    const bodyStart = source.indexOf('{', start);
+    let depth = 0;
+
+    for (let index = bodyStart; index < source.length; index += 1) {
+        const char = source[index];
+        if (char === '{') depth += 1;
+        if (char === '}') depth -= 1;
+        if (depth === 0) {
+            return source.slice(start, index + 1);
+        }
+    }
+
+    throw new Error(`Function ${name} did not terminate`);
+}
+
+describe('track basketball finish timer', () => {
+    it('pauses the timer before rendering Finish so later ticks cannot add playing time', () => {
+        const clearInterval = vi.fn();
+        const renderFinish = vi.fn();
+        const classList = {
+            toggle: vi.fn(),
+            remove: vi.fn(),
+            add: vi.fn()
+        };
+        const state = {
+            running: true,
+            tick: 42,
+            lastTick: 1000,
+            clock: 1000,
+            onCourt: ['p1'],
+            stats: { p1: { time: 1000 } }
+        };
+        const els = {
+            panelLineup: { classList },
+            panelLive: { classList },
+            panelOpp: { classList },
+            panelFin: { classList },
+            startStop: { textContent: 'Pause', classList }
+        };
+        const performance = { now: vi.fn(() => 61000) };
+        const renderHeader = vi.fn();
+        const renderLive = vi.fn();
+        const renderFairness = vi.fn();
+
+        const run = new Function(
+            'state',
+            'els',
+            'clearInterval',
+            'renderFinish',
+            'performance',
+            'renderHeader',
+            'renderLive',
+            'renderFairness',
+            `${extractFunction('pauseTimer')}
+${extractFunction('tick')}
+${extractFunction('setTab')}
+setTab('finish');
+tick();`
+        );
+
+        run(
+            state,
+            els,
+            clearInterval,
+            renderFinish,
+            performance,
+            renderHeader,
+            renderLive,
+            renderFairness
+        );
+
+        expect(state.running).toBe(false);
+        expect(state.clock).toBe(1000);
+        expect(state.stats.p1.time).toBe(1000);
+        expect(clearInterval).toHaveBeenCalledWith(42);
+        expect(els.startStop.textContent).toBe('Start');
+        expect(renderFinish).toHaveBeenCalledOnce();
+        expect(performance.now).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Closes #4204

## What changed
- Reused a shared timer pause helper for manual Pause and the Finish workflow.
- Added a focused regression test proving Finish prevents subsequent timer ticks from changing game or player time.

## Root Cause
The Finish tab only rendered its panel. Timer shutdown existed exclusively in the Start/Pause button path, leaving `state.running` enabled while the scorekeeper reviewed the recap.

## Prevention / Learning
Treat terminal workflow transitions as state transitions, not view-only navigation. Reuse shared shutdown logic and verify subsequent timer callbacks are inert.

## Regression Tests
- `npx vitest run tests/unit/track-basketball-finish-timer.test.js --reporter=verbose`
- `git show --check HEAD`