### PR TITLE
Fix natural-language roster team resolution

### DIFF
--- a/apps/app/src/lib/privateAiService.ts
+++ b/apps/app/src/lib/privateAiService.ts
@@ -5877,6 +5877,8 @@ type AccessibleAiTeamsResult = {
   teams: AccessibleAiTeam[];
   isPartial: boolean;
   partialError?: unknown;
+  managerTeamsPartial: boolean;
+  managerPartialError?: unknown;
 };
 
 async function loadAccessibleAiTeams(user: AuthUser): Promise<AccessibleAiTeamsResult> {
@@ -5901,23 +5903,47 @@ async function loadAccessibleAiTeams(user: AuthUser): Promise<AccessibleAiTeamsR
     : { teams: [] };
   const scheduleScope = scheduleScopeResult.status === 'fulfilled'
     ? scheduleScopeResult.value
-    : { staffTeams: [], isPartial: true };
+    : { children: [], staffTeams: [], isPartial: true, staffTeamsPartial: true };
   if (scheduleScope.isPartial === true) isPartial = true;
+  let managerTeamsPartial = scheduleScopeResult.status === 'rejected'
+    || (scheduleScope.staffTeamsPartial ?? scheduleScope.isPartial) === true;
+  let managerPartialError: unknown = scheduleScopeResult.status === 'rejected'
+    ? scheduleScopeResult.reason
+    : undefined;
   const teamIds = new Set<string>();
+  const managerTeamIds = new Set<string>();
   (home.teams || []).forEach((team: any) => {
     const teamId = compactText(team.teamId || team.id);
     if (teamId) teamIds.add(teamId);
   });
+  (scheduleScope.children || []).forEach((child) => {
+    const teamId = compactText(child.teamId);
+    if (teamId) teamIds.add(teamId);
+  });
   (scheduleScope.staffTeams || []).forEach((team) => {
     const teamId = compactText(team.teamId);
-    if (teamId) teamIds.add(teamId);
+    if (teamId) {
+      teamIds.add(teamId);
+      managerTeamIds.add(teamId);
+    }
   });
   (user.coachOf || []).forEach((teamId) => {
     const normalized = compactText(teamId);
-    if (normalized) teamIds.add(normalized);
+    if (normalized) {
+      teamIds.add(normalized);
+      managerTeamIds.add(normalized);
+    }
   });
 
-  const detailResults = await Promise.allSettled(Array.from(teamIds).slice(0, 60).map(async (teamId) => {
+  const candidateTeamIds = Array.from(teamIds);
+  const loadedTeamIds = candidateTeamIds.slice(0, 60);
+  if (candidateTeamIds.length > loadedTeamIds.length) {
+    isPartial = true;
+    if (candidateTeamIds.slice(60).some((teamId) => managerTeamIds.has(teamId))) {
+      managerTeamsPartial = true;
+    }
+  }
+  const detailResults = await Promise.allSettled(loadedTeamIds.map(async (teamId) => {
     const detail = await loadParentTeamDetail(teamId, user);
     if (!detail?.team) return null;
     return {
@@ -5929,18 +5955,30 @@ async function loadAccessibleAiTeams(user: AuthUser): Promise<AccessibleAiTeamsR
     } satisfies AccessibleAiTeam;
   }));
   const details: AccessibleAiTeam[] = [];
-  detailResults.forEach((result) => {
+  detailResults.forEach((result, index) => {
     if (result.status === 'fulfilled' && result.value) {
       details.push(result.value);
     } else {
       isPartial = true;
+      if (managerTeamIds.has(loadedTeamIds[index])) {
+        managerTeamsPartial = true;
+      }
       if (result.status === 'rejected') {
         partialError ||= result.reason;
+        if (managerTeamIds.has(loadedTeamIds[index])) {
+          managerPartialError ||= result.reason;
+        }
         logger.warn('Unable to verify one private AI team.', { error: result.reason });
       }
     }
   });
-  return { teams: details, isPartial, ...(partialError ? { partialError } : {}) };
+  return {
+    teams: details,
+    isPartial,
+    managerTeamsPartial,
+    ...(partialError ? { partialError } : {}),
+    ...(managerPartialError ? { managerPartialError } : {})
+  };
 }
 
 async function resolveAccessibleTeamId(
@@ -5986,8 +6024,14 @@ async function resolveAccessibleTeamId(
   if (exactPromptTeams.length === 1) {
     return exactPromptTeams[0].teamId;
   }
-  if (access.isPartial) {
-    if (access.partialError instanceof Error) throw access.partialError;
+  const teamIdentityIsPartial = options.requireManager
+    ? access.managerTeamsPartial
+    : access.isPartial;
+  const teamIdentityError = options.requireManager
+    ? access.managerPartialError
+    : access.partialError;
+  if (teamIdentityIsPartial) {
+    if (teamIdentityError instanceof Error) throw teamIdentityError;
     throw new Error('Could not verify all team access. Use an exact team name or team ID and try again.');
   }
   const partiallyNamedTeams = teamName && !exactNamedTeams.length && teamName.length >= 3
@@ -6586,7 +6630,7 @@ function looksLikeFunctionalHelpQuestion(question: string) {
 }
 
 function looksLikeImperativePrivateAiWriteRequest(question: string) {
-  const text = compactText(question).toLowerCase();
+  const text = normalizePrivateAiIntentText(question);
   const writeVerb = '(?:add|invite|create|update|change|remove|delete|deactivate|reactivate|cancel|schedule|reschedule|move|send|resend|retry|set|mark|record|assign|claim|release|save|import|complete|submit|request|revoke|retire|toggle|enable|disable|approve|reject|review|close|reopen|offer|post|pay|favorite|unfavorite)';
   return new RegExp(`^(?:please\\s+)?${writeVerb}\\b`).test(text)
     || new RegExp(`^(?:can|could|would)\\s+you\\s+(?:please\\s+)?${writeVerb}\\b`).test(text)
@@ -6614,7 +6658,7 @@ function privateAiWriteToolMatchesQuestion(question: string, toolName: string) {
 }
 
 function getExpectedPrivateAiWriteToolNames(question: string): Set<string> | null {
-  const text = compactText(question).toLowerCase();
+  const text = normalizePrivateAiIntentText(question);
   if (/\b(?:resend|retry)\b.{0,80}\b(?:parent|guardian|invite|invitation|email)\b/.test(text)) {
     return new Set(['resend_roster_parent_invite']);
   }
@@ -6631,6 +6675,7 @@ function getExpectedPrivateAiWriteToolNames(question: string): Set<string> | nul
       && /\b(?:add|remove|delete|deactivate|reactivate|import)\b/.test(text)
       && !/\b(?:profile|tracking|incentive|fee|registration|assignment)\b/.test(text)
     )
+    || looksLikePrivateAiRosterMembershipRequest(text)
   ) {
     return new Set(['apply_roster_import']);
   }
@@ -6741,6 +6786,23 @@ function getExpectedPrivateAiWriteToolNames(question: string): Set<string> | nul
     }
   }
   return null;
+}
+
+function normalizePrivateAiIntentText(question: string) {
+  return compactText(question)
+    .toLowerCase()
+    .replace(/^[\s"'“”‘’`()[\]{}<>]+/, '')
+    .trim();
+}
+
+function looksLikePrivateAiRosterMembershipRequest(text: string) {
+  const match = text.match(
+    /\b(?:add|remove|delete|deactivate|reactivate)\s+(.{1,120}?)\s+(?:to|from|on)\s+(?:the\s+)?(.{1,120}?)\s+(?:team|roster)\b/
+  );
+  if (!match) return false;
+  const requestedMember = compactText(match[1]).toLowerCase();
+  if (!requestedMember) return false;
+  return !/\b(?:admin|administrator|coach|staff|game|match|practice|event|schedule|fee|payment|message|email|drill|score|registration|assignment|ride|rideshare)\b/.test(requestedMember);
 }
 
 function getPrivateAiPlannerToolCallKey(call: PrivateAiToolCall) {

--- a/apps/app/src/lib/privateAiService.ts
+++ b/apps/app/src/lib/privateAiService.ts
@@ -6668,6 +6668,9 @@ function getExpectedPrivateAiWriteToolNames(question: string): Set<string> | nul
   ) {
     return new Set(['invite_roster_parent']);
   }
+  if (looksLikePrivateAiTeamAdminRequest(text)) {
+    return new Set(['invite_team_admin']);
+  }
   if (
     /\broster\b/.test(text)
     || (
@@ -6720,9 +6723,6 @@ function getExpectedPrivateAiWriteToolNames(question: string): Set<string> | nul
   }
   if (/\b(?:team settings?|team name|team sport|league url|livestream url)\b/.test(text)) {
     return new Set(['update_team_settings']);
-  }
-  if (/\b(?:team admin|administrator)\b/.test(text) && /\b(?:invite|add)\b/.test(text)) {
-    return new Set(['invite_team_admin']);
   }
   if (/\b(?:stat configuration|stat tracker|tracker configuration)\b/.test(text)) {
     return new Set(['save_stat_configuration']);
@@ -6795,6 +6795,15 @@ function normalizePrivateAiIntentText(question: string) {
     .trim();
 }
 
+function looksLikePrivateAiTeamAdminRequest(text: string) {
+  return (
+    /\b(?:team admin|administrator)\b/.test(text)
+    && /\b(?:invite|add)\b/.test(text)
+  ) || (
+    /\b(?:invite|add)\s+.{1,120}?\s+(?:to|on)\s+(?:the\s+)?.{1,120}?\s+team\b.{0,80}\b(?:as|to be)\s+(?:an?\s+)?(?:team\s+)?(?:admin|administrator)\b/.test(text)
+  );
+}
+
 function looksLikePrivateAiRosterMembershipRequest(text: string) {
   const match = text.match(
     /\b(?:add|remove|delete|deactivate|reactivate)\s+(.{1,120}?)\s+(?:to|from|on)\s+(?:the\s+)?(.{1,120}?)\s+(?:team|roster)\b/
@@ -6802,7 +6811,11 @@ function looksLikePrivateAiRosterMembershipRequest(text: string) {
   if (!match) return false;
   const requestedMember = compactText(match[1]).toLowerCase();
   if (!requestedMember) return false;
-  return !/\b(?:admin|administrator|coach|staff|game|match|practice|event|schedule|fee|payment|message|email|drill|score|registration|assignment|ride|rideshare)\b/.test(requestedMember);
+  const trailingQualifier = text.slice((match.index || 0) + match[0].length);
+  if (/\b(?:as|with|to be)\b.{0,40}\b(?:admin|administrator|coach|staff|manager)\b/.test(trailingQualifier)) {
+    return false;
+  }
+  return !/\b(?:admin|administrator|coach|staff|manager|game|match|practice|event|schedule|fee|payment|message|email|drill|score|registration|assignment|ride|rideshare)\b/.test(requestedMember);
 }
 
 function getPrivateAiPlannerToolCallKey(call: PrivateAiToolCall) {

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -375,6 +375,7 @@ describe('parent schedule child scope', () => {
 
     expect(scope.children).toEqual([]);
     expect(scope.isPartial).toBe(true);
+    expect(scope.staffTeamsPartial).toBe(false);
   });
 
   it('reloads profile scope during schedule enrichment when the fast scope is partial', async () => {
@@ -458,6 +459,7 @@ describe('parent schedule child scope', () => {
 
     expect(scope.staffTeams).toEqual([{ teamId: 'team-owned', teamName: 'Vipers' }]);
     expect(scope.isPartial).toBe(false);
+    expect(scope.staffTeamsPartial).toBe(false);
     expect(schedule.staffTeams).toEqual([{ teamId: 'team-owned', teamName: 'Vipers' }]);
     expect(getStaffTeams).toHaveBeenCalledTimes(1);
     expect(getGames).toHaveBeenCalledWith('team-owned', expect.objectContaining({
@@ -473,6 +475,7 @@ describe('parent schedule child scope', () => {
     const scope = await loadParentScheduleScope(coachUser);
 
     expect(scope.isPartial).toBe(true);
+    expect(scope.staffTeamsPartial).toBe(true);
     expect(scope.staffTeams).toEqual([]);
   });
 
@@ -487,6 +490,7 @@ describe('parent schedule child scope', () => {
     const scope = await loadParentScheduleScope(coachUser);
 
     expect(scope.isPartial).toBe(true);
+    expect(scope.staffTeamsPartial).toBe(true);
     expect(scope.staffTeams).toEqual([{ teamId: 'team-owned', teamName: 'Vipers' }]);
   });
 
@@ -539,6 +543,7 @@ describe('parent schedule child scope', () => {
       const scope = await loadParentScheduleScope(coachUser);
 
       expect(scope.isPartial).toBe(true);
+      expect(scope.staffTeamsPartial).toBe(true);
       expect(scope.staffTeams).toEqual([{ teamId: 'team-owned', teamName: 'Vipers' }]);
     } finally {
       (globalThis as any).window = previousWindow;

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -378,6 +378,8 @@ export type ParentScheduleScope = {
   children: ParentScheduleChild[];
   /** Teams the user can manage, including newly created teams with no players or chat yet. */
   staffTeams?: ParentScheduleStaffTeam[];
+  /** True only when manager-team identity discovery was incomplete. */
+  staffTeamsPartial?: boolean;
   /** True when any authoritative scope read failed and cached access should be preserved. */
   isPartial?: boolean;
 };
@@ -2913,6 +2915,7 @@ export async function loadParentScheduleScope(user: AuthUser | null): Promise<Pa
     profile: profile as Record<string, unknown>,
     children: childResult.children,
     isPartial,
+    staffTeamsPartial: staffTeamResult.isPartial,
     staffTeams: staffTeamResult.teams
       .map((team: any) => {
         const teamId = compactString(team?.id);

--- a/tests/unit/app-private-ai-service.test.js
+++ b/tests/unit/app-private-ai-service.test.js
@@ -1388,6 +1388,97 @@ describe('private AI service', () => {
         expect(directResult.assistantMessage.text).toContain('Reply yes to apply these roster changes.');
     });
 
+    it('stages a quoted natural-language player add against a unique verified shortened team name', async () => {
+        const coachUser = {
+            ...authUser,
+            roles: ['coach', 'parent'],
+            coachOf: ['team-cougars'],
+            parentPlayerKeys: []
+        };
+        homeMocks.loadParentHome.mockRejectedValueOnce(new Error('Unrelated Home slice unavailable'));
+        scheduleMocks.loadParentScheduleScope.mockResolvedValue({
+            profile: {},
+            children: [],
+            staffTeams: [{ teamId: 'team-cougars', teamName: 'K - Cougars' }],
+            isPartial: true,
+            staffTeamsPartial: false
+        });
+        teamMocks.loadParentTeamDetail.mockResolvedValue({
+            team: { id: 'team-cougars', name: 'K - Cougars' },
+            players: [],
+            inactivePlayers: [],
+            canManageTeam: true
+        });
+        const addOperation = {
+            type: 'add',
+            payload: { name: 'Tad Mac' },
+            errors: []
+        };
+        rosterAiMocks.normalizeRosterAiImportResponse.mockReturnValue({
+            rows: [rosterPreviewRow({
+                action: 'add',
+                playerId: '',
+                name: 'Tad Mac',
+                number: '',
+                operation: addOperation
+            })],
+            errors: []
+        });
+        aiMocks.model.generateContent
+            .mockResolvedValueOnce(modelText(JSON.stringify({
+                answer: 'I could not identify a roster action.'
+            })))
+            .mockResolvedValueOnce(modelText(JSON.stringify({
+                toolCalls: [{
+                    name: 'apply_roster_import',
+                    args: {
+                        teamName: 'Cougars',
+                        operations: [{
+                            action: 'add',
+                            player: { name: 'Tad Mac' }
+                        }]
+                    }
+                }]
+            })))
+            .mockResolvedValueOnce(modelText(JSON.stringify({
+                answer: 'Tad Mac is staged for the K - Cougars roster. Reply yes to confirm.'
+            })));
+        const { generatePrivateAiAnswer } = await import('../../apps/app/src/lib/privateAiService.ts');
+
+        const result = await generatePrivateAiAnswer(coachUser, '“Add Tad Mac to the Cougars team');
+
+        expect(result.answer).toContain('staged for the K - Cougars roster');
+        expect(result.toolResults).toEqual([
+            expect.objectContaining({
+                name: 'apply_roster_import',
+                ok: true,
+                requiresConfirmation: true,
+                data: expect.objectContaining({
+                    previewSummary: expect.objectContaining({ add: 1 })
+                })
+            })
+        ]);
+        expect(aiMocks.model.generateContent).toHaveBeenCalledTimes(3);
+        expect(aiMocks.model.generateContent.mock.calls[1][0]).toContain(
+            'prior response claimed or described a change without calling a write tool'
+        );
+        expect(firebaseMocks.setDoc).toHaveBeenCalledWith(
+            expect.objectContaining({
+                path: ['teams', 'team-cougars', 'privateAiPendingActions', expect.any(String)]
+            }),
+            expect.objectContaining({
+                teamId: 'team-cougars',
+                args: expect.objectContaining({
+                    teamId: 'team-cougars',
+                    operations: [expect.objectContaining({
+                        type: 'add',
+                        payload: { name: 'Tad Mac' }
+                    })]
+                })
+            })
+        );
+    });
+
     it('reports home and team-management read failures instead of presenting empty complete data', async () => {
         const coachUser = {
             ...authUser,
@@ -5442,6 +5533,47 @@ describe('private AI service', () => {
             })
         ]);
         expect(firebaseMocks.setDoc.mock.calls.some((call) => call[1]?.toolName === 'create_schedule_event')).toBe(false);
+    });
+
+    it.each([
+        'Add a game to the Cougars team.',
+        'Add a team admin to the Cougars team.'
+    ])('does not misclassify another domain as a roster membership request: %s', async (prompt) => {
+        const coachUser = {
+            ...authUser,
+            roles: ['coach'],
+            coachOf: ['team-1'],
+            parentPlayerKeys: []
+        };
+        aiMocks.model.generateContent
+            .mockResolvedValueOnce(modelText(JSON.stringify({
+                toolCalls: [{
+                    name: 'apply_roster_import',
+                    args: {
+                        teamName: 'Cougars',
+                        operations: [{
+                            action: 'add',
+                            player: { name: 'Wrong Domain' }
+                        }]
+                    }
+                }]
+            })))
+            .mockResolvedValueOnce(modelText(JSON.stringify({
+                answer: 'The roster change is staged.'
+            })));
+        const { generatePrivateAiAnswer } = await import('../../apps/app/src/lib/privateAiService.ts');
+
+        const result = await generatePrivateAiAnswer(coachUser, prompt);
+
+        expect(result.answer).toBe('I could not prepare that change because no reviewed action was staged. Please try the request again.');
+        expect(result.toolResults).toEqual([
+            expect.objectContaining({
+                name: 'apply_roster_import',
+                ok: false,
+                error: expect.stringContaining('does not match the requested operation')
+            })
+        ]);
+        expect(firebaseMocks.setDoc).not.toHaveBeenCalled();
     });
 
     it.each([

--- a/tests/unit/app-private-ai-service.test.js
+++ b/tests/unit/app-private-ai-service.test.js
@@ -5537,7 +5537,8 @@ describe('private AI service', () => {
 
     it.each([
         'Add a game to the Cougars team.',
-        'Add a team admin to the Cougars team.'
+        'Add a team admin to the Cougars team.',
+        'Add Jane to the Cougars team as an admin.'
     ])('does not misclassify another domain as a roster membership request: %s', async (prompt) => {
         const coachUser = {
             ...authUser,
@@ -5574,6 +5575,54 @@ describe('private AI service', () => {
             })
         ]);
         expect(firebaseMocks.setDoc).not.toHaveBeenCalled();
+    });
+
+    it('routes a trailing team-admin qualifier to the administrator invite tool', async () => {
+        const coachUser = {
+            ...authUser,
+            roles: ['coach'],
+            coachOf: ['team-1'],
+            parentPlayerKeys: []
+        };
+        aiMocks.model.generateContent
+            .mockResolvedValueOnce(modelText(JSON.stringify({
+                toolCalls: [{
+                    name: 'invite_team_admin',
+                    args: {
+                        teamName: 'Bears',
+                        email: 'jane.admin@example.com'
+                    }
+                }]
+            })))
+            .mockResolvedValueOnce(modelText(JSON.stringify({
+                answer: 'The administrator invitation is staged. Reply yes to confirm.'
+            })));
+        const { generatePrivateAiAnswer } = await import('../../apps/app/src/lib/privateAiService.ts');
+
+        const result = await generatePrivateAiAnswer(
+            coachUser,
+            'Add Jane to the Bears team as an admin at jane.admin@example.com.'
+        );
+
+        expect(result.toolResults).toEqual([
+            expect.objectContaining({
+                name: 'invite_team_admin',
+                ok: true,
+                requiresConfirmation: true
+            })
+        ]);
+        expect(firebaseMocks.setDoc).toHaveBeenCalledWith(
+            expect.objectContaining({
+                path: ['users', 'user-1', 'privateAiPendingActions', expect.any(String)]
+            }),
+            expect.objectContaining({
+                toolName: 'invite_team_admin',
+                args: expect.objectContaining({
+                    teamId: 'team-1',
+                    email: 'jane.admin@example.com'
+                })
+            })
+        );
     });
 
     it.each([


### PR DESCRIPTION
## Summary

- recognize quoted imperative chat requests such as “Add Tad Mac to the Cougars team” as roster writes
- resolve a unique shortened manager team name even when unrelated parent-home data is partially unavailable
- preserve fail-closed behavior when any manager-team identity or detail is incomplete
- route trailing staff-role qualifiers such as “as an admin” to the administrator invite tool instead of the roster
- add regressions for quoted prompts, shortened team names, role qualifiers, and non-roster phrases

## Root cause

The write classifier required the prompt to begin directly with an imperative verb and only inferred roster tools when roster/player terminology was present. Team resolution also treated unrelated partial parent-home reads as incomplete manager-team identity, blocking otherwise unambiguous manager-owned teams. A broad roster phrase matcher also stopped at the word `team`, overlooking trailing role qualifiers.

## Safety

Roster and administrator changes are still staged as durable pending actions and require confirmation before any write. Fuzzy matching remains disabled whenever manager-team identity is genuinely incomplete, and unrelated game/admin requests cannot be routed to roster tools.

## Validation

Exact head: `a7c7383ab7e57447e444a4efda81763203c2bb08`

- `npx vitest run tests/unit/app-private-ai-service.test.js --reporter=dot` (147 passed)
- `npm run test:app -- src/lib/scheduleService.test.ts --reporter=dot` (137 passed)
- `npm test` (full root suite)
- `npm run test:app -- --reporter=dot` (1,544 passed on the initial head; follow-up is root-only classifier/test coverage)
- `npm run app:build`
- app lint (0 errors; existing warning baseline)
- critical cache-bust guard
- `git diff --check origin/master...HEAD`