### PR TITLE
Skip redundant Firestore rules writes

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -517,8 +517,9 @@ jobs:
             local_rules_b64="$(base64 < "$FIREBASE_PRODUCTION_BUNDLE/firestore.rules" | tr -d '\n')"
             active_rules_b64="$(
               jq -er '
-                [.source.files[]? | select(.name == "firestore.rules")]
-                | if length == 1 then (.[0].content | @base64)
+                (.source.files // [])
+                | if length == 1 and .[0].name == "firestore.rules"
+                  then (.[0].content | @base64)
                   else error("expected exactly one firestore.rules source file")
                   end
               ' "$ruleset_json" 2>/dev/null || true

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -756,14 +756,22 @@ jobs:
           if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then
             # Keep coupled authorization/index changes fail-closed: application code
             # must not publish until its Firestore configuration is active.
-            # Probe the non-persistent projects:test endpoint first. A known
-            # Rules API outage opens the circuit before any ruleset/release
-            # mutation. The actual idempotent deploy gets three bounded attempts
-            # because the API can recover between a successful preflight and the
-            # Firebase CLI's own compile request. This keeps the total
-            # projects:test calls bounded to at most five per release run.
-            test_firestore_rules_api 2 20
-            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 3 20
+            # A prior partial attempt may already have activated this exact,
+            # immutable rules source before its release call returned an error.
+            # In that case, update indexes without making another Rules API write.
+            if verify_active_firestore_rules; then
+              echo "::notice::The active Firestore rules exactly match this commit; deploying indexes without a redundant ruleset write."
+              retry_firebase_deploy "firestore:indexes" "firestore-indexes" 3 20
+            else
+              # Probe the non-persistent projects:test endpoint first. A known
+              # Rules API outage opens the circuit before any ruleset/release
+              # mutation. The actual idempotent deploy gets three bounded attempts
+              # because the API can recover between a successful preflight and the
+              # Firebase CLI's own compile request. This keeps the total
+              # projects:test calls bounded to at most five per release run.
+              test_firestore_rules_api 2 20
+              retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 3 20
+            fi
           else
             # No authorization/index drift exists relative to the last successful
             # production deployment. Do not make a redundant Rules API write: an

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -323,7 +323,12 @@ export function validateProductionDeployCommand(deployProd) {
         'projects/game-flow-c6311/releases/cloud.firestore',
         'Production Firestore active release lookup'
     );
-    assertIncludes(deployProd, '.source.files[]? | select(.name == "firestore.rules")', 'Production Firestore active source lookup');
+    assertIncludes(deployProd, '(.source.files // [])', 'Production Firestore active source lookup');
+    assertIncludes(
+        deployProd,
+        'if length == 1 and .[0].name == "firestore.rules"',
+        'Production Firestore active source must contain only firestore.rules'
+    );
     assertIncludes(
         deployProd,
         'The active Firestore rules exactly match this commit; deploying indexes without a redundant ruleset write.',

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -326,6 +326,16 @@ export function validateProductionDeployCommand(deployProd) {
     assertIncludes(deployProd, '.source.files[]? | select(.name == "firestore.rules")', 'Production Firestore active source lookup');
     assertIncludes(
         deployProd,
+        'The active Firestore rules exactly match this commit; deploying indexes without a redundant ruleset write.',
+        'Production Firestore exact-source write avoidance'
+    );
+    assertIncludes(
+        deployProd,
+        'retry_firebase_deploy "firestore:indexes" "firestore-indexes" 3 20',
+        'Production Firestore exact-source indexes-only deploy'
+    );
+    assertIncludes(
+        deployProd,
         'The active Firestore release exactly matches this commit and indexes deployed',
         'Production Firestore exact-source duplicate-release recovery'
     );
@@ -413,6 +423,11 @@ export function validateProductionDeployCommand(deployProd) {
         changedBranch,
         'retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 3 20',
         'Production Firestore transient deploy retries'
+    );
+    assertMatches(
+        changedBranch,
+        /if verify_active_firestore_rules; then[\s\S]*retry_firebase_deploy "firestore:indexes" "firestore-indexes" 3 20[\s\S]*else[\s\S]*test_firestore_rules_api 2 20[\s\S]*retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 3 20[\s\S]*fi/,
+        'Production Firestore exact-source short circuit'
     );
     assertIncludes(
         changedBranch,

--- a/tests/unit/auth-email-resend-routing.test.js
+++ b/tests/unit/auth-email-resend-routing.test.js
@@ -141,6 +141,8 @@ describe('authentication email delivery routing', () => {
         expect(productionSource).toContain('if (( retry_delay_seconds > 120 )); then');
         expect(productionSource).toContain('test_firestore_rules_api 2 20');
         expect(productionSource).toContain('retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 3 20');
+        expect(productionSource).toContain('if verify_active_firestore_rules; then');
+        expect(productionSource).toContain('retry_firebase_deploy "firestore:indexes" "firestore-indexes" 3 20');
         expect(productionSource).toContain('projects:test calls bounded to at most five per release run');
         expect(productionSource).toContain('retry_firebase_deploy "hosting,functions" "application"');
         const retryEnabledDeploy = productionSource.indexOf('"retry-enabled-functions"');
@@ -151,6 +153,7 @@ describe('authentication email delivery routing', () => {
         const unchangedBranch = productionSource.slice(unchangedBranchStart, conditionalEnd);
         const applicationDeploy = productionSource.lastIndexOf('retry_firebase_deploy "hosting,functions" "application"');
         expect(changedBranch).toContain('"firestore"');
+        expect(changedBranch).toContain('"firestore-indexes"');
         expect(unchangedBranch).not.toContain('"application"');
         expect(unchangedBranch).not.toContain('"firestore"');
         expect(retryEnabledDeploy).toBeGreaterThan(conditionalEnd);

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -168,7 +168,7 @@ concurrency:
           verify_active_firestore_rules() {
             curl "https://firebaserules.googleapis.com/v1/projects/game-flow-c6311/releases/cloud.firestore"
             curl "https://firebaserules.googleapis.com/v1/\${ruleset_name}"
-            jq '.source.files[]? | select(.name == "firestore.rules")'
+            jq '(.source.files // []) | if length == 1 and .[0].name == "firestore.rules"'
           }
           if [[ "$deploy_label" == "firestore" ]]; then
             echo "latest version of firestore.rules already up to date, skipping upload"
@@ -305,6 +305,10 @@ concurrency:
             'retry_firebase_deploy "firestore:indexes" "firestore-indexes" 3 20',
             'retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore-indexes" 3 20'
         ))).toThrow('Production Firestore exact-source indexes-only deploy');
+        expect(() => validateProductionDeployCommand(validDeployCommand.replace(
+            'if length == 1 and .[0].name == "firestore.rules"',
+            'if any(.[]; .name == "firestore.rules")'
+        ))).toThrow('Production Firestore active source must contain only firestore.rules');
         expect(() => validateProductionDeployCommand(validDeployCommand.replace(
             `else
             :

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -190,9 +190,14 @@ concurrency:
             curl "https://firebaserules.googleapis.com/v1/projects/game-flow-c6311:test"
           }
           if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then
-            projects:test calls bounded to at most five per release run
-            test_firestore_rules_api 2 20
-            retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 3 20
+            if verify_active_firestore_rules; then
+              echo "The active Firestore rules exactly match this commit; deploying indexes without a redundant ruleset write."
+              retry_firebase_deploy "firestore:indexes" "firestore-indexes" 3 20
+            else
+              projects:test calls bounded to at most five per release run
+              test_firestore_rules_api 2 20
+              retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 3 20
+            fi
           else
             :
           fi
@@ -296,6 +301,10 @@ concurrency:
             `retry_firebase_deploy "hosting,functions" "application"
             retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore" 3 20`
         ))).toThrow('Production Firestore deploy and component marker must run first when its configuration changed');
+        expect(() => validateProductionDeployCommand(validDeployCommand.replace(
+            'retry_firebase_deploy "firestore:indexes" "firestore-indexes" 3 20',
+            'retry_firebase_deploy "firestore:rules,firestore:indexes" "firestore-indexes" 3 20'
+        ))).toThrow('Production Firestore exact-source indexes-only deploy');
         expect(() => validateProductionDeployCommand(validDeployCommand.replace(
             `else
             :


### PR DESCRIPTION
## Change
- prove the active Firestore release source matches the candidate byte-for-byte before a rules write
- when it matches, deploy indexes only and avoid a redundant Rules API mutation
- retain the existing bounded preflight and rules/index fallback when the active source is unavailable or differs
- extend CI policy contracts for the exact-source short circuit

## Why
Firebase Rules API ruleset creation is returning persistent 503 responses after intermittent successful compilation. Earlier partial deploys may already have activated the exact source. Repeating the identical ruleset write blocks Functions and Hosting unnecessarily.

## Tests
- npx vitest run tests/unit/validate-firebase-rules-ci.test.js tests/unit/auth-email-resend-routing.test.js --reporter=verbose (14 passed)
- npm run ci:firebase-rules
- deploy-prod.yml parsed with Ruby YAML
- git diff --check

## Manual evidence
Production deploy run 30222026521 passed regression guards, unit tests, trusted handoff, Storage, and OIDC, then exhausted three bounded Firestore Rules API attempts with HTTP 503. No Functions or Hosting deploy occurred.