### PR TITLE
Retry transient Firestore deploy failures

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -707,10 +707,12 @@ jobs:
             # must not publish until its Firestore configuration is active.
             # Probe the non-persistent projects:test endpoint first. A known
             # Rules API outage opens the circuit before any ruleset/release
-            # mutation. The actual deploy gets one attempt, keeping the total
-            # projects:test calls bounded to at most three per release run.
+            # mutation. The actual idempotent deploy gets three bounded attempts
+            # because the API can recover between a successful preflight and the
+            # Firebase CLI's own compile request. This keeps the total
+            # projects:test calls bounded to at most five per release run.
             test_firestore_rules_api 2 20
-            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 1 0
+            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 3 20
           else
             # No authorization/index drift exists relative to the last successful
             # production deployment. Do not make a redundant Rules API write: an

--- a/docs/observability-runbook.md
+++ b/docs/observability-runbook.md
@@ -69,7 +69,7 @@ If the critical workflow monitor is noisy, disable only its schedule while inves
 
 ## Firestore Rules API retry exhaustion
 
-The serialized production release train allows at most three Firestore Rules API checks per release: up to two non-persistent `projects:test` health probes, followed by one persistent Firestore rules/index deployment attempt only after the probe passes. If the probe or deployment fails, the job summary identifies the Google API surface, final HTTP error class, attempt count, and surfaces that were not deployed. The summary uses only fixed operational labels and does not copy API response bodies, credentials, tenant identifiers, or application data.
+The serialized production release train allows at most five Firestore Rules API checks per release: up to two non-persistent `projects:test` health probes, followed by up to three persistent Firestore rules/index deployment attempts only after the probe passes. If the probe or deployment fails, the job summary identifies the Google API surface, final HTTP error class, attempt count, and surfaces that were not deployed. The summary uses only fixed operational labels and does not copy API response bodies, credentials, tenant identifiers, or application data.
 
 Application deployment remains fail-closed. When Rules or indexes differ from the last successful production deployment, Hosting and Functions do not deploy until the combined Firestore configuration command succeeds. The Firebase CLI may apply indexes before a later Rules API failure, so treat the Rules and index state as potentially partial and verify both before retrying. Existing Hosting and Functions production remains active; do not bypass the workflow or deploy application surfaces separately.
 

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -309,8 +309,8 @@ export function validateProductionDeployCommand(deployProd) {
     );
     assertIncludes(
         deployProd,
-        'retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 1 0',
-        'Production Firestore deploy gets one post-preflight mutation attempt'
+        'retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 3 20',
+        'Production Firestore deploy gets bounded post-preflight retries'
     );
     assertIncludes(deployProd, 'if (( retry_delay_seconds > 120 )); then', 'Production Firebase retry delay cap');
     assertIncludes(deployProd, 'retry_jitter_seconds=$((RANDOM % 16))', 'Production Firebase retry jitter');
@@ -397,6 +397,16 @@ export function validateProductionDeployCommand(deployProd) {
     if (unchangedBranch.includes('"firestore"')) {
         throw new Error('Production must not redeploy unchanged Firestore configuration.');
     }
+    assertIncludes(
+        changedBranch,
+        'retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 3 20',
+        'Production Firestore transient deploy retries'
+    );
+    assertIncludes(
+        changedBranch,
+        'projects:test calls bounded to at most five per release run',
+        'Production Firestore retry request bound'
+    );
     const retryEnabledDeploy = deployProd.indexOf('"retry-enabled-functions"', conditionalEnd);
     const componentMarker = deployProd.indexOf('record_component_deployment', conditionalEnd);
     const applicationDeploy = deployProd.indexOf('retry_firebase_deploy "hosting,functions" "application"', conditionalEnd);

--- a/tests/unit/auth-email-resend-routing.test.js
+++ b/tests/unit/auth-email-resend-routing.test.js
@@ -110,7 +110,7 @@ describe('authentication email delivery routing', () => {
         }
     });
 
-    it('bounds normal deploys to three attempts and Firestore to a probe-gated mutation', () => {
+    it('bounds normal and probe-gated Firestore deploys to three attempts', () => {
         const productionSource = read('.github/workflows/deploy-prod.yml');
         const firebaseDeployCommands = productionSource
             .split('\n')
@@ -140,7 +140,8 @@ describe('authentication email delivery routing', () => {
         expect(productionSource).toContain('retry_delay_seconds=$((base_delay_seconds * (2 ** (attempt - 1))))');
         expect(productionSource).toContain('if (( retry_delay_seconds > 120 )); then');
         expect(productionSource).toContain('test_firestore_rules_api 2 20');
-        expect(productionSource).toContain('retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 1 0');
+        expect(productionSource).toContain('retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 3 20');
+        expect(productionSource).toContain('projects:test calls bounded to at most five per release run');
         expect(productionSource).toContain('retry_firebase_deploy "hosting,functions" "application"');
         const retryEnabledDeploy = productionSource.indexOf('"retry-enabled-functions"');
         const changedBranchStart = productionSource.indexOf('if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then');

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -184,8 +184,9 @@ concurrency:
             curl "https://firebaserules.googleapis.com/v1/projects/game-flow-c6311:test"
           }
           if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then
+            projects:test calls bounded to at most five per release run
             test_firestore_rules_api 2 20
-            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 1 0
+            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 3 20
           else
             :
           fi
@@ -285,16 +286,16 @@ concurrency:
             'docs/observability-runbook.md'
         ))).toThrow('Production Firestore retry-exhaustion recovery link');
         expect(() => validateProductionDeployCommand(validDeployCommand.replace(
-            `retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 1 0`,
+            `retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 3 20`,
             `retry_firebase_deploy "hosting,functions" "application"
-            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 1 0`
+            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 3 20`
         ))).toThrow('Production Firestore deploy and component marker must run first when its configuration changed');
         expect(() => validateProductionDeployCommand(validDeployCommand.replace(
             `else
             :
           fi`,
             `else
-            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 1 0
+            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 3 20
           fi`
         ))).toThrow('Production must not redeploy unchanged Firestore configuration');
     });


### PR DESCRIPTION
## What changed

- retry the real Firestore rules/index deploy up to three times for transient Google API failures
- retain the non-persistent preflight and fail-closed rules-first ordering
- add contract coverage for the five-call upper bound and the exact retry policy

## Why

Production run #30215564542 passed the Rules API preflight and then received HTTP 503 during the Firebase CLI compile request. The single real attempt blocked Hosting and Functions correctly, but could not recover from the transient race.

Closes #4217

## Validation

- `npm run ci:firebase-rules`
- `npx vitest run tests/unit/auth-email-resend-routing.test.js tests/unit/validate-firebase-rules-ci.test.js --reporter=verbose` (14 passed)
- Ruby YAML parse for `.github/workflows/deploy-prod.yml`
- `git diff --check`

## Security/trust review

No trigger, permission, OIDC, secret, artifact, environment, or deploy target changed. The protected deployment remains exact-workflow OIDC-authenticated and Firestore remains fail-closed ahead of Hosting and Functions.