### PR TITLE
Serialize production release publishing

### DIFF
--- a/.github/workflows/app-github-pages.yml
+++ b/.github/workflows/app-github-pages.yml
@@ -2,16 +2,9 @@ name: app-github-pages
 
 on:
   pull_request:
-  push:
-    branches:
-      - master
   workflow_dispatch:
-    inputs:
-      deploy:
-        description: "Deploy the staged site to GitHub Pages. Requires Pages source to be GitHub Actions."
-        required: false
-        type: boolean
-        default: false
+
+permissions: {}
 
 concurrency:
   group: app-github-pages-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
@@ -25,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: npm
@@ -52,45 +45,9 @@ jobs:
         run: node scripts/stage-pages-bundle.mjs "$RUNNER_TEMP/allplays-pages"
 
       - name: Upload app Pages bundle artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: allplays-pages-with-app
           path: ${{ runner.temp }}/allplays-pages
           include-hidden-files: true
           retention-days: 7
-
-  deploy:
-    if: (github.event_name == 'push' && vars.APP_GITHUB_PAGES_DEPLOY_ENABLED == 'true') || (github.event_name == 'workflow_dispatch' && inputs.deploy)
-    needs: build-pages-bundle
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
-      - name: Checkout deployment verifier
-        uses: actions/checkout@v5
-
-      - name: Download staged Pages bundle
-        uses: actions/download-artifact@v4
-        with:
-          name: allplays-pages-with-app
-          path: ${{ runner.temp }}/allplays-pages
-
-      - name: Verify staged Pages deployment artifact
-        env:
-          ALLPLAYS_APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY: ${{ vars.APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY }}
-        run: node scripts/verify-pages-deploy-artifact.mjs "$RUNNER_TEMP/allplays-pages"
-
-      - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ${{ runner.temp }}/allplays-pages
-
-      - name: Deploy GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - master
 
+permissions: {}
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -16,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 2
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
 
@@ -36,16 +38,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: npm
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           distribution: temurin
           java-version: 21
@@ -96,12 +98,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,15 @@ concurrency:
 jobs:
   cache-bust-guard:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
@@ -35,10 +38,14 @@ jobs:
 
   unit-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
@@ -95,12 +102,15 @@ jobs:
 
   app-quality:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -809,14 +809,23 @@ jobs:
 
       - name: Validate Pages handoff identity
         env:
+          EXPECTED_APP_CHECK_SITE_KEY: ${{ vars.APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY }}
           PREPARED_HEAD_SHA: ${{ needs.prepare-deploy.outputs.head_sha }}
         run: |
           set -euo pipefail
           bundle="$RUNNER_TEMP/firebase-production-ready"
+          runtime_config="$bundle/site/.well-known/allplays-runtime-config.json"
           [[ "$PREPARED_HEAD_SHA" == "$GITHUB_SHA" ]]
           grep -Fxq "$GITHUB_SHA" "$bundle/head-sha"
           test -f "$bundle/site/index.html"
           test -f "$bundle/site/app/index.html"
+          test -f "$bundle/site/.nojekyll"
+          [[ "$EXPECTED_APP_CHECK_SITE_KEY" =~ ^[A-Za-z0-9_-]{10,200}$ ]]
+          jq -e \
+            --arg expected_site_key "$EXPECTED_APP_CHECK_SITE_KEY" \
+            '.appCheck.enabled == true and
+             .appCheck.recaptchaEnterpriseSiteKey == $expected_site_key' \
+            "$runtime_config" >/dev/null
 
       - name: Upload exact-SHA Pages artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -6,13 +6,17 @@ on:
       - master
   workflow_dispatch:
 
+permissions: {}
+
 concurrency:
   group: production-deploy-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
@@ -47,6 +51,8 @@ jobs:
 
   regression-guards:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
@@ -570,6 +576,64 @@ jobs:
             done
           }
 
