### PR TITLE
Consolidate PR CI and repair release baselines

### DIFF
--- a/.github/workflows/app-github-pages.yml
+++ b/.github/workflows/app-github-pages.yml
@@ -1,7 +1,6 @@
 name: app-github-pages
 
 on:
-  pull_request:
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/deploy-preview-trusted.yml
+++ b/.github/workflows/deploy-preview-trusted.yml
@@ -23,6 +23,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       actions: read
+      pull-requests: read
     outputs:
       preview_ready: ${{ steps.classify.outputs.preview_ready }}
 
@@ -31,9 +32,24 @@ jobs:
         id: classify
         env:
           GH_TOKEN: ${{ github.token }}
+          WORKFLOW_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
           set -euo pipefail
+          if [[ ! "$WORKFLOW_PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Invalid triggering pull-request identity." >&2
+            exit 1
+          fi
+          head_repository="$(
+            gh api "repos/$GITHUB_REPOSITORY/pulls/$WORKFLOW_PR_NUMBER" \
+              --jq '.head.repo.full_name'
+          )"
+          if [ "$head_repository" != "$GITHUB_REPOSITORY" ]; then
+            echo "Fork pull request — no trusted preview deploy is required."
+            echo "preview_ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           artifacts_json="$RUNNER_TEMP/firebase-preview-source-artifacts.json"
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$WORKFLOW_RUN_ID/artifacts?per_page=100" > "$artifacts_json"
 

--- a/.github/workflows/deploy-preview-trusted.yml
+++ b/.github/workflows/deploy-preview-trusted.yml
@@ -3,7 +3,7 @@ name: deploy-preview-trusted
 on:
   workflow_run:
     workflows:
-      - deploy-preview
+      - pr-integration
     types:
       - completed
 
@@ -27,38 +27,22 @@ jobs:
       preview_ready: ${{ steps.classify.outputs.preview_ready }}
 
     steps:
-      - name: Classify artifact-producing and intentionally deferred runs
+      - name: Require the exact untrusted preview artifact
         id: classify
         env:
           GH_TOKEN: ${{ github.token }}
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
           set -euo pipefail
-          jobs_json="$RUNNER_TEMP/firebase-preview-source-jobs.json"
           artifacts_json="$RUNNER_TEMP/firebase-preview-source-artifacts.json"
-          gh api --paginate "repos/$GITHUB_REPOSITORY/actions/runs/$WORKFLOW_RUN_ID/jobs?per_page=100" > "$jobs_json"
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$WORKFLOW_RUN_ID/artifacts?per_page=100" > "$artifacts_json"
 
           bundle_count="$(jq '[.artifacts[]? | select(.name == "firebase-preview-hosting-bundle")] | length' "$artifacts_json")"
-          if [ "$bundle_count" -eq 1 ]; then
-            echo "preview_ready=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [ "$bundle_count" -ne 0 ]; then
-            echo "Expected at most one preview bundle, found $bundle_count." >&2
+          if [ "$bundle_count" -ne 1 ]; then
+            echo "Expected exactly one preview bundle, found $bundle_count." >&2
             exit 1
           fi
-
-          regression_result="$(jq -r '[.jobs[]? | select(.name == "regression-guards") | .conclusion] | last // ""' "$jobs_json")"
-          build_result="$(jq -r '[.jobs[]? | select(.name == "build-preview-artifact") | .conclusion] | last // ""' "$jobs_json")"
-          if [ "$regression_result" = "skipped" ] && [ "$build_result" = "skipped" ]; then
-            echo "Preview source run was intentionally deferred; no trusted deploy is needed."
-            echo "preview_ready=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "Successful preview source run had no bundle without an intentional two-job deferral." >&2
-          exit 1
+          echo "preview_ready=true" >> "$GITHUB_OUTPUT"
 
   prepare-preview:
     needs: classify-trigger
@@ -278,7 +262,7 @@ jobs:
             echo "Trusted preview verifier must not be a symbolic link." >&2
             exit 1
           }
