### PR TITLE
Recover Firestore release updates after transient failures

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -528,6 +528,168 @@ jobs:
             [[ -n "$active_rules_b64" && "$active_rules_b64" == "$local_rules_b64" ]]
           }
 
+          find_recent_matching_firestore_ruleset() {
+            local list_file ruleset_file ruleset_name local_rules_b64 candidate_rules_b64
+            local attempt curl_status http_status list_succeeded
+            list_file="$(mktemp "$RUNNER_TEMP/firestore-rulesets.XXXXXX.json")"
+            ruleset_file="$(mktemp "$RUNNER_TEMP/firestore-ruleset-candidate.XXXXXX.json")"
+            local_rules_b64="$(base64 < "$FIREBASE_PRODUCTION_BUNDLE/firestore.rules" | tr -d '\n')"
+            list_succeeded="false"
+
+            for attempt in 1 2 3; do
+              set +e
+              http_status="$(
+                curl --silent --show-error \
+                  --connect-timeout 10 \
+                  --max-time 30 \
+                  --output "$list_file" \
+                  --write-out '%{http_code}' \
+                  --header "Authorization: Bearer ${GOOGLE_OAUTH_ACCESS_TOKEN}" \
+                  "https://firebaserules.googleapis.com/v1/projects/game-flow-c6311/rulesets?pageSize=20"
+              )"
+              curl_status="$?"
+              set -e
+              if (( curl_status == 0 )) && [[ "$http_status" =~ ^2[0-9][0-9]$ ]]; then
+                list_succeeded="true"
+                break
+              fi
+              if (( curl_status == 0 )) && [[ ! "$http_status" =~ ^(408|429|500|502|503|504)$ ]]; then
+                break
+              fi
+              if (( attempt < 3 )); then
+                sleep $((10 * attempt))
+              fi
+            done
+
+            if [[ "$list_succeeded" != "true" ]]; then
+              rm -f "$list_file" "$ruleset_file"
+              return 1
+            fi
+
+            while IFS= read -r ruleset_name; do
+              [[ "$ruleset_name" =~ ^projects/game-flow-c6311/rulesets/[A-Za-z0-9_-]+$ ]] || continue
+              for attempt in 1 2 3; do
+                set +e
+                http_status="$(
+                  curl --silent --show-error \
+                    --connect-timeout 10 \
+                    --max-time 30 \
+                    --output "$ruleset_file" \
+                    --write-out '%{http_code}' \
+                    --header "Authorization: Bearer ${GOOGLE_OAUTH_ACCESS_TOKEN}" \
+                    "https://firebaserules.googleapis.com/v1/${ruleset_name}"
+                )"
+                curl_status="$?"
+                set -e
+                if (( curl_status == 0 )) && [[ "$http_status" =~ ^2[0-9][0-9]$ ]]; then
+                  break
+                fi
+                if (( curl_status == 0 )) && [[ ! "$http_status" =~ ^(408|429|500|502|503|504)$ ]]; then
+                  break
+                fi
+                if (( attempt < 3 )); then
+                  sleep $((5 * attempt))
+                fi
+              done
+              if (( curl_status != 0 )) || [[ ! "$http_status" =~ ^2[0-9][0-9]$ ]]; then
+                continue
+              fi
+              candidate_rules_b64="$(
+                jq -er '
+                  (.source.files // [])
+                  | if length == 1 and .[0].name == "firestore.rules"
+                    then (.[0].content | @base64)
+                    else error("expected exactly one firestore.rules source file")
+                    end
+                ' "$ruleset_file" 2>/dev/null || true
+              )"
+              if [[ -n "$candidate_rules_b64" && "$candidate_rules_b64" == "$local_rules_b64" ]]; then
+                rm -f "$list_file" "$ruleset_file"
+                printf '%s\n' "$ruleset_name"
+                return 0
+              fi
+            done < <(
+              jq -r '
+                (.rulesets // [])
+                | sort_by(.createTime)
+                | reverse
+                | .[].name
+              ' "$list_file"
+            )
+
+            rm -f "$list_file" "$ruleset_file"
+            return 1
+          }
+
+          activate_firestore_ruleset_with_retry() {
+            local ruleset_name="$1"
+            local payload_file response_file attempt verify_attempt curl_status http_status retry_delay_seconds
+            [[ "$ruleset_name" =~ ^projects/game-flow-c6311/rulesets/[A-Za-z0-9_-]+$ ]] || return 1
+            payload_file="$(mktemp "$RUNNER_TEMP/firestore-release-patch.XXXXXX.json")"
+            response_file="$(mktemp "$RUNNER_TEMP/firestore-release-patch-response.XXXXXX.json")"
+            jq -n \
+              --arg release_name "projects/game-flow-c6311/releases/cloud.firestore" \
+              --arg ruleset_name "$ruleset_name" \
+              '{
+                release:{
+                  name:$release_name,
+                  rulesetName:$ruleset_name
+                },
+                updateMask:"rulesetName"
+              }' > "$payload_file"
+
+            for attempt in 1 2 3 4 5; do
+              set +e
+              http_status="$(
+                curl --silent --show-error \
+                  --connect-timeout 10 \
+                  --max-time 60 \
+                  --output "$response_file" \
+                  --write-out '%{http_code}' \
+                  --request PATCH \
+                  --header "Authorization: Bearer ${GOOGLE_OAUTH_ACCESS_TOKEN}" \
+                  --header "Content-Type: application/json" \
+                  --data-binary "@${payload_file}" \
+                  "https://firebaserules.googleapis.com/v1/projects/game-flow-c6311/releases/cloud.firestore"
+              )"
+              curl_status="$?"
+              set -e
+
+              if (( curl_status == 0 )) \
+                && [[ "$http_status" =~ ^2[0-9][0-9]$ ]] \
+                && [[ "$(jq -r '.rulesetName // ""' "$response_file")" == "$ruleset_name" ]]; then
+                for verify_attempt in 1 2 3 4 5; do
+                  if verify_active_firestore_rules; then
+                    rm -f "$payload_file" "$response_file"
+                    return 0
+                  fi
+                  if (( verify_attempt < 5 )); then
+                    sleep $((5 * verify_attempt))
+                  fi
+                done
+                break
+              fi
+
+              if (( curl_status == 0 )) && [[ ! "$http_status" =~ ^(408|409|429|500|502|503|504)$ ]]; then
+                break
+              fi
+              if (( attempt < 5 )); then
+                retry_delay_seconds=$((15 * attempt))
+                echo "Transient Firestore release update failure; retrying in ${retry_delay_seconds}s (attempt $((attempt + 1))/5)." >&2
+                sleep "$retry_delay_seconds"
+              fi
+            done
+
+            rm -f "$payload_file" "$response_file"
+            return 1
+          }
+
+          recover_firestore_release_after_duplicate() {
+            local ruleset_name
+            ruleset_name="$(find_recent_matching_firestore_ruleset)" || return 1
+            activate_firestore_ruleset_with_retry "$ruleset_name"
+          }
+
           retry_firebase_deploy() {
             local deploy_targets="$1"
             local deploy_label="$2"
@@ -581,6 +743,12 @@ jobs:
                     && grep -Fq "uploading rules firestore.rules" "$deploy_plain_log" \
                     && verify_active_firestore_rules; then
                     echo "::notice::The active Firestore release exactly matches this commit and indexes deployed; accepting the duplicate release 409 as success."
+                    return 0
+                  fi
+                  if grep -Fq "rules file firestore.rules compiled successfully" "$deploy_plain_log" \
+                    && grep -Fq "uploading rules firestore.rules" "$deploy_plain_log" \
+                    && recover_firestore_release_after_duplicate; then
+                    echo "::notice::Recovered the Firebase CLI release race by activating the exact uploaded ruleset; accepting the duplicate release 409 as success."
                     return 0
                   fi
                 fi

--- a/docs/observability-runbook.md
+++ b/docs/observability-runbook.md
@@ -73,6 +73,8 @@ The serialized production release train allows at most five Firestore Rules API 
 
 Application deployment remains fail-closed. When Rules or indexes differ from the last successful production deployment, Hosting and Functions do not deploy until the combined Firestore configuration command succeeds. The Firebase CLI may apply indexes before a later Rules API failure, so treat the Rules and index state as potentially partial and verify both before retrying. Existing Hosting and Functions production remains active; do not bypass the workflow or deploy application surfaces separately.
 
+The Firebase CLI can turn a transient release `PATCH` failure into a misleading duplicate-release `409` by falling back to release creation. Recovery is allowed only after the same attempt compiled and uploaded `firestore.rules` and successfully deployed indexes. The workflow searches at most the 20 most recent immutable rulesets, compares the full single-file source with the staged commit-bound rules, retries an idempotent `PATCH` of only `rulesetName`, and then verifies that the active release resolves to those exact bytes. A matching name, a `409`, or a successful index deploy alone is never sufficient to continue to Hosting or Functions.
+
 Safe manual retry:
 
 1. Confirm the failed run targeted `master` and that its summary reports a transient Google API failure rather than a configuration or authorization error. Check the Firebase deploy log or console to determine whether Rules or indexes were already applied.

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -324,11 +324,10 @@ export function validateProductionDeployCommand(deployProd) {
         'Production Firestore active release lookup'
     );
     assertIncludes(deployProd, '(.source.files // [])', 'Production Firestore active source lookup');
-    assertIncludes(
-        deployProd,
-        'if length == 1 and .[0].name == "firestore.rules"',
-        'Production Firestore active source must contain only firestore.rules'
-    );
+    const exactSingleRulesFileGuard = 'if length == 1 and .[0].name == "firestore.rules"';
+    if (deployProd.split(exactSingleRulesFileGuard).length - 1 < 2) {
+        throw new Error('Production Firestore active source must contain only firestore.rules.');
+    }
     assertIncludes(
         deployProd,
         'The active Firestore rules exactly match this commit; deploying indexes without a redundant ruleset write.',
@@ -343,6 +342,63 @@ export function validateProductionDeployCommand(deployProd) {
         deployProd,
         'The active Firestore release exactly matches this commit and indexes deployed',
         'Production Firestore exact-source duplicate-release recovery'
+    );
+    assertIncludes(
+        deployProd,
+        'find_recent_matching_firestore_ruleset()',
+        'Production Firestore exact uploaded-ruleset lookup'
+    );
+    assertIncludes(
+        deployProd,
+        'rulesets?pageSize=20',
+        'Production Firestore bounded recent-ruleset lookup'
+    );
+    assertIncludes(
+        deployProd,
+        '[[ -n "$candidate_rules_b64" && "$candidate_rules_b64" == "$local_rules_b64" ]]',
+        'Production Firestore recent-ruleset exact-source comparison'
+    );
+    assertMatches(
+        deployProd,
+        /\(\.rulesets \/\/ \[\]\)\s*\|\s*sort_by\(\.createTime\)\s*\|\s*reverse\s*\|\s*\.\[\]\.name/,
+        'Production Firestore newest-ruleset-first lookup'
+    );
+    assertIncludes(
+        deployProd,
+        'activate_firestore_ruleset_with_retry()',
+        'Production Firestore idempotent release updater'
+    );
+    assertIncludes(deployProd, '--request PATCH', 'Production Firestore release PATCH method');
+    assertIncludes(
+        deployProd,
+        '[[ "$ruleset_name" =~ ^projects/game-flow-c6311/rulesets/[A-Za-z0-9_-]+$ ]] || return 1',
+        'Production Firestore release PATCH ruleset-name validation'
+    );
+    assertIncludes(
+        deployProd,
+        '"https://firebaserules.googleapis.com/v1/projects/game-flow-c6311/releases/cloud.firestore"',
+        'Production Firestore release PATCH endpoint'
+    );
+    assertIncludes(deployProd, 'updateMask:"rulesetName"', 'Production Firestore release PATCH field restriction');
+    assertIncludes(
+        deployProd,
+        '[[ "$(jq -r \'.rulesetName // ""\' "$response_file")" == "$ruleset_name" ]]',
+        'Production Firestore release PATCH response validation'
+    );
+    assertIncludes(
+        deployProd,
+        'recover_firestore_release_after_duplicate',
+        'Production Firestore duplicate-release recovery call'
+    );
+    assertIncludes(
+        deployProd,
+        'Recovered the Firebase CLI release race by activating the exact uploaded ruleset',
+        'Production Firestore duplicate-release recovery evidence'
+    );
+    assertMatches(
+        deployProd,
+        /deployed indexes in firestore\.indexes\.json successfully[\s\S]{0,2500}rules file firestore\.rules compiled successfully[\s\S]{0,500}uploading rules firestore\.rules[\s\S]{0,500}recover_firestore_release_after_duplicate/,
+        'Production Firestore release recovery safety gates'
     );
     assertIncludes(deployProd, 'accepting the duplicate release 409 as success', 'Production Firestore verified duplicate-release recovery');
     assertIncludes(deployProd, 'if [[ "$deploy_label" == "firestore" ]]; then', 'Production Firestore retry-exhaustion summary scope');

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -170,10 +170,31 @@ concurrency:
             curl "https://firebaserules.googleapis.com/v1/\${ruleset_name}"
             jq '(.source.files // []) | if length == 1 and .[0].name == "firestore.rules"'
           }
+          find_recent_matching_firestore_ruleset() {
+            curl "https://firebaserules.googleapis.com/v1/projects/game-flow-c6311/rulesets?pageSize=20"
+            jq '(.rulesets // []) | sort_by(.createTime) | reverse | .[].name'
+            jq '(.source.files // []) | if length == 1 and .[0].name == "firestore.rules"'
+            [[ -n "$candidate_rules_b64" && "$candidate_rules_b64" == "$local_rules_b64" ]]
+          }
+          activate_firestore_ruleset_with_retry() {
+            [[ "$ruleset_name" =~ ^projects/game-flow-c6311/rulesets/[A-Za-z0-9_-]+$ ]] || return 1
+            curl --request PATCH "https://firebaserules.googleapis.com/v1/projects/game-flow-c6311/releases/cloud.firestore"
+            jq 'updateMask:"rulesetName"'
+            [[ "$(jq -r '.rulesetName // ""' "$response_file")" == "$ruleset_name" ]]
+            verify_active_firestore_rules
+          }
+          recover_firestore_release_after_duplicate() {
+            find_recent_matching_firestore_ruleset
+            activate_firestore_ruleset_with_retry
+          }
           if [[ "$deploy_label" == "firestore" ]]; then
             echo "latest version of firestore.rules already up to date, skipping upload"
             echo "deployed indexes in firestore.indexes.json successfully"
+            echo "rules file firestore.rules compiled successfully"
+            echo "uploading rules firestore.rules"
             echo "The active Firestore release exactly matches this commit and indexes deployed"
+            recover_firestore_release_after_duplicate
+            echo "Recovered the Firebase CLI release race by activating the exact uploaded ruleset"
             echo "accepting the duplicate release 409 as success"
             api_surface="Firestore Rules API (firebaserules.googleapis.com)"
             grep -Eio 'HTTP Error:[[:space:]]*(409|429|500|502|503|504)|(^|[^[:digit:]])(409|429|500|502|503|504)([^[:digit:]]|$)' "$deploy_log" \\
@@ -309,6 +330,18 @@ concurrency:
             'if length == 1 and .[0].name == "firestore.rules"',
             'if any(.[]; .name == "firestore.rules")'
         ))).toThrow('Production Firestore active source must contain only firestore.rules');
