### PR TITLE
Add public team roster and games APIs

### DIFF
--- a/docs/public-team-api.md
+++ b/docs/public-team-api.md
@@ -1,0 +1,105 @@
+# Public Team API v1
+
+The public team API exposes a small, read-only projection for websites that
+need a current roster or game schedule. A team must have `isPublic: true` and
+must not be inactive. Missing, private, and inactive teams all return the same
+generic `404` response.
+
+Base URL:
+
+`https://us-central1-game-flow-c6311.cloudfunctions.net`
+
+## Roster
+
+`GET /publicTeamRosterV1?teamId={teamId}`
+
+```json
+{
+  "version": 1,
+  "generatedAt": "2026-07-26T12:00:00.000Z",
+  "team": {
+    "id": "team-id",
+    "name": "Team name",
+    "sport": "Soccer",
+    "photoUrl": null
+  },
+  "players": [
+    {
+      "id": "player-id",
+      "name": "Player name",
+      "number": "10",
+      "photoUrl": null,
+      "position": null
+    }
+  ]
+}
+```
+
+Only active roster members are returned. Contact details, parent links,
+tracking information, notes, and authorization fields are never projected.
+
+## Games
+
+`GET /publicTeamGamesV1?teamId={teamId}&from={YYYY-MM-DD}&to={YYYY-MM-DD}&limit={1-500}`
+
+`from`, `to`, and `limit` are optional. The default range is one year back
+through two years ahead, with a default limit of 100. A requested range cannot
+exceed 3,660 days.
+
+```json
+{
+  "version": 1,
+  "generatedAt": "2026-07-26T12:00:00.000Z",
+  "team": {
+    "id": "team-id",
+    "name": "Team name",
+    "sport": "Soccer",
+    "photoUrl": null
+  },
+  "range": {
+    "from": "2026-01-01",
+    "to": "2026-12-31",
+    "truncated": false
+  },
+  "games": [
+    {
+      "id": "game-id",
+      "startsAt": "2026-07-31T15:00:00.000Z",
+      "endsAt": null,
+      "opponent": "Opponent",
+      "location": "Public field name",
+      "isHome": true,
+      "status": "scheduled",
+      "teamScore": null,
+      "opponentScore": null,
+      "result": null,
+      "seasonLabel": null,
+      "competitionType": null,
+      "countsTowardSeasonRecord": true,
+      "summary": null,
+      "videoUrl": null
+    }
+  ]
+}
+```
+
+Only game events are included. Private and deleted events are excluded.
+Imported arrival-time and assignment text is removed from public locations.
+RSVPs, assignments, notes, member identities, and internal event data are never
+projected.
+
+## HTTP behavior
+
+- Methods: `GET`, `HEAD`, and `OPTIONS`
+- CORS: public read access (`Access-Control-Allow-Origin: *`), no credentials
+- Cache: one minute in a browser, five minutes in a shared cache, stale serving
+  permitted for one day
+- Rate limit: 120 requests per minute per observed client IP and function
+  instance
+- Errors: `{ "error": { "code": "...", "message": "..." } }`
+
+Expected statuses are `400`, `404`, `405`, `429`, and `500`.
+
+The existing public calendar subscription remains available at:
+
+`GET /publicTeamGamesIcs?teamId={teamId}`

--- a/docs/public-team-api.md
+++ b/docs/public-team-api.md
@@ -92,8 +92,8 @@ projected.
 
 - Methods: `GET`, `HEAD`, and `OPTIONS`
 - CORS: public read access (`Access-Control-Allow-Origin: *`), no credentials
-- Cache: one minute in a browser, five minutes in a shared cache, stale serving
-  permitted for one day
+- Cache: one minute in a browser and five minutes in a shared cache, with no
+  stale serving after expiration
 - Rate limit: 120 requests per minute per observed client IP and function
   instance
 - Errors: `{ "error": { "code": "...", "message": "..." } }`

--- a/functions/index.js
+++ b/functions/index.js
@@ -80,6 +80,13 @@ const {
   normalizePublicRegistrationSecurityMode
 } = require('./public-registration-abuse-core.cjs');
 const { buildPublicGamesIcs, canExposeEmptyPublicFeed, isPublicFanGame } = require('./public-calendar-core.cjs');