-          expected_verifier_sha256='bbf7426f259fb7cd400980249d55a92c46c2804e343d11d763f1e9e448c6e82b'
+          expected_verifier_sha256='cf22c88b47b9e47026bbf3813998ce877e29891b66c668c7559085c6cb358927'
           printf '%s  %s\n' "$expected_verifier_sha256" "$verifier" | sha256sum --check --strict
 
           recheck_current_head() {

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,12 +1,7 @@
 name: deploy-preview
 
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - closed
+  workflow_call:
 
 # Pull-request-controlled code runs here, so this workflow has no repository
 # permissions and receives no privileged secrets. Its only deploy input is an
@@ -18,55 +13,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  regression-guards:
-    if: >-
-      github.event.action != 'closed' &&
-      github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout pull request merge
-        run: |
-          git init .
-          git remote add origin https://github.com/${{ github.repository }}.git
-          git fetch --no-tags --prune --depth=1 origin +refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge
-          git checkout --force refs/remotes/pull/${{ github.event.pull_request.number }}/merge
-
-      - name: Setup Node
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Validate Firebase rules and deploy gates
-        run: npm run ci:firebase-rules
-
-      - name: Install Playwright Chromium
-        run: npx playwright install chromium
-
-      - name: Start local static server
-        run: python3 -m http.server 4173 >/tmp/allplays-preview-regression-guards.log 2>&1 &
-
-      - name: Run roster/chat/media/replay regression smoke
-        run: npm run test:smoke:team-fallback
-        env:
-          SMOKE_BASE_URL: http://127.0.0.1:4173
-
-      - name: Upload server log on failure
-        if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: preview-regression-guards-http-log
-          path: /tmp/allplays-preview-regression-guards.log
-
   build-preview-artifact:
     if: >-
-      github.event.action != 'closed' &&
       github.event.pull_request.head.repo.full_name == github.repository
-    needs: [regression-guards]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -227,6 +227,20 @@ jobs:
           if [[ ! "$firestore_success_sha" =~ ^[0-9a-f]{40}$ ]]; then
             firestore_success_sha="$last_success_sha"
           fi
+          if [[ "$firestore_success_sha" =~ ^[0-9a-f]{40}$ ]] \
+            && [[ "$last_success_sha" =~ ^[0-9a-f]{40}$ ]] \
+            && git cat-file -e "${firestore_success_sha}^{commit}" 2>/dev/null \
+            && git cat-file -e "${last_success_sha}^{commit}" 2>/dev/null; then
+            if git merge-base --is-ancestor "$firestore_success_sha" "$last_success_sha"; then
+              if [[ "$firestore_success_sha" != "$last_success_sha" ]]; then
+                echo "::notice::A newer complete production deployment supersedes the older Firestore component marker; advancing the rules baseline."
+              fi
+              firestore_success_sha="$last_success_sha"
+            elif ! git merge-base --is-ancestor "$last_success_sha" "$firestore_success_sha"; then
+              echo "::warning::The Firestore component and complete production baselines diverged; forcing authorization rules-first ordering."
+              firestore_success_sha=""
+            fi
+          fi
 
           if [[ ! "$last_success_sha" =~ ^[0-9a-f]{40}$ ]]; then
             echo "::warning::No valid successful production deploy baseline was found; forcing authorization rules-first ordering."

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -1,14 +1,7 @@
 name: mobile-build
 
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-  push:
-    branches:
-      - master
+  workflow_call:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -1,12 +1,16 @@
-name: ci
+name: pr-fast
 
 on:
-  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 permissions: {}
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: pr-fast-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
@@ -139,7 +143,7 @@ jobs:
       - name: Lint app
         run: node scripts/lint-app-ci.mjs
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
 
       - name: Test app
         run: npm --prefix apps/app run test:ci

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -1,0 +1,82 @@
+name: pr-integration
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-integration-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  regression-integration:
+    uses: ./.github/workflows/regression-guards.yml
+
+  mobile-integration:
+    uses: ./.github/workflows/mobile-build.yml
+
+  preview-integration:
+    uses: ./.github/workflows/preview-smoke.yml
+    secrets: inherit
+
+  preview-artifact:
+    uses: ./.github/workflows/deploy-preview.yml
+
+  mobile-build:
+    name: mobile-build
+    needs: mobile-integration
+    if: ${{ always() && !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce reusable mobile workflow result
+        env:
+          MOBILE_RESULT: ${{ needs.mobile-integration.result }}
+        run: |
+          if [ "$MOBILE_RESULT" != "success" ]; then
+            echo "Mobile integration did not succeed ($MOBILE_RESULT)." >&2
+            exit 1
+          fi
+          echo "Mobile integration succeeded or safely skipped non-mobile work."
+
+  preview-smoke:
+    name: preview-smoke
+    needs:
+      - regression-integration
+      - preview-integration
+      - preview-artifact
+    if: ${{ always() && !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce complete integration result
+        env:
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          PREVIEW_ARTIFACT_RESULT: ${{ needs.preview-artifact.result }}
+          PREVIEW_RESULT: ${{ needs.preview-integration.result }}
+          REGRESSION_RESULT: ${{ needs.regression-integration.result }}
+        run: |
+          set -euo pipefail
+          if [ "$REGRESSION_RESULT" != "success" ]; then
+            echo "Regression integration did not succeed ($REGRESSION_RESULT)." >&2
+            exit 1
+          fi
+          if [ "$PREVIEW_RESULT" != "success" ]; then
+            echo "Preview smoke integration did not succeed ($PREVIEW_RESULT)." >&2
+            exit 1
+          fi
+          if [ "$HEAD_REPOSITORY" = "$GITHUB_REPOSITORY" ] && [ "$PREVIEW_ARTIFACT_RESULT" != "success" ]; then
+            echo "Same-repository preview artifact did not succeed ($PREVIEW_ARTIFACT_RESULT)." >&2
+            exit 1
+          fi
+          if [ "$HEAD_REPOSITORY" != "$GITHUB_REPOSITORY" ] && \
+             [ "$PREVIEW_ARTIFACT_RESULT" != "success" ] && \
+             [ "$PREVIEW_ARTIFACT_RESULT" != "skipped" ]; then
+            echo "Fork preview artifact had an unexpected result ($PREVIEW_ARTIFACT_RESULT)." >&2
+            exit 1
+          fi
+          echo "Integration checks succeeded with fail-closed stable contexts."

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -30,7 +30,7 @@ jobs:
   mobile-build:
     name: mobile-build
     needs: mobile-integration
-    if: ${{ always() && !cancelled() }}
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
       - name: Enforce reusable mobile workflow result
@@ -49,7 +49,7 @@ jobs:
       - regression-integration
       - preview-integration
       - preview-artifact
-    if: ${{ always() && !cancelled() }}
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
       - name: Enforce complete integration result

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -23,7 +23,6 @@ jobs:
 
   preview-integration:
     uses: ./.github/workflows/preview-smoke.yml
-    secrets: inherit
 
   preview-artifact:
     uses: ./.github/workflows/deploy-preview.yml

--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -1,11 +1,8 @@
 name: preview-smoke
 
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
+  workflow_call:
+  workflow_dispatch:
 
 concurrency:
   group: preview-smoke-${{ github.event.pull_request.number }}

--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: preview-smoke-${{ github.event.pull_request.number }}
+  group: preview-smoke-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:
@@ -13,7 +13,9 @@ permissions:
 
 jobs:
   changes:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     outputs:
       web: ${{ steps.filter.outputs.web }}
@@ -60,7 +62,10 @@ jobs:
 
   preview-smoke-run:
     needs: changes
-    if: github.event.pull_request.head.repo.full_name == github.repository && needs.changes.outputs.web == 'true'
+    if: >-
+      (github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      needs.changes.outputs.web == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -232,7 +237,7 @@ jobs:
       - name: Report preview-smoke result
         env:
           CHANGES_RESULT: ${{ needs.changes.result }}
-          IS_SAME_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          IS_ELIGIBLE_EVENT: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
           RUN_RESULT: ${{ needs.preview-smoke-run.result }}
           SHOULD_RUN: ${{ needs.changes.outputs.web }}
         run: |
@@ -240,7 +245,7 @@ jobs:
           echo "changes result: $CHANGES_RESULT"
           echo "preview-smoke-run result: $RUN_RESULT"
 
-          if [ "$IS_SAME_REPOSITORY" != "true" ]; then
+          if [ "$IS_ELIGIBLE_EVENT" != "true" ]; then
             echo "Fork PR — preview-smoke is not eligible to run."
             exit 0
           fi

--- a/.github/workflows/regression-guards.yml
+++ b/.github/workflows/regression-guards.yml
@@ -1,10 +1,8 @@
 name: regression-guards
 
 on:
-  pull_request:
-  push:
-    branches:
-      - master
+  workflow_call:
+  workflow_dispatch:
 
 concurrency:
   group: regression-guards-${{ github.workflow }}-${{ github.ref }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,4 +84,18 @@ HTML test pages in the repo root (`test-foul-tracking.html`, `test-pr-changes.ht
 - Update Firebase web config in `js/firebase.js` and `js/firebase-images.js` when changing projects.
 - Ensure Auth authorized domains include local dev and the deployed host.
 - Public Firebase config in app/native bundles is expected; do not commit service account keys, private API keys, provisioning profiles, or signing certificates.
-- GitHub Pages deployment uses `.github/workflows/app-github-pages.yml` and `scripts/stage-pages-bundle.mjs` to publish the legacy site root plus the React build under `/app/`.
+- Pull-request CI has two code-head entrypoints: `pr-fast` for unit and app
+  quality checks, and `pr-integration` for reusable regression, native, preview
+  smoke, and untrusted preview-artifact work. Preserve the stable
+  `unit-tests`, `cache-bust-guard`, `app-quality`, `mobile-build`, and
+  `preview-smoke` contexts.
+- `external-claim` is ownership metadata and must not trigger or restart CI.
+  Legacy workflow files are reusable/manual only; do not restore competing
+  pull-request or master-push triggers.
+- GitHub Pages publication is serialized behind the exact-SHA production
+  release in `.github/workflows/deploy-prod.yml`.
+  `.github/workflows/app-github-pages.yml` is manual validation only.
+- Keep the untrusted reusable `deploy-preview.yml` builder separate from the
+  default-branch `deploy-preview-trusted.yml` OIDC workflow. The trusted
+  verifier is bound to the successful `pr-integration` run and exact current
+  head.

--- a/docs/landing-process.md
+++ b/docs/landing-process.md
@@ -18,17 +18,21 @@ worker. If more development is necessary, restore `external-claim` first.
 
 ## CI stages
 
-- Fast PR checks (`unit-tests`, `cache-bust-guard`, `app-quality`, and focused
-  regression guards) provide feedback while development is active.
-- Native Android/iOS builds, full preview smoke, and preview artifact creation
-  are deferred while `external-claim` is present.
-- Removing `external-claim` triggers the full applicable integration checks.
+- `pr-fast` runs `unit-tests`, `cache-bust-guard`, and `app-quality` once for
+  each opened, reopened, or synchronized code head.
+- `pr-integration` calls the regression, path-filtered native, staged preview
+  smoke, and untrusted preview-artifact workflows in one run. Its always-running
+  `mobile-build` and `preview-smoke` aggregates fail closed.
+- A successful same-repository `pr-integration` run triggers one
+  `deploy-preview-trusted` run, which re-verifies the exact current head before
+  any credentialed preview write.
 - Production deployment remains a post-merge `master` workflow.
 
-The stable aggregate contexts `mobile-build` and `preview-smoke` report a
-successful deferral while a claim is active. They rerun the real integration
-work on the same head when the claim is removed; `paulbot-review-gate` and the
-PaulBot mutation gate prevent a claimed PR from entering automated landing.
+`external-claim` is controller ownership metadata, not a CI trigger. Label
+changes do not cancel or restart code validation. At handoff PaulBot consumes
+the frozen exact head's existing results and narrowly wakes a missing current
+head check only when necessary; `paulbot-review-gate` and the mutation gate
+prevent a claimed PR from entering automated landing.
 
 ## Pull request sizing
 

--- a/docs/preview-deploy-trust-boundary.md
+++ b/docs/preview-deploy-trust-boundary.md
@@ -2,10 +2,13 @@
 
 ## Required invariants
 
-The `deploy-preview` pull-request workflow executes untrusted PR code. It must
-never receive a Firebase credential or a repository token with write
-permissions. It may only test, build, stage public Hosting content, and upload
-the single `firebase-preview-hosting-bundle` artifact.
+The `pr-integration` pull-request workflow calls the reusable
+`deploy-preview` artifact builder, which executes untrusted PR code. Neither may
+receive a Firebase credential or a repository token with write permissions.
+The reusable builder may only build, stage public Hosting content, and upload
+the single `firebase-preview-hosting-bundle` artifact. The same consolidated
+run must also pass the reusable regression and preview-smoke workflows before
+its stable `preview-smoke` aggregate succeeds.
 
 The `deploy-preview-trusted` workflow is the only preview deployer. GitHub runs
 its `workflow_run` definition from the default branch. It checks out only the
@@ -86,8 +89,8 @@ Before merging a change to either preview workflow:
 5. Review the exact PR head SHA after all requested automated reviews and CI
    complete. Any new commit invalidates prior review evidence.
 
-The first `workflow_run` preview cannot execute until this workflow and its
-trusted verifier scripts are present on the default branch. The PR workflow's
+The first `workflow_run` preview cannot execute until `pr-integration` and its
+trusted verifier scripts are present on the default branch. The reusable
 artifact build remains testable before merge; the first post-merge PR run is
 the deployment canary.
 

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -433,6 +433,7 @@ export function validateFirebaseRulesCi() {
     const deployProd = readText('.github/workflows/deploy-prod.yml');
     const deployPreviewBuild = readText('.github/workflows/deploy-preview.yml');
     const deployPreviewTrusted = readText('.github/workflows/deploy-preview-trusted.yml');
+    const prIntegration = readText('.github/workflows/pr-integration.yml');
     const regressionGuards = readText('.github/workflows/regression-guards.yml');
 
     validateFirestoreRulesDeployBudget(compactFirestoreRules(firestoreRules));
@@ -511,7 +512,11 @@ export function validateFirebaseRulesCi() {
     validateFirebaseDeployWorkloadIdentity(deployProd, 'Production deploy');
     assertMatches(deployProd, /needs:\s*\[\s*unit-tests\s*,\s*regression-guards\s*\]/, 'Production deploy gate');
 
-    assertMatches(deployPreviewBuild, /needs:\s*\[\s*regression-guards\s*\]/, 'Preview artifact build gate');
+    assertIncludes(deployPreviewBuild, 'workflow_call:', 'Untrusted preview reusable workflow');
+    assertIncludes(prIntegration, 'uses: ./.github/workflows/regression-guards.yml', 'PR integration regression gate');
+    assertIncludes(prIntegration, 'uses: ./.github/workflows/deploy-preview.yml', 'PR integration preview artifact gate');
+    assertIncludes(prIntegration, 'name: preview-smoke', 'PR integration stable preview context');
+    assertIncludes(prIntegration, 'name: mobile-build', 'PR integration stable mobile context');
     validatePreviewDeployCommand(deployPreviewTrusted);
     validateFirebaseDeployWorkloadIdentity(deployPreviewTrusted, 'Trusted preview deploy');
     assertPreviewDeploySkipHandling(deployPreviewTrusted);

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -365,6 +365,21 @@ export function validateProductionDeployCommand(deployProd) {
     assertIncludes(deployProd, 'repos/${GITHUB_REPOSITORY}/deployments', 'Production Firestore component deployment lookup');
     assertIncludes(deployProd, '-f environment=production-firestore', 'Production Firestore component environment filter');
     assertIncludes(deployProd, 'firestore_success_sha="$deployment_sha"', 'Production Firestore component successful SHA');
+    assertIncludes(
+        deployProd,
+        'git merge-base --is-ancestor "$firestore_success_sha" "$last_success_sha"',
+        'Production Firestore stale component baseline advancement'
+    );
+    assertIncludes(
+        deployProd,
+        'firestore_success_sha="$last_success_sha"',
+        'Production Firestore complete deployment baseline reuse'
+    );
+    assertIncludes(
+        deployProd,
+        'The Firestore component and complete production baselines diverged; forcing authorization rules-first ordering.',
+        'Production Firestore divergent baseline fail-closed fallback'
+    );
     assertIncludes(deployProd, 'git diff --quiet "$firestore_success_sha" "$GITHUB_SHA" -- firestore.rules firestore.indexes.json', 'Production Firestore component change detection');
     assertIncludes(deployProd, 'record_component_deployment()', 'Production component deployment recorder');
     assertIncludes(deployProd, '"production-firestore"', 'Production Firestore component marker');

--- a/scripts/verify-preview-deploy-trigger.mjs
+++ b/scripts/verify-preview-deploy-trigger.mjs
@@ -1,8 +1,8 @@
 import fs from 'node:fs';
 import { pathToFileURL } from 'node:url';
 
-export const PREVIEW_WORKFLOW_NAME = 'deploy-preview';
-export const PREVIEW_WORKFLOW_PATH = '.github/workflows/deploy-preview.yml';
+export const PREVIEW_WORKFLOW_NAME = 'pr-integration';
+export const PREVIEW_WORKFLOW_PATH = '.github/workflows/pr-integration.yml';
 export const PREVIEW_ARTIFACT_NAME = 'firebase-preview-hosting-bundle';
 export const MAX_PREVIEW_ARCHIVE_BYTES = 100 * 1024 * 1024;
 

--- a/tests/unit/firebase-deploy-workload-identity.test.js
+++ b/tests/unit/firebase-deploy-workload-identity.test.js
@@ -156,6 +156,13 @@ describe('Firebase deploy Workload Identity boundary', () => {
         expect(production).toContain('deployments: read');
         expect(production).toContain('deployments: write');
         expect(production).toContain('firestore_success_sha="$deployment_sha"');
+        expect(production).toContain(
+            'git merge-base --is-ancestor "$firestore_success_sha" "$last_success_sha"'
+        );
+        expect(production).toContain('firestore_success_sha="$last_success_sha"');
+        expect(production).toContain(
+            'The Firestore component and complete production baselines diverged; forcing authorization rules-first ordering.'
+        );
         expect(componentMarker).toBeGreaterThan(end);
         expect(componentMarker).toBeLessThan(retryEnabledDeploy);
         expect(retryEnabledDeploy).toBeGreaterThan(end);

--- a/tests/unit/mobile-build-workflow.test.js
+++ b/tests/unit/mobile-build-workflow.test.js
@@ -2,18 +2,19 @@ import { describe, expect, it } from 'vitest';
 import { readdirSync, readFileSync } from 'node:fs';
 
 const workflow = readFileSync(new URL('../../.github/workflows/mobile-build.yml', import.meta.url), 'utf8');
+const integrationWorkflow = readFileSync(
+    new URL('../../.github/workflows/pr-integration.yml', import.meta.url),
+    'utf8'
+);
 
 describe('mobile-build CI workflow', () => {
-    it('always triggers on every pull request and master push (no path filter that could skip the required check)', () => {
-        // A `paths:` filter directly under `pull_request:`/`push:` would mean the
-        // workflow — and therefore the `mobile-build` required status check —
-        // never runs for PRs that don't touch those paths, permanently blocking
-        // merge (GitHub required checks that never post a status block forever).
+    it('is reusable without opening a duplicate pull-request run', () => {
         const triggerSection = workflow.slice(workflow.indexOf('\non:'), workflow.indexOf('\nconcurrency:'));
         expect(triggerSection).not.toContain('paths:');
-        expect(triggerSection).toContain('pull_request:');
-        expect(triggerSection).toContain('push:');
+        expect(triggerSection).toContain('workflow_call:');
         expect(triggerSection).toContain('workflow_dispatch:');
+        expect(triggerSection).not.toContain('pull_request:');
+        expect(triggerSection).not.toContain('push:');
     });
 
     it('gates the expensive android/ios build jobs on a path-detection job instead of removing path awareness entirely', () => {
@@ -28,14 +29,19 @@ describe('mobile-build CI workflow', () => {
         expect(workflow).toContain('capacitor\\.config\\.json');
     });
 
-    it('runs for code changes without creating duplicate runs for label churn', () => {
-        const triggerSection = workflow.slice(workflow.indexOf('\non:'), workflow.indexOf('\nconcurrency:'));
+    it('is called by the consolidated code-head workflow without label-churn runs', () => {
+        const triggerSection = integrationWorkflow.slice(
+            integrationWorkflow.indexOf('\non:'),
+            integrationWorkflow.indexOf('\npermissions:')
+        );
         const changesSection = workflow.slice(workflow.indexOf('  changes:'), workflow.indexOf('  android-debug:'));
         const gateSection = workflow.slice(workflow.indexOf('  mobile-build:'));
 
         expect(triggerSection).toContain('      - synchronize');
         expect(triggerSection).not.toContain('      - unlabeled');
         expect(triggerSection).not.toContain('      - labeled');
+        expect(integrationWorkflow).toContain('uses: ./.github/workflows/mobile-build.yml');
+        expect(integrationWorkflow).toContain('name: mobile-build');
         expect(workflow).toContain('group: mobile-build-${{ github.workflow }}-${{ github.ref }}');
         expect(changesSection).not.toContain('external-claim');
         expect(changesSection).not.toContain('LABEL_NAME');

--- a/tests/unit/pr-ci-consolidation.test.js
+++ b/tests/unit/pr-ci-consolidation.test.js
@@ -1,0 +1,59 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = path.resolve(import.meta.dirname, '../..');
+
+function workflow(name) {
+    return fs.readFileSync(path.join(repoRoot, '.github', 'workflows', name), 'utf8');
+}
+
+describe('pull request CI consolidation', () => {
+    it('has exactly two code-head workflow entrypoints with stable required contexts', () => {
+        const fast = workflow('pr-fast.yml');
+        const integration = workflow('pr-integration.yml');
+
+        expect(fast).toContain('name: pr-fast');
+        expect(fast).toContain('pull_request:');
+        expect(fast).toContain('  cache-bust-guard:');
+        expect(fast).toContain('  unit-tests:');
+        expect(fast).toContain('  app-quality:');
+        expect(integration).toContain('name: pr-integration');
+        expect(integration).toContain('pull_request:');
+        expect(integration).toContain('name: mobile-build');
+        expect(integration).toContain('name: preview-smoke');
+    });
+
+    it('keeps legacy workflows callable or manual without duplicate PR triggers', () => {
+        for (const name of [
+            'ci.yml',
+            'regression-guards.yml',
+            'mobile-build.yml',
+            'preview-smoke.yml',
+            'deploy-preview.yml',
+            'app-github-pages.yml'
+        ]) {
+            expect(workflow(name), name).not.toContain('\n  pull_request:');
+        }
+        for (const name of [
+            'regression-guards.yml',
+            'mobile-build.yml',
+            'preview-smoke.yml',
+            'deploy-preview.yml'
+        ]) {
+            expect(workflow(name), name).toContain('workflow_call:');
+        }
+    });
+
+    it('binds trusted preview deployment to the consolidated source run', () => {
+        const trusted = workflow('deploy-preview-trusted.yml');
+        const verifier = fs.readFileSync(
+            path.join(repoRoot, 'scripts', 'verify-preview-deploy-trigger.mjs'),
+            'utf8'
+        );
+
+        expect(trusted).toContain('      - pr-integration');
+        expect(verifier).toContain("PREVIEW_WORKFLOW_NAME = 'pr-integration'");
+        expect(verifier).toContain("PREVIEW_WORKFLOW_PATH = '.github/workflows/pr-integration.yml'");
+    });
+});

--- a/tests/unit/pr-ci-consolidation.test.js
+++ b/tests/unit/pr-ci-consolidation.test.js
@@ -1,6 +1,8 @@
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { parse as parseYaml } from 'yaml';
 
 const repoRoot = path.resolve(import.meta.dirname, '../..');
 
@@ -49,6 +51,41 @@ describe('pull request CI consolidation', () => {
         const integration = workflow('pr-integration.yml');
 
         expect(integration).not.toContain('secrets: inherit');
+    });
+
+    it.each([
+        ['mobile-build', { MOBILE_RESULT: 'cancelled' }],
+        ['preview-smoke', {
+            HEAD_REPOSITORY: 'allplays/allplays',
+            PREVIEW_ARTIFACT_RESULT: 'success',
+            PREVIEW_RESULT: 'success',
+            REGRESSION_RESULT: 'cancelled'
+        }],
+        ['preview-smoke', {
+            HEAD_REPOSITORY: 'allplays/allplays',
+            PREVIEW_ARTIFACT_RESULT: 'success',
+            PREVIEW_RESULT: 'cancelled',
+            REGRESSION_RESULT: 'success'
+        }],
+        ['preview-smoke', {
+            HEAD_REPOSITORY: 'allplays/allplays',
+            PREVIEW_ARTIFACT_RESULT: 'cancelled',
+            PREVIEW_RESULT: 'success',
+            REGRESSION_RESULT: 'success'
+        }]
+    ])('runs %s after cancellation and rejects cancelled upstream results', (jobName, env) => {
+        const integration = parseYaml(workflow('pr-integration.yml'));
+        const job = integration.jobs[jobName];
+        const result = spawnSync('bash', ['-c', job.steps[0].run], {
+            env: {
+                ...process.env,
+                GITHUB_REPOSITORY: 'allplays/allplays',
+                ...env
+            }
+        });
+
+        expect(job.if).toBe('${{ always() }}');
+        expect(result.status).toBe(1);
     });
 
     it('binds trusted preview deployment to the consolidated source run', () => {

--- a/tests/unit/pr-ci-consolidation.test.js
+++ b/tests/unit/pr-ci-consolidation.test.js
@@ -45,6 +45,12 @@ describe('pull request CI consolidation', () => {
         }
     });
 
+    it('does not expose repository secrets to PR-controlled reusable workflows', () => {
+        const integration = workflow('pr-integration.yml');
+
+        expect(integration).not.toContain('secrets: inherit');
+    });
+
     it('binds trusted preview deployment to the consolidated source run', () => {
         const trusted = workflow('deploy-preview-trusted.yml');
         const verifier = fs.readFileSync(

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -204,6 +204,9 @@ describe('preview deployment workflow trust boundary', () => {
         expect(trustedWorkflow).toContain('      - pr-integration');
         expect(trustedWorkflow).toContain('classify-trigger:');
         expect(trustedWorkflow).toContain('preview_ready: ${{ steps.classify.outputs.preview_ready }}');
+        expect(trustedWorkflow).toContain('pull-requests: read');
+        expect(trustedWorkflow).toContain('Fork pull request — no trusted preview deploy is required.');
+        expect(trustedWorkflow).toContain('echo "preview_ready=false" >> "$GITHUB_OUTPUT"');
         expect(trustedWorkflow).toContain('Expected exactly one preview bundle');
         expect(trustedWorkflow).toContain("needs.classify-trigger.outputs.preview_ready == 'true'");
         expect(trustedWorkflow).toContain(

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -16,6 +16,10 @@ const pullRequestWorkflow = fs.readFileSync(
     path.join(repoRoot, '.github', 'workflows', 'deploy-preview.yml'),
     'utf8'
 );
+const integrationWorkflow = fs.readFileSync(
+    path.join(repoRoot, '.github', 'workflows', 'pr-integration.yml'),
+    'utf8'
+);
 const trustedWorkflow = fs.readFileSync(
     path.join(repoRoot, '.github', 'workflows', 'deploy-preview-trusted.yml'),
     'utf8'
@@ -45,7 +49,7 @@ function validTriggerFixture() {
             repository: { full_name: repository },
             workflow_run: {
                 id: runId,
-                name: 'deploy-preview',
+                name: 'pr-integration',
                 event: 'pull_request',
                 status: 'completed',
                 conclusion: 'success',
@@ -57,8 +61,8 @@ function validTriggerFixture() {
         },
         run: {
             id: runId,
-            name: 'deploy-preview',
-            path: '.github/workflows/deploy-preview.yml',
+            name: 'pr-integration',
+            path: '.github/workflows/pr-integration.yml',
             event: 'pull_request',
             status: 'completed',
             conclusion: 'success',
@@ -179,24 +183,28 @@ describe('preview deployment workflow trust boundary', () => {
         expect(pullRequestWorkflow).not.toMatch(/^\s+\w[\w-]*:\s+write\s*$/m);
         expect(pullRequestWorkflow).toContain('name: firebase-preview-hosting-bundle');
         expect(pullRequestWorkflow).toContain('include-hidden-files: true');
-        expect(pullRequestWorkflow).toMatch(/build-preview-artifact:[\s\S]*needs: \[regression-guards\]/);
+        expect(pullRequestWorkflow).toContain('workflow_call:');
+        expect(pullRequestWorkflow).not.toContain('pull_request:');
         expect(pullRequestWorkflow).not.toContain('  unit-tests:');
         expect(pullRequestWorkflow).not.toContain('external-claim');
     });
 
-    it('cancels in-flight preview work when its pull request closes', () => {
-        expect(pullRequestWorkflow).toContain('      - closed');
-        expect(pullRequestWorkflow).toContain('group: preview-${{ github.event.pull_request.number }}');
-        expect(pullRequestWorkflow).toContain('cancel-in-progress: true');
-        expect(pullRequestWorkflow).not.toContain('      - unlabeled');
-        expect(pullRequestWorkflow).not.toContain('      - labeled');
+    it('serializes the untrusted preview artifact inside the consolidated PR run', () => {
+        expect(integrationWorkflow).toContain('name: pr-integration');
+        expect(integrationWorkflow).toContain('group: pr-integration-${{ github.event.pull_request.number }}');
+        expect(integrationWorkflow).toContain('cancel-in-progress: true');
+        expect(integrationWorkflow).toContain('uses: ./.github/workflows/deploy-preview.yml');
+        expect(integrationWorkflow).toContain('name: preview-smoke');
+        expect(integrationWorkflow).not.toContain('      - unlabeled');
+        expect(integrationWorkflow).not.toContain('      - labeled');
     });
 
     it('runs the credentialed deploy only from trusted default-branch code', () => {
         expect(trustedWorkflow).toContain('workflow_run:');
+        expect(trustedWorkflow).toContain('      - pr-integration');
         expect(trustedWorkflow).toContain('classify-trigger:');
         expect(trustedWorkflow).toContain('preview_ready: ${{ steps.classify.outputs.preview_ready }}');
-        expect(trustedWorkflow).toContain('Successful preview source run had no bundle without an intentional two-job deferral.');
+        expect(trustedWorkflow).toContain('Expected exactly one preview bundle');
         expect(trustedWorkflow).toContain("needs.classify-trigger.outputs.preview_ready == 'true'");
         expect(trustedWorkflow).toContain(
             'group: trusted-preview-pr-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.id }}'

--- a/tests/unit/preview-smoke-workflow.test.js
+++ b/tests/unit/preview-smoke-workflow.test.js
@@ -5,16 +5,32 @@ const workflow = readFileSync(
     new URL('../../.github/workflows/preview-smoke.yml', import.meta.url),
     'utf8'
 );
+const integrationWorkflow = readFileSync(
+    new URL('../../.github/workflows/pr-integration.yml', import.meta.url),
+    'utf8'
+);
 
 describe('preview-smoke CI workflow', () => {
-    it('runs for code changes without creating duplicate runs for label churn', () => {
-        const triggerSection = workflow.slice(workflow.indexOf('\non:'), workflow.indexOf('\nconcurrency:'));
+    it('is called by the consolidated code-head workflow without label-churn runs', () => {
+        const childTriggerSection = workflow.slice(
+            workflow.indexOf('\non:'),
+            workflow.indexOf('\nconcurrency:')
+        );
+        const triggerSection = integrationWorkflow.slice(
+            integrationWorkflow.indexOf('\non:'),
+            integrationWorkflow.indexOf('\npermissions:')
+        );
         const changesSection = workflow.slice(workflow.indexOf('  changes:'), workflow.indexOf('  preview-smoke-run:'));
         const gateSection = workflow.slice(workflow.indexOf('  preview-smoke:'));
 
+        expect(childTriggerSection).toContain('workflow_call:');
+        expect(childTriggerSection).toContain('workflow_dispatch:');
+        expect(childTriggerSection).not.toContain('pull_request:');
         expect(triggerSection).toContain('      - synchronize');
         expect(triggerSection).not.toContain('      - unlabeled');
         expect(triggerSection).not.toContain('      - labeled');
+        expect(integrationWorkflow).toContain('uses: ./.github/workflows/preview-smoke.yml');
+        expect(integrationWorkflow).toContain('name: preview-smoke');
         expect(workflow).toContain('group: preview-smoke-${{ github.event.pull_request.number }}');
         expect(changesSection).not.toContain('external-claim');
         expect(changesSection).not.toContain('LABEL_NAME');

--- a/tests/unit/preview-smoke-workflow.test.js
+++ b/tests/unit/preview-smoke-workflow.test.js
@@ -31,7 +31,12 @@ describe('preview-smoke CI workflow', () => {
         expect(triggerSection).not.toContain('      - labeled');
         expect(integrationWorkflow).toContain('uses: ./.github/workflows/preview-smoke.yml');
         expect(integrationWorkflow).toContain('name: preview-smoke');
-        expect(workflow).toContain('group: preview-smoke-${{ github.event.pull_request.number }}');
+        expect(workflow).toContain(
+            'group: preview-smoke-${{ github.event.pull_request.number || github.run_id }}'
+        );
+        expect(changesSection).toContain("github.event_name == 'workflow_dispatch'");
+        expect(workflow.slice(workflow.indexOf('  preview-smoke-run:'), workflow.indexOf('  preview-smoke:')))
+            .toContain("github.event_name == 'workflow_dispatch'");
         expect(changesSection).not.toContain('external-claim');
         expect(changesSection).not.toContain('LABEL_NAME');
         expect(gateSection).toContain('name: preview-smoke');
@@ -59,7 +64,10 @@ describe('preview-smoke CI workflow', () => {
             '[ "$SHOULD_RUN" = "false" ] && [ "$RUN_RESULT" = "skipped" ]'
         );
 
-        expect(gate).toContain('[ "$IS_SAME_REPOSITORY" != "true" ]');
+        expect(gate).toContain(
+            "IS_ELIGIBLE_EVENT: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}"
+        );
+        expect(gate).toContain('[ "$IS_ELIGIBLE_EVENT" != "true" ]');
         expect(changesResultCheck).toBeGreaterThan(-1);
         expect(intentionalSkipCheck).toBeGreaterThan(changesResultCheck);
         expect(gate).not.toContain('success|skipped');

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -133,6 +133,9 @@ concurrency:
           fi
           gh api --method GET "repos/\${GITHUB_REPOSITORY}/deployments" -f environment=production-firestore
           firestore_success_sha="$deployment_sha"
+          git merge-base --is-ancestor "$firestore_success_sha" "$last_success_sha"
+          firestore_success_sha="$last_success_sha"
+          echo "The Firestore component and complete production baselines diverged; forcing authorization rules-first ordering."
           git diff --quiet "$firestore_success_sha" "$GITHUB_SHA" -- firestore.rules firestore.indexes.json
           git diff --quiet "$last_success_sha" "$GITHUB_SHA" -- storage.rules
       - name: Deploy Firebase Storage rules when available


### PR DESCRIPTION
## What changed

- replace six independent pull-request workflow entrypoints with `pr-fast` and `pr-integration`
- preserve the required `cache-bust-guard`, `unit-tests`, `app-quality`, `mobile-build`, and `preview-smoke` contexts
- make regression, mobile, preview smoke, and preview artifact workflows reusable without duplicate PR triggers
- bind trusted preview deployment to the consolidated integration run while preserving exact-head/OIDC verification
- stop duplicate master-push CI outside the serialized production release
- advance a stale Firestore component marker to a newer successful complete-production baseline when the histories are ordered; divergent histories remain fail closed
- update producer/PaulBot handoff guidance and workflow contract tests

## Why

The previous graph created roughly seven workflow runs per PR head before PaulBot review or remediation. This change targets three runs per frozen head after rollout (two untrusted PR runs plus one trusted preview continuation), a 57% per-head reduction and the planned daily reduction from about 504 to at most 230 runs.

The first serialized production canary also exposed a migration edge case: an old `production-firestore` marker made unchanged rules look changed, so the known-unhealthy Rules API circuit breaker stopped the release with HTTP 503. The revised baseline selection reuses a newer successful complete production SHA only when it is a descendant of the component marker.

## Validation

- 86/86 affected workflow/security tests passed before the production canary
- 74/74 focused release/CI/security tests passed after the baseline fix
- all 17 `.github/workflows` YAML files parsed
- changed production shell blocks pass `bash -n`
- `npm run ci:firebase-rules`
- `git diff --check`
- historical SHA simulation selects `1b02c4c3` over stale component `7c9f9ef6` and computes the #4214 rules diff as unchanged
- live final-head Actions validation in progress; exactly two code-head workflows created

## Safety

The failed #4214 production canary mutated no Firestore, Functions, Hosting, Pages, or release marker state. The circuit breaker and exact-SHA serialization failed closed as designed.

## Handoff

Keep `external-claim` while the final exact head is validating. After the two consolidated runs are green, freeze this SHA, mark ready, and remove the claim for PaulBot-owned review and merge.