### PR TITLE
Deploy reviewed retry-enabled functions

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -482,6 +482,7 @@ jobs:
           firebase_cli="$FIREBASE_PRODUCTION_BUNDLE/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js"
           firebase_config="$FIREBASE_PRODUCTION_BUNDLE/firebase-prod.generated.json"
           transient_pattern='(^|[^[:alnum:]])(429|500|502|503|504)([^[:alnum:]]|$)|HTTP Error:[[:space:]]*409,[[:space:]]*Requested entity already exists|service[[:space:]_-]+unavailable|econnreset|connection[[:space:]_-]+reset|network[[:space:]_-]+reset|etimedout|timed[[:space:]_-]+out|timeout'
+          retry_enabled_function_targets="functions:processAccountDeletionRequest,functions:queueParentInviteEmail,functions:syncPublicUserProfileOnUserWrite,functions:syncPublicUserProfilesOnTeamWrite,functions:syncTeamOwnerAccessOnCreate"
 
           verify_active_firestore_rules() {
             local release_json ruleset_json ruleset_name local_rules_b64 active_rules_b64
@@ -804,7 +805,7 @@ jobs:
             )
 
             if [[ "$acknowledge_failure_policy" == "true" ]]; then
-              if [[ "$deploy_targets" != "functions:processAccountDeletionRequest,functions:syncTeamOwnerAccessOnCreate" ]]; then
+              if [[ "$deploy_targets" != "$retry_enabled_function_targets" ]]; then
                 echo "Refusing --force outside the reviewed retry-enabled function allowlist." >&2
                 return 1
               fi
@@ -941,12 +942,13 @@ jobs:
             echo "::warning::Firestore is current, but its component marker could not be recorded. A future failed production retry may conservatively redeploy it."
           fi
 
-          # These two event handlers intentionally enable automatic retries and
-          # have idempotency coverage. A targeted --force acknowledges only that
-          # failure policy; the subsequent full-fleet deploy remains unforced so
-          # deletions and unsafe trigger migrations still fail closed.
+          # These event handlers intentionally enable automatic retries and have
+          # deterministic-write, retry-anchor, or convergence coverage. A targeted
+          # --force acknowledges only their reviewed failure policies; the
+          # subsequent full-fleet deploy remains unforced so deletions and unsafe
+          # trigger migrations still fail closed.
           retry_firebase_deploy \
