### PR TITLE
Disable candidate production deployment

### DIFF
--- a/.github/workflows/deploy-candidate-host.yml
+++ b/.github/workflows/deploy-candidate-host.yml
@@ -3,19 +3,24 @@ name: deploy-candidate-host
 on:
   workflow_dispatch:
 
+permissions: {}
+
 concurrency:
-  group: candidate-host-deploy
+  group: candidate-host-validation
   cancel-in-progress: true
 
 jobs:
-  prepare-candidate-artifact:
+  validate-candidate-bundle:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
 
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
@@ -32,119 +37,37 @@ jobs:
       - name: Build React app
         run: npm run app:build
 
-      - name: Stage root site and React app
+      - name: Stage and validate production-equivalent candidate bundle
         env:
           ALLPLAYS_APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY: ${{ vars.APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY }}
           ALLPLAYS_APP_CHECK_ENFORCEMENT_READY: ${{ vars.APP_CHECK_ENFORCEMENT_READY }}
         run: |
           set -euo pipefail
-          bundle="$RUNNER_TEMP/firebase-candidate-ready"
+          bundle="$RUNNER_TEMP/firebase-candidate-validation"
+          config="$bundle/firebase-candidate.generated.json"
           node scripts/stage-pages-bundle.mjs "$bundle/site"
-          node scripts/write-firebase-hosting-config.mjs "$bundle/site" "$bundle/firebase-candidate.generated.json"
+          node scripts/write-firebase-hosting-config.mjs "$bundle/site" "$config"
           jq '
             .hosting.public = "site"
-            | .hosting.site = "game-flow-c6311"
-            | del(.functions, .firestore, .storage)
-          ' "$bundle/firebase-candidate.generated.json" > "$bundle/firebase-candidate.generated.json.tmp"
-          mv "$bundle/firebase-candidate.generated.json.tmp" "$bundle/firebase-candidate.generated.json"
-          printf '%s\n' "$GITHUB_SHA" > "$bundle/head-sha"
-
-      - name: Install isolated Firebase Hosting deploy CLI without OIDC or lifecycle scripts
-        run: |
-          set -euo pipefail
-          bundle="$RUNNER_TEMP/firebase-candidate-ready"
-          npm install \
-            --prefix "$bundle/firebase-cli" \
-            --ignore-scripts \
-            --no-audit \
-            --no-fund \
-            --package-lock=false \
-            firebase-tools@15.24.0
-          node "$bundle/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js" --version
-
-      - name: Upload trusted candidate deploy handoff
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: firebase-candidate-trusted-ready
-          path: ${{ runner.temp }}/firebase-candidate-ready
-          if-no-files-found: error
-          include-hidden-files: true
-          retention-days: 7
-
-  deploy-candidate:
-    needs: prepare-candidate-artifact
-    runs-on: ubuntu-latest
-    environment: candidate-host
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-
-    steps:
-      - name: Download trusted candidate deploy handoff
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: firebase-candidate-trusted-ready
-          path: ${{ runner.temp }}/firebase-candidate-ready
-
-      - name: Validate candidate target and artifact before OIDC
-        run: |
-          set -euo pipefail
-          bundle="$RUNNER_TEMP/firebase-candidate-ready"
-          grep -Fxq "$GITHUB_SHA" "$bundle/head-sha"
+            | del(.hosting.site, .functions, .firestore, .storage)
+          ' "$config" > "$config.tmp"
+          mv "$config.tmp" "$config"
           test -f "$bundle/site/index.html"
           test -f "$bundle/site/app/index.html"
-          test -f "$bundle/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js"
           jq -e '
             .hosting.public == "site"
-            and .hosting.site == "game-flow-c6311"
+            and (.hosting | has("site") | not)
             and (has("functions") | not)
             and (has("firestore") | not)
             and (has("storage") | not)
-          ' "$bundle/firebase-candidate.generated.json" >/dev/null
+          ' "$config" >/dev/null
 
