### PR TITLE
Reduce scheduled production smoke cadence

### DIFF
--- a/.github/workflows/scheduled-prod-smoke.yml
+++ b/.github/workflows/scheduled-prod-smoke.yml
@@ -2,7 +2,7 @@ name: scheduled-prod-smoke
 
 on:
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '23 */6 * * *'
   workflow_dispatch:
 
 permissions:

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -316,6 +316,11 @@ describe('preview deployment workflow trust boundary', () => {
         expect(scheduledProdSmokeWorkflow).toContain('ref: master');
     });
 
+    it('limits scheduled production browser smoke to four runs per day', () => {
+        expect(scheduledProdSmokeWorkflow).toContain("cron: '23 */6 * * *'");
+        expect(scheduledProdSmokeWorkflow).not.toContain("cron: '*/15 * * * *'");
+    });
+
     it('documents the keyless credential and exact-head operational contract', () => {
         expect(trustBoundaryRunbook).toContain('must remain absent');
         expect(trustBoundaryRunbook).toContain('firebase-preview-trusted');


### PR DESCRIPTION
## Summary

- Run the scheduled production Playwright smoke every six hours instead of every 15 minutes.
- Keep manual dispatch and post-deployment smoke coverage unchanged.
- Add a regression assertion that locks the reduced cadence.

## Why

The full production browser suite was running 96 times per day and generating most of the project's reCAPTCHA Enterprise App Check assessments. Normal traffic is below the free monthly assessment tier; reducing redundant scheduled browser runs should keep usage below that tier while retaining immediate post-deploy coverage.

## Impact

- Scheduled browser runs decrease from approximately 2,880 to 120 per month.
- Scheduled execution occurs at 00:23, 06:23, 12:23, and 18:23 UTC.
- No application, Firebase App Check, enforcement, token TTL, or public API behavior changes.

## Validation

- `npx vitest run tests/unit/preview-deploy-trust-boundary.test.js --reporter=verbose` — 21/21 passed.
- `npm test -- --reporter=dot` — 691 test files passed; 4,945 tests passed; 114 skipped.
- Workflow YAML parsed successfully with the expected cron.
- `git diff --check` passed.
- GitHub Actions hardening review found no issues across trigger trust, permissions, action pinning, secret handling, checkout credentials, or interpolation sinks.

## Manual testing

- Not applicable; this is a scheduled workflow cadence-only change.