-            "functions:processAccountDeletionRequest,functions:syncTeamOwnerAccessOnCreate" \
+            "$retry_enabled_function_targets" \
             "retry-enabled-functions" \
             3 \
             15 \

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -287,13 +287,18 @@ export function validateProductionDeployCommand(deployProd) {
     assertIncludes(deployProd, 'retry_firebase_deploy "hosting,functions" "application"', 'Production application deploy targets');
     assertIncludes(
         deployProd,
-        '"functions:processAccountDeletionRequest,functions:syncTeamOwnerAccessOnCreate"',
+        'retry_enabled_function_targets="functions:processAccountDeletionRequest,functions:queueParentInviteEmail,functions:syncPublicUserProfileOnUserWrite,functions:syncPublicUserProfilesOnTeamWrite,functions:syncTeamOwnerAccessOnCreate"',
         'Production retry-enabled function allowlist'
+    );
+    assertIncludes(
+        deployProd,
+        'if [[ "$deploy_targets" != "$retry_enabled_function_targets" ]]; then',
+        'Production force-deploy exact allowlist guard'
     );
     assertIncludes(deployProd, 'deploy_args+=(--force)', 'Production targeted failure-policy acknowledgement');
     assertMatches(
         deployProd,
-        /retry_firebase_deploy\s+\\?\s*"functions:processAccountDeletionRequest,functions:syncTeamOwnerAccessOnCreate"\s+\\?\s*"retry-enabled-functions"\s+\\?\s*3\s+\\?\s*15\s+\\?\s*true/,
+        /retry_firebase_deploy\s+\\?\s*"\$retry_enabled_function_targets"\s+\\?\s*"retry-enabled-functions"\s+\\?\s*3\s+\\?\s*15\s+\\?\s*true/,
         'Production retry-enabled function failure-policy acknowledgement call'
     );
     assertIncludes(

--- a/tests/unit/auth-email-resend-routing.test.js
+++ b/tests/unit/auth-email-resend-routing.test.js
@@ -124,11 +124,11 @@ describe('authentication email delivery routing', () => {
         expect(productionSource).toContain('firebase-tools@14.25.0');
         expect(productionSource).toContain('[[ "$STORAGE_RULES_CHANGED" != "true" ]]');
         expect(productionSource).toContain('exit "$storage_status"');
-        expect(productionSource).toContain('if [[ "$deploy_targets" != "functions:processAccountDeletionRequest,functions:syncTeamOwnerAccessOnCreate" ]]; then');
+        expect(productionSource).toContain('if [[ "$deploy_targets" != "$retry_enabled_function_targets" ]]; then');
         expect(productionSource).toContain('deploy_args+=(--force)');
         expect(productionSource).toContain('Refusing --force outside the reviewed retry-enabled function allowlist.');
         expect(productionSource).toContain(
-            '"functions:processAccountDeletionRequest,functions:syncTeamOwnerAccessOnCreate"'
+            'retry_enabled_function_targets="functions:processAccountDeletionRequest,functions:queueParentInviteEmail,functions:syncPublicUserProfileOnUserWrite,functions:syncPublicUserProfilesOnTeamWrite,functions:syncTeamOwnerAccessOnCreate"'
         );
         expect(productionSource).toContain('"retry-enabled-functions"');
         expect(productionSource.match(/deploy_args\+=\(--force\)/g) ?? []).toHaveLength(1);

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -153,7 +153,8 @@ concurrency:
               --config "$firebase_config"
               --non-interactive
             )
-            if [[ "$deploy_targets" != "functions:processAccountDeletionRequest,functions:syncTeamOwnerAccessOnCreate" ]]; then
+            retry_enabled_function_targets="functions:processAccountDeletionRequest,functions:queueParentInviteEmail,functions:syncPublicUserProfileOnUserWrite,functions:syncPublicUserProfilesOnTeamWrite,functions:syncTeamOwnerAccessOnCreate"
+            if [[ "$deploy_targets" != "$retry_enabled_function_targets" ]]; then
               echo "Refusing --force outside the reviewed retry-enabled function allowlist."
             fi
             deploy_args+=(--force)
@@ -221,7 +222,7 @@ concurrency:
             echo 'state: "success"'
           }
           record_component_deployment "production-firestore"
-          retry_firebase_deploy "functions:processAccountDeletionRequest,functions:syncTeamOwnerAccessOnCreate" "retry-enabled-functions" 3 15 true
+          retry_firebase_deploy "$retry_enabled_function_targets" "retry-enabled-functions" 3 15 true
           retry_firebase_deploy "hosting,functions" "application"
         `;
 


### PR DESCRIPTION
## Summary

- predeploy all five reviewed retry-enabled event handlers through the existing targeted `--force` path
- keep the full Functions/Hosting fleet deploy unforced and fail-closed
- define the exact target set once so the guard and invocation cannot drift

## Why

Production run 30282374534 proved the new Firestore RuleSet path works, then Firebase blocked the full fleet because three additional handlers now enable failure-policy retries. All three use deterministic writes, retry anchors, or convergence behavior and already have retry/idempotency tests.

## Validation

- `npm run test:unit:ci` — 5,194 unit tests and 122 emulator authorization tests passed
- focused workflow/source contracts — 46 passed
- focused retry/idempotency handler tests — 75 passed
- `npm run ci:firebase-rules`
- `deploy-prod.yml` parsed as YAML
- all 27 workflow `run` blocks passed `bash -n`
- `git diff --check`

## Safety boundary

The only `--force` call remains guarded by exact string equality and applies only to:

- `processAccountDeletionRequest`
- `queueParentInviteEmail`
- `syncPublicUserProfileOnUserWrite`
- `syncPublicUserProfilesOnTeamWrite`
- `syncTeamOwnerAccessOnCreate`

The later full-fleet deploy remains unforced, so unrelated retry-policy changes, deletions, and trigger migrations continue to stop for review.

## Handoff

Keep draft and `external-claim` until exact-head CI, review, and thread checks are complete. PaulBot owns landing after ready handoff.