+          test_firestore_rules_api() {
+            local max_attempts="${1:-2}"
+            local base_delay_seconds="${2:-20}"
+            local attempt request_file response_file curl_status http_status retry_delay_seconds
+            request_file="$RUNNER_TEMP/firestore-rules-preflight-request.json"
+            jq -n \
+              --rawfile content "$FIREBASE_PRODUCTION_BUNDLE/firestore.rules" \
+              '{
+                source:{
+                  files:[{
+                    name:"firestore.rules",
+                    content:$content
+                  }]
+                },
+                testSuite:{testCases:[]}
+              }' >"$request_file"
+
+            for ((attempt = 1; attempt <= max_attempts; attempt += 1)); do
+              response_file="$RUNNER_TEMP/firestore-rules-preflight-attempt-${attempt}.json"
+              set +e
+              http_status="$(
+                curl --silent --show-error \
+                  --connect-timeout 10 \
+                  --max-time 60 \
+                  --output "$response_file" \
+                  --write-out '%{http_code}' \
+                  --request POST \
+                  --header "Authorization: Bearer ${GOOGLE_OAUTH_ACCESS_TOKEN}" \
+                  --header "Content-Type: application/json" \
+                  --data-binary "@${request_file}" \
+                  "https://firebaserules.googleapis.com/v1/projects/game-flow-c6311:test"
+              )"
+              curl_status="$?"
+              set -e
+
+              if (( curl_status == 0 )) \
+                && [[ "$http_status" =~ ^2[0-9][0-9]$ ]] \
+                && ! jq -e 'any(.issues[]?; .severity == "ERROR")' "$response_file" >/dev/null; then
+                echo "::notice::The non-persistent Firestore Rules API preflight passed on attempt ${attempt}/${max_attempts}."
+                return 0
+              fi
+
+              if (( curl_status == 0 )) \
+                && [[ ! "$http_status" =~ ^(408|409|429|500|502|503|504)$ ]]; then
+                echo "Firestore Rules API preflight failed with non-transient HTTP ${http_status}." >&2
+                return 1
+              fi
+              if (( attempt == max_attempts )); then
+                echo "Firestore Rules API health preflight did not recover after ${max_attempts} bounded attempts; no persistent Firestore, Functions, or Hosting mutation was attempted." >&2
+                return 1
+              fi
+
+              retry_delay_seconds=$((base_delay_seconds * attempt))
+              echo "Transient Firestore Rules API preflight failure (curl=${curl_status}, HTTP=${http_status}); retrying in ${retry_delay_seconds}s." >&2
+              sleep "$retry_delay_seconds"
+            done
+          }
+
           record_component_deployment() {
             local component_environment="$1"
             local component_description="$2"
@@ -627,7 +691,12 @@ jobs:
           if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then
             # Keep coupled authorization/index changes fail-closed: application code
             # must not publish until its Firestore configuration is active.
-            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30
+            # Probe the non-persistent projects:test endpoint first. A known
+            # Rules API outage opens the circuit before any ruleset/release
+            # mutation. The actual deploy gets one attempt, keeping the total
+            # projects:test calls bounded to at most three per release run.
+            test_firestore_rules_api 2 20
+            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 1 0
           else
             # No authorization/index drift exists relative to the last successful
             # production deployment. Do not make a redundant Rules API write: an
@@ -658,6 +727,51 @@ jobs:
             node "$FIREBASE_PRODUCTION_BUNDLE/_migration/backfill-admin-user-search-index.mjs" --apply
           fi
 
+      - name: Record Firebase component deployment markers
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          record_component() {
+            local environment="$1"
+            local description="$2"
+            local deployment_id
+            deployment_id="$(
+              jq -n \
+                --arg ref "$GITHUB_SHA" \
+                --arg environment "$environment" \
+                '{
+                  ref:$ref,
+                  environment:$environment,
+                  auto_merge:false,
+                  required_contexts:[],
+                  transient_environment:false,
+                  production_environment:true,
+                  description:"Release-train component marker"
+                }' \
+                | gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments" --input - --jq '.id'
+            )"
+            jq -n \
+              --arg description "$description" \
+              --arg environment "$environment" \
+              --arg log_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+              '{
+                state:"success",
+                description:$description,
+                environment:$environment,
+                log_url:$log_url,
+                auto_inactive:true
+              }' \
+              | gh api --method POST \
+                "repos/${GITHUB_REPOSITORY}/deployments/${deployment_id}/statuses" \
+                --input - \
+                --jq '.state' \
+                | grep -Fxq success
+          }
+          record_component production-storage "Storage authorization is current at ${GITHUB_SHA}."
+          record_component production-functions "Firebase Functions are current at ${GITHUB_SHA}."
+          record_component production-firebase-hosting "Firebase Hosting is current at ${GITHUB_SHA}."
+
       - name: Remove production deploy credential
         if: always()
         env:
@@ -672,3 +786,88 @@ jobs:
             echo "GOOGLE_APPLICATION_CREDENTIALS="
             echo "GOOGLE_GHA_CREDS_PATH="
           } >> "$GITHUB_ENV"
+
+  deploy-pages:
+    if: vars.RELEASE_GITHUB_PAGES_DEPLOY_ENABLED == 'true'
+    needs: [prepare-deploy, deploy]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      pages: write
+    environment:
+      name: github-pages
+      url: ${{ steps.pages.outputs.page_url }}
+
+    steps:
+      - name: Download exact-SHA production handoff
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: firebase-production-trusted-ready
+          path: ${{ runner.temp }}/firebase-production-ready
+
+      - name: Validate Pages handoff identity
+        env:
+          PREPARED_HEAD_SHA: ${{ needs.prepare-deploy.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          bundle="$RUNNER_TEMP/firebase-production-ready"
+          [[ "$PREPARED_HEAD_SHA" == "$GITHUB_SHA" ]]
+          grep -Fxq "$GITHUB_SHA" "$bundle/head-sha"
+          test -f "$bundle/site/index.html"
+          test -f "$bundle/site/app/index.html"
+
+      - name: Upload exact-SHA Pages artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        with:
+          path: ${{ runner.temp }}/firebase-production-ready/site
+
+      - name: Deploy exact-SHA Pages artifact
+        id: pages
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+
+  release-marker:
+    if: >-
+      always() &&
+      needs.deploy.result == 'success' &&
+      (needs.deploy-pages.result == 'success' || needs.deploy-pages.result == 'skipped')
+    needs: [deploy, deploy-pages]
+    runs-on: ubuntu-latest
+    permissions:
+      deployments: write
+
+    steps:
+      - name: Record complete release marker
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          deployment_id="$(
+            jq -n \
+              --arg ref "$GITHUB_SHA" \
+              '{
+                ref:$ref,
+                environment:"production-release",
+                auto_merge:false,
+                required_contexts:[],
+                transient_environment:false,
+                production_environment:true,
+                description:"Complete serialized production release"
+              }' \
+              | gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments" --input - --jq '.id'
+          )"
+          jq -n \
+            --arg log_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            '{
+              state:"success",
+              description:"All enabled production components reached the exact release SHA.",
+              environment:"production-release",
+              log_url:$log_url,
+              auto_inactive:true
+            }' \
+            | gh api --method POST \
+              "repos/${GITHUB_REPOSITORY}/deployments/${deployment_id}/statuses" \
+              --input - \
+              --jq '.state' \
+              | grep -Fxq success

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -28,16 +28,16 @@ jobs:
     runs-on: ubuntu-latest
     environment: mobile-release
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: npm
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           distribution: temurin
           java-version: 21
-      - uses: android-actions/setup-android@v3
+      - uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
       - name: Install dependencies
         run: |
           npm ci
@@ -67,7 +67,7 @@ jobs:
           ALLPLAYS_VERSION_NAME: ${{ inputs.version_name }}
         run: npm run mobile:bundle:android
       - name: Upload signed AAB artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: allplays-android-${{ inputs.version_name }}-${{ github.run_number }}
           path: android/app/build/outputs/bundle/release/app-release.aab
