### PR TITLE
Fix recurring practices in private calendar feeds

### DIFF
--- a/apps/app/src/lib/adapters/legacyScheduleHelpers.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleHelpers.ts
@@ -312,6 +312,7 @@ export function applyPracticeRecurrenceFields(payload: {
     recurrenceConfig?: Record<string, unknown>;
     startDate?: Date;
     endDate?: Date;
+    timeZone?: string;
     Timestamp: { fromDate: (date: Date) => unknown };
     deleteField: () => unknown;
     generateSeriesId?: () => string;

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -950,6 +950,7 @@ describe('scheduled practice writes', () => {
       title: 'Summer Skills',
       startDate: new Date('2026-06-24T18:00:00.000Z'),
       endDate: new Date('2026-06-24T19:30:00.000Z'),
+      timeZone: 'America/Chicago',
       location: 'Field 3',
       notes: 'Bring pinnies',
       recurrence: {
@@ -990,6 +991,7 @@ describe('scheduled practice writes', () => {
       },
       startDate: new Date('2026-06-24T18:00:00.000Z'),
       endDate: new Date('2026-06-24T19:30:00.000Z'),
+      timeZone: 'America/Chicago',
       Timestamp: { fromDate: (value: Date) => value },
       deleteField: () => ({ __deleteField: true }),
       generateSeriesId: () => 'series-generated'
@@ -1014,6 +1016,7 @@ describe('scheduled practice writes', () => {
       title: 'Special Session',
       startTime: '17:15',
       endTime: '18:45',
+      endDayOffset: 0,
       location: 'Indoor court',
       notes: 'Film first 15 minutes'
     });
@@ -1049,6 +1052,7 @@ describe('scheduled practice writes', () => {
           title: { stringValue: 'Special Session' },
           startTime: { stringValue: '17:15' },
           endTime: { stringValue: '18:45' },
+          endDayOffset: { integerValue: '0' },
           location: { stringValue: 'Indoor court' },
           notes: { stringValue: 'Film first 15 minutes' }
         }
@@ -1056,6 +1060,25 @@ describe('scheduled practice writes', () => {
     });
     expect(payload.fields.updatedBy).toEqual({ stringValue: 'coach-1' });
     expect(typeof payload.fields.updatedAt.timestampValue).toBe('string');
+  });
+
+  it('persists overnight occurrence overrides with the next-day offset', async () => {
+    await updateScheduledPracticeForApp('team-1', {
+      title: 'Late Practice',
+      startDate: new Date(2026, 5, 24, 23, 30),
+      endDate: new Date(2026, 5, 25, 1, 0),
+      location: 'Indoor court',
+      notes: ''
+    }, coachUser, {
+      eventId: 'practice-master__2026-06-24',
+      scope: 'occurrence'
+    });
+
+    expect(updateOccurrence).toHaveBeenCalledWith('team-1', 'practice-master', '2026-06-24', expect.objectContaining({
+      startTime: '23:30',
+      endTime: '01:00',
+      endDayOffset: 1
+    }));
   });
 
   it('reverts occurrence overrides without touching the series master', async () => {

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -159,7 +159,7 @@ vi.mock('./adapters/legacyScheduleHelpers', () => ({
   hasScorekeepingTeamAccess: vi.fn(),
   isTeamActive: vi.fn(() => true),
   applyPracticeRecurrenceFields: vi.fn((payload: any) => {
-    const { practiceData, isRecurring, editingPracticeId = null, editingSeriesId = null, recurrenceConfig = {}, startDate, endDate, Timestamp, deleteField, generateSeriesId } = payload;
+    const { practiceData, isRecurring, editingPracticeId = null, editingSeriesId = null, recurrenceConfig = {}, startDate, endDate, timeZone = '', Timestamp, deleteField, generateSeriesId } = payload;
     if (isRecurring) {
       const { freq = 'weekly', interval = 1, byDays = [], endType = 'never', untilValue = '', countValue = 10 } = recurrenceConfig;
       practiceData.isSeriesMaster = true;
@@ -171,6 +171,7 @@ vi.mock('./adapters/legacyScheduleHelpers', () => ({
       practiceData.startTime = startDate.toTimeString().slice(0, 5);
       practiceData.endTime = endDate.toTimeString().slice(0, 5);
       practiceData.endDayOffset = Math.max(0, Math.round((endDay.getTime() - startDay.getTime()) / 86400000));
+      practiceData.timeZone = String(timeZone || '').trim();
       practiceData.recurrence = { freq, interval, byDays };
       if (endType === 'until' && untilValue) {
         practiceData.recurrence.until = Timestamp.fromDate(new Date(untilValue));

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -1985,6 +1985,7 @@ export type SchedulePracticeFormInput = {
   title: string;
   startDate: Date;
   endDate: Date;
+  timeZone?: string | null;
   location?: string | null;
   notes?: string | null;
   scheduleNotifications?: Record<string, unknown> | null;
@@ -2219,6 +2220,7 @@ function buildScheduledPracticePayload(input: SchedulePracticeFormInput, user: A
     recurrenceConfig: recurrence,
     startDate,
     endDate,
+    timeZone: compactString(input.timeZone) || Intl.DateTimeFormat().resolvedOptions().timeZone,
     Timestamp,
     deleteField,
     generateSeriesId
@@ -2246,10 +2248,15 @@ function buildOccurrenceOverridePayload(input: SchedulePracticeFormInput) {
   if (Number.isNaN(startDate.getTime())) throw new Error('Practice start time is invalid.');
   if (Number.isNaN(endDate.getTime())) throw new Error('Practice end time is invalid.');
   if (endDate.getTime() <= startDate.getTime()) throw new Error('Practice end time must be after the start time.');
+  const startDay = new Date(startDate);
+  const endDay = new Date(endDate);
+  startDay.setHours(0, 0, 0, 0);
+  endDay.setHours(0, 0, 0, 0);
   return {
     title,
     startTime: startDate.toTimeString().slice(0, 5),
     endTime: endDate.toTimeString().slice(0, 5),
+    endDayOffset: Math.max(0, Math.round((endDay.getTime() - startDay.getTime()) / 86400000)),
     location: compactString(input.location),
     notes: compactString(input.notes)
   };

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -960,7 +960,7 @@
         import { getGoalSportProfile } from './js/live-sport-config.js?v=3';
         import { cancelScheduledGame } from './js/edit-schedule-cancel-game.js?v=3';
         import { applyPracticeRecurrenceFields } from './js/edit-schedule-practice-payload.js?v=1';
-        import { savePracticeForm } from './js/edit-schedule-practice-submit.js?v=2';
+        import { savePracticeForm } from './js/edit-schedule-practice-submit.js?v=3';
         import { buildBulkAiPracticePayload, createBulkAiImageController, normalizeBulkAiAssignments, normalizeBulkAiEventForAdd, normalizeBulkAiIsHome } from './js/edit-schedule-ai-import.js?v=2';
         import { buildSeasonRecordGameFields, hydrateSeasonRecordFormFields } from './js/edit-schedule-season-record.js?v=1';
         import { normalizeOfficialsDirectory } from './js/officiating-slots.js?v=1';

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -3772,6 +3772,7 @@
                 title: document.getElementById('occurrence-title').value,
                 startTime: document.getElementById('occurrence-start-time').value,
                 endTime: document.getElementById('occurrence-end-time').value,
+                endDayOffset: document.getElementById('occurrence-end-time').value <= document.getElementById('occurrence-start-time').value ? 1 : 0,
                 location: document.getElementById('occurrence-location').value,
                 notes: document.getElementById('occurrence-notes').value
             };

--- a/functions/calendar-feed-window-core.cjs
+++ b/functions/calendar-feed-window-core.cjs
@@ -26,9 +26,18 @@ function buildCalendarFeedGamesQuery(gamesCollection, { now = new Date() } = {})
     .orderBy('date');
 }
 
+function buildCalendarFeedRecurringMastersQuery(gamesCollection) {
+  if (!gamesCollection || typeof gamesCollection.where !== 'function') {
+    throw new TypeError('Calendar feed games collection must support recurring-master queries');
+  }
+
+  return gamesCollection.where('isSeriesMaster', '==', true);
+}
+
 module.exports = {
   CALENDAR_FEED_LOOKAHEAD_DAYS,
   CALENDAR_FEED_LOOKBACK_DAYS,
   buildCalendarFeedGamesQuery,
+  buildCalendarFeedRecurringMastersQuery,
   getCalendarFeedDateWindow
 };

--- a/functions/index.js
+++ b/functions/index.js
@@ -88,7 +88,10 @@ const {
   parsePublicGamesQuery,
   serializePublicGame
 } = require('./public-team-api-core.cjs');
-const { buildCalendarFeedGamesQuery } = require('./calendar-feed-window-core.cjs');
+const {
+  buildCalendarFeedGamesQuery,
+  buildCalendarFeedRecurringMastersQuery
+} = require('./calendar-feed-window-core.cjs');
 const {
   buildPublicRsvpSummaryProjection,
   buildPublicRsvpSummaryJobPlan,
@@ -5900,6 +5903,10 @@ function getCalendarFeedGamesQuery(teamId) {
   return buildCalendarFeedGamesQuery(firestore.collection(`teams/${teamId}/games`));
 }
 
+function getCalendarFeedRecurringMastersQuery(teamId) {
+  return buildCalendarFeedRecurringMastersQuery(firestore.collection(`teams/${teamId}/games`));
+}
+
 const PUBLIC_TEAM_API_CACHE_CONTROL = 'public, max-age=60, s-maxage=300';
 const PUBLIC_TEAM_API_MAX_ROSTER_SCAN_DOCUMENTS = 1000;
 const PUBLIC_TEAM_API_MAX_GAME_SCAN_DOCUMENTS = 5000;
@@ -6194,8 +6201,18 @@ exports.teamCalendarFeed = functions.https.onRequest(async (req, res) => {
       return;
     }
 
-    const eventsSnap = await getCalendarFeedGamesQuery(teamId).get();
-    const events = eventsSnap.docs.map((docSnap) => {
+    const [eventsSnap, recurringMastersSnap] = await Promise.all([
+      getCalendarFeedGamesQuery(teamId).get(),
+      getCalendarFeedRecurringMastersQuery(teamId).get()
+    ]);
+    const recurringPracticeDocs = recurringMastersSnap.docs.filter((docSnap) => {
+      const event = docSnap.data() || {};
+      return event.type === 'practice' && event.isSeriesMaster === true && Boolean(event.recurrence);
+    });
+    const eventDocs = new Map(
+      [...eventsSnap.docs, ...recurringPracticeDocs].map((docSnap) => [docSnap.id, docSnap])
+    );
+    const events = [...eventDocs.values()].map((docSnap) => {
       const game = { id: docSnap.id, ...(docSnap.data() || {}) };
       game.officiating = Array.isArray(game.officiating) ? game.officiating : (Array.isArray(game.officials) ? game.officials : []);
       return game;

--- a/functions/team-calendar-feed-core.cjs
+++ b/functions/team-calendar-feed-core.cjs
@@ -8,6 +8,16 @@ const DEFAULT_EVENT_DURATION_MS = 60 * 60 * 1000;
 const DEFAULT_RECURRENCE_TIME_ZONE = 'America/Chicago';
 const MILLIS_PER_DAY = 24 * 60 * 60 * 1000;
 const RECURRENCE_DAY_CODES = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
+const LEGACY_RECURRENCE_TIME_ZONES = [
+  'America/New_York',
+  'America/Chicago',
+  'America/Denver',
+  'America/Los_Angeles',
+  'America/Anchorage',
+  'Pacific/Honolulu',
+  'Pacific/Pago_Pago',
+  'Pacific/Kiritimati'
+];
 
 function hashCalendarToken(token) {
   const normalized = String(token || '').trim();
@@ -156,11 +166,22 @@ function getRecurrenceUtcOffsetMinutes(master) {
   if (!masterStart || !/^\d{2}:\d{2}$/.test(startTime)) return 0;
 
   const [localHours, localMinutes] = startTime.split(':').map(Number);
-  let offsetMinutes = (localHours * 60 + localMinutes) -
+  const rawOffsetMinutes = (localHours * 60 + localMinutes) -
     (masterStart.getUTCHours() * 60 + masterStart.getUTCMinutes());
-  if (offsetMinutes > 14 * 60) offsetMinutes -= 24 * 60;
-  if (offsetMinutes < -12 * 60) offsetMinutes += 24 * 60;
-  return offsetMinutes;
+  const candidates = [rawOffsetMinutes, rawOffsetMinutes - 24 * 60, rawOffsetMinutes + 24 * 60]
+    .filter((offset) => offset >= -12 * 60 && offset <= 14 * 60);
+  const recurrenceDays = new Set(
+    (Array.isArray(master.recurrence?.byDays) ? master.recurrence.byDays : [])
+      .map((day) => String(day || '').toUpperCase())
+      .filter((day) => RECURRENCE_DAY_CODES.includes(day))
+  );
+  const matchingDayOffset = recurrenceDays.size > 0
+    ? candidates.find((offset) => {
+      const localStart = new Date(masterStart.getTime() + offset * 60 * 1000);
+      return recurrenceDays.has(RECURRENCE_DAY_CODES[localStart.getUTCDay()]);
+    })
+    : null;
+  return matchingDayOffset ?? candidates[0] ?? 0;
 }
 
 function getWallClockParts(date, timeZone) {
@@ -226,11 +247,24 @@ function getRecurrenceTimeZone(master, fallbackTimeZone = DEFAULT_RECURRENCE_TIM
   const masterStart = toDate(master.date);
   const startTime = String(master.startTime || '').trim();
   const fallback = String(fallbackTimeZone || '').trim();
-  if (!masterStart || !fallback || !/^\d{2}:\d{2}$/.test(startTime)) return '';
+  if (!masterStart || !/^\d{2}:\d{2}$/.test(startTime)) return '';
 
-  const wallClock = getWallClockParts(masterStart, fallback);
   const [hours, minutes] = startTime.split(':').map(Number);
-  return wallClock?.hour === hours && wallClock?.minute === minutes ? fallback : '';
+  const recurrenceDays = new Set(
+    (Array.isArray(master.recurrence?.byDays) ? master.recurrence.byDays : [])
+      .map((day) => String(day || '').toUpperCase())
+      .filter((day) => RECURRENCE_DAY_CODES.includes(day))
+  );
+  const candidates = [fallback, ...LEGACY_RECURRENCE_TIME_ZONES]
+    .filter((timeZone, index, all) => timeZone && all.indexOf(timeZone) === index);
+
+  return candidates.find((timeZone) => {
+    const wallClock = getWallClockParts(masterStart, timeZone);
+    if (!wallClock || wallClock.hour !== hours || wallClock.minute !== minutes) return false;
+    if (recurrenceDays.size === 0) return true;
+    const wallClockDay = new Date(Date.UTC(wallClock.year, wallClock.month, wallClock.day)).getUTCDay();
+    return recurrenceDays.has(RECURRENCE_DAY_CODES[wallClockDay]);
+  }) || '';
 }
 
 function buildRecurringOccurrence(

--- a/functions/team-calendar-feed-core.cjs
+++ b/functions/team-calendar-feed-core.cjs
@@ -1,7 +1,12 @@
 const crypto = require('node:crypto');
+const {
+  getCalendarFeedDateWindow
+} = require('./calendar-feed-window-core.cjs');
 
 const FEED_PRODUCT_ID = '-//ALL PLAYS//Team Calendar//EN';
 const DEFAULT_EVENT_DURATION_MS = 60 * 60 * 1000;
+const MILLIS_PER_DAY = 24 * 60 * 60 * 1000;
+const RECURRENCE_DAY_CODES = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
 
 function hashCalendarToken(token) {
   const normalized = String(token || '').trim();
@@ -140,6 +145,148 @@ function getEventDescription(event) {
   return parts.join('\n');
 }
 
+function toUtcDateKey(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function getRecurrenceUtcOffsetMinutes(master) {
+  const masterStart = toDate(master.date);
+  const startTime = String(master.startTime || '').trim();
+  if (!masterStart || !/^\d{2}:\d{2}$/.test(startTime)) return 0;
+
+  const [localHours, localMinutes] = startTime.split(':').map(Number);
+  let offsetMinutes = (localHours * 60 + localMinutes) -
+    (masterStart.getUTCHours() * 60 + masterStart.getUTCMinutes());
+  if (offsetMinutes > 12 * 60) offsetMinutes -= 24 * 60;
+  if (offsetMinutes < -12 * 60) offsetMinutes += 24 * 60;
+  return offsetMinutes;
+}
+
+function buildRecurringOccurrence(master, occurrenceDay, dateKey, override = {}, utcOffsetMinutes = 0) {
+  const startDate = new Date(occurrenceDay);
+  const startTime = String(override.startTime || master.startTime || '').trim();
+  if (/^\d{2}:\d{2}$/.test(startTime)) {
+    const [hours, minutes] = startTime.split(':').map(Number);
+    startDate.setUTCHours(hours, minutes - utcOffsetMinutes, 0, 0);
+  } else {
+    const masterStart = toDate(master.date);
+    startDate.setUTCHours(
+      masterStart.getUTCHours(),
+      masterStart.getUTCMinutes(),
+      masterStart.getUTCSeconds(),
+      masterStart.getUTCMilliseconds()
+    );
+  }
+
+  const occurrence = {
+    ...master,
+    ...override,
+    id: `${master.id || master.gameId || master.eventId}__${dateKey}`,
+    masterId: master.id || master.gameId || master.eventId,
+    instanceDate: dateKey,
+    isInstance: true,
+    isSeriesMaster: false,
+    date: startDate
+  };
+
+  const endTime = String(override.endTime || master.endTime || '').trim();
+  if (/^\d{2}:\d{2}$/.test(endTime)) {
+    const [hours, minutes] = endTime.split(':').map(Number);
+    const endDate = new Date(occurrenceDay);
+    endDate.setUTCHours(hours, minutes - utcOffsetMinutes, 0, 0);
+    const explicitDayOffset = override.endDayOffset ?? master.endDayOffset;
+    const inferredDayOffset = endDate <= startDate ? 1 : 0;
+    endDate.setUTCDate(endDate.getUTCDate() + (
+      explicitDayOffset == null ? inferredDayOffset : Math.max(0, Number(explicitDayOffset) || 0)
+    ));
+    occurrence.end = endDate;
+  } else {
+    const masterStart = toDate(master.date);
+    const masterEnd = toDate(master.end || master.endDate || master.endsAt);
+    if (masterStart && masterEnd && masterEnd > masterStart) {
+      occurrence.end = new Date(startDate.getTime() + (masterEnd.getTime() - masterStart.getTime()));
+    }
+  }
+
+  return occurrence;
+}
+
+function expandRecurringCalendarEvent(master, { now = new Date() } = {}) {
+  if (master?.type !== 'practice' || master?.isSeriesMaster !== true || !master?.recurrence) {
+    return [master];
+  }
+
+  const seriesStart = toDate(master.date);
+  if (!seriesStart) return [];
+
+  const { start: windowStart, end: windowEnd } = getCalendarFeedDateWindow(now);
+  const recurrence = master.recurrence || {};
+  const frequency = String(recurrence.freq || '').toLowerCase();
+  if (!['daily', 'weekly'].includes(frequency)) return [];
+
+  const interval = Math.max(1, Number.parseInt(recurrence.interval, 10) || 1);
+  const count = Math.max(0, Number.parseInt(recurrence.count, 10) || 0);
+  const until = toDate(recurrence.until || recurrence.endDate || recurrence.untilDate);
+  const untilEnd = until
+    ? new Date(Date.UTC(until.getUTCFullYear(), until.getUTCMonth(), until.getUTCDate(), 23, 59, 59, 999))
+    : null;
+  const byDays = new Set(
+    (Array.isArray(recurrence.byDays) ? recurrence.byDays : [])
+      .map((day) => String(day || '').toUpperCase())
+      .filter((day) => RECURRENCE_DAY_CODES.includes(day))
+  );
+  const excludedDates = new Set(Array.isArray(master.exDates) ? master.exDates : []);
+  const overrides = master.overrides && typeof master.overrides === 'object' && !Array.isArray(master.overrides)
+    ? master.overrides
+    : {};
+  const utcOffsetMinutes = getRecurrenceUtcOffsetMinutes(master);
+  const localSeriesStart = new Date(seriesStart.getTime() + utcOffsetMinutes * 60 * 1000);
+  const startDay = new Date(Date.UTC(
+    localSeriesStart.getUTCFullYear(),
+    localSeriesStart.getUTCMonth(),
+    localSeriesStart.getUTCDate()
+  ));
+  const startDayNumber = Math.floor(startDay.getTime() / MILLIS_PER_DAY);
+  const startWeekNumber = Math.floor((startDayNumber - startDay.getUTCDay()) / 7);
+  const lastDay = new Date(Math.min(windowEnd.getTime(), untilEnd?.getTime() || windowEnd.getTime()));
+  const occurrences = [];
+  let generated = 0;
+
+  for (let current = new Date(startDay); current <= lastDay; current.setUTCDate(current.getUTCDate() + 1)) {
+    const currentDayNumber = Math.floor(current.getTime() / MILLIS_PER_DAY);
+    const daysSinceStart = currentDayNumber - startDayNumber;
+    const currentWeekNumber = Math.floor((currentDayNumber - current.getUTCDay()) / 7);
+    const weeksSinceStart = currentWeekNumber - startWeekNumber;
+    const dayCode = RECURRENCE_DAY_CODES[current.getUTCDay()];
+    const matches = frequency === 'daily'
+      ? daysSinceStart >= 0 && daysSinceStart % interval === 0
+      : daysSinceStart >= 0 &&
+        weeksSinceStart >= 0 &&
+        weeksSinceStart % interval === 0 &&
+        (byDays.size > 0 ? byDays.has(dayCode) : current.getUTCDay() === startDay.getUTCDay());
+
+    if (!matches) continue;
+    generated += 1;
+    if (count && generated > count) break;
+    if (current < windowStart) continue;
+
+    const dateKey = toUtcDateKey(current);
+    const occurrence = buildRecurringOccurrence(
+      master,
+      current,
+      dateKey,
+      overrides[dateKey] || {},
+      utcOffsetMinutes
+    );
+    if (excludedDates.has(dateKey)) {
+      occurrence.status = 'cancelled';
+    }
+    occurrences.push(occurrence);
+  }
+
+  return occurrences;
+}
+
 function buildTeamCalendarIcs({ teamId, team = {}, events = [], now = new Date() }) {
   const teamName = team.name || 'Team';
   const dtstamp = formatIcsDate(now);
@@ -153,6 +300,7 @@ function buildTeamCalendarIcs({ teamId, team = {}, events = [], now = new Date()
   ];
 
   events
+    .flatMap((event) => expandRecurringCalendarEvent(event, { now }))
     .filter(isVisibleCalendarEvent)
     .sort((a, b) => toDate(a.date) - toDate(b.date))
     .forEach((event) => {
@@ -189,6 +337,7 @@ function buildTeamCalendarIcs({ teamId, team = {}, events = [], now = new Date()
 
 module.exports = {
   buildTeamCalendarIcs,
+  expandRecurringCalendarEvent,
   escapeIcsText,
   formatIcsDate,
   formatRsvpSummary,

--- a/functions/team-calendar-feed-core.cjs
+++ b/functions/team-calendar-feed-core.cjs
@@ -5,6 +5,7 @@ const {
 
 const FEED_PRODUCT_ID = '-//ALL PLAYS//Team Calendar//EN';
 const DEFAULT_EVENT_DURATION_MS = 60 * 60 * 1000;
+const DEFAULT_RECURRENCE_TIME_ZONE = 'America/Chicago';
 const MILLIS_PER_DAY = 24 * 60 * 60 * 1000;
 const RECURRENCE_DAY_CODES = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
 
@@ -157,7 +158,7 @@ function getRecurrenceUtcOffsetMinutes(master) {
   const [localHours, localMinutes] = startTime.split(':').map(Number);
   let offsetMinutes = (localHours * 60 + localMinutes) -
     (masterStart.getUTCHours() * 60 + masterStart.getUTCMinutes());
-  if (offsetMinutes > 12 * 60) offsetMinutes -= 24 * 60;
+  if (offsetMinutes > 14 * 60) offsetMinutes -= 24 * 60;
   if (offsetMinutes < -12 * 60) offsetMinutes += 24 * 60;
   return offsetMinutes;
 }
@@ -218,10 +219,30 @@ function parseWallClockTime(occurrenceDay, time, timeZone) {
   return null;
 }
 
-function buildRecurringOccurrence(master, occurrenceDay, dateKey, override = {}, utcOffsetMinutes = 0) {
+function getRecurrenceTimeZone(master, fallbackTimeZone = DEFAULT_RECURRENCE_TIME_ZONE) {
+  const explicitTimeZone = String(master.timeZone || master.timezone || '').trim();
+  if (explicitTimeZone) return explicitTimeZone;
+
+  const masterStart = toDate(master.date);
+  const startTime = String(master.startTime || '').trim();
+  const fallback = String(fallbackTimeZone || '').trim();
+  if (!masterStart || !fallback || !/^\d{2}:\d{2}$/.test(startTime)) return '';
+
+  const wallClock = getWallClockParts(masterStart, fallback);
+  const [hours, minutes] = startTime.split(':').map(Number);
+  return wallClock?.hour === hours && wallClock?.minute === minutes ? fallback : '';
+}
+
+function buildRecurringOccurrence(
+  master,
+  occurrenceDay,
+  dateKey,
+  override = {},
+  utcOffsetMinutes = 0,
+  timeZone = ''
+) {
   const startDate = new Date(occurrenceDay);
   const startTime = String(override.startTime || master.startTime || '').trim();
-  const timeZone = String(master.timeZone || master.timezone || '').trim();
   if (/^\d{2}:\d{2}$/.test(startTime)) {
     const [hours, minutes] = startTime.split(':').map(Number);
     const zonedStart = timeZone ? parseWallClockTime(occurrenceDay, startTime, timeZone) : null;
@@ -261,7 +282,10 @@ function buildRecurringOccurrence(master, occurrenceDay, dateKey, override = {},
   if (/^\d{2}:\d{2}$/.test(endTime)) {
     const [hours, minutes] = endTime.split(':').map(Number);
     const endDate = new Date(occurrenceDay);
-    const explicitDayOffset = override.endDayOffset ?? master.endDayOffset;
+    const hasOverrideEndTime = Object.prototype.hasOwnProperty.call(override, 'endTime');
+    const explicitDayOffset = Object.prototype.hasOwnProperty.call(override, 'endDayOffset')
+      ? override.endDayOffset
+      : (hasOverrideEndTime ? null : master.endDayOffset);
     const [startHours, startMinutes] = startTime.split(':').map(Number);
     const inferredDayOffset = hours * 60 + minutes <= startHours * 60 + startMinutes ? 1 : 0;
     const endDayOffset = explicitDayOffset == null
@@ -292,7 +316,10 @@ function buildRecurringOccurrence(master, occurrenceDay, dateKey, override = {},
   return occurrence;
 }
 
-function expandRecurringCalendarEvent(master, { now = new Date() } = {}) {
+function expandRecurringCalendarEvent(master, {
+  now = new Date(),
+  fallbackTimeZone = DEFAULT_RECURRENCE_TIME_ZONE
+} = {}) {
   if (master?.type !== 'practice' || master?.isSeriesMaster !== true || !master?.recurrence) {
     return [master];
   }
@@ -321,7 +348,7 @@ function expandRecurringCalendarEvent(master, { now = new Date() } = {}) {
     ? master.overrides
     : {};
   const utcOffsetMinutes = getRecurrenceUtcOffsetMinutes(master);
-  const timeZone = String(master.timeZone || master.timezone || '').trim();
+  const timeZone = getRecurrenceTimeZone(master, fallbackTimeZone);
   const zonedSeriesStart = timeZone ? getWallClockParts(seriesStart, timeZone) : null;
   const localSeriesStart = zonedSeriesStart
     ? new Date(Date.UTC(zonedSeriesStart.year, zonedSeriesStart.month, zonedSeriesStart.day))
@@ -361,7 +388,8 @@ function expandRecurringCalendarEvent(master, { now = new Date() } = {}) {
       current,
       dateKey,
       overrides[dateKey] || {},
-      utcOffsetMinutes
+      utcOffsetMinutes,
+      timeZone
     );
     if (excludedDates.has(dateKey)) {
       occurrence.status = 'cancelled';
@@ -385,7 +413,10 @@ function buildTeamCalendarIcs({ teamId, team = {}, events = [], now = new Date()
   ];
 
   events
-    .flatMap((event) => expandRecurringCalendarEvent(event, { now }))
+    .flatMap((event) => expandRecurringCalendarEvent(event, {
+      now,
+      fallbackTimeZone: team.timeZone || team.timezone || DEFAULT_RECURRENCE_TIME_ZONE
+    }))
     .filter(isVisibleCalendarEvent)
     .sort((a, b) => toDate(a.date) - toDate(b.date))
     .forEach((event) => {

--- a/functions/team-calendar-feed-core.cjs
+++ b/functions/team-calendar-feed-core.cjs
@@ -8,16 +8,6 @@ const DEFAULT_EVENT_DURATION_MS = 60 * 60 * 1000;
 const DEFAULT_RECURRENCE_TIME_ZONE = 'America/Chicago';
 const MILLIS_PER_DAY = 24 * 60 * 60 * 1000;
 const RECURRENCE_DAY_CODES = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
-const LEGACY_RECURRENCE_TIME_ZONES = [
-  'America/New_York',
-  'America/Chicago',
-  'America/Denver',
-  'America/Los_Angeles',
-  'America/Anchorage',
-  'Pacific/Honolulu',
-  'Pacific/Pago_Pago',
-  'Pacific/Kiritimati'
-];
 
 function hashCalendarToken(token) {
   const normalized = String(token || '').trim();
@@ -244,27 +234,8 @@ function getRecurrenceTimeZone(master, fallbackTimeZone = DEFAULT_RECURRENCE_TIM
   const explicitTimeZone = String(master.timeZone || master.timezone || '').trim();
   if (explicitTimeZone) return explicitTimeZone;
 
-  const masterStart = toDate(master.date);
-  const startTime = String(master.startTime || '').trim();
   const fallback = String(fallbackTimeZone || '').trim();
-  if (!masterStart || !/^\d{2}:\d{2}$/.test(startTime)) return '';
-
-  const [hours, minutes] = startTime.split(':').map(Number);
-  const recurrenceDays = new Set(
-    (Array.isArray(master.recurrence?.byDays) ? master.recurrence.byDays : [])
-      .map((day) => String(day || '').toUpperCase())
-      .filter((day) => RECURRENCE_DAY_CODES.includes(day))
-  );
-  const candidates = [fallback, ...LEGACY_RECURRENCE_TIME_ZONES]
-    .filter((timeZone, index, all) => timeZone && all.indexOf(timeZone) === index);
-
-  return candidates.find((timeZone) => {
-    const wallClock = getWallClockParts(masterStart, timeZone);
-    if (!wallClock || wallClock.hour !== hours || wallClock.minute !== minutes) return false;
-    if (recurrenceDays.size === 0) return true;
-    const wallClockDay = new Date(Date.UTC(wallClock.year, wallClock.month, wallClock.day)).getUTCDay();
-    return recurrenceDays.has(RECURRENCE_DAY_CODES[wallClockDay]);
-  }) || '';
+  return fallback && getWallClockParts(new Date(0), fallback) ? fallback : '';
 }
 
 function buildRecurringOccurrence(

--- a/functions/team-calendar-feed-core.cjs
+++ b/functions/team-calendar-feed-core.cjs
@@ -162,12 +162,80 @@ function getRecurrenceUtcOffsetMinutes(master) {
   return offsetMinutes;
 }
 
+function getWallClockParts(date, timeZone) {
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hourCycle: 'h23'
+    }).formatToParts(date);
+    const values = Object.fromEntries(parts.map(({ type, value }) => [type, value]));
+    return {
+      year: Number(values.year),
+      month: Number(values.month) - 1,
+      day: Number(values.day),
+      hour: Number(values.hour),
+      minute: Number(values.minute),
+      second: Number(values.second)
+    };
+  } catch (_) {
+    return null;
+  }
+}
+
+function parseWallClockTime(occurrenceDay, time, timeZone) {
+  const [hour, minute] = time.split(':').map(Number);
+  const targetMs = Date.UTC(
+    occurrenceDay.getUTCFullYear(),
+    occurrenceDay.getUTCMonth(),
+    occurrenceDay.getUTCDate(),
+    hour,
+    minute
+  );
+  let resolvedMs = targetMs;
+
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const observed = getWallClockParts(new Date(resolvedMs), timeZone);
+    if (!observed) return null;
+    const observedMs = Date.UTC(
+      observed.year,
+      observed.month,
+      observed.day,
+      observed.hour,
+      observed.minute,
+      observed.second
+    );
+    const nextMs = resolvedMs + (targetMs - observedMs);
+    if (nextMs === resolvedMs) return new Date(resolvedMs);
+    resolvedMs = nextMs;
+  }
+
+  return null;
+}
+
 function buildRecurringOccurrence(master, occurrenceDay, dateKey, override = {}, utcOffsetMinutes = 0) {
   const startDate = new Date(occurrenceDay);
   const startTime = String(override.startTime || master.startTime || '').trim();
+  const timeZone = String(master.timeZone || master.timezone || '').trim();
   if (/^\d{2}:\d{2}$/.test(startTime)) {
     const [hours, minutes] = startTime.split(':').map(Number);
-    startDate.setUTCHours(hours, minutes - utcOffsetMinutes, 0, 0);
+    const zonedStart = timeZone ? parseWallClockTime(occurrenceDay, startTime, timeZone) : null;
+    if (zonedStart) {
+      startDate.setTime(zonedStart.getTime());
+    } else {
+      startDate.setTime(Date.UTC(
+        occurrenceDay.getUTCFullYear(),
+        occurrenceDay.getUTCMonth(),
+        occurrenceDay.getUTCDate(),
+        hours,
+        minutes
+      ) - utcOffsetMinutes * 60 * 1000);
+    }
   } else {
     const masterStart = toDate(master.date);
     startDate.setUTCHours(
@@ -193,12 +261,25 @@ function buildRecurringOccurrence(master, occurrenceDay, dateKey, override = {},
   if (/^\d{2}:\d{2}$/.test(endTime)) {
     const [hours, minutes] = endTime.split(':').map(Number);
     const endDate = new Date(occurrenceDay);
-    endDate.setUTCHours(hours, minutes - utcOffsetMinutes, 0, 0);
     const explicitDayOffset = override.endDayOffset ?? master.endDayOffset;
-    const inferredDayOffset = endDate <= startDate ? 1 : 0;
-    endDate.setUTCDate(endDate.getUTCDate() + (
-      explicitDayOffset == null ? inferredDayOffset : Math.max(0, Number(explicitDayOffset) || 0)
-    ));
+    const [startHours, startMinutes] = startTime.split(':').map(Number);
+    const inferredDayOffset = hours * 60 + minutes <= startHours * 60 + startMinutes ? 1 : 0;
+    const endDayOffset = explicitDayOffset == null
+      ? inferredDayOffset
+      : Math.max(0, Number(explicitDayOffset) || 0);
+    endDate.setUTCDate(endDate.getUTCDate() + endDayOffset);
+    const zonedEnd = timeZone ? parseWallClockTime(endDate, endTime, timeZone) : null;
+    if (zonedEnd) {
+      endDate.setTime(zonedEnd.getTime());
+    } else {
+      endDate.setTime(Date.UTC(
+        endDate.getUTCFullYear(),
+        endDate.getUTCMonth(),
+        endDate.getUTCDate(),
+        hours,
+        minutes
+      ) - utcOffsetMinutes * 60 * 1000);
+    }
     occurrence.end = endDate;
   } else {
     const masterStart = toDate(master.date);
@@ -240,7 +321,11 @@ function expandRecurringCalendarEvent(master, { now = new Date() } = {}) {
     ? master.overrides
     : {};
   const utcOffsetMinutes = getRecurrenceUtcOffsetMinutes(master);
-  const localSeriesStart = new Date(seriesStart.getTime() + utcOffsetMinutes * 60 * 1000);
+  const timeZone = String(master.timeZone || master.timezone || '').trim();
+  const zonedSeriesStart = timeZone ? getWallClockParts(seriesStart, timeZone) : null;
+  const localSeriesStart = zonedSeriesStart
+    ? new Date(Date.UTC(zonedSeriesStart.year, zonedSeriesStart.month, zonedSeriesStart.day))
+    : new Date(seriesStart.getTime() + utcOffsetMinutes * 60 * 1000);
   const startDay = new Date(Date.UTC(
     localSeriesStart.getUTCFullYear(),
     localSeriesStart.getUTCMonth(),

--- a/js/edit-schedule-practice-payload.js
+++ b/js/edit-schedule-practice-payload.js
@@ -17,6 +17,7 @@ export function applyPracticeRecurrenceFields({
     recurrenceConfig = {},
     startDate,
     endDate,
+    timeZone = '',
     Timestamp,
     deleteField,
     generateSeriesId
@@ -47,6 +48,7 @@ export function applyPracticeRecurrenceFields({
         practiceData.startTime = startDate.toTimeString().slice(0, 5);
         practiceData.endTime = endDate.toTimeString().slice(0, 5);
         practiceData.endDayOffset = Math.max(0, Math.round((endDay.getTime() - startDay.getTime()) / 86400000));
+        practiceData.timeZone = String(timeZone || '').trim();
         practiceData.recurrence = {
             freq,
             interval,

--- a/js/edit-schedule-practice-submit.js
+++ b/js/edit-schedule-practice-submit.js
@@ -58,6 +58,7 @@ export async function savePracticeForm({
         },
         startDate,
         endDate,
+        timeZone: formState.timeZone || Intl.DateTimeFormat().resolvedOptions().timeZone,
         Timestamp,
         deleteField,
         generateSeriesId

--- a/tests/unit/calendar-feed-window.test.js
+++ b/tests/unit/calendar-feed-window.test.js
@@ -6,6 +6,7 @@ const {
     CALENDAR_FEED_LOOKAHEAD_DAYS,
     CALENDAR_FEED_LOOKBACK_DAYS,
     buildCalendarFeedGamesQuery,
+    buildCalendarFeedRecurringMastersQuery,
     getCalendarFeedDateWindow
 } = require('../../functions/calendar-feed-window-core.cjs');
 
@@ -37,8 +38,21 @@ describe('calendar feed game query window', () => {
         expect(result).toBe(query);
     });
 
+    it('loads recurring masters independently of their original start date', () => {
+        const query = {
+            where: vi.fn()
+        };
+        query.where.mockReturnValue(query);
+
+        const result = buildCalendarFeedRecurringMastersQuery(query);
+
+        expect(query.where).toHaveBeenCalledWith('isSeriesMaster', '==', true);
+        expect(result).toBe(query);
+    });
+
     it('rejects invalid anchors and unqueryable collections', () => {
         expect(() => getCalendarFeedDateWindow('not-a-date')).toThrow('requires a valid date');
         expect(() => buildCalendarFeedGamesQuery(null)).toThrow('must support bounded queries');
+        expect(() => buildCalendarFeedRecurringMastersQuery(null)).toThrow('must support recurring-master queries');
     });
 });

--- a/tests/unit/edit-schedule-practice-payload.test.js
+++ b/tests/unit/edit-schedule-practice-payload.test.js
@@ -56,6 +56,7 @@ describe('edit schedule practice recurrence payload', () => {
             },
             startDate: createLocalDate(2026, 2, 16, 17, 0),
             endDate: createLocalDate(2026, 2, 16, 18, 30),
+            timeZone: 'America/Chicago',
             Timestamp: { fromDate: (value) => value },
             deleteField: () => {
                 throw new Error('deleteField should not be used for recurring series updates');
@@ -68,6 +69,7 @@ describe('edit schedule practice recurrence payload', () => {
         expect(result.startTime).toBe('17:00');
         expect(result.endTime).toBe('18:30');
         expect(result.endDayOffset).toBe(0);
+        expect(result.timeZone).toBe('America/Chicago');
         expect(result.recurrence).toEqual({
             freq: 'weekly',
             interval: 2,
@@ -154,7 +156,7 @@ describe('edit schedule practice recurrence payload', () => {
         const source = readFileSync(new URL('../../edit-schedule.html', import.meta.url), 'utf8');
         const helperSource = readFileSync(new URL('../../js/edit-schedule-practice-submit.js', import.meta.url), 'utf8');
 
-        expect(source).toContain("import { savePracticeForm } from './js/edit-schedule-practice-submit.js?v=2';");
+        expect(source).toContain("import { savePracticeForm } from './js/edit-schedule-practice-submit.js?v=3';");
         expect(helperSource).toContain("import { applyPracticeRecurrenceFields } from './edit-schedule-practice-payload.js';");
         expect(helperSource).toContain('applyPracticeRecurrenceFields({');
         expect(helperSource).toContain('deleteField,');

--- a/tests/unit/edit-schedule-practice-submit.test.js
+++ b/tests/unit/edit-schedule-practice-submit.test.js
@@ -261,6 +261,7 @@ describe('edit schedule practice save flow', () => {
         expect(source).toContain("import { savePracticeForm } from './js/edit-schedule-practice-submit.js?v=3';");
         expect(source).toContain('const { savedPracticeId } = await savePracticeForm({');
         expect(source).toContain('applyPracticeRecurrenceFields');
+        expect(source).toContain("endDayOffset: document.getElementById('occurrence-end-time').value <= document.getElementById('occurrence-start-time').value ? 1 : 0");
     });
 
     it('does not save isSeriesMaster or recurrence when editing a non-recurring practice', async () => {

--- a/tests/unit/edit-schedule-practice-submit.test.js
+++ b/tests/unit/edit-schedule-practice-submit.test.js
@@ -126,6 +126,7 @@ describe('edit schedule practice save flow', () => {
                 title: 'Recurring Practice',
                 startDate,
                 endDate,
+                timeZone: 'America/Chicago',
                 location: 'Main Gym',
                 notes: 'Ball movement',
                 scheduleNotifications: {
@@ -165,6 +166,7 @@ describe('edit schedule practice save flow', () => {
             startTime: '17:00',
             endTime: '18:30',
             endDayOffset: 0,
+            timeZone: 'America/Chicago',
             recurrence: {
                 freq: 'weekly',
                 interval: 2,
@@ -199,6 +201,7 @@ describe('edit schedule practice save flow', () => {
                 title: 'Recurring Practice',
                 startDate,
                 endDate,
+                timeZone: 'America/Chicago',
                 location: 'Aux Gym',
                 notes: 'Update cadence',
                 scheduleNotifications: {
@@ -238,6 +241,7 @@ describe('edit schedule practice save flow', () => {
             startTime: '17:15',
             endTime: '18:45',
             endDayOffset: 0,
+            timeZone: 'America/Chicago',
             recurrence: {
                 freq: 'weekly',
                 interval: 1,
@@ -254,7 +258,7 @@ describe('edit schedule practice save flow', () => {
     it('wires the practice submit flow through the shared save helper', () => {
         const source = readEditSchedule();
 
-        expect(source).toContain("import { savePracticeForm } from './js/edit-schedule-practice-submit.js?v=2';");
+        expect(source).toContain("import { savePracticeForm } from './js/edit-schedule-practice-submit.js?v=3';");
         expect(source).toContain('const { savedPracticeId } = await savePracticeForm({');
         expect(source).toContain('applyPracticeRecurrenceFields');
     });

--- a/tests/unit/team-calendar-feed.test.js
+++ b/tests/unit/team-calendar-feed.test.js
@@ -151,8 +151,8 @@ describe('team calendar subscription feed', () => {
         });
 
         expect(occurrences.find((occurrence) => occurrence.instanceDate === '2026-07-27')).toMatchObject({
-            date: new Date('2026-07-28T00:00:00Z'),
-            end: new Date('2026-07-28T01:30:00Z')
+            date: new Date('2026-07-27T23:00:00Z'),
+            end: new Date('2026-07-28T00:30:00Z')
         });
     });
 
@@ -175,6 +175,90 @@ describe('team calendar subscription feed', () => {
         expect(chicagoOccurrences.find((occurrence) => occurrence.instanceDate === '2026-07-27')).toMatchObject({
             date: new Date('2026-07-27T23:00:00Z'),
             end: new Date('2026-07-28T00:30:00Z')
+        });
+    });
+
+    it('infers legacy US timezones so wall-clock times remain stable across DST', () => {
+        const newYorkOccurrences = expandRecurringCalendarEvent({
+            id: 'new-york-evening',
+            type: 'practice',
+            isSeriesMaster: true,
+            date: new Date('2025-01-06T23:00:00Z'),
+            startTime: '18:00',
+            endTime: '19:30',
+            recurrence: {
+                freq: 'weekly',
+                interval: 1,
+                byDays: ['MO']
+            }
+        }, {
+            now: new Date('2026-07-25T12:00:00Z')
+        });
+        const losAngelesOccurrences = expandRecurringCalendarEvent({
+            id: 'los-angeles-evening',
+            type: 'practice',
+            isSeriesMaster: true,
+            date: new Date('2025-01-07T02:00:00Z'),
+            startTime: '18:00',
+            endTime: '19:30',
+            recurrence: {
+                freq: 'weekly',
+                interval: 1,
+                byDays: ['MO']
+            }
+        }, {
+            now: new Date('2026-07-25T12:00:00Z')
+        });
+
+        expect(newYorkOccurrences.find((occurrence) => occurrence.instanceDate === '2026-07-27')).toMatchObject({
+            date: new Date('2026-07-27T22:00:00Z'),
+            end: new Date('2026-07-27T23:30:00Z')
+        });
+        expect(losAngelesOccurrences.find((occurrence) => occurrence.instanceDate === '2026-07-27')).toMatchObject({
+            date: new Date('2026-07-28T01:00:00Z'),
+            end: new Date('2026-07-28T02:30:00Z')
+        });
+    });
+
+    it('uses recurrence weekdays to disambiguate legacy negative-antimeridian offsets', () => {
+        const honoluluOccurrences = expandRecurringCalendarEvent({
+            id: 'honolulu-evening',
+            type: 'practice',
+            isSeriesMaster: true,
+            date: new Date('2025-01-07T04:00:00Z'),
+            startTime: '18:00',
+            endTime: '19:30',
+            recurrence: {
+                freq: 'weekly',
+                interval: 1,
+                byDays: ['MO']
+            }
+        }, {
+            now: new Date('2026-07-25T12:00:00Z')
+        });
+        const pagoPagoOccurrences = expandRecurringCalendarEvent({
+            id: 'pago-pago-evening',
+            type: 'practice',
+            isSeriesMaster: true,
+            date: new Date('2025-01-07T05:00:00Z'),
+            startTime: '18:00',
+            endTime: '19:30',
+            recurrence: {
+                freq: 'weekly',
+                interval: 1,
+                byDays: ['MO']
+            }
+        }, {
+            now: new Date('2026-07-25T12:00:00Z')
+        });
+
+        expect(honoluluOccurrences.find((occurrence) => occurrence.instanceDate === '2026-07-27')).toMatchObject({
+            date: new Date('2026-07-28T04:00:00Z'),
+            end: new Date('2026-07-28T05:30:00Z')
+        });
+        expect(pagoPagoOccurrences.find((occurrence) => occurrence.instanceDate === '2026-07-27')).toMatchObject({
+            date: new Date('2026-07-28T05:00:00Z'),
+            end: new Date('2026-07-28T06:30:00Z')
         });
     });
 

--- a/tests/unit/team-calendar-feed.test.js
+++ b/tests/unit/team-calendar-feed.test.js
@@ -156,7 +156,7 @@ describe('team calendar subscription feed', () => {
         });
     });
 
-    it('preserves recurring wall-clock times across DST and positive UTC offsets', () => {
+    it('preserves legacy Chicago wall-clock times across DST without a stored timezone', () => {
         const chicagoOccurrences = expandRecurringCalendarEvent({
             id: 'chicago-evening',
             type: 'practice',
@@ -164,7 +164,6 @@ describe('team calendar subscription feed', () => {
             date: new Date('2025-01-07T00:00:00Z'),
             startTime: '18:00',
             endTime: '19:30',
-            timeZone: 'America/Chicago',
             recurrence: {
                 freq: 'weekly',
                 interval: 1,
@@ -173,6 +172,13 @@ describe('team calendar subscription feed', () => {
         }, {
             now: new Date('2026-07-25T12:00:00Z')
         });
+        expect(chicagoOccurrences.find((occurrence) => occurrence.instanceDate === '2026-07-27')).toMatchObject({
+            date: new Date('2026-07-27T23:00:00Z'),
+            end: new Date('2026-07-28T00:30:00Z')
+        });
+    });
+
+    it('preserves explicit timezones and legacy offsets above UTC+12', () => {
         const karachiOccurrences = expandRecurringCalendarEvent({
             id: 'karachi-evening',
             type: 'practice',
@@ -189,14 +195,59 @@ describe('team calendar subscription feed', () => {
         }, {
             now: new Date('2026-07-25T12:00:00Z')
         });
-
-        expect(chicagoOccurrences.find((occurrence) => occurrence.instanceDate === '2026-07-27')).toMatchObject({
-            date: new Date('2026-07-27T23:00:00Z'),
-            end: new Date('2026-07-28T00:30:00Z')
+        const kiritimatiOccurrences = expandRecurringCalendarEvent({
+            id: 'kiritimati-evening',
+            type: 'practice',
+            isSeriesMaster: true,
+            date: new Date('2025-01-06T04:00:00Z'),
+            startTime: '18:00',
+            endTime: '19:30',
+            recurrence: {
+                freq: 'weekly',
+                interval: 1,
+                byDays: ['MO']
+            }
+        }, {
+            now: new Date('2026-07-25T12:00:00Z')
         });
+
         expect(karachiOccurrences.find((occurrence) => occurrence.instanceDate === '2026-07-27')).toMatchObject({
             date: new Date('2026-07-27T13:00:00Z'),
             end: new Date('2026-07-27T14:30:00Z')
+        });
+        expect(kiritimatiOccurrences.find((occurrence) => occurrence.instanceDate === '2026-07-27')).toMatchObject({
+            date: new Date('2026-07-27T04:00:00Z'),
+            end: new Date('2026-07-27T05:30:00Z')
+        });
+    });
+
+    it('infers an overnight day offset for legacy occurrence overrides', () => {
+        const occurrences = expandRecurringCalendarEvent({
+            id: 'overnight-override',
+            type: 'practice',
+            isSeriesMaster: true,
+            date: new Date('2025-01-07T00:00:00Z'),
+            startTime: '18:00',
+            endTime: '19:00',
+            endDayOffset: 0,
+            recurrence: {
+                freq: 'weekly',
+                interval: 1,
+                byDays: ['MO']
+            },
+            overrides: {
+                '2026-07-27': {
+                    startTime: '23:30',
+                    endTime: '01:00'
+                }
+            }
+        }, {
+            now: new Date('2026-07-25T12:00:00Z')
+        });
+
+        expect(occurrences.find((occurrence) => occurrence.instanceDate === '2026-07-27')).toMatchObject({
+            date: new Date('2026-07-28T04:30:00Z'),
+            end: new Date('2026-07-28T06:00:00Z')
         });
     });
 

--- a/tests/unit/team-calendar-feed.test.js
+++ b/tests/unit/team-calendar-feed.test.js
@@ -156,6 +156,50 @@ describe('team calendar subscription feed', () => {
         });
     });
 
+    it('preserves recurring wall-clock times across DST and positive UTC offsets', () => {
+        const chicagoOccurrences = expandRecurringCalendarEvent({
+            id: 'chicago-evening',
+            type: 'practice',
+            isSeriesMaster: true,
+            date: new Date('2025-01-07T00:00:00Z'),
+            startTime: '18:00',
+            endTime: '19:30',
+            timeZone: 'America/Chicago',
+            recurrence: {
+                freq: 'weekly',
+                interval: 1,
+                byDays: ['MO']
+            }
+        }, {
+            now: new Date('2026-07-25T12:00:00Z')
+        });
+        const karachiOccurrences = expandRecurringCalendarEvent({
+            id: 'karachi-evening',
+            type: 'practice',
+            isSeriesMaster: true,
+            date: new Date('2025-01-06T13:00:00Z'),
+            startTime: '18:00',
+            endTime: '19:30',
+            timeZone: 'Asia/Karachi',
+            recurrence: {
+                freq: 'weekly',
+                interval: 1,
+                byDays: ['MO']
+            }
+        }, {
+            now: new Date('2026-07-25T12:00:00Z')
+        });
+
+        expect(chicagoOccurrences.find((occurrence) => occurrence.instanceDate === '2026-07-27')).toMatchObject({
+            date: new Date('2026-07-27T23:00:00Z'),
+            end: new Date('2026-07-28T00:30:00Z')
+        });
+        expect(karachiOccurrences.find((occurrence) => occurrence.instanceDate === '2026-07-27')).toMatchObject({
+            date: new Date('2026-07-27T13:00:00Z'),
+            end: new Date('2026-07-27T14:30:00Z')
+        });
+    });
+
     it('builds feeds from game-level fields without depending on attendee RSVP arrays', () => {
         const baseEvent = {
             id: 'game-2',

--- a/tests/unit/team-calendar-feed.test.js
+++ b/tests/unit/team-calendar-feed.test.js
@@ -5,6 +5,7 @@ import { readFileSync } from 'node:fs';
 const require = createRequire(import.meta.url);
 const {
     buildTeamCalendarIcs,
+    expandRecurringCalendarEvent,
     formatRsvpSummary,
     hashCalendarToken,
     normalizeCalendarRequest
@@ -81,6 +82,80 @@ describe('team calendar subscription feed', () => {
         expect(updated).toContain('STATUS:CANCELLED');
     });
 
+    it('emits bounded future occurrences for old recurring practice masters', () => {
+        const master = {
+            id: 'practice-series',
+            type: 'practice',
+            isSeriesMaster: true,
+            date: new Date('2025-01-06T18:00:00Z'),
+            startTime: '18:00',
+            endTime: '19:30',
+            title: 'Weekly Skills',
+            location: 'North Field',
+            recurrence: {
+                freq: 'weekly',
+                interval: 1,
+                byDays: ['MO']
+            },
+            exDates: ['2026-07-27'],
+            overrides: {
+                '2026-08-03': {
+                    title: 'Indoor Skills',
+                    location: 'Fieldhouse',
+                    startTime: '19:00',
+                    endTime: '20:00'
+                }
+            }
+        };
+
+        const occurrences = expandRecurringCalendarEvent(master, {
+            now: new Date('2026-07-25T12:00:00Z')
+        });
+        const ics = buildTeamCalendarIcs({
+            teamId: 'team-1',
+            team: { name: 'Sharks' },
+            events: [master],
+            now: new Date('2026-07-25T12:00:00Z')
+        });
+
+        expect(occurrences.find((occurrence) => occurrence.instanceDate === '2026-07-27')).toMatchObject({
+            id: 'practice-series__2026-07-27',
+            status: 'cancelled'
+        });
+        expect(ics).toContain('UID:team-1-practice-series__2026-07-27@allplays.ai');
+        expect(ics).toContain('DTSTART:20260727T180000Z');
+        expect(ics).toContain('STATUS:CANCELLED');
+        expect(ics).toContain('UID:team-1-practice-series__2026-08-03@allplays.ai');
+        expect(ics).toContain('DTSTART:20260803T190000Z');
+        expect(ics).toContain('DTEND:20260803T200000Z');
+        expect(ics).toContain('SUMMARY:Indoor Skills');
+        expect(ics).toContain('LOCATION:Fieldhouse');
+        expect(ics).not.toContain('UID:team-1-practice-series@allplays.ai');
+    });
+
+    it('preserves the stored local weekday when the practice starts on the next UTC day', () => {
+        const occurrences = expandRecurringCalendarEvent({
+            id: 'monday-evening',
+            type: 'practice',
+            isSeriesMaster: true,
+            date: new Date('2025-01-07T00:00:00Z'),
+            startTime: '19:00',
+            endTime: '20:30',
+            recurrence: {
+                freq: 'weekly',
+                interval: 1,
+                byDays: ['MO']
+            }
+        }, {
+            now: new Date('2026-07-25T12:00:00Z')
+        });
+
+        expect(occurrences.find((occurrence) => occurrence.instanceDate === '2026-07-27')).toMatchObject({
+            date: new Date('2026-07-28T00:00:00Z'),
+            end: new Date('2026-07-28T01:30:00Z')
+        });
+    });
+
     it('builds feeds from game-level fields without depending on attendee RSVP arrays', () => {
         const baseEvent = {
             id: 'game-2',
@@ -150,6 +225,8 @@ describe('team calendar subscription feed', () => {
         const teamCalendarFeedSource = functionsSource.slice(feedStart, feedEnd);
 
         expect(teamCalendarFeedSource).toContain('getCalendarFeedGamesQuery(teamId).get()');
+        expect(teamCalendarFeedSource).toContain('getCalendarFeedRecurringMastersQuery(teamId).get()');
+        expect(teamCalendarFeedSource).toContain('[...eventsSnap.docs, ...recurringPracticeDocs]');
         expect(teamCalendarFeedSource).not.toContain("firestore.collection(`teams/${teamId}/games`).get()");
         expect(teamCalendarFeedSource).not.toContain("firestore.collection(`teams/${teamId}/games`).orderBy('date').get()");
         expect(teamCalendarFeedSource).toContain('const game = { id: docSnap.id, ...(docSnap.data() || {}) }');

--- a/tests/unit/team-calendar-feed.test.js
+++ b/tests/unit/team-calendar-feed.test.js
@@ -113,7 +113,7 @@ describe('team calendar subscription feed', () => {
         });
         const ics = buildTeamCalendarIcs({
             teamId: 'team-1',
-            team: { name: 'Sharks' },
+            team: { name: 'Sharks', timeZone: 'UTC' },
             events: [master],
             now: new Date('2026-07-25T12:00:00Z')
         });
@@ -147,7 +147,8 @@ describe('team calendar subscription feed', () => {
                 byDays: ['MO']
             }
         }, {
-            now: new Date('2026-07-25T12:00:00Z')
+            now: new Date('2026-07-25T12:00:00Z'),
+            fallbackTimeZone: 'America/New_York'
         });
 
         expect(occurrences.find((occurrence) => occurrence.instanceDate === '2026-07-27')).toMatchObject({
@@ -178,7 +179,7 @@ describe('team calendar subscription feed', () => {
         });
     });
 
-    it('infers legacy US timezones so wall-clock times remain stable across DST', () => {
+    it('uses the configured team timezone for legacy US series across DST', () => {
         const newYorkOccurrences = expandRecurringCalendarEvent({
             id: 'new-york-evening',
             type: 'practice',
@@ -192,7 +193,8 @@ describe('team calendar subscription feed', () => {
                 byDays: ['MO']
             }
         }, {
-            now: new Date('2026-07-25T12:00:00Z')
+            now: new Date('2026-07-25T12:00:00Z'),
+            fallbackTimeZone: 'America/New_York'
         });
         const losAngelesOccurrences = expandRecurringCalendarEvent({
             id: 'los-angeles-evening',
@@ -207,7 +209,8 @@ describe('team calendar subscription feed', () => {
                 byDays: ['MO']
             }
         }, {
-            now: new Date('2026-07-25T12:00:00Z')
+            now: new Date('2026-07-25T12:00:00Z'),
+            fallbackTimeZone: 'America/Los_Angeles'
         });
 
         expect(newYorkOccurrences.find((occurrence) => occurrence.instanceDate === '2026-07-27')).toMatchObject({
@@ -220,7 +223,46 @@ describe('team calendar subscription feed', () => {
         });
     });
 
-    it('uses recurrence weekdays to disambiguate legacy negative-antimeridian offsets', () => {
+    it('uses configured Arizona and European timezones instead of guessing from a winter offset', () => {
+        const legacyMaster = {
+            type: 'practice',
+            isSeriesMaster: true,
+            startTime: '18:00',
+            endTime: '19:30',
+            recurrence: {
+                freq: 'weekly',
+                interval: 1,
+                byDays: ['MO']
+            }
+        };
+        const phoenixOccurrences = expandRecurringCalendarEvent({
+            ...legacyMaster,
+            id: 'phoenix-evening',
+            date: new Date('2025-01-07T01:00:00Z')
+        }, {
+            now: new Date('2026-07-25T12:00:00Z'),
+            fallbackTimeZone: 'America/Phoenix'
+        });
+        const londonOccurrences = expandRecurringCalendarEvent({
+            ...legacyMaster,
+            id: 'london-evening',
+            date: new Date('2025-01-06T18:00:00Z')
+        }, {
+            now: new Date('2026-07-25T12:00:00Z'),
+            fallbackTimeZone: 'Europe/London'
+        });
+
+        expect(phoenixOccurrences.find((occurrence) => occurrence.instanceDate === '2026-07-27')).toMatchObject({
+            date: new Date('2026-07-28T01:00:00Z'),
+            end: new Date('2026-07-28T02:30:00Z')
+        });
+        expect(londonOccurrences.find((occurrence) => occurrence.instanceDate === '2026-07-27')).toMatchObject({
+            date: new Date('2026-07-27T17:00:00Z'),
+            end: new Date('2026-07-27T18:30:00Z')
+        });
+    });
+
+    it('uses the configured team timezone for legacy negative-antimeridian series', () => {
         const honoluluOccurrences = expandRecurringCalendarEvent({
             id: 'honolulu-evening',
             type: 'practice',
@@ -234,7 +276,8 @@ describe('team calendar subscription feed', () => {
                 byDays: ['MO']
             }
         }, {
-            now: new Date('2026-07-25T12:00:00Z')
+            now: new Date('2026-07-25T12:00:00Z'),
+            fallbackTimeZone: 'Pacific/Honolulu'
         });
         const pagoPagoOccurrences = expandRecurringCalendarEvent({
             id: 'pago-pago-evening',
@@ -249,7 +292,8 @@ describe('team calendar subscription feed', () => {
                 byDays: ['MO']
             }
         }, {
-            now: new Date('2026-07-25T12:00:00Z')
+            now: new Date('2026-07-25T12:00:00Z'),
+            fallbackTimeZone: 'Pacific/Pago_Pago'
         });
 
         expect(honoluluOccurrences.find((occurrence) => occurrence.instanceDate === '2026-07-27')).toMatchObject({
@@ -262,7 +306,7 @@ describe('team calendar subscription feed', () => {
         });
     });
 
-    it('preserves explicit timezones and legacy offsets above UTC+12', () => {
+    it('preserves explicit timezones and configured legacy zones above UTC+12', () => {
         const karachiOccurrences = expandRecurringCalendarEvent({
             id: 'karachi-evening',
             type: 'practice',
@@ -292,7 +336,8 @@ describe('team calendar subscription feed', () => {
                 byDays: ['MO']
             }
         }, {
-            now: new Date('2026-07-25T12:00:00Z')
+            now: new Date('2026-07-25T12:00:00Z'),
+            fallbackTimeZone: 'Pacific/Kiritimati'
         });
 
         expect(karachiOccurrences.find((occurrence) => occurrence.instanceDate === '2026-07-27')).toMatchObject({
@@ -333,6 +378,81 @@ describe('team calendar subscription feed', () => {
             date: new Date('2026-07-28T04:30:00Z'),
             end: new Date('2026-07-28T06:00:00Z')
         });
+    });
+
+    it('honors daily occurrence counts when the master predates the feed window', () => {
+        const occurrences = expandRecurringCalendarEvent({
+            id: 'daily-counted',
+            type: 'practice',
+            isSeriesMaster: true,
+            date: new Date('2026-04-20T18:00:00Z'),
+            startTime: '18:00',
+            endTime: '19:00',
+            recurrence: {
+                freq: 'daily',
+                interval: 1,
+                count: 10
+            }
+        }, {
+            now: new Date('2026-07-25T12:00:00Z'),
+            fallbackTimeZone: 'UTC'
+        });
+
+        expect(occurrences.map((occurrence) => occurrence.instanceDate)).toEqual([
+            '2026-04-27',
+            '2026-04-28',
+            '2026-04-29'
+        ]);
+    });
+
+    it('honors daily end-date boundaries when the master predates the feed window', () => {
+        const occurrences = expandRecurringCalendarEvent({
+            id: 'daily-until',
+            type: 'practice',
+            isSeriesMaster: true,
+            date: new Date('2026-04-20T18:00:00Z'),
+            startTime: '18:00',
+            endTime: '19:00',
+            recurrence: {
+                freq: 'daily',
+                interval: 1,
+                until: '2026-04-28'
+            }
+        }, {
+            now: new Date('2026-07-25T12:00:00Z'),
+            fallbackTimeZone: 'UTC'
+        });
+
+        expect(occurrences.map((occurrence) => occurrence.instanceDate)).toEqual([
+            '2026-04-27',
+            '2026-04-28'
+        ]);
+    });
+
+    it('honors multi-week intervals when the master predates the feed window', () => {
+        const occurrences = expandRecurringCalendarEvent({
+            id: 'biweekly',
+            type: 'practice',
+            isSeriesMaster: true,
+            date: new Date('2025-01-06T18:00:00Z'),
+            startTime: '18:00',
+            endTime: '19:00',
+            recurrence: {
+                freq: 'weekly',
+                interval: 2,
+                byDays: ['MO']
+            }
+        }, {
+            now: new Date('2026-07-25T12:00:00Z'),
+            fallbackTimeZone: 'UTC'
+        });
+
+        expect(occurrences.slice(0, 3).map((occurrence) => occurrence.instanceDate)).toEqual([
+            '2026-04-27',
+            '2026-05-11',
+            '2026-05-25'
+        ]);
+        expect(occurrences.some((occurrence) => occurrence.instanceDate === '2026-05-04')).toBe(false);
     });
 
     it('builds feeds from game-level fields without depending on attendee RSVP arrays', () => {


### PR DESCRIPTION
Closes #4206

## What changed
- Load recurring practice masters independently of the 90-day event window.
- Expand active daily and weekly series into bounded calendar occurrences.
- Preserve stable occurrence UIDs, cancellations, overrides, intervals, counts, end dates, and overnight durations.
- Deduplicate masters already returned by the normal date query.

## Root Cause
The private feed queried only records whose original date was within the bounded calendar window. Recurring masters older than 90 days were therefore omitted. Masters that were returned were serialized as single events without recurrence expansion.

## Prevention / Learning
Any bounded event query must separately include persisted recurrence masters and materialize them within the requested output window. Regression coverage must include an unbounded series whose master predates the query lookback, plus cancellation and override behavior.

## Regression Tests
- `tests/unit/calendar-feed-window.test.js` verifies recurring masters are queried independently of their original date.
- `tests/unit/team-calendar-feed.test.js` verifies old weekly masters emit bounded future occurrences with stable UIDs, cancellations, overrides, and cross-UTC-day timing.
- Focused Vitest suite: 13 tests passed.
- Node syntax checks passed for all affected function files.