### PR TITLE
Verify Firestore state after duplicate release

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -483,6 +483,50 @@ jobs:
           firebase_config="$FIREBASE_PRODUCTION_BUNDLE/firebase-prod.generated.json"
           transient_pattern='(^|[^[:alnum:]])(429|500|502|503|504)([^[:alnum:]]|$)|HTTP Error:[[:space:]]*409,[[:space:]]*Requested entity already exists|service[[:space:]_-]+unavailable|econnreset|connection[[:space:]_-]+reset|network[[:space:]_-]+reset|etimedout|timed[[:space:]_-]+out|timeout'
 
+          verify_active_firestore_rules() {
+            local release_json ruleset_json ruleset_name local_rules_b64 active_rules_b64
+            release_json="$(mktemp "$RUNNER_TEMP/firestore-release.XXXXXX.json")"
+            ruleset_json="$(mktemp "$RUNNER_TEMP/firestore-ruleset.XXXXXX.json")"
+
+            if ! curl --silent --show-error --fail \
+              --connect-timeout 10 \
+              --max-time 30 \
+              --header "Authorization: Bearer ${GOOGLE_OAUTH_ACCESS_TOKEN}" \
+              "https://firebaserules.googleapis.com/v1/projects/game-flow-c6311/releases/cloud.firestore" \
+              > "$release_json"; then
+              rm -f "$release_json" "$ruleset_json"
+              return 1
+            fi
+
+            ruleset_name="$(jq -er '.rulesetName' "$release_json" 2>/dev/null || true)"
+            if [[ ! "$ruleset_name" =~ ^projects/game-flow-c6311/rulesets/[A-Za-z0-9_-]+$ ]]; then
+              rm -f "$release_json" "$ruleset_json"
+              return 1
+            fi
+
+            if ! curl --silent --show-error --fail \
+              --connect-timeout 10 \
+              --max-time 30 \
+              --header "Authorization: Bearer ${GOOGLE_OAUTH_ACCESS_TOKEN}" \
+              "https://firebaserules.googleapis.com/v1/${ruleset_name}" \
+              > "$ruleset_json"; then
+              rm -f "$release_json" "$ruleset_json"
+              return 1
+            fi
+
+            local_rules_b64="$(base64 < "$FIREBASE_PRODUCTION_BUNDLE/firestore.rules" | tr -d '\n')"
+            active_rules_b64="$(
+              jq -er '
+                [.source.files[]? | select(.name == "firestore.rules")]
+                | if length == 1 then (.[0].content | @base64)
+                  else error("expected exactly one firestore.rules source file")
+                  end
+              ' "$ruleset_json" 2>/dev/null || true
+            )"
+            rm -f "$release_json" "$ruleset_json"
+            [[ -n "$active_rules_b64" && "$active_rules_b64" == "$local_rules_b64" ]]
+          }
+
           retry_firebase_deploy() {
             local deploy_targets="$1"
             local deploy_label="$2"
@@ -526,11 +570,18 @@ jobs:
               if [[ "$deploy_label" == "firestore" ]]; then
                 deploy_plain_log="${deploy_log}.plain"
                 sed -E 's/\x1B\[[0-9;]*[[:alpha:]]//g' "$deploy_log" > "$deploy_plain_log"
-                if grep -Fq "latest version of firestore.rules already up to date, skipping upload" "$deploy_plain_log" \
-                  && grep -Fq "deployed indexes in firestore.indexes.json successfully" "$deploy_plain_log" \
+                if grep -Fq "deployed indexes in firestore.indexes.json successfully" "$deploy_plain_log" \
                   && grep -Eq 'HTTP Error:[[:space:]]*409,[[:space:]]*Requested entity already exists' "$deploy_plain_log"; then
-                  echo "::notice::Firestore rules and indexes are already current; accepting the duplicate release 409 as success."
-                  return 0
+                  if grep -Fq "latest version of firestore.rules already up to date, skipping upload" "$deploy_plain_log"; then
+                    echo "::notice::Firestore rules and indexes are already current; accepting the duplicate release 409 as success."
+                    return 0
+                  fi
+                  if grep -Fq "rules file firestore.rules compiled successfully" "$deploy_plain_log" \
+                    && grep -Fq "uploading rules firestore.rules" "$deploy_plain_log" \
+                    && verify_active_firestore_rules; then
+                    echo "::notice::The active Firestore release exactly matches this commit and indexes deployed; accepting the duplicate release 409 as success."
+                    return 0
+                  fi
                 fi
               fi
 

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -317,6 +317,18 @@ export function validateProductionDeployCommand(deployProd) {
     assertIncludes(deployProd, 'HTTP Error:[[:space:]]*409,[[:space:]]*Requested entity already exists', 'Production Firestore release-race retry');
     assertIncludes(deployProd, 'latest version of firestore.rules already up to date, skipping upload', 'Production Firestore current-rules verification');
     assertIncludes(deployProd, 'deployed indexes in firestore.indexes.json successfully', 'Production Firestore current-indexes verification');
+    assertIncludes(deployProd, 'verify_active_firestore_rules()', 'Production Firestore active-release verifier');
+    assertIncludes(
+        deployProd,
+        'projects/game-flow-c6311/releases/cloud.firestore',
+        'Production Firestore active release lookup'
+    );
+    assertIncludes(deployProd, '.source.files[]? | select(.name == "firestore.rules")', 'Production Firestore active source lookup');
+    assertIncludes(
+        deployProd,
+        'The active Firestore release exactly matches this commit and indexes deployed',
+        'Production Firestore exact-source duplicate-release recovery'
+    );
     assertIncludes(deployProd, 'accepting the duplicate release 409 as success', 'Production Firestore verified duplicate-release recovery');
     assertIncludes(deployProd, 'if [[ "$deploy_label" == "firestore" ]]; then', 'Production Firestore retry-exhaustion summary scope');
     assertIncludes(deployProd, 'Firestore Rules API (firebaserules.googleapis.com)', 'Production Firestore retry-exhaustion API surface');

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -165,9 +165,15 @@ concurrency:
           if (( retry_delay_seconds > 120 )); then
             retry_delay_seconds=120
           fi
+          verify_active_firestore_rules() {
+            curl "https://firebaserules.googleapis.com/v1/projects/game-flow-c6311/releases/cloud.firestore"
+            curl "https://firebaserules.googleapis.com/v1/\${ruleset_name}"
+            jq '.source.files[]? | select(.name == "firestore.rules")'
+          }
           if [[ "$deploy_label" == "firestore" ]]; then
             echo "latest version of firestore.rules already up to date, skipping upload"
             echo "deployed indexes in firestore.indexes.json successfully"
+            echo "The active Firestore release exactly matches this commit and indexes deployed"
             echo "accepting the duplicate release 409 as success"
             api_surface="Firestore Rules API (firebaserules.googleapis.com)"
             grep -Eio 'HTTP Error:[[:space:]]*(409|429|500|502|503|504)|(^|[^[:digit:]])(409|429|500|502|503|504)([^[:digit:]]|$)' "$deploy_log" \\


### PR DESCRIPTION
## Change

- on a Firestore release 409, read the active cloud.firestore release through the authenticated Rules API
- validate the returned ruleset resource name before fetching it
- compare the active immutable ruleset's firestore.rules source byte-for-byte with the deploy artifact
- accept the 409 only when indexes also completed successfully; otherwise retain bounded retries and fail closed
- extend the production deploy contract tests

## Why

Three production runs compiled and uploaded the candidate rules and deployed indexes, then received an idempotent release 409. Retrying the already-current release eventually hit the ongoing Rules API 503 and prevented Hosting/Functions from deploying.

## Validation

- targeted Firebase CI contract suite: 7/7 passed
- workflow YAML parsed successfully
- git diff --check

## Security

The recovery is read-only and exact-content-bound. It validates the Rules API resource name, uses the existing short-lived OIDC token, never prints the token, and fails closed on any API, permission, schema, source, or content mismatch.