@@ -86,8 +86,8 @@ jobs:
     runs-on: macos-15
     environment: mobile-release
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: npm
@@ -162,7 +162,7 @@ jobs:
             -exportPath "$RUNNER_TEMP/ios-export" \
             -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist"
       - name: Upload signed IPA artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: allplays-ios-${{ inputs.version_name }}-${{ github.run_number }}
           path: ${{ runner.temp }}/ios-export/*.ipa

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  deployments: read
 
 concurrency:
   group: post-deploy-smoke-${{ github.event.workflow_run.head_branch }}
@@ -23,6 +24,36 @@ jobs:
       name: production-smoke
 
     steps:
+      - name: Verify complete exact-SHA release marker
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          deployment_ids="$(
+            gh api --method GET "repos/${GITHUB_REPOSITORY}/deployments" \
+              -f environment=production-release \
+              -f sha="$RELEASE_SHA" \
+              -F per_page=20 \
+              --jq '.[].id'
+          )"
+          [[ -n "$deployment_ids" ]]
+          release_current=false
+          while IFS= read -r deployment_id; do
+            [[ "$deployment_id" =~ ^[0-9]+$ ]] || continue
+            state="$(
+              gh api --method GET \
+                "repos/${GITHUB_REPOSITORY}/deployments/${deployment_id}/statuses" \
+                -F per_page=1 \
+                --jq '.[0].state // ""'
+            )"
+            if [[ "$state" == "success" ]]; then
+              release_current=true
+              break
+            fi
+          done <<<"$deployment_ids"
+          [[ "$release_current" == "true" ]]
+
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:

--- a/.github/workflows/regression-guards.yml
+++ b/.github/workflows/regression-guards.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: npm
@@ -38,10 +38,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: npm
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload server log on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: regression-guards-http-log
           path: /tmp/allplays-regression-guards.log

--- a/.github/workflows/update-visual-baselines.yml
+++ b/.github/workflows/update-visual-baselines.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: npm
@@ -59,7 +59,7 @@ jobs:
           SMOKE_SUITE: preview
 
       - name: Upload visual baselines
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: visual-baselines-linux
           path: |

--- a/docs/observability-runbook.md
+++ b/docs/observability-runbook.md
@@ -69,7 +69,7 @@ If the critical workflow monitor is noisy, disable only its schedule while inves
 
 ## Firestore Rules API retry exhaustion
 
-The production workflow makes eight bounded attempts when a transient Firestore configuration deployment fails. If those attempts are exhausted, the job summary identifies the Google API surface, final HTTP error class, attempt count, and surfaces that were not deployed. The summary uses only fixed operational labels and does not copy API response bodies, credentials, tenant identifiers, or application data.
+The serialized production release train allows at most three Firestore Rules API checks per release: up to two non-persistent `projects:test` health probes, followed by one persistent Firestore rules/index deployment attempt only after the probe passes. If the probe or deployment fails, the job summary identifies the Google API surface, final HTTP error class, attempt count, and surfaces that were not deployed. The summary uses only fixed operational labels and does not copy API response bodies, credentials, tenant identifiers, or application data.
 
 Application deployment remains fail-closed. When Rules or indexes differ from the last successful production deployment, Hosting and Functions do not deploy until the combined Firestore configuration command succeeds. The Firebase CLI may apply indexes before a later Rules API failure, so treat the Rules and index state as potentially partial and verify both before retrying. Existing Hosting and Functions production remains active; do not bypass the workflow or deploy application surfaces separately.
 
@@ -77,7 +77,7 @@ Safe manual retry:
 
 1. Confirm the failed run targeted `master` and that its summary reports a transient Google API failure rather than a configuration or authorization error. Check the Firebase deploy log or console to determine whether Rules or indexes were already applied.
 2. Confirm `master` still contains the intended Firestore configuration. If a newer production deployment succeeded, no retry is needed.
-3. In GitHub Actions, open `deploy-prod`, choose **Run workflow**, select `master`, and run it. Manual dispatch is restricted to the current `master` branch and repeats the protected tests, change detection, keyless authentication, bounded retries, and fail-closed ordering.
+3. In GitHub Actions, open `deploy-prod`, choose **Run workflow**, select `master`, and run it. Manual dispatch is restricted to the current `master` branch and repeats the protected tests, change detection, keyless authentication, bounded health probe, exact-SHA Firebase/Pages ordering, and fail-closed release marker.
 4. Confirm the Firestore configuration step succeeds before Hosting and Functions, then confirm the production smoke workflow succeeds.
 
 Do not run a local `firebase deploy`, increase retry limits, expose raw API output in the summary, or bypass the protected production environment. If another bounded run ends with the same external error class, treat it as an ongoing Google service incident and leave production on the last successful configuration.

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -114,7 +114,9 @@ export function validateFirebaseDeployWorkloadIdentity(workflow, label) {
         }
         if (job.steps.some((step) => typeof step?.uses === 'string' &&
             !/^actions\/download-artifact@[0-9a-f]{40}$/.test(step.uses) &&
-            !/^google-github-actions\/auth@/.test(step.uses)
+            !/^google-github-actions\/auth@/.test(step.uses) &&
+            !/^actions\/upload-pages-artifact@[0-9a-f]{40}$/.test(step.uses) &&
+            !/^actions\/deploy-pages@[0-9a-f]{40}$/.test(step.uses)
         )) {
             throw new Error(`${label} credentialed deploy job contains an unapproved action.`);
         }
@@ -262,6 +264,7 @@ export function validateProductionDeployCommand(deployProd) {
         'Production push and manual retry triggers'
     );
     assertIncludes(deployProd, 'group: production-deploy-${{ github.ref }}', 'Production ref-scoped concurrency');
+    assertIncludes(deployProd, 'cancel-in-progress: false', 'Production release serialization without cancellation');
     assertIncludes(deployProd, 'baseline_branch="$GITHUB_REF_NAME"', 'Production push baseline branch');
     assertIncludes(deployProd, 'if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then', 'Production manual retry baseline selection');
     assertIncludes(deployProd, 'if [[ "$GITHUB_REF" != "refs/heads/master" ]]; then', 'Production manual retry master restriction');
@@ -298,7 +301,17 @@ export function validateProductionDeployCommand(deployProd) {
         'Refusing --force outside the reviewed retry-enabled function allowlist.',
         'Production force-deploy allowlist guard'
     );
-    assertIncludes(deployProd, 'retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30', 'Production Firestore deploy targets and bounded extended retry');
+    assertIncludes(deployProd, 'test_firestore_rules_api 2 20', 'Production non-persistent Firestore Rules API health preflight');
+    assertIncludes(
+        deployProd,
+        'https://firebaserules.googleapis.com/v1/projects/game-flow-c6311:test',
+        'Production Firestore projects:test health endpoint'
+    );
+    assertIncludes(
+        deployProd,
+        'retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 1 0',
+        'Production Firestore deploy gets one post-preflight mutation attempt'
+    );
     assertIncludes(deployProd, 'if (( retry_delay_seconds > 120 )); then', 'Production Firebase retry delay cap');
     assertIncludes(deployProd, 'retry_jitter_seconds=$((RANDOM % 16))', 'Production Firebase retry jitter');
     assertIncludes(deployProd, 'HTTP Error:[[:space:]]*409,[[:space:]]*Requested entity already exists', 'Production Firestore release-race retry');

--- a/tests/unit/auth-email-resend-routing.test.js
+++ b/tests/unit/auth-email-resend-routing.test.js
@@ -110,7 +110,7 @@ describe('authentication email delivery routing', () => {
         }
     });
 
-    it('bounds normal deploys to three attempts and gives Firestore an extended retry window', () => {
+    it('bounds normal deploys to three attempts and Firestore to a probe-gated mutation', () => {
         const productionSource = read('.github/workflows/deploy-prod.yml');
         const firebaseDeployCommands = productionSource
             .split('\n')
@@ -139,7 +139,8 @@ describe('authentication email delivery routing', () => {
         expect(productionSource).toContain('if (( attempt == max_attempts )); then');
         expect(productionSource).toContain('retry_delay_seconds=$((base_delay_seconds * (2 ** (attempt - 1))))');
         expect(productionSource).toContain('if (( retry_delay_seconds > 120 )); then');
-        expect(productionSource).toContain('retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30');
+        expect(productionSource).toContain('test_firestore_rules_api 2 20');
+        expect(productionSource).toContain('retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 1 0');
         expect(productionSource).toContain('retry_firebase_deploy "hosting,functions" "application"');
         const retryEnabledDeploy = productionSource.indexOf('"retry-enabled-functions"');
         const changedBranchStart = productionSource.indexOf('if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then');

--- a/tests/unit/firebase-deploy-workload-identity.test.js
+++ b/tests/unit/firebase-deploy-workload-identity.test.js
@@ -118,9 +118,12 @@ describe('Firebase deploy Workload Identity boundary', () => {
         expect(production.slice(storageDeploy, storageCleanup)).toContain('timeout-minutes: 4');
         expect(production.slice(productionDeploy)).toContain('timeout-minutes: 20');
         const oidcJobs = workflowJobs(production).filter((job) => job.permissions?.['id-token'] === 'write');
-        expect(oidcJobs).toHaveLength(1);
-        expect(JSON.stringify(oidcJobs[0])).not.toMatch(/npm (?:ci|install)|stage-pages-bundle|write-firebase-hosting-config/);
-        expect(JSON.stringify(oidcJobs[0])).toMatch(/actions\/download-artifact@[0-9a-f]{40}/);
+        expect(oidcJobs).toHaveLength(2);
+        for (const oidcJob of oidcJobs) {
+            expect(JSON.stringify(oidcJob)).not.toMatch(/npm (?:ci|install)|stage-pages-bundle|write-firebase-hosting-config/);
+            expect(JSON.stringify(oidcJob)).toMatch(/actions\/download-artifact@[0-9a-f]{40}/);
+        }
+        expect(production).toMatch(/actions\/deploy-pages@[0-9a-f]{40}/);
         expect(production).toMatch(/name: Upload trusted production deploy handoff[\s\S]*retention-days: 30/);
         expect(production).toContain('functions-runtime.tar');
         expect(production).toContain('cp scripts/extract-production-functions-handoff.py "$FIREBASE_PRODUCTION_BUNDLE/context/"');

--- a/tests/unit/pages-bundle-staging.test.js
+++ b/tests/unit/pages-bundle-staging.test.js
@@ -470,29 +470,31 @@ describe('pages bundle staging', () => {
         expect(previewWorkflow).not.toContain('APP_CHECK_PREVIEW_RECAPTCHA_ENTERPRISE_SITE_KEY ||');
     });
 
-    it('preserves hidden Pages files and verifies them after artifact download', () => {
+    it('keeps Pages publication inside the exact-SHA production release train', () => {
         const repoRoot = path.resolve(import.meta.dirname, '../..');
         const pagesWorkflow = fs.readFileSync(
             path.join(repoRoot, '.github', 'workflows', 'app-github-pages.yml'),
             'utf8'
         );
-        const intermediateUpload = pagesWorkflow.slice(
-            pagesWorkflow.indexOf('- name: Upload app Pages bundle artifact'),
-            pagesWorkflow.indexOf('\n  deploy:')
+        const productionWorkflow = fs.readFileSync(
+            path.join(repoRoot, '.github', 'workflows', 'deploy-prod.yml'),
+            'utf8'
         );
-        const deployJob = pagesWorkflow.slice(pagesWorkflow.indexOf('\n  deploy:'));
-        const downloadIndex = deployJob.indexOf('- name: Download staged Pages bundle');
-        const verifyIndex = deployJob.indexOf('- name: Verify staged Pages deployment artifact');
-        const pagesUploadIndex = deployJob.indexOf('- name: Upload GitHub Pages artifact');
+        const deployJob = productionWorkflow.slice(productionWorkflow.indexOf('\n  deploy-pages:'));
+        const downloadIndex = deployJob.indexOf('- name: Download exact-SHA production handoff');
+        const verifyIndex = deployJob.indexOf('- name: Validate Pages handoff identity');
+        const pagesUploadIndex = deployJob.indexOf('- name: Upload exact-SHA Pages artifact');
+        const pagesDeployIndex = deployJob.indexOf('- name: Deploy exact-SHA Pages artifact');
 
-        expect(intermediateUpload).toContain('include-hidden-files: true');
-        expect(pagesWorkflow).toContain("github.event_name == 'workflow_dispatch' && inputs.deploy");
-        expect(deployJob).toContain('ALLPLAYS_APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY: ${{ vars.APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY }}');
-        expect(deployJob).not.toContain('ALLPLAYS_PAGES_DEPLOY_ENABLED');
-        expect(deployJob).toContain('node scripts/verify-pages-deploy-artifact.mjs "$RUNNER_TEMP/allplays-pages"');
+        expect(pagesWorkflow).toContain('include-hidden-files: true');
+        expect(pagesWorkflow).not.toContain('\n  push:');
+        expect(pagesWorkflow).not.toContain('\n  deploy:');
+        expect(deployJob).toContain("vars.RELEASE_GITHUB_PAGES_DEPLOY_ENABLED == 'true'");
+        expect(deployJob).toContain('grep -Fxq "$GITHUB_SHA" "$bundle/head-sha"');
         expect(downloadIndex).toBeGreaterThan(-1);
         expect(verifyIndex).toBeGreaterThan(downloadIndex);
         expect(pagesUploadIndex).toBeGreaterThan(verifyIndex);
+        expect(pagesDeployIndex).toBeGreaterThan(pagesUploadIndex);
     });
 
     it('runs preview browser smoke against the exact staged Pages artifact', () => {

--- a/tests/unit/pages-bundle-staging.test.js
+++ b/tests/unit/pages-bundle-staging.test.js
@@ -491,6 +491,10 @@ describe('pages bundle staging', () => {
         expect(pagesWorkflow).not.toContain('\n  deploy:');
         expect(deployJob).toContain("vars.RELEASE_GITHUB_PAGES_DEPLOY_ENABLED == 'true'");
         expect(deployJob).toContain('grep -Fxq "$GITHUB_SHA" "$bundle/head-sha"');
+        expect(deployJob).toContain('EXPECTED_APP_CHECK_SITE_KEY: ${{ vars.APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY }}');
+        expect(deployJob).toContain('test -f "$bundle/site/.nojekyll"');
+        expect(deployJob).toContain('.appCheck.enabled == true');
+        expect(deployJob).toContain('.appCheck.recaptchaEnterpriseSiteKey == $expected_site_key');
         expect(downloadIndex).toBeGreaterThan(-1);
         expect(verifyIndex).toBeGreaterThan(downloadIndex);
         expect(pagesUploadIndex).toBeGreaterThan(verifyIndex);

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -95,7 +95,7 @@ on:
 
 concurrency:
   group: production-deploy-\${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
       - name: Checkout
         uses: actions/checkout@v5
@@ -177,8 +177,12 @@ concurrency:
             echo "Recovery: \${GITHUB_SERVER_URL}/\${GITHUB_REPOSITORY}/blob/master/docs/observability-runbook.md#firestore-rules-api-retry-exhaustion"
           } >> "$GITHUB_STEP_SUMMARY"
           fi
+          test_firestore_rules_api() {
+            curl "https://firebaserules.googleapis.com/v1/projects/game-flow-c6311:test"
+          }
           if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then
-            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30
+            test_firestore_rules_api 2 20
+            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 1 0
           else
             :
           fi
@@ -278,16 +282,16 @@ concurrency:
             'docs/observability-runbook.md'
         ))).toThrow('Production Firestore retry-exhaustion recovery link');
         expect(() => validateProductionDeployCommand(validDeployCommand.replace(
-            `retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30`,
+            `retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 1 0`,
             `retry_firebase_deploy "hosting,functions" "application"
-            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30`
+            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 1 0`
         ))).toThrow('Production Firestore deploy and component marker must run first when its configuration changed');
         expect(() => validateProductionDeployCommand(validDeployCommand.replace(
             `else
             :
           fi`,
             `else
-            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 8 30
+            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 1 0
           fi`
         ))).toThrow('Production must not redeploy unchanged Firestore configuration');
     });


### PR DESCRIPTION
## Change
- move GitHub Pages publication behind the exact-SHA Firebase production handoff
- serialize production releases without canceling an in-flight release
- gate Firestore mutation on a bounded non-persistent Rules API health probe
- record exact-SHA component/release markers before production smoke
- pin all remaining mutable Actions references and apply least-privilege workflow permissions

## Why
Independent Pages publication allowed the canonical UI to move ahead of failed Firestore/Functions releases. The eight-attempt Firestore retry loop also turned an external Rules API outage into a long-running release storm.

## Validation
- YAML parse for every workflow
- bash syntax for every changed run block
- 58 focused Vitest contract/security tests
- npm run ci:firebase-rules
- git diff --check and secret-pattern scan

## Operations
APP_GITHUB_PAGES_DEPLOY_ENABLED is already false. After this PR lands, RELEASE_GITHUB_PAGES_DEPLOY_ENABLED can enable Pages only inside the serialized release train.