-      - name: Authenticate candidate Hosting deploy through OIDC
-        id: google_auth_candidate
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
-        with:
-          workload_identity_provider: ${{ vars.FIREBASE_DEPLOY_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.FIREBASE_DEPLOY_SERVICE_ACCOUNT }}
-          project_id: game-flow-c6311
-          create_credentials_file: true
-          cleanup_credentials: true
-
-      - name: Deploy candidate Firebase Hosting site
-        timeout-minutes: 4
+      - name: Report deployment boundary
         run: |
-          set -euo pipefail
-          bundle="$RUNNER_TEMP/firebase-candidate-ready"
-          node "$bundle/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js" \
-            deploy \
-            --only hosting \
-            --project game-flow-c6311 \
-            --config "$bundle/firebase-candidate.generated.json" \
-            --non-interactive
-
-  smoke-candidate:
-    needs: deploy-candidate
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    env:
-      CANDIDATE_HOST_URL: https://game-flow-c6311.web.app
-      ALLPLAYS_APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY: ${{ vars.APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-
-      - name: Setup Node
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
-        with:
-          node-version: 22
-
-      - name: Smoke candidate host
-        run: |
-          set -euo pipefail
-          echo "Testing candidate origin: $CANDIDATE_HOST_URL"
-          npm run smoke:candidate-host -- "$CANDIDATE_HOST_URL"
+          {
+            echo "### Candidate bundle validation"
+            echo
+            echo "The production-equivalent candidate bundle built and validated successfully."
+            echo
+            echo "Deployment is intentionally disabled until an isolated integration Firebase project is available."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/hosting-cutover-runbook.md
+++ b/docs/hosting-cutover-runbook.md
@@ -4,6 +4,12 @@ This runbook gates a future move of `allplays.ai` and `www.allplays.ai` from
 GitHub Pages to the Firebase Hosting candidate at
 `https://game-flow-c6311.web.app`. It does not authorize or execute that change.
 
+The candidate origin currently uses the production Firebase project and is
+therefore refreshed only by the protected production deployment. The
+`deploy-candidate-host` workflow validates a production-equivalent bundle but
+cannot authenticate or deploy. Independent candidate deployments remain
+disabled until an isolated integration Firebase project is provisioned.
+
 The rollback target is the last known-good GitHub Pages deployment serving the
 canonical domains immediately before cutover. The GitHub Pages origin is
 `pauljsnider.github.io`. The exact pre-cutover DNS provider export is the

--- a/tests/unit/candidate-host-deploy-workflow.test.js
+++ b/tests/unit/candidate-host-deploy-workflow.test.js
@@ -7,66 +7,47 @@ const workflowPath = '.github/workflows/deploy-candidate-host.yml';
 const workflowSource = readFileSync(resolve(process.cwd(), workflowPath), 'utf8');
 const workflow = parseYaml(workflowSource);
 
-describe('candidate-host deployment workflow', () => {
-    it('is manually gated and targets only the fixed candidate Hosting site', () => {
+describe('candidate-host validation workflow', () => {
+    it('is manually gated, deny-by-default, and contains one read-only job', () => {
         expect(workflow.on).toHaveProperty('workflow_dispatch');
         expect(workflow.on).not.toHaveProperty('push');
+        expect(workflow.permissions).toEqual({});
+        expect(Object.keys(workflow.jobs)).toEqual(['validate-candidate-bundle']);
 
-        const deployJob = workflow.jobs['deploy-candidate'];
-        expect(deployJob.environment).toBe('candidate-host');
-        expect(workflowSource).toContain('.hosting.site = "game-flow-c6311"');
-        expect(workflowSource).toContain('--project game-flow-c6311');
-        expect(workflowSource).toContain('--only hosting');
+        const validationJob = workflow.jobs['validate-candidate-bundle'];
+        expect(validationJob.permissions).toEqual({ contents: 'read' });
+        expect(validationJob.permissions?.['id-token']).toBeUndefined();
+        expect(validationJob['timeout-minutes']).toBe(15);
+    });
+
+    it('builds and validates a production-equivalent credential-free bundle', () => {
+        const validationJob = workflow.jobs['validate-candidate-bundle'];
+        const validationText = JSON.stringify(validationJob);
+
+        expect(validationText).toContain('npm run app:build');
+        expect(validationText).toContain('scripts/stage-pages-bundle.mjs');
+        expect(validationText).toContain('scripts/write-firebase-hosting-config.mjs');
+        expect(validationText).toContain('$bundle/site/index.html');
+        expect(validationText).toContain('$bundle/site/app/index.html');
+        expect(validationText).toContain('del(.hosting.site, .functions, .firestore, .storage)');
+        expect(validationText).toContain('persist-credentials');
+    });
+
+    it('cannot authenticate, publish an artifact handoff, or deploy', () => {
+        expect(workflowSource).not.toContain('id-token: write');
+        expect(workflowSource).not.toContain('google-github-actions/auth');
+        expect(workflowSource).not.toContain('firebase-tools@');
+        expect(workflowSource).not.toContain('actions/upload-artifact');
+        expect(workflowSource).not.toContain('actions/download-artifact');
+        expect(workflowSource).not.toMatch(/\bhosting:channel:deploy\b/);
+        expect(workflowSource).not.toMatch(/\bdeploy\s+--only\b/);
+        expect(workflowSource).not.toContain('game-flow-c6311');
         expect(workflowSource).not.toContain('allplays.ai');
-        expect(workflowSource).not.toMatch(/\b(dns|domain:|functions|firestore|storage)\s+deploy\b/i);
     });
 
-    it('prepares executable tooling outside the OIDC-capable deploy job', () => {
-        const prepareJob = workflow.jobs['prepare-candidate-artifact'];
-        const deployJob = workflow.jobs['deploy-candidate'];
-        const prepareText = JSON.stringify(prepareJob);
-        const deployText = JSON.stringify(deployJob);
-
-        expect(prepareText).toContain('npm run app:build');
-        expect(prepareText).toContain('scripts/stage-pages-bundle.mjs');
-        expect(prepareText).toContain('scripts/write-firebase-hosting-config.mjs');
-        expect(deployText).toContain('$bundle/site/index.html');
-        expect(deployText).toContain('$bundle/site/app/index.html');
-        expect(prepareText).toContain('firebase-tools@15.24.0');
-        expect(prepareText).toContain('$bundle/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js');
-        expect(deployText).not.toMatch(/npm (?:ci|install)/);
-        expect(deployText).toContain('$bundle/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js');
-        expect(prepareJob.permissions?.['id-token']).toBeUndefined();
-        expect(deployJob.permissions?.['id-token']).toBe('write');
-        expect(deployText).not.toMatch(/stage-pages-bundle|write-firebase-hosting-config/);
-    });
-
-    it('validates the explicit Hosting-only handoff before authentication', () => {
-        const validation = workflowSource.indexOf('name: Validate candidate target and artifact before OIDC');
-        const authentication = workflowSource.indexOf('name: Authenticate candidate Hosting deploy through OIDC');
-        const deployment = workflowSource.indexOf('name: Deploy candidate Firebase Hosting site');
-
-        expect(validation).toBeGreaterThan(-1);
-        expect(authentication).toBeGreaterThan(validation);
-        expect(deployment).toBeGreaterThan(authentication);
-        expect(workflowSource.slice(validation, authentication)).toContain('.hosting.site == "game-flow-c6311"');
-        expect(workflowSource.slice(validation, authentication)).toContain('has("functions") | not');
-        expect(workflowSource.slice(validation, authentication)).toContain('has("firestore") | not');
-        expect(workflowSource.slice(validation, authentication)).toContain('has("storage") | not');
-        expect(workflowSource).not.toMatch(/credentials_json\s*:/i);
-    });
-
-    it('smokes and reports the candidate origin only after deployment succeeds', () => {
-        const smokeJob = workflow.jobs['smoke-candidate'];
-        const smokeText = JSON.stringify(smokeJob);
-
-        expect(smokeJob.needs).toBe('deploy-candidate');
-        expect(smokeJob.permissions).toEqual({ contents: 'read' });
-        expect(smokeJob.permissions?.['id-token']).toBeUndefined();
-        expect(smokeJob.env.CANDIDATE_HOST_URL).toBe('https://game-flow-c6311.web.app');
-        expect(smokeJob.env.ALLPLAYS_APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY)
-            .toBe('${{ vars.APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY }}');
-        expect(smokeText).toContain('echo \\"Testing candidate origin: $CANDIDATE_HOST_URL\\"');
-        expect(smokeText).toContain('npm run smoke:candidate-host -- \\"$CANDIDATE_HOST_URL\\"');
+    it('reports why deployment is disabled', () => {
+        expect(workflowSource).toContain(
+            'Deployment is intentionally disabled until an isolated integration Firebase project is available.'
+        );
     });
 });

--- a/tests/unit/firebase-deploy-workload-identity.test.js
+++ b/tests/unit/firebase-deploy-workload-identity.test.js
@@ -32,7 +32,7 @@ function expectPinnedActions(workflow) {
 
 describe('Firebase deploy Workload Identity boundary', () => {
     it('uses only pinned keyless authentication in all credentialed deployers', () => {
-        for (const workflow of [production, preview, candidate]) {
+        for (const workflow of [production, preview]) {
             expectPinnedActions(workflow);
             expect(workflow).toContain('id-token: write');
             expect(workflow).toMatch(/google-github-actions\/auth@[0-9a-f]{40}/);
@@ -47,7 +47,9 @@ describe('Firebase deploy Workload Identity boundary', () => {
         }
         expect(production.match(/google-github-actions\/auth@[0-9a-f]{40}/g)).toHaveLength(2);
         expect(preview.match(/google-github-actions\/auth@[0-9a-f]{40}/g)).toHaveLength(1);
-        expect(candidate.match(/google-github-actions\/auth@[0-9a-f]{40}/g)).toHaveLength(1);
+        expect(candidate).not.toContain('google-github-actions/auth');
+        expect(candidate).not.toContain('id-token: write');
+        expect(candidate).not.toContain('project_id: game-flow-c6311');
     });
 
     it('keeps raw preview input and dependency preparation in a separate no-OIDC job', () => {
@@ -125,18 +127,14 @@ describe('Firebase deploy Workload Identity boundary', () => {
         expect(production).not.toContain('cp -R functions "$FIREBASE_PRODUCTION_BUNDLE/functions"');
     });
 
-    it('keeps candidate build and dependency work outside the minimal OIDC deploy job', () => {
-        const install = candidate.indexOf('firebase-tools@15.24.0');
-        const handoff = candidate.indexOf('name: Upload trusted candidate deploy handoff');
-        const authentication = candidate.indexOf('name: Authenticate candidate Hosting deploy through OIDC');
-
-        expect(install).toBeGreaterThan(-1);
-        expect(handoff).toBeGreaterThan(install);
-        expect(authentication).toBeGreaterThan(handoff);
+    it('keeps candidate validation outside every credential boundary', () => {
         const oidcJobs = workflowJobs(candidate).filter((job) => job.permissions?.['id-token'] === 'write');
-        expect(oidcJobs).toHaveLength(1);
-        expect(JSON.stringify(oidcJobs[0])).not.toMatch(/npm (?:ci|install)|stage-pages-bundle|write-firebase-hosting-config/);
-        expect(JSON.stringify(oidcJobs[0])).toMatch(/actions\/download-artifact@[0-9a-f]{40}/);
+        expect(oidcJobs).toHaveLength(0);
+        expect(candidate).toContain('npm run app:build');
+        expect(candidate).toContain('scripts/stage-pages-bundle.mjs');
+        expect(candidate).toContain('scripts/write-firebase-hosting-config.mjs');
+        expect(candidate).not.toContain('firebase-tools@');
+        expect(candidate).not.toContain('actions/upload-artifact');
     });
 
     it('keeps rule-changing releases rules-first and skips unchanged rule writes', () => {

--- a/tests/unit/firebase-live-deploy-policy.test.js
+++ b/tests/unit/firebase-live-deploy-policy.test.js
@@ -1,0 +1,58 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { parse as parseYaml } from 'yaml';
+
+const workflowDirectory = resolve(process.cwd(), '.github/workflows');
+const workflowNames = readdirSync(workflowDirectory)
+    .filter((name) => name.endsWith('.yml') || name.endsWith('.yaml'))
+    .sort();
+
+function readWorkflow(name) {
+    const source = readFileSync(join(workflowDirectory, name), 'utf8');
+    return { name, source, workflow: parseYaml(source) };
+}
+
+function runScripts(workflow) {
+    return Object.values(workflow.jobs ?? {})
+        .flatMap((job) => job.steps ?? [])
+        .map((step) => step.run)
+        .filter((run) => typeof run === 'string');
+}
+
+const firebaseLiveDeploy = /(?:\bnode\s+"?\$[^"\n]*firebase[^"\n]*"?|\bnpx\s+firebase|\bfirebase)\s+deploy\b/;
+const firebasePreviewDeploy = /(?:\bnode\s+"?\$[^"\n]*firebase[^"\n]*"?|\bnpx\s+firebase|\bfirebase)\s+hosting:channel:deploy\b/;
+
+describe('Firebase deployment workflow policy', () => {
+    it('allows live-channel Firebase deploy commands only in deploy-prod.yml', () => {
+        const liveDeployers = workflowNames
+            .map(readWorkflow)
+            .filter(({ workflow }) => runScripts(workflow).some((run) => firebaseLiveDeploy.test(run)))
+            .map(({ name }) => name);
+
+        expect(liveDeployers).toEqual(['deploy-prod.yml']);
+    });
+
+    it('allows preview-channel deploy commands only in deploy-preview-trusted.yml', () => {
+        const previewDeployers = workflowNames
+            .map(readWorkflow)
+            .filter(({ workflow }) => runScripts(workflow).some((run) => firebasePreviewDeploy.test(run)))
+            .map(({ name }) => name);
+
+        expect(previewDeployers).toEqual(['deploy-preview-trusted.yml']);
+    });
+
+    it('keeps the candidate workflow credential-free and validation-only', () => {
+        const candidate = readWorkflow('deploy-candidate-host.yml');
+
+        expect(candidate.workflow.permissions).toEqual({});
+        expect(candidate.source).not.toContain('id-token: write');
+        expect(candidate.source).not.toContain('google-github-actions/auth');
+        expect(candidate.source).not.toContain('game-flow-c6311');
+        expect(candidate.source).not.toContain('firebase-tools@');
+        for (const run of runScripts(candidate.workflow)) {
+            expect(run).not.toMatch(firebaseLiveDeploy);
+            expect(run).not.toMatch(firebasePreviewDeploy);
+        }
+    });
+});


### PR DESCRIPTION
## What changed
- converted the manual candidate-host workflow into a single read-only bundle-validation job
- removed production OIDC, Firebase CLI installation, artifact handoff, live deployment, and production-target references
- added a repository policy test that permits live Firebase deploys only in `deploy-prod.yml` and preview-channel deploys only in `deploy-preview-trusted.yml`
- documented that independent candidate deployment remains disabled until an isolated integration project exists

## Why
The candidate workflow targeted the production Firebase project and live Hosting channel. Candidate validation must not have production deployment authority.

## Validation
- `npx vitest run tests/unit/candidate-host-deploy-workflow.test.js tests/unit/firebase-live-deploy-policy.test.js tests/unit/firebase-deploy-workload-identity.test.js tests/unit/hosting-cutover-runbook.test.js --reporter=verbose` (17 passed)
- `npm run app:build`
- exact local stage/config validation from the workflow, including removal of site/functions/firestore/storage targets
- `git diff --check`

## Security boundary
The workflow now has top-level `permissions: {}`, one `contents: read` job, pinned actions, no persisted checkout credential, no OIDC, no Firebase deploy tooling, and no artifact handoff.