### PR TITLE
Skip trusted previews after PRs close

### DIFF
--- a/.github/workflows/deploy-preview-trusted.yml
+++ b/.github/workflows/deploy-preview-trusted.yml
@@ -285,6 +285,9 @@ jobs:
             local current_pr_json="$RUNNER_TEMP/firebase-preview-pre-deploy-pr.json"
             local recheck_output="$RUNNER_TEMP/firebase-preview-pre-deploy.outputs"
             gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > "$current_pr_json"
+            if jq -e '.state == "closed"' "$current_pr_json" >/dev/null; then
+              skip_preview "The pull request closed before the trusted preview write, so no preview channel is needed."
+            fi
             node "$verifier" \
               --event "$bundle/context/event.json" \
               --run "$bundle/context/run.json" \

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -245,6 +245,12 @@ describe('preview deployment workflow trust boundary', () => {
 
         expect(preDeployCheckIndex).toBeGreaterThan(deployStepIndex);
         expect(deployWriteIndex).toBeGreaterThan(preDeployCheckIndex);
+        expect(
+            trustedWorkflow.slice(preDeployCheckIndex, deployWriteIndex)
+        ).toContain('jq -e \'.state == "closed"\'');
+        expect(
+            trustedWorkflow.slice(preDeployCheckIndex, deployWriteIndex)
+        ).toContain('skip_preview "The pull request closed before the trusted preview write');
         expect(preCommentCheckIndex).toBeGreaterThan(commentStepIndex);
         expect(preCommentCheckIndex).toBeGreaterThan(commentDiscoveryIndex);
         expect(commentWriteIndex).toBeGreaterThan(preCommentCheckIndex);


### PR DESCRIPTION
## Change

- treat an already-closed PR as a successful no-op immediately before the credentialed preview write
- retain exact-head verification for every open PR
- add a trust-boundary regression assertion

## Why

Fast closeout can merge a PR while the trusted preview job is preparing. The preview is no longer useful after merge, and the current fail-closed verifier reports that safe race as a failed Actions run.

## Validation

- targeted preview trust-boundary suite: 21/21 passed
- workflow YAML parsed successfully
- git diff --check

## Security

No credential or trust boundary is relaxed: closed PRs perform no Firebase write; open PRs still require the exact same-repository head and artifact binding.