+const {
+  buildPublicGamesResponse,
+  buildPublicRosterResponse,
+  isStrictPublicTeam,
+  normalizeTeamId,
+  parsePublicGamesQuery
+} = require('./public-team-api-core.cjs');
 const { buildCalendarFeedGamesQuery } = require('./calendar-feed-window-core.cjs');
 const {
   buildPublicRsvpSummaryProjection,
@@ -360,6 +367,11 @@ const checkPasswordResetEmailRateLimit = createInMemoryRateLimiter({
   maxKeys: 10_000
 });
 const checkCalendarFetchRateLimit = createInMemoryRateLimiter({
+  windowMs: 60_000,
+  maxRequests: 120,
+  maxKeys: 5_000
+});
+const checkPublicTeamApiRateLimit = createInMemoryRateLimiter({
   windowMs: 60_000,
   maxRequests: 120,
   maxKeys: 5_000
@@ -5886,6 +5898,143 @@ const calendarIcsCache = createCalendarIcsCache({
 function getCalendarFeedGamesQuery(teamId) {
   return buildCalendarFeedGamesQuery(firestore.collection(`teams/${teamId}/games`));
 }
+
+const PUBLIC_TEAM_API_CACHE_CONTROL = 'public, max-age=60, s-maxage=300, stale-while-revalidate=86400';
+
+function setPublicTeamApiCorsHeaders(res) {
+  res.set('Access-Control-Allow-Origin', '*');
+  res.set('Access-Control-Allow-Methods', 'GET, HEAD, OPTIONS');
+  res.set('Access-Control-Allow-Headers', 'Content-Type');
+  res.set('Access-Control-Max-Age', '86400');
+  res.set('Vary', 'Accept-Encoding');
+}
+
+function sendPublicTeamApiError(res, status, code, message) {
+  res.set('Cache-Control', 'no-store');
+  res.status(status).json({ error: { code, message } });
+}
+
+function beginPublicTeamApiRequest(req, res) {
+  setPublicTeamApiCorsHeaders(res);
+  if (req.method === 'OPTIONS') {
+    res.status(204).end();
+    return { complete: true };
+  }
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    sendPublicTeamApiError(res, 405, 'method_not_allowed', 'Use GET or HEAD for this endpoint.');
+    return { complete: true };
+  }
+
+  const rateLimit = checkPublicTeamApiRateLimit(req);
+  res.set('X-RateLimit-Remaining', String(rateLimit.remaining));
+  if (!rateLimit.allowed) {
+    res.set('Retry-After', String(rateLimit.retryAfterSeconds));
+    sendPublicTeamApiError(res, 429, 'rate_limited', 'Too many requests. Please try again shortly.');
+    return { complete: true };
+  }
+
+  const teamId = normalizeTeamId(req.query.teamId);
+  if (!teamId) {
+    sendPublicTeamApiError(res, 400, 'invalid_team_id', 'A valid teamId query parameter is required.');
+    return { complete: true };
+  }
+  return { complete: false, teamId };
+}
+
+async function getStrictPublicTeam(teamId) {
+  const teamSnap = await firestore.doc(`teams/${teamId}`).get();
+  if (!teamSnap.exists) return null;
+  const team = { id: teamId, ...(teamSnap.data() || {}) };
+  return isStrictPublicTeam(team) ? team : null;
+}
+
+function sendPublicTeamApiSuccess(req, res, body) {
+  res.set('Cache-Control', PUBLIC_TEAM_API_CACHE_CONTROL);
+  res.set('Content-Type', 'application/json; charset=utf-8');
+  if (req.method === 'HEAD') {
+    res.status(200).end();
+    return;
+  }
+  res.status(200).json(body);
+}
+
+exports.publicTeamRosterV1 = functions
+  .runWith(fetchCalendarRuntime)
+  .https
+  .onRequest(async (req, res) => {
+    const request = beginPublicTeamApiRequest(req, res);
+    if (request.complete) return;
+
+    try {
+      const team = await getStrictPublicTeam(request.teamId);
+      if (!team) {
+        sendPublicTeamApiError(res, 404, 'not_found', 'Public team not found.');
+        return;
+      }
+
+      const playersSnap = await firestore.collection(`teams/${request.teamId}/players`).get();
+      const players = [];
+      playersSnap.forEach((docSnap) => players.push({ id: docSnap.id, ...(docSnap.data() || {}) }));
+      const body = buildPublicRosterResponse({
+        teamId: request.teamId,
+        team,
+        players
+      });
+      sendPublicTeamApiSuccess(req, res, body);
+    } catch (error) {
+      functions.logger.error('Failed to build public team roster response.', {
+        teamId: request.teamId,
+        error: error?.message || String(error)
+      });
+      sendPublicTeamApiError(res, 500, 'unavailable', 'Public roster is temporarily unavailable.');
+    }
+  });
+
+exports.publicTeamGamesV1 = functions
+  .runWith(fetchCalendarRuntime)
+  .https
+  .onRequest(async (req, res) => {
+    const request = beginPublicTeamApiRequest(req, res);
+    if (request.complete) return;
+
+    const range = parsePublicGamesQuery(req.query || {});
+    if (range.error) {
+      sendPublicTeamApiError(res, 400, 'invalid_query', range.error);
+      return;
+    }
+
+    try {
+      const team = await getStrictPublicTeam(request.teamId);
+      if (!team) {
+        sendPublicTeamApiError(res, 404, 'not_found', 'Public team not found.');
+        return;
+      }
+
+      const gamesSnap = await firestore.collection(`teams/${request.teamId}/games`)
+        .where('date', '>=', range.fromDate)
+        .where('date', '<=', range.toDate)
+        .orderBy('date')
+        .limit(range.limit + 1)
+        .get();
+      const games = [];
+      gamesSnap.forEach((docSnap) => games.push({ id: docSnap.id, ...(docSnap.data() || {}) }));
+      const body = buildPublicGamesResponse({
+        teamId: request.teamId,
+        team,
+        games,
+        from: range.from,
+        to: range.to,
+        limit: range.limit
+      });
+      sendPublicTeamApiSuccess(req, res, body);
+    } catch (error) {
+      functions.logger.error('Failed to build public team games response.', {
+        teamId: request.teamId,
+        error: error?.message || String(error)
+      });
+      sendPublicTeamApiError(res, 500, 'unavailable', 'Public games are temporarily unavailable.');
+    }
+  });
 
 exports.publicTeamGamesIcs = functions
   .runWith(fetchCalendarRuntime)

--- a/functions/index.js
+++ b/functions/index.js
@@ -85,7 +85,8 @@ const {
   buildPublicRosterResponse,
   isStrictPublicTeam,
   normalizeTeamId,
-  parsePublicGamesQuery
+  parsePublicGamesQuery,
+  serializePublicGame
 } = require('./public-team-api-core.cjs');
 const { buildCalendarFeedGamesQuery } = require('./calendar-feed-window-core.cjs');
 const {
@@ -5900,6 +5901,7 @@ function getCalendarFeedGamesQuery(teamId) {
 }
 
 const PUBLIC_TEAM_API_CACHE_CONTROL = 'public, max-age=60, s-maxage=300, stale-while-revalidate=86400';
+const PUBLIC_TEAM_API_MAX_GAME_SCAN_DOCUMENTS = 5000;
 
 function setPublicTeamApiCorsHeaders(res) {
   res.set('Access-Control-Allow-Origin', '*');
@@ -5946,6 +5948,41 @@ async function getStrictPublicTeam(teamId) {
   if (!teamSnap.exists) return null;
   const team = { id: teamId, ...(teamSnap.data() || {}) };
   return isStrictPublicTeam(team) ? team : null;
+}
+
+async function getPublicTeamGames(teamId, range) {
+  const games = [];
+  const batchSize = Math.min(range.limit + 1, 500);
+  let lastDoc = null;
+  let scannedDocuments = 0;
+
+  while (games.length <= range.limit && scannedDocuments < PUBLIC_TEAM_API_MAX_GAME_SCAN_DOCUMENTS) {
+    const currentBatchSize = Math.min(
+      batchSize,
+      PUBLIC_TEAM_API_MAX_GAME_SCAN_DOCUMENTS - scannedDocuments
+    );
+    let query = firestore.collection(`teams/${teamId}/games`)
+      .where('date', '>=', range.fromDate)
+      .where('date', '<=', range.toDate)
+      .orderBy('date');
+    if (lastDoc) query = query.startAfter(lastDoc);
+
+    const gamesSnap = await query.limit(currentBatchSize).get();
+    if (gamesSnap.empty) break;
+
+    gamesSnap.forEach((docSnap) => {
+      const game = { id: docSnap.id, ...(docSnap.data() || {}) };
+      if (serializePublicGame(game)) games.push(game);
+    });
+    scannedDocuments += gamesSnap.size;
+    lastDoc = gamesSnap.docs[gamesSnap.docs.length - 1];
+    if (gamesSnap.size < currentBatchSize) break;
+  }
+
+  if (games.length <= range.limit && scannedDocuments >= PUBLIC_TEAM_API_MAX_GAME_SCAN_DOCUMENTS) {
+    throw new Error('Public games scan limit exceeded.');
+  }
+  return games;
 }
 
 function sendPublicTeamApiSuccess(req, res, body) {
@@ -6010,14 +6047,7 @@ exports.publicTeamGamesV1 = functions
         return;
       }
 
-      const gamesSnap = await firestore.collection(`teams/${request.teamId}/games`)
-        .where('date', '>=', range.fromDate)
-        .where('date', '<=', range.toDate)
-        .orderBy('date')
-        .limit(range.limit + 1)
-        .get();
-      const games = [];
-      gamesSnap.forEach((docSnap) => games.push({ id: docSnap.id, ...(docSnap.data() || {}) }));
+      const games = await getPublicTeamGames(request.teamId, range);
       const body = buildPublicGamesResponse({
         teamId: request.teamId,
         team,

--- a/functions/index.js
+++ b/functions/index.js
@@ -5900,7 +5900,8 @@ function getCalendarFeedGamesQuery(teamId) {
   return buildCalendarFeedGamesQuery(firestore.collection(`teams/${teamId}/games`));
 }
 
-const PUBLIC_TEAM_API_CACHE_CONTROL = 'public, max-age=60, s-maxage=300, stale-while-revalidate=86400';
+const PUBLIC_TEAM_API_CACHE_CONTROL = 'public, max-age=60, s-maxage=300';
+const PUBLIC_TEAM_API_MAX_ROSTER_SCAN_DOCUMENTS = 1000;
 const PUBLIC_TEAM_API_MAX_GAME_SCAN_DOCUMENTS = 5000;
 
 function setPublicTeamApiCorsHeaders(res) {
@@ -5948,6 +5949,19 @@ async function getStrictPublicTeam(teamId) {
   if (!teamSnap.exists) return null;
   const team = { id: teamId, ...(teamSnap.data() || {}) };
   return isStrictPublicTeam(team) ? team : null;
+}
+
+async function getPublicTeamPlayers(teamId) {
+  const playersSnap = await firestore.collection(`teams/${teamId}/players`)
+    .limit(PUBLIC_TEAM_API_MAX_ROSTER_SCAN_DOCUMENTS + 1)
+    .get();
+  if (playersSnap.size > PUBLIC_TEAM_API_MAX_ROSTER_SCAN_DOCUMENTS) {
+    throw new Error('Public roster scan limit exceeded.');
+  }
+
+  const players = [];
+  playersSnap.forEach((docSnap) => players.push({ id: docSnap.id, ...(docSnap.data() || {}) }));
+  return players;
 }
 
 async function getPublicTeamGames(teamId, range) {
@@ -6009,9 +6023,7 @@ exports.publicTeamRosterV1 = functions
         return;
       }
 
-      const playersSnap = await firestore.collection(`teams/${request.teamId}/players`).get();
-      const players = [];
-      playersSnap.forEach((docSnap) => players.push({ id: docSnap.id, ...(docSnap.data() || {}) }));
+      const players = await getPublicTeamPlayers(request.teamId);
       const body = buildPublicRosterResponse({
         teamId: request.teamId,
         team,

--- a/functions/public-calendar-core.cjs
+++ b/functions/public-calendar-core.cjs
@@ -5,7 +5,7 @@ function toBooleanTrue(value) {
 }
 
 function isPublicTeam(team = {}) {
-  return team?.isPublic !== false && team?.active !== false;
+  return team?.isPublic === true && team?.active !== false;
 }
 
 function canExposeEmptyPublicFeed(team = {}) {

--- a/functions/public-team-api-core.cjs
+++ b/functions/public-team-api-core.cjs
@@ -122,8 +122,8 @@ function sanitizePublicLocation(value) {
   const raw = typeof value === 'string' ? value.replace(/\r/g, '') : '';
   if (!raw.trim()) return '';
   const sensitiveBoundaries = [
-    raw.search(/(?:^|\n)\s*(?:\(?\s*arrival\s+time\b|assignments?\s*:)/i),
-    raw.search(/\s+\(\s*arrival\s+time\b/i),
+    raw.search(/(?:^|\n)\s*\(?\s*(?:arrival\s+time\b|assignments?\s*:)/i),
+    raw.search(/\s+\(\s*(?:arrival\s+time\b|assignments?\s*:)/i),
     raw.search(/\s+assignments?\s*:/i)
   ].filter((index) => index >= 0);
   const sensitiveBoundary = sensitiveBoundaries.length ? Math.min(...sensitiveBoundaries) : -1;

--- a/functions/public-team-api-core.cjs
+++ b/functions/public-team-api-core.cjs
@@ -39,7 +39,11 @@ function normalizeTeamId(value) {
 }
 
 function isStrictPublicTeam(team = {}) {
-  return team?.isPublic === true && team?.active !== false;
+  const status = compactText(team?.status, 32).toLowerCase();
+  return team?.isPublic === true &&
+    team?.active !== false &&
+    team?.archived !== true &&
+    !['archived', 'inactive', 'disabled'].includes(status);
 }
 
 function isActivePublicPlayer(player = {}) {
@@ -182,12 +186,27 @@ function parsePublicGamesQuery(query = {}, now = new Date()) {
 
   const hasFrom = query.from !== undefined && String(query.from).trim() !== '';
   const hasTo = query.to !== undefined && String(query.to).trim() !== '';
+  const defaultDate = (yearOffset, endOfDay) => {
+    const year = anchor.getUTCFullYear() + yearOffset;
+    const month = anchor.getUTCMonth();
+    const lastDay = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+    const day = Math.min(anchor.getUTCDate(), lastDay);
+    return new Date(Date.UTC(
+      year,
+      month,
+      day,
+      endOfDay ? 23 : 0,
+      endOfDay ? 59 : 0,
+      endOfDay ? 59 : 0,
+      endOfDay ? 999 : 0
+    ));
+  };
   const fromDate = hasFrom
     ? parseDateOnly(query.from, false)
-    : new Date(anchor.getTime() - 365 * MILLIS_PER_DAY);
+    : defaultDate(-1, false);
   const toDateValue = hasTo
     ? parseDateOnly(query.to, true)
-    : new Date(anchor.getTime() + 730 * MILLIS_PER_DAY);
+    : defaultDate(2, true);
   if (!fromDate || !toDateValue) {
     return { error: 'from and to must use YYYY-MM-DD format.' };
   }

--- a/functions/public-team-api-core.cjs
+++ b/functions/public-team-api-core.cjs
@@ -1,0 +1,275 @@
+const PUBLIC_TEAM_API_VERSION = 1;
+const PUBLIC_TEAM_API_MAX_GAMES = 500;
+const PUBLIC_TEAM_API_DEFAULT_GAMES = 100;
+const PUBLIC_TEAM_API_MAX_RANGE_DAYS = 3660;
+const MILLIS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function compactText(value, maxLength = 256) {
+  if (typeof value !== 'string' && typeof value !== 'number') return '';
+  return String(value).replace(/\s+/g, ' ').trim().slice(0, maxLength);
+}
+
+function nullableText(value, maxLength = 256) {
+  return compactText(value, maxLength) || null;
+}
+
+function publicHttpUrl(value) {
+  const text = compactText(value, 2048);
+  if (!text) return null;
+  try {
+    const url = new URL(text);
+    return url.protocol === 'https:' || url.protocol === 'http:' ? url.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
+function toDate(value) {
+  if (!value) return null;
+  if (typeof value?.toDate === 'function') return value.toDate();
+  if (typeof value?.toMillis === 'function') return new Date(value.toMillis());
+  if (value instanceof Date) return new Date(value.getTime());
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function normalizeTeamId(value) {
+  const teamId = compactText(value, 128);
+  return /^[A-Za-z0-9_-]{1,128}$/.test(teamId) ? teamId : '';
+}
+
+function isStrictPublicTeam(team = {}) {
+  return team?.isPublic === true && team?.active !== false;
+}
+
+function isActivePublicPlayer(player = {}) {
+  const status = compactText(player?.status, 32).toLowerCase();
+  return player?.active !== false &&
+    player?.archived !== true &&
+    player?.deleted !== true &&
+    !['archived', 'deleted', 'inactive', 'removed'].includes(status);
+}
+
+function isPublicGame(game = {}) {
+  const type = compactText(game?.type || 'game', 32).toLowerCase();
+  const visibility = compactText(game?.visibility, 32).toLowerCase();
+  const status = compactText(game?.status, 32).toLowerCase();
+  const liveStatus = compactText(game?.liveStatus, 32).toLowerCase();
+  return type === 'game' &&
+    visibility !== 'private' &&
+    game?.isPrivate !== true &&
+    game?.private !== true &&
+    game?.deleted !== true &&
+    status !== 'deleted' &&
+    liveStatus !== 'deleted';
+}
+
+function serializePublicTeam(teamId, team = {}) {
+  return {
+    id: teamId,
+    name: compactText(team?.name || team?.teamName, 160) || 'Team',
+    sport: nullableText(team?.sport, 80),
+    photoUrl: publicHttpUrl(team?.photoUrl || team?.logoUrl || team?.imageUrl)
+  };
+}
+
+function serializePublicPlayer(player = {}) {
+  if (!isActivePublicPlayer(player)) return null;
+  const name = compactText(player?.name || player?.displayName, 160);
+  if (!name) return null;
+  return {
+    id: compactText(player?.id, 128),
+    name,
+    number: compactText(player?.number ?? player?.jerseyNumber ?? player?.jersey, 32),
+    photoUrl: publicHttpUrl(player?.photoUrl || player?.imageUrl),
+    position: nullableText(player?.position, 80)
+  };
+}
+
+function compareRosterPlayers(left, right) {
+  const leftNumber = Number.parseInt(left.number, 10);
+  const rightNumber = Number.parseInt(right.number, 10);
+  const leftNumeric = Number.isFinite(leftNumber);
+  const rightNumeric = Number.isFinite(rightNumber);
+  if (leftNumeric && rightNumeric && leftNumber !== rightNumber) return leftNumber - rightNumber;
+  if (leftNumeric !== rightNumeric) return leftNumeric ? -1 : 1;
+  if (left.number !== right.number) return left.number.localeCompare(right.number, undefined, { numeric: true });
+  return left.name.localeCompare(right.name);
+}
+
+function normalizeGameStatus(game = {}) {
+  const statuses = [game?.status, game?.liveStatus]
+    .map((value) => compactText(value, 32).toLowerCase())
+    .filter(Boolean);
+  if (statuses.some((value) => ['cancelled', 'canceled'].includes(value))) return 'cancelled';
+  if (statuses.some((value) => ['postponed', 'delayed'].includes(value))) return 'postponed';
+  if (statuses.some((value) => ['completed', 'complete', 'final', 'finished'].includes(value))) return 'completed';
+  if (statuses.some((value) => ['live', 'in_progress', 'in-progress'].includes(value))) return 'live';
+  return 'scheduled';
+}
+
+function finiteScore(value) {
+  if (value === null || value === undefined || value === '') return null;
+  const score = Number(value);
+  return Number.isFinite(score) && score >= 0 ? score : null;
+}
+
+function sanitizePublicLocation(value) {
+  const raw = typeof value === 'string' ? value.replace(/\r/g, '') : '';
+  if (!raw.trim()) return '';
+  const sensitiveBoundaries = [
+    raw.search(/(?:^|\n)\s*(?:\(?\s*arrival\s+time\b|assignments?\s*:)/i),
+    raw.search(/\s+\(\s*arrival\s+time\b/i),
+    raw.search(/\s+assignments?\s*:/i)
+  ].filter((index) => index >= 0);
+  const sensitiveBoundary = sensitiveBoundaries.length ? Math.min(...sensitiveBoundaries) : -1;
+  const publicPart = sensitiveBoundary >= 0 ? raw.slice(0, sensitiveBoundary) : raw;
+  return publicPart
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join(', ')
+    .slice(0, 500);
+}
+
+function serializePublicGame(game = {}) {
+  if (!isPublicGame(game)) return null;
+  const startsAt = toDate(game?.date || game?.startsAt || game?.startDate || game?.start);
+  if (!startsAt) return null;
+
+  const isHome = game?.isHome !== false;
+  const homeScore = finiteScore(game?.homeScore);
+  const awayScore = finiteScore(game?.awayScore);
+  const teamScore = isHome ? homeScore : awayScore;
+  const opponentScore = isHome ? awayScore : homeScore;
+  const status = normalizeGameStatus(game);
+  let result = null;
+  if (status === 'completed' && teamScore !== null && opponentScore !== null) {
+    result = teamScore > opponentScore ? 'win' : teamScore < opponentScore ? 'loss' : 'tie';
+  }
+
+  const endsAt = toDate(game?.endDate || game?.endsAt || game?.end || game?.dtend);
+  return {
+    id: compactText(game?.id || game?.gameId, 128),
+    startsAt: startsAt.toISOString(),
+    endsAt: endsAt ? endsAt.toISOString() : null,
+    opponent: compactText(game?.opponent || game?.opponentTeamName, 160) || 'TBD',
+    location: sanitizePublicLocation(game?.location),
+    isHome,
+    status,
+    teamScore,
+    opponentScore,
+    result,
+    seasonLabel: nullableText(game?.seasonLabel, 100),
+    competitionType: nullableText(game?.competitionType, 80),
+    countsTowardSeasonRecord: game?.countsTowardSeasonRecord !== false,
+    summary: nullableText(game?.summary || game?.publicSummary, 2000),
+    videoUrl: publicHttpUrl(game?.videoUrl)
+  };
+}
+
+function parseDateOnly(value, endOfDay = false) {
+  const text = compactText(value, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(text)) return null;
+  const suffix = endOfDay ? 'T23:59:59.999Z' : 'T00:00:00.000Z';
+  const parsed = new Date(`${text}${suffix}`);
+  return Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== text ? null : parsed;
+}
+
+function parsePublicGamesQuery(query = {}, now = new Date()) {
+  const anchor = toDate(now);
+  if (!anchor) throw new TypeError('A valid current date is required.');
+
+  const hasFrom = query.from !== undefined && String(query.from).trim() !== '';
+  const hasTo = query.to !== undefined && String(query.to).trim() !== '';
+  const fromDate = hasFrom
+    ? parseDateOnly(query.from, false)
+    : new Date(anchor.getTime() - 365 * MILLIS_PER_DAY);
+  const toDateValue = hasTo
+    ? parseDateOnly(query.to, true)
+    : new Date(anchor.getTime() + 730 * MILLIS_PER_DAY);
+  if (!fromDate || !toDateValue) {
+    return { error: 'from and to must use YYYY-MM-DD format.' };
+  }
+  if (toDateValue < fromDate) {
+    return { error: 'to must be on or after from.' };
+  }
+  if (toDateValue.getTime() - fromDate.getTime() > PUBLIC_TEAM_API_MAX_RANGE_DAYS * MILLIS_PER_DAY) {
+    return { error: `Date range cannot exceed ${PUBLIC_TEAM_API_MAX_RANGE_DAYS} days.` };
+  }
+
+  const requestedLimit = query.limit === undefined || String(query.limit).trim() === ''
+    ? PUBLIC_TEAM_API_DEFAULT_GAMES
+    : Number(query.limit);
+  if (!Number.isSafeInteger(requestedLimit) || requestedLimit < 1 || requestedLimit > PUBLIC_TEAM_API_MAX_GAMES) {
+    return { error: `limit must be an integer from 1 to ${PUBLIC_TEAM_API_MAX_GAMES}.` };
+  }
+
+  return {
+    fromDate,
+    toDate: toDateValue,
+    from: fromDate.toISOString().slice(0, 10),
+    to: toDateValue.toISOString().slice(0, 10),
+    limit: requestedLimit
+  };
+}
+
+function buildPublicRosterResponse({ teamId, team = {}, players = [], now = new Date() }) {
+  return {
+    version: PUBLIC_TEAM_API_VERSION,
+    generatedAt: toDate(now).toISOString(),
+    team: serializePublicTeam(teamId, team),
+    players: players
+      .map(serializePublicPlayer)
+      .filter(Boolean)
+      .sort(compareRosterPlayers)
+  };
+}
+
+function buildPublicGamesResponse({
+  teamId,
+  team = {},
+  games = [],
+  from,
+  to,
+  limit = PUBLIC_TEAM_API_DEFAULT_GAMES,
+  now = new Date()
+}) {
+  const publicGames = games
+    .map(serializePublicGame)
+    .filter(Boolean)
+    .sort((left, right) => left.startsAt.localeCompare(right.startsAt));
+  return {
+    version: PUBLIC_TEAM_API_VERSION,
+    generatedAt: toDate(now).toISOString(),
+    team: serializePublicTeam(teamId, team),
+    range: {
+      from,
+      to,
+      truncated: publicGames.length > limit
+    },
+    games: publicGames.slice(0, limit)
+  };
+}
+
+module.exports = {
+  PUBLIC_TEAM_API_DEFAULT_GAMES,
+  PUBLIC_TEAM_API_MAX_GAMES,
+  PUBLIC_TEAM_API_MAX_RANGE_DAYS,
+  PUBLIC_TEAM_API_VERSION,
+  buildPublicGamesResponse,
+  buildPublicRosterResponse,
+  compareRosterPlayers,
+  isActivePublicPlayer,
+  isPublicGame,
+  isStrictPublicTeam,
+  normalizeGameStatus,
+  normalizeTeamId,
+  parsePublicGamesQuery,
+  publicHttpUrl,
+  sanitizePublicLocation,
+  serializePublicGame,
+  serializePublicPlayer,
+  serializePublicTeam,
+  toDate
+};

--- a/functions/test/public-team-api-core.test.cjs
+++ b/functions/test/public-team-api-core.test.cjs
@@ -1,0 +1,170 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  buildPublicGamesResponse,
+  buildPublicRosterResponse,
+  isStrictPublicTeam,
+  normalizeTeamId,
+  parsePublicGamesQuery,
+  sanitizePublicLocation,
+  serializePublicGame
+} = require('../public-team-api-core.cjs');
+
+test('strict public teams require an explicit public flag and cannot be inactive', () => {
+  assert.equal(isStrictPublicTeam({ isPublic: true, active: true }), true);
+  assert.equal(isStrictPublicTeam({ isPublic: true }), true);
+  assert.equal(isStrictPublicTeam({ active: true }), false);
+  assert.equal(isStrictPublicTeam({ isPublic: false, active: true }), false);
+  assert.equal(isStrictPublicTeam({ isPublic: true, active: false }), false);
+});
+
+test('roster response includes only active players and returns whitelisted fields in jersey order', () => {
+  const response = buildPublicRosterResponse({
+    teamId: 'team-1',
+    team: {
+      name: 'Current',
+      sport: 'Soccer',
+      photoUrl: 'https://images.example/team.png',
+      ownerEmail: 'private@example.com'
+    },
+    now: new Date('2026-07-26T12:00:00Z'),
+    players: [
+      { id: 'p12', name: 'Charlotte', number: '12', parentEmails: ['private@example.com'] },
+      { id: 'p5', name: 'Blake', number: '5', photoUrl: 'javascript:alert(1)' },
+      { id: 'inactive', name: 'Former Player', number: '1', active: false },
+      { id: 'archived', name: 'Archived Player', number: '2', status: 'archived' },
+      { id: 'p-no-number', name: 'Zoe' }
+    ]
+  });
+
+  assert.deepEqual(response, {
+    version: 1,
+    generatedAt: '2026-07-26T12:00:00.000Z',
+    team: {
+      id: 'team-1',
+      name: 'Current',
+      sport: 'Soccer',
+      photoUrl: 'https://images.example/team.png'
+    },
+    players: [
+      { id: 'p5', name: 'Blake', number: '5', photoUrl: null, position: null },
+      { id: 'p12', name: 'Charlotte', number: '12', photoUrl: null, position: null },
+      { id: 'p-no-number', name: 'Zoe', number: '', photoUrl: null, position: null }
+    ]
+  });
+  assert.equal(JSON.stringify(response).includes('parentEmails'), false);
+  assert.equal(JSON.stringify(response).includes('ownerEmail'), false);
+});
+
+test('games omit private/deleted/non-game events and remove imported assignment details', () => {
+  const response = buildPublicGamesResponse({
+    teamId: 'team-1',
+    team: { name: 'Current', sport: 'Soccer' },
+    from: '2026-01-01',
+    to: '2026-12-31',
+    limit: 10,
+    now: new Date('2026-07-26T12:00:00Z'),
+    games: [
+      {
+        id: 'later',
+        type: 'game',
+        date: '2026-08-02T20:00:00Z',
+        opponent: 'Tigers',
+        location: 'Swope Soccer Village\n(Arrival Time: 2:30 PM)\nAssignments: Snacks - Parent Name',
+        isHome: false,
+        status: 'completed',
+        homeScore: 1,
+        awayScore: 3,
+        summary: 'A strong finish.',
+        notes: 'Private scouting note',
+        rsvpSummary: { going: 12 },
+        assignments: [{ name: 'Snacks' }]
+      },
+      {
+        id: 'earlier',
+        date: '2026-07-31T15:00:00Z',
+        opponent: 'test'
+      },
+      { id: 'practice', type: 'practice', date: '2026-08-01T15:00:00Z' },
+      { id: 'private', type: 'game', visibility: 'private', date: '2026-08-01T15:00:00Z' },
+      { id: 'deleted', type: 'game', status: 'deleted', date: '2026-08-01T15:00:00Z' }
+    ]
+  });
+
+  assert.equal(response.games.length, 2);
+  assert.equal(response.games[0].id, 'earlier');
+  assert.equal(response.games[0].opponent, 'test');
+  assert.equal(response.games[1].location, 'Swope Soccer Village');
+  assert.equal(response.games[1].teamScore, 3);
+  assert.equal(response.games[1].opponentScore, 1);
+  assert.equal(response.games[1].result, 'win');
+  assert.equal(response.games[1].summary, 'A strong finish.');
+  assert.equal(response.range.truncated, false);
+  const json = JSON.stringify(response);
+  assert.equal(json.includes('Private scouting note'), false);
+  assert.equal(json.includes('Parent Name'), false);
+  assert.equal(json.includes('rsvpSummary'), false);
+});
+
+test('game results require completed status and both scores', () => {
+  assert.equal(serializePublicGame({
+    id: 'scheduled',
+    date: '2026-08-01T15:00:00Z',
+    homeScore: 2,
+    awayScore: 0
+  }).result, null);
+  assert.equal(serializePublicGame({
+    id: 'tie',
+    date: '2026-08-01T15:00:00Z',
+    status: 'final',
+    homeScore: 2,
+    awayScore: 2
+  }).result, 'tie');
+  assert.equal(serializePublicGame({
+    id: 'away-loss',
+    date: '2026-08-01T15:00:00Z',
+    status: 'completed',
+    isHome: false,
+    homeScore: 4,
+    awayScore: 1
+  }).result, 'loss');
+});
+
+test('games response reports truncation after public filtering and chronological sorting', () => {
+  const response = buildPublicGamesResponse({
+    teamId: 'team-1',
+    team: { name: 'Current' },
+    from: '2026-01-01',
+    to: '2026-12-31',
+    limit: 1,
+    games: [
+      { id: 'two', date: '2026-02-01T00:00:00Z' },
+      { id: 'private', date: '2026-01-15T00:00:00Z', isPrivate: true },
+      { id: 'one', date: '2026-01-01T00:00:00Z' }
+    ],
+    now: new Date('2026-01-01T00:00:00Z')
+  });
+  assert.equal(response.range.truncated, true);
+  assert.deepEqual(response.games.map((game) => game.id), ['one']);
+});
+
+test('query parsing validates dates, range, and limit', () => {
+  const valid = parsePublicGamesQuery(
+    { from: '2026-01-01', to: '2026-12-31', limit: '500' },
+    new Date('2026-07-26T12:00:00Z')
+  );
+  assert.equal(valid.from, '2026-01-01');
+  assert.equal(valid.to, '2026-12-31');
+  assert.equal(valid.limit, 500);
+  assert.equal(parsePublicGamesQuery({ from: '01/01/2026' }).error.includes('YYYY-MM-DD'), true);
+  assert.equal(parsePublicGamesQuery({ from: '2026-02-30' }).error.includes('YYYY-MM-DD'), true);
+  assert.equal(parsePublicGamesQuery({ from: '2026-02-01', to: '2026-01-01' }).error.includes('on or after'), true);
+  assert.equal(parsePublicGamesQuery({ limit: '501' }).error.includes('1 to 500'), true);
+});
+
+test('location and team id sanitizers reject unsafe values', () => {
+  assert.equal(sanitizePublicLocation('Field 4\nArrival Time: 5:00 PM\nAssignments: snacks'), 'Field 4');
+  assert.equal(sanitizePublicLocation('Field 4 (Arrival Time: 5:00 PM) Assignments: snacks'), 'Field 4');
+  assert.equal(normalizeTeamId('team_123-ABC'), 'team_123-ABC');
+  assert.equal(normalizeTeamId('../team'), '');
+});

--- a/functions/test/public-team-api-core.test.cjs
+++ b/functions/test/public-team-api-core.test.cjs
@@ -181,6 +181,8 @@ test('query parsing uses complete UTC days and calendar years for default bounds
 test('location and team id sanitizers reject unsafe values', () => {
   assert.equal(sanitizePublicLocation('Field 4\nArrival Time: 5:00 PM\nAssignments: snacks'), 'Field 4');
   assert.equal(sanitizePublicLocation('Field 4 (Arrival Time: 5:00 PM) Assignments: snacks'), 'Field 4');
+  assert.equal(sanitizePublicLocation('Field 4 (Assignments: Snacks - Parent Name)'), 'Field 4');
+  assert.equal(sanitizePublicLocation('(Assignment: Parent Name)'), '');
   assert.equal(normalizeTeamId('team_123-ABC'), 'team_123-ABC');
   assert.equal(normalizeTeamId('../team'), '');
 });

--- a/functions/test/public-team-api-core.test.cjs
+++ b/functions/test/public-team-api-core.test.cjs
@@ -16,6 +16,10 @@ test('strict public teams require an explicit public flag and cannot be inactive
   assert.equal(isStrictPublicTeam({ active: true }), false);
   assert.equal(isStrictPublicTeam({ isPublic: false, active: true }), false);
   assert.equal(isStrictPublicTeam({ isPublic: true, active: false }), false);
+  assert.equal(isStrictPublicTeam({ isPublic: true, active: true, archived: true }), false);
+  for (const status of ['archived', 'inactive', 'disabled', 'ARCHIVED']) {
+    assert.equal(isStrictPublicTeam({ isPublic: true, active: true, status }), false);
+  }
 });
 
 test('roster response includes only active players and returns whitelisted fields in jersey order', () => {
@@ -160,6 +164,18 @@ test('query parsing validates dates, range, and limit', () => {
   assert.equal(parsePublicGamesQuery({ from: '2026-02-30' }).error.includes('YYYY-MM-DD'), true);
   assert.equal(parsePublicGamesQuery({ from: '2026-02-01', to: '2026-01-01' }).error.includes('on or after'), true);
   assert.equal(parsePublicGamesQuery({ limit: '501' }).error.includes('1 to 500'), true);
+});
+
+test('query parsing uses complete UTC days and calendar years for default bounds', () => {
+  const defaults = parsePublicGamesQuery({}, new Date('2026-07-26T12:34:56.789Z'));
+  assert.equal(defaults.fromDate.toISOString(), '2025-07-26T00:00:00.000Z');
+  assert.equal(defaults.toDate.toISOString(), '2028-07-26T23:59:59.999Z');
+  assert.equal(defaults.from, '2025-07-26');
+  assert.equal(defaults.to, '2028-07-26');
+
+  const leapDayDefaults = parsePublicGamesQuery({}, new Date('2024-02-29T23:00:00.000Z'));
+  assert.equal(leapDayDefaults.fromDate.toISOString(), '2023-02-28T00:00:00.000Z');
+  assert.equal(leapDayDefaults.toDate.toISOString(), '2026-02-28T23:59:59.999Z');
 });
 
 test('location and team id sanitizers reject unsafe values', () => {

--- a/functions/test/public-team-api-handler-contract.test.cjs
+++ b/functions/test/public-team-api-handler-contract.test.cjs
@@ -13,7 +13,7 @@ test('exports versioned public roster and games HTTPS handlers', () => {
 });
 
 test('public team handlers use bounded games reads and field-whitelisting serializers', () => {
-  const start = source.indexOf('exports.publicTeamRosterV1 = functions');
+  const start = source.indexOf('async function getPublicTeamGames');
   const end = source.indexOf('exports.publicTeamGamesIcs = functions', start);
   const apiSource = source.slice(start, end);
 
@@ -21,7 +21,10 @@ test('public team handlers use bounded games reads and field-whitelisting serial
   assert.match(apiSource, /buildPublicGamesResponse/);
   assert.match(apiSource, /\.where\('date', '>=', range\.fromDate\)/);
   assert.match(apiSource, /\.where\('date', '<=', range\.toDate\)/);
-  assert.match(apiSource, /\.limit\(range\.limit \+ 1\)/);
+  assert.match(apiSource, /PUBLIC_TEAM_API_MAX_GAME_SCAN_DOCUMENTS/);
+  assert.match(apiSource, /\.limit\(currentBatchSize\)/);
+  assert.match(apiSource, /\.startAfter\(lastDoc\)/);
+  assert.match(apiSource, /if \(serializePublicGame\(game\)\) games\.push\(game\)/);
   assert.doesNotMatch(apiSource, /collection\(`teams\/\$\{request\.teamId\}\/games`\)\.get\(\)/);
 });
 

--- a/functions/test/public-team-api-handler-contract.test.cjs
+++ b/functions/test/public-team-api-handler-contract.test.cjs
@@ -2,8 +2,90 @@ const assert = require('node:assert/strict');
 const { readFileSync } = require('node:fs');
 const test = require('node:test');
 const { join } = require('node:path');
+const { serializePublicGame } = require('../public-team-api-core.cjs');
 
 const source = readFileSync(join(__dirname, '..', 'index.js'), 'utf8');
+
+function loadPublicTeamDataAccess(firestore) {
+  const constantsStart = source.indexOf('const PUBLIC_TEAM_API_MAX_ROSTER_SCAN_DOCUMENTS');
+  const constantsEnd = source.indexOf('function setPublicTeamApiCorsHeaders', constantsStart);
+  const playersStart = source.indexOf('async function getPublicTeamPlayers');
+  const functionsEnd = source.indexOf('function sendPublicTeamApiSuccess', playersStart);
+  const implementation = [
+    source.slice(constantsStart, constantsEnd),
+    source.slice(playersStart, functionsEnd),
+    'return { getPublicTeamPlayers, getPublicTeamGames };'
+  ].join('\n');
+
+  return new Function('firestore', 'serializePublicGame', implementation)(
+    firestore,
+    serializePublicGame
+  );
+}
+
+function makeQuerySnapshot(docs) {
+  return {
+    docs,
+    size: docs.length,
+    empty: docs.length === 0,
+    forEach(callback) {
+      docs.forEach(callback);
+    }
+  };
+}
+
+function makeDoc(id, data) {
+  return { id, data: () => data };
+}
+
+function makeFirestore({ players = [], games = [], metrics = {} } = {}) {
+  metrics.gameLimits = [];
+  metrics.gameStartAfterIds = [];
+  metrics.gameDocumentsRead = 0;
+
+  function makeGamesQuery(lastDoc = null, limitCount = games.length) {
+    return {
+      where() {
+        return this;
+      },
+      orderBy() {
+        return this;
+      },
+      startAfter(doc) {
+        metrics.gameStartAfterIds.push(doc.id);
+        return makeGamesQuery(doc, limitCount);
+      },
+      limit(count) {
+        metrics.gameLimits.push(count);
+        return makeGamesQuery(lastDoc, count);
+      },
+      async get() {
+        const start = lastDoc ? games.indexOf(lastDoc) + 1 : 0;
+        const docs = games.slice(start, start + limitCount);
+        metrics.gameDocumentsRead += docs.length;
+        return makeQuerySnapshot(docs);
+      }
+    };
+  }
+
+  return {
+    collection(path) {
+      if (path.endsWith('/players')) {
+        return {
+          limit(count) {
+            return {
+              async get() {
+                return makeQuerySnapshot(players.slice(0, count));
+              }
+            };
+          }
+        };
+      }
+      if (path.endsWith('/games')) return makeGamesQuery();
+      throw new Error(`Unexpected collection path: ${path}`);
+    }
+  };
+}
 
 test('exports versioned public roster and games HTTPS handlers', () => {
   assert.match(source, /exports\.publicTeamRosterV1 = functions/);
@@ -48,4 +130,74 @@ test('public team handlers define public cache, CORS, method, and rate-limit beh
   assert.match(source, /req\.method !== 'GET' && req\.method !== 'HEAD'/);
   assert.match(source, /maxRequests: 120/);
   assert.match(source, /sendPublicTeamApiError\(res, 429, 'rate_limited'/);
+});
+
+test('public roster scan accepts 1,000 documents and safely rejects 1,001', async () => {
+  const players = Array.from({ length: 1001 }, (_, index) => (
+    makeDoc(`player-${index}`, { name: `Player ${index}` })
+  ));
+  const atLimit = loadPublicTeamDataAccess(makeFirestore({ players: players.slice(0, 1000) }));
+  const overLimit = loadPublicTeamDataAccess(makeFirestore({ players }));
+
+  const result = await atLimit.getPublicTeamPlayers('team-1');
+  assert.equal(result.length, 1000);
+  assert.equal(result[999].id, 'player-999');
+  await assert.rejects(
+    overLimit.getPublicTeamPlayers('team-1'),
+    /Public roster scan limit exceeded/
+  );
+});
+
+test('public games scan paginates past filtered documents', async () => {
+  const games = [
+    ...Array.from({ length: 3 }, (_, index) => (
+      makeDoc(`private-${index}`, { date: new Date(`2026-07-0${index + 1}T00:00:00Z`), private: true })
+    )),
+    ...Array.from({ length: 3 }, (_, index) => (
+      makeDoc(`public-${index}`, { date: new Date(`2026-07-1${index + 1}T00:00:00Z`), opponent: `Team ${index}` })
+    ))
+  ];
+  const metrics = {};
+  const dataAccess = loadPublicTeamDataAccess(makeFirestore({ games, metrics }));
+
+  const result = await dataAccess.getPublicTeamGames('team-1', {
+    fromDate: new Date('2026-07-01T00:00:00Z'),
+    toDate: new Date('2026-07-31T23:59:59Z'),
+    limit: 2
+  });
+
+  assert.deepEqual(result.map((game) => game.id), ['public-0', 'public-1', 'public-2']);
+  assert.deepEqual(metrics.gameLimits, [3, 3]);
+  assert.deepEqual(metrics.gameStartAfterIds, ['private-2']);
+  assert.equal(metrics.gameDocumentsRead, 6);
+});
+
+test('public games scan returns below 5,000 documents and fails safely at the cap', async () => {
+  const privateGames = Array.from({ length: 5000 }, (_, index) => (
+    makeDoc(`private-${index}`, {
+      date: new Date(Date.UTC(2026, 0, 1, 0, index)),
+      private: true
+    })
+  ));
+  const range = {
+    fromDate: new Date('2026-01-01T00:00:00Z'),
+    toDate: new Date('2026-12-31T23:59:59Z'),
+    limit: 499
+  };
+  const belowMetrics = {};
+  const belowCap = loadPublicTeamDataAccess(makeFirestore({
+    games: privateGames.slice(0, 4999),
+    metrics: belowMetrics
+  }));
+  const capMetrics = {};
+  const atCap = loadPublicTeamDataAccess(makeFirestore({ games: privateGames, metrics: capMetrics }));
+
+  assert.deepEqual(await belowCap.getPublicTeamGames('team-1', range), []);
+  assert.equal(belowMetrics.gameDocumentsRead, 4999);
+  await assert.rejects(
+    atCap.getPublicTeamGames('team-1', range),
+    /Public games scan limit exceeded/
+  );
+  assert.equal(capMetrics.gameDocumentsRead, 5000);
+  assert.deepEqual(capMetrics.gameLimits, Array(10).fill(500));
 });

--- a/functions/test/public-team-api-handler-contract.test.cjs
+++ b/functions/test/public-team-api-handler-contract.test.cjs
@@ -1,0 +1,35 @@
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const test = require('node:test');
+const { join } = require('node:path');
+
+const source = readFileSync(join(__dirname, '..', 'index.js'), 'utf8');
+
+test('exports versioned public roster and games HTTPS handlers', () => {
+  assert.match(source, /exports\.publicTeamRosterV1 = functions/);
+  assert.match(source, /exports\.publicTeamGamesV1 = functions/);
+  assert.match(source, /getStrictPublicTeam\(request\.teamId\)/);
+  assert.match(source, /isStrictPublicTeam\(team\)/);
+});
+
+test('public team handlers use bounded games reads and field-whitelisting serializers', () => {
+  const start = source.indexOf('exports.publicTeamRosterV1 = functions');
+  const end = source.indexOf('exports.publicTeamGamesIcs = functions', start);
+  const apiSource = source.slice(start, end);
+
+  assert.match(apiSource, /buildPublicRosterResponse/);
+  assert.match(apiSource, /buildPublicGamesResponse/);
+  assert.match(apiSource, /\.where\('date', '>=', range\.fromDate\)/);
+  assert.match(apiSource, /\.where\('date', '<=', range\.toDate\)/);
+  assert.match(apiSource, /\.limit\(range\.limit \+ 1\)/);
+  assert.doesNotMatch(apiSource, /collection\(`teams\/\$\{request\.teamId\}\/games`\)\.get\(\)/);
+});
+
+test('public team handlers define public cache, CORS, method, and rate-limit behavior', () => {
+  assert.match(source, /public, max-age=60, s-maxage=300, stale-while-revalidate=86400/);
+  assert.match(source, /Access-Control-Allow-Origin', '\*'/);
+  assert.match(source, /Access-Control-Allow-Methods', 'GET, HEAD, OPTIONS'/);
+  assert.match(source, /req\.method !== 'GET' && req\.method !== 'HEAD'/);
+  assert.match(source, /maxRequests: 120/);
+  assert.match(source, /sendPublicTeamApiError\(res, 429, 'rate_limited'/);
+});

--- a/functions/test/public-team-api-handler-contract.test.cjs
+++ b/functions/test/public-team-api-handler-contract.test.cjs
@@ -28,8 +28,21 @@ test('public team handlers use bounded games reads and field-whitelisting serial
   assert.doesNotMatch(apiSource, /collection\(`teams\/\$\{request\.teamId\}\/games`\)\.get\(\)/);
 });
 
+test('public roster handler bounds its player scan before filtering sensitive documents', () => {
+  const start = source.indexOf('async function getPublicTeamPlayers');
+  const end = source.indexOf('async function getPublicTeamGames', start);
+  const rosterSource = source.slice(start, end);
+
+  assert.match(source, /const PUBLIC_TEAM_API_MAX_ROSTER_SCAN_DOCUMENTS = 1000/);
+  assert.match(rosterSource, /\.limit\(PUBLIC_TEAM_API_MAX_ROSTER_SCAN_DOCUMENTS \+ 1\)/);
+  assert.match(rosterSource, /playersSnap\.size > PUBLIC_TEAM_API_MAX_ROSTER_SCAN_DOCUMENTS/);
+  assert.doesNotMatch(rosterSource, /collection\(`teams\/\$\{teamId\}\/players`\)\.get\(\)/);
+  assert.match(source, /const players = await getPublicTeamPlayers\(request\.teamId\)/);
+});
+
 test('public team handlers define public cache, CORS, method, and rate-limit behavior', () => {
-  assert.match(source, /public, max-age=60, s-maxage=300, stale-while-revalidate=86400/);
+  assert.match(source, /public, max-age=60, s-maxage=300'/);
+  assert.doesNotMatch(source, /stale-while-revalidate/);
   assert.match(source, /Access-Control-Allow-Origin', '\*'/);
   assert.match(source, /Access-Control-Allow-Methods', 'GET, HEAD, OPTIONS'/);
   assert.match(source, /req\.method !== 'GET' && req\.method !== 'HEAD'/);

--- a/tests/coverage/feature-coverage-map.json
+++ b/tests/coverage/feature-coverage-map.json
@@ -771,12 +771,16 @@
                 "listPublicOpportunities",
                 "listPublicOpportunityReports",
                 "moderatePublicOpportunity",
+                "publicTeamGamesV1",
+                "publicTeamRosterV1",
                 "renewPublicOpportunity",
                 "replyToOpportunityInquiry",
                 "reportPublicOpportunity",
                 "updatePublicOpportunity"
             ],
             "unitTests": [
+                "functions/test/public-team-api-core.test.cjs",
+                "functions/test/public-team-api-handler-contract.test.cjs",
                 "tests/unit/public-opportunities-core.test.js",
                 "tests/unit/public-opportunities-functions-source.test.js",
                 "tests/unit/public-opportunities-rules.test.js"

--- a/tests/unit/public-calendar-core.test.js
+++ b/tests/unit/public-calendar-core.test.js
@@ -82,6 +82,7 @@ describe('public games calendar feed helpers', () => {
         });
 
         expect(canExposeEmptyPublicFeed({ isPublic: true, active: true })).toBe(true);
+        expect(canExposeEmptyPublicFeed({ active: true })).toBe(false);
         expect(canExposeEmptyPublicFeed({ isPublic: true, active: false })).toBe(false);
         expect(canExposeEmptyPublicFeed({ isPublic: false, active: true })).toBe(false);
         expect(ics).toContain('BEGIN:VCALENDAR');


### PR DESCRIPTION
## What changed

- add versioned, read-only public roster and games HTTP endpoints for explicitly public teams
- project only approved team, player, and game fields while excluding contact, RSVP, assignment, and authorization data
- sanitize imported locations and filter private, deleted, inactive, or non-game records
- add public CORS, cache headers, bounded queries, rate limiting, structured errors, and API documentation
- require the existing public calendar feed to use the same explicit public-team flag

## Why

Public team websites need a stable API for current rosters and schedules without exposing private AllPlays data or duplicating team information.

## Validation

- `npm test` in `functions/` — 330 tests passed
- JavaScript syntax and diff checks passed after rebasing onto the latest `origin/master`
- production GET, HEAD, OPTIONS, invalid-input, missing-team, and method responses smoke-tested
- production payloads verified for CORS, cache behavior, v1 schema, field whitelists, and location sanitization
- Playwright validated the JRKC website against the deployed production endpoints
