### PR TITLE
Fix React app test isolation guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,11 +34,12 @@ Open legacy pages at `http://localhost:8000`. Open the app locally at `http://lo
 ## Testing Guidelines
 
 ### Test suite overview
-The repo has two automated test tiers:
+The repo has three automated test tiers:
 
 | Tier | Framework | Location | Run command |
 |------|-----------|----------|-------------|
-| Unit | Vitest | `tests/unit/` | `npm test` |
+| Legacy unit/contracts | Vitest | `tests/unit/` | `npm test` |
+| React app | Vitest | `apps/app/src/` | `npm run test:app` |
 | Smoke (E2E) | Playwright | `tests/smoke/` | `npm run test:smoke` |
 
 ### Unit tests (`tests/unit/`)
@@ -46,6 +47,13 @@ The repo has two automated test tiers:
 - Test pure logic extracted into JS modules, and assert on HTML structure/content of static pages.
 - Mock Firebase and external deps with `vi.fn()` / `vi.mock()`.
 - Run a single file during development: `npx vitest run tests/unit/my-file.test.js --reporter=verbose`
+
+### React app tests (`apps/app/src/`)
+- Keep React component and app unit tests colocated with app code.
+- Run focused tests through the app package configuration:
+  `npm run test:app -- src/path/to/file.test.tsx`.
+- The app setup loads `@testing-library/jest-dom/vitest`; do not move app tests
+  to root `tests/unit/` to work around missing DOM matchers.
 
 ### Smoke tests (`tests/smoke/`)
 - Use Playwright against a live server (`npm run serve:firebase` or `python3 -m http.server`).
@@ -55,7 +63,7 @@ The repo has two automated test tiers:
 
 ### What to write for each change
 - **New JS module:** unit test covering the exported functions and error branches.
-- **New React app helper:** unit test in `tests/unit/` and focused Playwright smoke when it changes a user flow.
+- **New React app helper:** colocated app unit test and focused Playwright smoke when it changes a user flow.
 - **New static HTML page:** unit test checking structure, data attributes, JS wiring, and internal link targets; smoke test checking boot, key selectors, and interactive behaviors.
 - **Bug fix:** add a regression unit test that fails before the fix and passes after.
 - **UI flow change:** update or extend the relevant smoke spec.

--- a/apps/app/AGENTS.md
+++ b/apps/app/AGENTS.md
@@ -12,7 +12,15 @@
 - `npm run mobile:build:ios` and `npm run mobile:build:android` run local native build checks.
 
 ## Testing
-- Put app unit tests in root `tests/unit/`, importing app helpers from `apps/app/src/`.
+- Keep React component and app unit tests colocated under `apps/app/src/`.
+- Run app tests with the app package's Vitest configuration: use
+  `npm run test:app -- src/path/to/file.test.tsx` from the repository root, or
+  `npm test -- --run src/path/to/file.test.tsx` from `apps/app/`.
+- Keep `@testing-library/jest-dom/vitest` in `src/setupTests.ts` so focused
+  Vitest runs register DOM matchers. Do not rely on the root unit-test setup.
+- Keep legacy static-site contract tests in root `tests/unit/`; those tests may
+  import pure app helpers when they are intentionally validating a legacy/app
+  boundary.
 - Put app Playwright flows in root `tests/smoke/app-*.spec.js`.
 - For user-facing app changes, run the targeted unit tests, `npm run app:build`, and the relevant app smoke spec with `SMOKE_APP_BASE_URL`.
 - Production boot coverage for `https://allplays.ai/app/` lives in `tests/smoke/app-production-bootstrap.spec.js`.

--- a/apps/app/src/setupTests.test.ts
+++ b/apps/app/src/setupTests.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from 'vitest';
+
+describe('Vitest DOM matcher setup', () => {
+  it('registers jest-dom matchers for isolated app tests', () => {
+    expect(document.body).toBeInTheDocument();
+  });
+});

--- a/apps/app/src/setupTests.ts
+++ b/apps/app/src/setupTests.ts
@@ -1,1 +1,1 @@
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run tests/unit",
     "test:unit": "vitest run tests/unit",
     "test:unit:ci": "vitest run tests/unit --reporter=dot && npm run test:storage-rules:ci",
+    "test:app": "npm --prefix apps/app test -- --run",
     "test:storage-rules:ci": "firebase emulators:exec --only firestore,storage --project demo-allplays \"vitest run tests/unit/storage-rules-team-boundary.test.js tests/unit/player-rules-privacy.test.js tests/unit/private-ai-rules.test.js tests/unit/team-entitlement-rules.test.js tests/unit/team-email-send-rules.test.js tests/unit/app-social-rules.test.js tests/unit/rsvp-note-privacy-rules.test.js tests/unit/stored-xss-media-rules.test.js tests/unit/verified-email-policy-rules.test.js tests/unit/public-registration-rules.test.js tests/unit/team-fee-recipient-rules.test.js --reporter=dot --no-file-parallelism\"",
     "test:coverage-map": "node scripts/report-test-coverage-map.mjs --check",
     "test:functions:notifications": "npm run test:notifications --prefix functions",


### PR DESCRIPTION
## Summary
- add a stable root `test:app` command that runs the app package Vitest config
- correct root and app guidance so React tests stay colocated under `apps/app/src`
- load the Vitest-specific jest-dom adapter and add a focused matcher regression

## Validation
- `npm run test:app -- src/setupTests.test.ts`
- `npm --prefix apps/app run typecheck`
- `git diff --check`

No CI workflow files changed.