### PR TITLE
Repair production smoke gating

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -88,7 +88,59 @@ jobs:
           SMOKE_AUTH_EMAIL: ${{ secrets.SMOKE_AUTH_EMAIL }}
           SMOKE_AUTH_PASSWORD: ${{ secrets.SMOKE_AUTH_PASSWORD }}
 
-      - name: Run production smoke
+      - name: Inspect fixture-backed smoke readiness
+        id: core_config
+        env:
+          SMOKE_TEAM_ID: ${{ vars.SMOKE_TEAM_ID }}
+          SMOKE_GAME_ID: ${{ vars.SMOKE_GAME_ID }}
+          SMOKE_EVENT_ID: ${{ vars.SMOKE_EVENT_ID }}
+          SMOKE_PLAYER_ID: ${{ vars.SMOKE_PLAYER_ID }}
+          SMOKE_REGISTRATION_FORM_ID: ${{ vars.SMOKE_REGISTRATION_FORM_ID }}
+          SMOKE_STAFF_EMAIL: ${{ secrets.SMOKE_STAFF_EMAIL }}
+          SMOKE_STAFF_PASSWORD: ${{ secrets.SMOKE_STAFF_PASSWORD }}
+          SMOKE_PARENT_EMAIL: ${{ secrets.SMOKE_PARENT_EMAIL }}
+          SMOKE_PARENT_PASSWORD: ${{ secrets.SMOKE_PARENT_PASSWORD }}
+        run: |
+          set -euo pipefail
+          required_names=(
+            SMOKE_TEAM_ID
+            SMOKE_GAME_ID
+            SMOKE_EVENT_ID
+            SMOKE_PLAYER_ID
+            SMOKE_REGISTRATION_FORM_ID
+            SMOKE_STAFF_EMAIL
+            SMOKE_STAFF_PASSWORD
+            SMOKE_PARENT_EMAIL
+            SMOKE_PARENT_PASSWORD
+          )
+          missing_names=()
+          for name in "${required_names[@]}"; do
+            if [[ -z "${!name:-}" ]]; then
+              missing_names+=("$name")
+            fi
+          done
+
+          if (( ${#missing_names[@]} > 0 )); then
+            missing_csv="$(IFS=,; echo "${missing_names[*]}")"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "missing=$missing_csv" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Fixture-backed production smoke not configured::Missing protected configuration names: $missing_csv"
+          else
+            staff_email_normalized="$(printf '%s' "$SMOKE_STAFF_EMAIL" | tr '[:upper:]' '[:lower:]')"
+            parent_email_normalized="$(printf '%s' "$SMOKE_PARENT_EMAIL" | tr '[:upper:]' '[:lower:]')"
+          fi
+
+          if (( ${#missing_names[@]} == 0 )) &&
+             [[ "$staff_email_normalized" == "$parent_email_normalized" ]]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "missing=distinct-role-accounts" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Fixture-backed production smoke not configured::Staff and parent smoke accounts must be distinct."
+          elif (( ${#missing_names[@]} == 0 )); then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "missing=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run production smoke baseline
         id: canonical_prod
         continue-on-error: true
         run: >-
@@ -96,7 +148,6 @@ jobs:
           tests/smoke/app-production-bootstrap.spec.js
           tests/smoke/static-hosting-bootstrap.spec.js
           tests/smoke/legacy-auth-redirects.spec.js
-          tests/smoke/app-authenticated-core.spec.js
           --config=playwright.smoke.config.js
           --project=smoke
           --reporter=line
@@ -120,6 +171,33 @@ jobs:
           SMOKE_AUTH_EMAIL: ${{ secrets.SMOKE_AUTH_EMAIL }}
           SMOKE_AUTH_PASSWORD: ${{ secrets.SMOKE_AUTH_PASSWORD }}
 
+      - name: Run fixture-backed core production smoke
+        if: steps.core_config.outputs.enabled == 'true'
+        id: canonical_core
+        continue-on-error: true
+        run: >-
+          npx playwright test
+          tests/smoke/app-authenticated-core.spec.js
+          --config=playwright.smoke.config.js
+          --project=smoke
+          --reporter=line
+        env:
+          SMOKE_APP_BOOT_URL: https://allplays.ai/app/
+          SMOKE_APP_BASE_URL: https://allplays.ai/app/
+          SMOKE_SUITE: production
+          SMOKE_TEAM_ID: ${{ vars.SMOKE_TEAM_ID }}
+          SMOKE_GAME_ID: ${{ vars.SMOKE_GAME_ID }}
+          SMOKE_EVENT_ID: ${{ vars.SMOKE_EVENT_ID }}
+          SMOKE_PLAYER_ID: ${{ vars.SMOKE_PLAYER_ID }}
+          SMOKE_REGISTRATION_FORM_ID: ${{ vars.SMOKE_REGISTRATION_FORM_ID }}
+          SMOKE_CONVERSATION_ID: ${{ vars.SMOKE_CONVERSATION_ID }}
+          SMOKE_OPPORTUNITY_LISTING_ID: ${{ vars.SMOKE_OPPORTUNITY_LISTING_ID }}
+          SMOKE_OPPORTUNITY_INQUIRY_ID: ${{ vars.SMOKE_OPPORTUNITY_INQUIRY_ID }}
+          SMOKE_STAFF_EMAIL: ${{ secrets.SMOKE_STAFF_EMAIL }}
+          SMOKE_STAFF_PASSWORD: ${{ secrets.SMOKE_STAFF_PASSWORD }}
+          SMOKE_PARENT_EMAIL: ${{ secrets.SMOKE_PARENT_EMAIL }}
+          SMOKE_PARENT_PASSWORD: ${{ secrets.SMOKE_PARENT_PASSWORD }}
+
       - name: Upload redacted candidate authentication diagnostic
         if: always() && steps.firebase_auth.outcome == 'failure'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -132,11 +210,18 @@ jobs:
       - name: Aggregate production smoke signals
         if: always()
         env:
+          CORE_CONFIGURED: ${{ steps.core_config.outputs.enabled }}
+          CORE_MISSING: ${{ steps.core_config.outputs.missing }}
+          CORE_OUTCOME: ${{ steps.canonical_core.outcome }}
           CANONICAL_PROD_OUTCOME: ${{ steps.canonical_prod.outcome }}
           FIREBASE_AUTH_OUTCOME: ${{ steps.firebase_auth.outcome }}
           FIREBASE_PUBLIC_OUTCOME: ${{ steps.firebase_public.outcome }}
         run: |
           set -euo pipefail
+          fixture_outcome="$CORE_OUTCOME"
+          if [[ "$CORE_CONFIGURED" != "true" ]]; then
+            fixture_outcome="not-configured ($CORE_MISSING)"
+          fi
           {
             echo "### Post-deploy production signals"
             echo
@@ -144,12 +229,17 @@ jobs:
             echo "| --- | --- |"
             echo "| Firebase public origin | $FIREBASE_PUBLIC_OUTCOME |"
             echo "| Firebase authenticated login | $FIREBASE_AUTH_OUTCOME |"
-            echo "| Canonical production | $CANONICAL_PROD_OUTCOME |"
+            echo "| Canonical production baseline | $CANONICAL_PROD_OUTCOME |"
+            echo "| Fixture-backed role workflows | $fixture_outcome |"
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [[ "$FIREBASE_PUBLIC_OUTCOME" != "success" ||
                 "$FIREBASE_AUTH_OUTCOME" != "success" ||
                 "$CANONICAL_PROD_OUTCOME" != "success" ]]; then
             echo "One or more independent post-deploy signals failed." >&2
+            exit 1
+          fi
+          if [[ "$CORE_CONFIGURED" == "true" && "$CORE_OUTCOME" != "success" ]]; then
+            echo "The configured fixture-backed production smoke failed." >&2
             exit 1
           fi

--- a/docs/production-smoke-and-email-acceptance.md
+++ b/docs/production-smoke-and-email-acceptance.md
@@ -34,16 +34,28 @@ artifacts, screenshots, traces, videos, or chat.
 
 ## Automated tiers
 
-The post-deploy workflow checks out the exact released SHA and runs:
+The post-deploy workflow checks out the exact released SHA and always runs:
 
 - public app and marketing/legal/support boots;
 - intentional public game/replay/report routes when fixture IDs are supplied;
 - compatibility redirects for legacy login, signup, invite, reset, and
   verification URLs;
+- a protected sign-in on the Firebase candidate origin and the canonical
+  production origin.
+
+When every required fixture ID and both distinct role-specific account pairs
+are configured, the same workflow also runs:
+
 - staff and parent sign-in, refresh persistence, protected routes, role
   boundaries, logout, and signed-out rejection;
 - fixture-backed staff, parent, notification, registration, fees, media,
   certificate, schedule, message, official, profile, and help views.
+
+Missing fixture-backed configuration is reported by name as a workflow warning
+and `not-configured` summary row; it does not convert successful baseline
+release probes into a false production outage. Once configured, any
+fixture-backed failure remains fail-closed. The nightly workflow remains the
+authoritative configuration and extended-coverage sentinel.
 
 The nightly workflow always runs the core read-only checks. Extended mutations
 are opt-in: set `SMOKE_EXTENDED_WRITES_ENABLED=1` only after the synthetic team

--- a/tests/smoke/app-parent-live.spec.js
+++ b/tests/smoke/app-parent-live.spec.js
@@ -42,7 +42,7 @@ async function signIn(page, baseURL) {
     await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 15000 });
 
     const emailField = page.getByLabel('Email');
-    const passwordField = page.getByLabel('Password');
+    const passwordField = page.getByLabel('Password', { exact: true });
     await expect(emailField).toBeVisible({ timeout: 10000 });
     await emailField.fill(parentEmail);
     await passwordField.fill(parentPassword);

--- a/tests/smoke/candidate-host-auth.spec.js
+++ b/tests/smoke/candidate-host-auth.spec.js
@@ -53,7 +53,7 @@ test('candidate host accepts authentication and loads a protected landing page',
             await expect(page.getByRole('heading', { name: 'Sign in' }), `Authentication form did not load at candidate URL ${candidateHostUrl}`)
                 .toBeVisible({ timeout: 10_000 });
             await page.getByLabel('Email').fill(authEmail);
-            await page.getByLabel('Password').fill(authPassword);
+            await page.getByLabel('Password', { exact: true }).fill(authPassword);
             const submitButton = page.getByRole('button', { name: 'Sign in' }).last();
             const errorMessage = page.locator('[role="alert"]').first();
             await submitButton.click();
@@ -100,7 +100,7 @@ test('candidate host accepts authentication and loads a protected landing page',
             ).toContainText(/Your day|Your teams|Team/, { timeout: 10_000 });
         });
     } catch (error) {
-        await page.getByLabel('Password').fill('').catch(() => {});
+        await page.getByLabel('Password', { exact: true }).fill('').catch(() => {});
         await page.getByLabel('Email').fill('').catch(() => {});
         await writeRedactedDiagnostic(page, testInfo, error);
         throw new Error(

--- a/tests/smoke/helpers/app-auth.js
+++ b/tests/smoke/helpers/app-auth.js
@@ -86,14 +86,14 @@ export async function signInToApp(page, { appBaseUrl, email, password, roleLabel
     await page.goto(buildAppSmokeUrl(appBaseUrl, '/auth'), { waitUntil: 'domcontentloaded' });
     await expect(page.getByRole('heading', { name: 'Sign in' })).toBeVisible({ timeout: 20_000 });
     await page.getByLabel('Email').fill(email);
-    await page.getByLabel('Password').fill(password);
+    await page.getByLabel('Password', { exact: true }).fill(password);
     await page.getByRole('button', { name: 'Sign in' }).last().click();
     await expect.poll(() => new URL(page.url()).hash, {
         message: `${roleLabel} remained in the authentication flow`,
         timeout: 25_000
     }).not.toMatch(/^#\/(?:auth|verify-pending)(?:\?|$)/);
     await expect(page.locator('main')).toBeVisible({ timeout: 15_000 });
-    await page.getByLabel('Password').fill('').catch(() => {});
+    await page.getByLabel('Password', { exact: true }).fill('').catch(() => {});
     await page.getByLabel('Email').fill('').catch(() => {});
 }
 

--- a/tests/smoke/static-hosting-bootstrap.spec.js
+++ b/tests/smoke/static-hosting-bootstrap.spec.js
@@ -10,7 +10,7 @@ import {
 async function loginWithPassword(page, baseURL, email, password) {
     await page.goto(`${baseURL}/app/#/auth`, { waitUntil: 'domcontentloaded' });
     await page.getByLabel('Email').fill(email);
-    await page.getByLabel('Password').fill(password);
+    await page.getByLabel('Password', { exact: true }).fill(password);
     await page.getByRole('button', { name: 'Sign in' }).last().click();
     await page.waitForURL((url) => url.pathname === '/app/' && !url.hash.startsWith('#/auth'), { timeout: 20000 });
     await page.waitForTimeout(1000);

--- a/tests/unit/candidate-host-auth-smoke.test.js
+++ b/tests/unit/candidate-host-auth-smoke.test.js
@@ -21,6 +21,7 @@ describe('candidate-host authenticated smoke coverage', () => {
         expect(spec).toContain('Candidate post-login assertion failed at ${candidateHostUrl}');
         expect(spec).toContain("expect(authEmail, 'SMOKE_STAFF_EMAIL or SMOKE_AUTH_EMAIL is required for candidate-host auth smoke').toBeTruthy()");
         expect(spec).toContain("expect(authPassword, 'SMOKE_STAFF_PASSWORD or SMOKE_AUTH_PASSWORD is required for candidate-host auth smoke').toBeTruthy()");
+        expect(spec).toContain("getByLabel('Password', { exact: true })");
         expect(spec).not.toContain('test.skip(!hasCredentials');
         expect(spec).toContain('landingUrl.origin');
         expect(spec).toContain('toBe(new URL(candidateHostUrl).origin)');
@@ -45,14 +46,33 @@ describe('candidate-host authenticated smoke coverage', () => {
 
         expect(workflow).toContain('id: firebase_public');
         expect(workflow).toContain('id: firebase_auth');
+        expect(workflow).toContain('id: core_config');
         expect(workflow).toContain('id: canonical_prod');
-        expect(workflow.match(/continue-on-error: true/g)).toHaveLength(3);
+        expect(workflow).toContain('id: canonical_core');
+        expect(workflow.match(/continue-on-error: true/g)).toHaveLength(4);
         expect(workflow).toContain('if: always()');
         expect(workflow).toContain('steps.firebase_public.outcome');
         expect(workflow).toContain('steps.firebase_auth.outcome');
         expect(workflow).toContain('steps.canonical_prod.outcome');
+        expect(workflow).toContain("if: steps.core_config.outputs.enabled == 'true'");
+        expect(workflow).toContain('Fixture-backed production smoke not configured');
+        expect(workflow).toContain('steps.canonical_core.outcome');
+        expect(workflow).toContain('The configured fixture-backed production smoke failed.');
         expect(workflow).toContain('test-results/**/candidate-auth-diagnostic.json');
         expect(workflow).toContain('One or more independent post-deploy signals failed.');
         expect(workflow).toContain('timeout-minutes: 30');
+    });
+
+    it('uses exact password labels everywhere the app auth form is automated', () => {
+        for (const file of [
+            'tests/smoke/candidate-host-auth.spec.js',
+            'tests/smoke/helpers/app-auth.js',
+            'tests/smoke/static-hosting-bootstrap.spec.js',
+            'tests/smoke/app-parent-live.spec.js'
+        ]) {
+            const source = readRepoFile(file);
+            expect(source).not.toMatch(/getByLabel\(['"]Password['"]\)(?!\s*,)/);
+            expect(source).toContain("getByLabel('Password', { exact: true })");
+        }
     });
 });


### PR DESCRIPTION
## Change
- use exact Playwright password-label matches so the adjacent “Show password” control cannot collide with the input
- split always-available public/auth release probes from the richer fixture-backed role suite
- detect missing protected fixture configuration by name and report it as `not-configured`
- keep fixture-backed role checks fail-closed whenever their complete configuration is present
- document the two production smoke tiers

## Why
Post-deploy smoke for merge `e34f25cf581c8298695db1269dd9b59cecad4c9b` showed that the production deployment was healthy but the monitor failed for two harness reasons: a strict-mode locator collision and incomplete synthetic fixture configuration. Twenty-four public/bootstrap checks passed. This change restores a meaningful baseline release signal without presenting missing optional setup as a production outage.

## Validation
- `npm exec -- vitest run tests/unit/candidate-host-auth-smoke.test.js tests/unit/preview-deploy-trust-boundary.test.js tests/unit/verify-response-headers.test.js --reporter=dot` (35 passed)
- `npm run test:unit:ci` (5,195 unit tests and 122 emulator tests passed)
- YAML parse and `bash -n` for all 9 workflow run blocks
- readiness behavior exercised for missing, same-account, case-insensitive same-account, and complete configurations
- `git diff --check`

## Production safety
- no new permissions, credentials, mutable actions, deploy authority, or untrusted trigger paths
- baseline failures remain blocking
- configured fixture-backed failures remain blocking
- missing fixture setup is visible by configuration name only; no secret values are logged
