### PR TITLE
Ignore untracked Resend webhook events

### DIFF
--- a/functions/resend-auth-email-delivery.cjs
+++ b/functions/resend-auth-email-delivery.cjs
@@ -96,6 +96,17 @@ function normalizeResendResult(result) {
   return providerMessageId;
 }
 
+function getResendEventTag(tags, name) {
+  if (Array.isArray(tags)) {
+    const tag = tags.find((entry) => String(entry?.name || '').trim() === name);
+    return String(tag?.value || '').trim();
+  }
+  if (tags && typeof tags === 'object') {
+    return String(tags[name] || '').trim();
+  }
+  return '';
+}
+
 function createResendAuthEmailDelivery({
   firestore,
   FieldValue,
@@ -297,6 +308,15 @@ function createResendAuthEmailDelivery({
 
     const deliveryId = await findDeliveryId(providerMessageId);
     if (!deliveryId) {
+      const category = getResendEventTag(event?.data?.tags, 'category').toLowerCase();
+      if (category !== 'auth') {
+        await webhookRef.set({
+          status: 'ignored',
+          ignoreReason: 'untracked_email',
+          updatedAt: FieldValue.serverTimestamp()
+        }, { merge: true });
+        return { ignored: true };
+      }
       await webhookRef.set({ status: 'pending_mapping', updatedAt: FieldValue.serverTimestamp() }, { merge: true });
       logger.warn('Resend webhook did not match an ALL PLAYS authentication delivery.', {
         eventType,

--- a/functions/test/auth-email-resend-delivery.test.cjs
+++ b/functions/test/auth-email-resend-delivery.test.cjs
@@ -307,7 +307,14 @@ test('an unmatched webhook returns 503 so Resend retries after the provider mapp
   const event = {
     type: 'email.bounced',
     created_at: '2026-07-17T12:00:01.000Z',
-    data: { email_id: 'resend-message-1' }
+    data: {
+      email_id: 'resend-message-1',
+      tags: {
+        category: 'auth',
+        auth_type: 'password_reset',
+        delivery_id: 'eventually-mapped'
+      }
+    }
   };
   const harness = createHarness({ verifiedEvent: event });
   const request = {
@@ -332,6 +339,33 @@ test('an unmatched webhook returns 503 so Resend retries after the provider mapp
   assert.equal(retryResponse.statusCode, 200);
   assert.equal(harness.db.get('authEmailDeliveries/eventually-mapped').fallbackState, 'sent');
   assert.equal(harness.db.get('resendWebhookEvents/early-webhook').status, 'processed');
+});
+
+test('an unmatched untagged SMTP webhook is acknowledged and ignored', async () => {
+  const harness = createHarness({
+    verifiedEvent: {
+      type: 'email.delivered',
+      created_at: '2026-07-17T12:00:01.000Z',
+      data: { email_id: 'smtp-invitation-message' }
+    }
+  });
+  const response = createResponse();
+
+  await harness.service.handleWebhook({
+    method: 'POST',
+    rawBody: Buffer.from('{"event":"smtp"}'),
+    headers: {
+      'svix-id': 'smtp-webhook',
+      'svix-timestamp': 'timestamp',
+      'svix-signature': 'signature'
+    }
+  }, response);
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(harness.db.get('resendWebhookEvents/smtp-webhook').status, 'ignored');
+  assert.equal(harness.db.get('resendWebhookEvents/smtp-webhook').ignoreReason, 'untracked_email');
+  assert.equal(harness.warnings.length, 0);
+  assert.equal(harness.errors.length, 0);
 });
 
 test('invalid webhook signature is rejected without changing delivery state', async () => {


### PR DESCRIPTION
## What changed

- Treat verified Resend events without the AllPlays `category=auth` tag as untracked mail.
- Record those events as `ignored` with `ignoreReason: untracked_email` and acknowledge them with HTTP 200.
- Preserve HTTP 503 retries for tagged authentication events that arrive before their provider-message mapping commits.
- Add regression coverage for ordinary Firebase Trigger Email / Resend SMTP traffic.

## Root cause

The account-wide Resend webhook receives events for both tracked authentication mail and ordinary SMTP mail. The handler previously returned HTTP 503 for every event without an `authEmailDeliveries` mapping, so normal invitation emails were retried until Resend disabled the endpoint.

## Impact

Ordinary SMTP delivery events no longer poison the authentication-mail webhook. Authentication delivery tracking, bounce alerts, and password-reset fallback behavior remain intact.

## Validation

- `node --test test/auth-email-resend-delivery.test.cjs` (16 passed)
- `npm test` in `functions/` (305 passed)
- `npx vitest run tests/unit/auth-email-resend-routing.test.js --reporter=verbose` (7 passed)
- Deployed only `resendEmailWebhook` to `game-flow-c6311`
- Controlled production SMTP test reported Firestore delivery `SUCCESS`, Resend `delivered`, and four webhook events stored as `ignored/untracked_email` without retries