+        expect(() => validateProductionDeployCommand(validDeployCommand.replaceAll(
+            'recover_firestore_release_after_duplicate',
+            'accept_duplicate_release_without_recovery'
+        ))).toThrow('Production Firestore duplicate-release recovery call');
+        expect(() => validateProductionDeployCommand(validDeployCommand.replace(
+            '[[ -n "$candidate_rules_b64" && "$candidate_rules_b64" == "$local_rules_b64" ]]',
+            '[[ -n "$candidate_rules_b64" ]]'
+        ))).toThrow('Production Firestore recent-ruleset exact-source comparison');
+        expect(() => validateProductionDeployCommand(validDeployCommand.replace(
+            'curl --request PATCH "https://firebaserules.googleapis.com/v1/projects/game-flow-c6311/releases/cloud.firestore"',
+            'curl --request POST "https://firebaserules.googleapis.com/v1/projects/game-flow-c6311/releases"'
+        ))).toThrow('Production Firestore release PATCH method');
         expect(() => validateProductionDeployCommand(validDeployCommand.replace(
             `else
             :


### PR DESCRIPTION
## What changed
- recover Firebase CLI duplicate-release `409` failures by locating a recent immutable ruleset whose complete single-file source exactly matches the staged commit-bound `firestore.rules`
- retry an idempotent `PATCH` of only the existing `cloud.firestore` release's `rulesetName`
- require the active release to resolve back to the exact staged bytes before Hosting or Functions may deploy
- document the partial-deploy/recovery behavior and add fail-closed deploy-contract coverage

## Why
Production deploy run 30274958850 showed the exact failure sequence: the Rules API preflight recovered, two CLI compilation calls returned transient 503s, the third compiled and uploaded the rules and deployed indexes, and Firebase CLI then returned `409 Requested entity already exists` while creating the already-existing release after its release update failed. The existing workflow could detect an already-active release but could not safely finish this partial state.

## Safety
- exact source bytes, validated ruleset resource names, bounded recent lookup, bounded PATCH retries, and exact active-release verification are required
- the recovery path is reachable only after the same CLI attempt reports successful rules compilation, upload, index deployment, and duplicate-release 409
- production remains fail-closed; no Hosting or Functions deploy occurs if lookup, PATCH, or verification fails
- trigger, least-privilege OIDC permissions, SHA-pinned actions, and trusted artifact boundary are unchanged

## Validation
- `npx vitest run tests/unit/validate-firebase-rules-ci.test.js --reporter=verbose`
- `npm run ci:firebase-rules`
- parsed `.github/workflows/deploy-prod.yml` with the repository YAML dependency
- extracted `Deploy Firebase production` and passed it through `bash -n`
- `git diff --check`

Tested head: `82df14c310727afea3ba186b6ae0de844d047997`