### PR TITLE
Stabilize production startup and discovery

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -88,8 +88,66 @@ jobs:
           name: prod-regression-guards-http-log
           path: /tmp/allplays-prod-regression-guards.log
 
-  prepare-deploy:
+  validate-production-smoke-config:
     needs: [unit-tests, regression-guards]
+    runs-on: ubuntu-latest
+    environment:
+      name: production-smoke
+    permissions: {}
+    env:
+      SMOKE_TEAM_ID: ${{ vars.SMOKE_TEAM_ID }}
+      SMOKE_GAME_ID: ${{ vars.SMOKE_GAME_ID }}
+      SMOKE_EVENT_ID: ${{ vars.SMOKE_EVENT_ID }}
+      SMOKE_PLAYER_ID: ${{ vars.SMOKE_PLAYER_ID }}
+      SMOKE_REGISTRATION_FORM_ID: ${{ vars.SMOKE_REGISTRATION_FORM_ID }}
+      SMOKE_ADMIN_EMAIL: ${{ secrets.SMOKE_ADMIN_EMAIL }}
+      SMOKE_ADMIN_PASSWORD: ${{ secrets.SMOKE_ADMIN_PASSWORD }}
+      SMOKE_STAFF_EMAIL: ${{ secrets.SMOKE_STAFF_EMAIL }}
+      SMOKE_STAFF_PASSWORD: ${{ secrets.SMOKE_STAFF_PASSWORD }}
+      SMOKE_PARENT_EMAIL: ${{ secrets.SMOKE_PARENT_EMAIL }}
+      SMOKE_PARENT_PASSWORD: ${{ secrets.SMOKE_PARENT_PASSWORD }}
+    steps:
+      - name: Require production role-smoke fixtures before deployment
+        shell: bash
+        run: |
+          set -euo pipefail
+          required_names=(
+            SMOKE_TEAM_ID
+            SMOKE_GAME_ID
+            SMOKE_EVENT_ID
+            SMOKE_PLAYER_ID
+            SMOKE_REGISTRATION_FORM_ID
+            SMOKE_ADMIN_EMAIL
+            SMOKE_ADMIN_PASSWORD
+            SMOKE_STAFF_EMAIL
+            SMOKE_STAFF_PASSWORD
+            SMOKE_PARENT_EMAIL
+            SMOKE_PARENT_PASSWORD
+          )
+          missing_names=()
+          for name in "${required_names[@]}"; do
+            if [[ -z "${!name:-}" ]]; then
+              missing_names+=("$name")
+            fi
+          done
+          if (( ${#missing_names[@]} > 0 )); then
+            missing_csv="$(IFS=,; echo "${missing_names[*]}")"
+            echo "::error title=Production smoke configuration incomplete::Missing protected configuration names: $missing_csv"
+            exit 1
+          fi
+
+          admin_email="$(printf '%s' "$SMOKE_ADMIN_EMAIL" | tr '[:upper:]' '[:lower:]')"
+          staff_email="$(printf '%s' "$SMOKE_STAFF_EMAIL" | tr '[:upper:]' '[:lower:]')"
+          parent_email="$(printf '%s' "$SMOKE_PARENT_EMAIL" | tr '[:upper:]' '[:lower:]')"
+          if [[ "$admin_email" == "$staff_email" ||
+                "$admin_email" == "$parent_email" ||
+                "$staff_email" == "$parent_email" ]]; then
+            echo "::error title=Production smoke roles are not isolated::Admin, staff, and parent accounts must be distinct."
+            exit 1
+          fi
+
+  prepare-deploy:
+    needs: [unit-tests, regression-guards, validate-production-smoke-config]
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -96,6 +96,8 @@ jobs:
           SMOKE_EVENT_ID: ${{ vars.SMOKE_EVENT_ID }}
           SMOKE_PLAYER_ID: ${{ vars.SMOKE_PLAYER_ID }}
           SMOKE_REGISTRATION_FORM_ID: ${{ vars.SMOKE_REGISTRATION_FORM_ID }}
+          SMOKE_ADMIN_EMAIL: ${{ secrets.SMOKE_ADMIN_EMAIL }}
+          SMOKE_ADMIN_PASSWORD: ${{ secrets.SMOKE_ADMIN_PASSWORD }}
           SMOKE_STAFF_EMAIL: ${{ secrets.SMOKE_STAFF_EMAIL }}
           SMOKE_STAFF_PASSWORD: ${{ secrets.SMOKE_STAFF_PASSWORD }}
           SMOKE_PARENT_EMAIL: ${{ secrets.SMOKE_PARENT_EMAIL }}
@@ -108,6 +110,8 @@ jobs:
             SMOKE_EVENT_ID
             SMOKE_PLAYER_ID
             SMOKE_REGISTRATION_FORM_ID
+            SMOKE_ADMIN_EMAIL
+            SMOKE_ADMIN_PASSWORD
             SMOKE_STAFF_EMAIL
             SMOKE_STAFF_PASSWORD
             SMOKE_PARENT_EMAIL
@@ -122,19 +126,22 @@ jobs:
 
           if (( ${#missing_names[@]} > 0 )); then
             missing_csv="$(IFS=,; echo "${missing_names[*]}")"
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
             echo "missing=$missing_csv" >> "$GITHUB_OUTPUT"
-            echo "::warning title=Fixture-backed production smoke not configured::Missing protected configuration names: $missing_csv"
+            echo "::error title=Fixture-backed production smoke not configured::Missing protected configuration names: $missing_csv"
+            exit 1
           else
+            admin_email_normalized="$(printf '%s' "$SMOKE_ADMIN_EMAIL" | tr '[:upper:]' '[:lower:]')"
             staff_email_normalized="$(printf '%s' "$SMOKE_STAFF_EMAIL" | tr '[:upper:]' '[:lower:]')"
             parent_email_normalized="$(printf '%s' "$SMOKE_PARENT_EMAIL" | tr '[:upper:]' '[:lower:]')"
           fi
 
           if (( ${#missing_names[@]} == 0 )) &&
-             [[ "$staff_email_normalized" == "$parent_email_normalized" ]]; then
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
+             [[ "$admin_email_normalized" == "$staff_email_normalized" ||
+                "$admin_email_normalized" == "$parent_email_normalized" ||
+                "$staff_email_normalized" == "$parent_email_normalized" ]]; then
             echo "missing=distinct-role-accounts" >> "$GITHUB_OUTPUT"
-            echo "::warning title=Fixture-backed production smoke not configured::Staff and parent smoke accounts must be distinct."
+            echo "::error title=Fixture-backed production smoke not configured::Admin, staff, and parent smoke accounts must be distinct."
+            exit 1
           elif (( ${#missing_names[@]} == 0 )); then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
             echo "missing=" >> "$GITHUB_OUTPUT"
@@ -177,6 +184,7 @@ jobs:
         continue-on-error: true
         run: >-
           npx playwright test
+          tests/smoke/app-admin-core.spec.js
           tests/smoke/app-authenticated-core.spec.js
           --config=playwright.smoke.config.js
           --project=smoke
@@ -193,6 +201,8 @@ jobs:
           SMOKE_CONVERSATION_ID: ${{ vars.SMOKE_CONVERSATION_ID }}
           SMOKE_OPPORTUNITY_LISTING_ID: ${{ vars.SMOKE_OPPORTUNITY_LISTING_ID }}
           SMOKE_OPPORTUNITY_INQUIRY_ID: ${{ vars.SMOKE_OPPORTUNITY_INQUIRY_ID }}
+          SMOKE_ADMIN_EMAIL: ${{ secrets.SMOKE_ADMIN_EMAIL }}
+          SMOKE_ADMIN_PASSWORD: ${{ secrets.SMOKE_ADMIN_PASSWORD }}
           SMOKE_STAFF_EMAIL: ${{ secrets.SMOKE_STAFF_EMAIL }}
           SMOKE_STAFF_PASSWORD: ${{ secrets.SMOKE_STAFF_PASSWORD }}
           SMOKE_PARENT_EMAIL: ${{ secrets.SMOKE_PARENT_EMAIL }}
@@ -219,9 +229,7 @@ jobs:
         run: |
           set -euo pipefail
           fixture_outcome="$CORE_OUTCOME"
-          if [[ "$CORE_CONFIGURED" != "true" ]]; then
-            fixture_outcome="not-configured ($CORE_MISSING)"
-          fi
+          [[ "$CORE_CONFIGURED" == "true" ]] || fixture_outcome="configuration-failed ($CORE_MISSING)"
           {
             echo "### Post-deploy production signals"
             echo
@@ -239,7 +247,7 @@ jobs:
             echo "One or more independent post-deploy signals failed." >&2
             exit 1
           fi
-          if [[ "$CORE_CONFIGURED" == "true" && "$CORE_OUTCOME" != "success" ]]; then
+          if [[ "$CORE_CONFIGURED" != "true" || "$CORE_OUTCOME" != "success" ]]; then
             echo "The configured fixture-backed production smoke failed." >&2
             exit 1
           fi

--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -108,6 +108,7 @@ jobs:
         env:
           ALLPLAYS_APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY: ${{ vars.APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY }}
           ALLPLAYS_APP_CHECK_ENFORCEMENT_READY: ${{ vars.APP_CHECK_ENFORCEMENT_READY }}
+          ALLPLAYS_FIREBASE_RUNTIME_TARGET: preview-smoke
         run: node scripts/stage-pages-bundle.mjs "$RUNNER_TEMP/allplays-pages"
 
       - name: Start staged Pages artifact server
@@ -172,6 +173,7 @@ jobs:
           SMOKE_APP_BOOT_URL: http://127.0.0.1:4173/app/
           SMOKE_EXPECTED_APP_CHECK_ENFORCEMENT_READY: ${{ vars.APP_CHECK_ENFORCEMENT_READY }}
           SMOKE_EXPECTED_APP_CHECK_SITE_KEY: ${{ vars.APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY }}
+          SMOKE_EXPECTED_FIREBASE_RUNTIME_TARGET: preview-smoke
           SMOKE_PAGES_STAGED_ARTIFACT: 'true'
           SMOKE_PARENT_EMAIL: ${{ vars.SMOKE_PARENT_EMAIL }}
           SMOKE_PARENT_PASSWORD: ${{ secrets.SMOKE_PARENT_PASSWORD }}

--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -115,7 +115,12 @@ jobs:
         run: python3 -m http.server 4173 --directory "$RUNNER_TEMP/allplays-pages" >/tmp/allplays-preview-smoke.log 2>&1 &
 
       - name: Start React app dev server
-        run: npm --prefix apps/app run dev -- --host 127.0.0.1 --port 5174 >/tmp/allplays-app-preview-smoke.log 2>&1 &
+        run: |
+          mkdir -p apps/app/public/.well-known
+          cp \
+            "$RUNNER_TEMP/allplays-pages/.well-known/allplays-runtime-config.json" \
+            apps/app/public/.well-known/allplays-runtime-config.json
+          npm --prefix apps/app run dev -- --host 127.0.0.1 --port 5174 >/tmp/allplays-app-preview-smoke.log 2>&1 &
 
       - name: Wait for local smoke servers
         run: |

--- a/.github/workflows/scheduled-prod-smoke.yml
+++ b/.github/workflows/scheduled-prod-smoke.yml
@@ -46,6 +46,7 @@ jobs:
           tests/smoke/app-production-bootstrap.spec.js
           tests/smoke/static-hosting-bootstrap.spec.js
           tests/smoke/legacy-auth-redirects.spec.js
+          tests/smoke/app-admin-core.spec.js
           tests/smoke/app-authenticated-core.spec.js
           tests/smoke/app-authenticated-extended.spec.js
           --config=playwright.smoke.config.js
@@ -66,6 +67,8 @@ jobs:
           SMOKE_CONVERSATION_ID: ${{ vars.SMOKE_CONVERSATION_ID }}
           SMOKE_OPPORTUNITY_LISTING_ID: ${{ vars.SMOKE_OPPORTUNITY_LISTING_ID }}
           SMOKE_OPPORTUNITY_INQUIRY_ID: ${{ vars.SMOKE_OPPORTUNITY_INQUIRY_ID }}
+          SMOKE_ADMIN_EMAIL: ${{ secrets.SMOKE_ADMIN_EMAIL }}
+          SMOKE_ADMIN_PASSWORD: ${{ secrets.SMOKE_ADMIN_PASSWORD }}
           SMOKE_STAFF_EMAIL: ${{ secrets.SMOKE_STAFF_EMAIL }}
           SMOKE_STAFF_PASSWORD: ${{ secrets.SMOKE_STAFF_PASSWORD }}
           SMOKE_PARENT_EMAIL: ${{ secrets.SMOKE_PARENT_EMAIL }}

--- a/.well-known/allplays-runtime-config.json
+++ b/.well-known/allplays-runtime-config.json
@@ -1,4 +1,13 @@
 {
+  "firebase": {
+    "apiKey": "AIzaSyDoixIoKJuUVWdmImwjYRTthjKOv2mU0Jc",
+    "authDomain": "game-flow-c6311.firebaseapp.com",
+    "projectId": "game-flow-c6311",
+    "storageBucket": "game-flow-c6311.firebasestorage.app",
+    "messagingSenderId": "982493478258",
+    "appId": "1:982493478258:web:1f942c420cef6c40e8b1eb",
+    "measurementId": "G-VTLSFV4PHW"
+  },
   "appCheck": {
     "enabled": false,
     "isTokenAutoRefreshEnabled": true

--- a/apps/app/src/lib/adapters/legacyScheduleDb.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.ts
@@ -160,7 +160,6 @@ export type StaffTeamsQuery = {
     userId: string;
     email?: string | null;
     coachTeamIds?: string[];
-    includeAll?: boolean;
 };
 
 export type StaffTeamsResult = {
@@ -168,14 +167,7 @@ export type StaffTeamsResult = {
     isPartial: boolean;
 };
 
-export async function getStaffTeams({ userId, email, coachTeamIds = [], includeAll = false }: StaffTeamsQuery) {
-    if (includeAll) {
-        return {
-            teams: await Promise.resolve(legacyGetTeams({ includePrivate: true })),
-            isPartial: false
-        };
-    }
-
+export async function getStaffTeams({ userId, email, coachTeamIds = [] }: StaffTeamsQuery) {
     const teamsRef = legacyFirebaseCollection(legacyFirebaseDb, 'teams');
     const staffEmail = String(email || '').trim();
     const normalizedEmail = staffEmail.toLowerCase();

--- a/apps/app/src/lib/authService.test.ts
+++ b/apps/app/src/lib/authService.test.ts
@@ -116,6 +116,7 @@ vi.mock('./logger', () => ({
 import { signInWithPopup, signInWithRedirect } from './firebaseAuthRuntime';
 import { Capacitor } from '@capacitor/core';
 import {
+  classifyAuthConnectivity,
   describeAuthError,
   getNativeAuthIdToken,
   getNativeAuthUserId,
@@ -229,6 +230,25 @@ describe('auth email validation', () => {
       .toBe('Too many attempts. Wait a few minutes and try again.');
     expect(describeAuthError({ code: 'auth/too-many-requests' }))
       .toBe('Too many attempts. Wait a few minutes and try again.');
+  });
+
+  it('distinguishes offline, timeout, and reachable-network authentication failures', () => {
+    expect(classifyAuthConnectivity({ code: 'auth/network-request-failed' }, false)).toBe('offline');
+    expect(classifyAuthConnectivity({
+      code: 'auth/network-request-failed',
+      message: 'Sign-in timed out.'
+    }, true)).toBe('timeout');
+    expect(classifyAuthConnectivity({ code: 'auth/network-request-failed' }, true))
+      .toBe('service-unreachable');
+  });
+
+  it('gives network failures retryable guidance without exposing implementation details', () => {
+    expect(describeAuthError({
+      code: 'auth/network-request-failed',
+      message: 'Sign-in timed out.'
+    })).toBe('Sign-in services took too long to respond. Try again.');
+    expect(describeAuthError({ code: 'auth/network-request-failed' }))
+      .toBe('ALL PLAYS could not reach sign-in services. Check your connection and try again.');
   });
 });
 

--- a/apps/app/src/lib/authService.ts
+++ b/apps/app/src/lib/authService.ts
@@ -239,7 +239,14 @@ export function describeAuthError(error: any) {
   }
 
   if (code === 'auth/network-request-failed') {
-    return 'Network request failed. Check the device connection.';
+    const connectivity = classifyAuthConnectivity(error);
+    if (connectivity === 'offline') {
+      return 'This device is offline. Reconnect to the internet, then try again.';
+    }
+    if (connectivity === 'timeout') {
+      return 'Sign-in services took too long to respond. Try again.';
+    }
+    return 'ALL PLAYS could not reach sign-in services. Check your connection and try again.';
   }
 
   if (code === 'auth/account-exists-with-different-credential') {
@@ -251,6 +258,30 @@ export function describeAuthError(error: any) {
   }
 
   return error?.message || 'Authentication failed.';
+}
+
+export function classifyAuthConnectivity(
+  error: any,
+  online = typeof navigator === 'undefined' ? undefined : navigator.onLine
+) {
+  if (online === false) return 'offline';
+
+  const diagnosticText = `${error?.code || ''} ${error?.message || ''} ${error?.name || ''}`.toLowerCase();
+  if (
+    diagnosticText.includes('timed out')
+    || diagnosticText.includes('timeout')
+    || diagnosticText.includes('aborterror')
+  ) {
+    return 'timeout';
+  }
+  if (
+    diagnosticText.includes('auth/network-request-failed')
+    || diagnosticText.includes('networkerror')
+    || diagnosticText.includes('failed to fetch')
+  ) {
+    return 'service-unreachable';
+  }
+  return 'unknown';
 }
 
 function getFirebaseAuthStorageKey() {

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -430,14 +430,42 @@ describe('parent schedule child scope', () => {
     expect(getStaffTeams).toHaveBeenCalledWith({
       userId: 'coach-1',
       email: ' Coach@Example.com ',
-      coachTeamIds: ['team-coach', 'team-coach'],
-      includeAll: false
+      coachTeamIds: ['team-coach', 'team-coach']
     });
     expect(getTeams).not.toHaveBeenCalled();
     expect(schedule.children).toEqual([]);
     expect(new Set(schedule.events.map((event) => event.teamId))).toEqual(new Set());
     expect(getTeam).not.toHaveBeenCalledWith('team-inactive');
     expect(getGames).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not turn platform admin authorization into global Home team membership', async () => {
+    const platformAdmin = {
+      uid: 'platform-admin-1',
+      email: 'admin@example.com',
+      isAdmin: true,
+      roles: ['admin'],
+      coachOf: []
+    } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [] } as any);
+    vi.mocked(getStaffTeams).mockResolvedValue({ teams: [], isPartial: false } as any);
+
+    const schedule = await loadParentSchedule(platformAdmin, {
+      hydrateDetails: false,
+      expandStaffPlayers: false
+    });
+
+    expect(getStaffTeams).toHaveBeenCalledWith({
+      userId: 'platform-admin-1',
+      email: 'admin@example.com',
+      coachTeamIds: []
+    });
+    expect(getTeams).not.toHaveBeenCalled();
+    expect(getTeam).not.toHaveBeenCalled();
+    expect(getGames).not.toHaveBeenCalled();
+    expect(getPracticeSessions).not.toHaveBeenCalled();
+    expect(schedule.staffTeams).toEqual([]);
+    expect(schedule.events).toEqual([]);
   });
 
   it('carries newly created staff teams through the reusable parent scope', async () => {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -1683,8 +1683,7 @@ async function loadStaffTeams(user: AuthUser): Promise<StaffTeamsLoadResult> {
       const staffTeamResult = await getStaffTeams({
         userId: user.uid,
         email: user.email,
-        coachTeamIds,
-        includeAll: (user as any).isAdmin === true
+        coachTeamIds
       });
       const teamsById = new Map<string, any>();
       staffTeamResult.teams.filter(Boolean).forEach((team: any) => {

--- a/apps/app/src/lib/useAuth.test.ts
+++ b/apps/app/src/lib/useAuth.test.ts
@@ -26,7 +26,7 @@ vi.mock('./gameWrapupService', () => ({ resetGameWrapupAiModel: cacheResetMocks.
 vi.mock('./privateAiService', () => ({ resetPrivateAiModel: cacheResetMocks.resetPrivateAiModel }));
 vi.mock('./gameDayLineupBuilder', () => ({ resetLineupAiModel: cacheResetMocks.resetLineupAiModel }));
 
-import { useAuth } from './useAuth';
+import { clearPerUserCaches, useAuth } from './useAuth';
 
 afterEach(() => {
   vi.clearAllMocks();
@@ -47,5 +47,21 @@ describe('useAuth signOut', () => {
     expect(cacheResetMocks.resetGameWrapupAiModel).toHaveBeenCalledTimes(1);
     expect(cacheResetMocks.resetPrivateAiModel).toHaveBeenCalledTimes(1);
     expect(cacheResetMocks.resetLineupAiModel).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues clearing independently loaded caches when one module import fails', async () => {
+    const firstReset = vi.fn();
+    const lastReset = vi.fn();
+
+    await expect(clearPerUserCaches([
+      async () => firstReset,
+      async () => {
+        throw new Error('stale offline chunk');
+      },
+      async () => lastReset
+    ])).rejects.toThrow('One or more per-user caches could not be reset.');
+
+    expect(firstReset).toHaveBeenCalledTimes(1);
+    expect(lastReset).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/app/src/lib/useAuth.ts
+++ b/apps/app/src/lib/useAuth.ts
@@ -3,19 +3,28 @@ import type { AuthState, AuthUser } from './types';
 import { clearAuthBootstrapHint, writeAuthBootstrapHint } from './authBootstrapHint';
 import { hydrateFirebaseUser, observeFirebaseUser, signOut } from './authService';
 import { createLogger } from './logger';
-import { resetChatAiModel } from './chatService';
-import { resetGameWrapupAiModel } from './gameWrapupService';
-import { resetLineupAiModel } from './gameDayLineupBuilder';
-import { resetPrivateAiModel } from './privateAiService';
-import { resetAppSearchCache } from './searchService';
 
 const logger = createLogger('app-auth');
 
-function clearPerUserCaches() {
+async function clearPerUserCaches() {
   // These module-level caches key on the signed-in user (search results, help
   // roles) or hold generative-model handles tied to the session's Firebase
   // app. Without this, a second user signing in on the same tab/device could
   // briefly see the previous user's cached search results.
+  const [
+    { resetAppSearchCache },
+    { resetChatAiModel },
+    { resetGameWrapupAiModel },
+    { resetPrivateAiModel },
+    { resetLineupAiModel }
+  ] = await Promise.all([
+    import('./searchService'),
+    import('./chatService'),
+    import('./gameWrapupService'),
+    import('./privateAiService'),
+    import('./gameDayLineupBuilder')
+  ]);
+
   resetAppSearchCache();
   resetChatAiModel();
   resetGameWrapupAiModel();
@@ -100,13 +109,26 @@ export function useAuth(): AuthState {
   const signOutAndClear = useCallback(async () => {
     setError(null);
     const cleanup = signOut();
+    const cacheCleanup = clearPerUserCaches();
     setUser(null);
     setProfile(null);
     clearAuthBootstrapHint();
-    clearPerUserCaches();
     setLoading(false);
     try {
-      await cleanup;
+      const [signOutResult, cacheCleanupResult] = await Promise.allSettled([
+        cleanup,
+        cacheCleanup
+      ]);
+      if (cacheCleanupResult.status === 'rejected') {
+        logger.warn('Per-user cache cleanup did not complete cleanly.', {
+          error: cacheCleanupResult.reason
+        });
+      }
+      if (signOutResult.status === 'rejected') {
+        logger.warn('Sign-out cleanup did not complete cleanly.', {
+          error: signOutResult.reason
+        });
+      }
     } catch (signOutError: any) {
       logger.warn('Sign-out cleanup did not complete cleanly.', { error: signOutError });
     } finally {

--- a/apps/app/src/lib/useAuth.ts
+++ b/apps/app/src/lib/useAuth.ts
@@ -6,30 +6,35 @@ import { createLogger } from './logger';
 
 const logger = createLogger('app-auth');
 
-async function clearPerUserCaches() {
+type PerUserCacheResetLoader = () => Promise<() => void>;
+
+const perUserCacheResetLoaders: PerUserCacheResetLoader[] = [
+  async () => (await import('./searchService')).resetAppSearchCache,
+  async () => (await import('./chatService')).resetChatAiModel,
+  async () => (await import('./gameWrapupService')).resetGameWrapupAiModel,
+  async () => (await import('./privateAiService')).resetPrivateAiModel,
+  async () => (await import('./gameDayLineupBuilder')).resetLineupAiModel
+];
+
+export async function clearPerUserCaches(
+  loaders: PerUserCacheResetLoader[] = perUserCacheResetLoaders
+) {
   // These module-level caches key on the signed-in user (search results, help
   // roles) or hold generative-model handles tied to the session's Firebase
   // app. Without this, a second user signing in on the same tab/device could
   // briefly see the previous user's cached search results.
-  const [
-    { resetAppSearchCache },
-    { resetChatAiModel },
-    { resetGameWrapupAiModel },
-    { resetPrivateAiModel },
-    { resetLineupAiModel }
-  ] = await Promise.all([
-    import('./searchService'),
-    import('./chatService'),
-    import('./gameWrapupService'),
-    import('./privateAiService'),
-    import('./gameDayLineupBuilder')
-  ]);
-
-  resetAppSearchCache();
-  resetChatAiModel();
-  resetGameWrapupAiModel();
-  resetPrivateAiModel();
-  resetLineupAiModel();
+  const results = await Promise.allSettled(loaders.map(async (loadReset) => {
+    const reset = await loadReset();
+    reset();
+  }));
+  const failures = results
+    .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+    .map((result) => result.reason);
+  if (failures.length > 0) {
+    const cleanupError = new Error('One or more per-user caches could not be reset.');
+    Object.assign(cleanupError, { failures });
+    throw cleanupError;
+  }
 }
 
 export function useAuth(): AuthState {

--- a/apps/app/src/setupTests.ts
+++ b/apps/app/src/setupTests.ts
@@ -1,1 +1,17 @@
 import '@testing-library/jest-dom/vitest';
+
+const testWindow = window as typeof window & {
+  __ALLPLAYS_CONFIG__?: Record<string, unknown>;
+};
+const existingConfig = testWindow.__ALLPLAYS_CONFIG__ || {};
+
+testWindow.__ALLPLAYS_CONFIG__ = {
+  ...existingConfig,
+  firebase: existingConfig.firebase || {
+    apiKey: 'test-api-key',
+    authDomain: 'test-allplays.firebaseapp.com',
+    projectId: 'test-allplays',
+    messagingSenderId: '123456789',
+    appId: 'test-app-id'
+  }
+};

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -64,31 +64,31 @@ export default defineConfig(({ mode }) => {
   },
   build: {
     chunkSizeWarningLimit: 1400,
+    modulePreload: {
+      resolveDependencies(_filename, dependencies, context) {
+        // Route components already use dynamic imports. Preloading every shared
+        // route dependency from index.html defeated that boundary and produced
+        // nearly one hundred cold-start requests before sign-in was usable.
+        return context.hostType === 'html' ? [] : dependencies;
+      }
+    },
     rollupOptions: {
       output: {
         manualChunks(id) {
           const normalizedId = id.split(path.sep).join('/');
-          const legacyFirebaseMatch = normalizedId.match(/\/js\/vendor\/firebase-([a-z-]+)\.js$/);
-          if (legacyFirebaseMatch) {
-            // Keep App Check from pulling the much larger Firestore client into
-            // the authentication bootstrap chunk through their shared app core.
-            return `legacy-firebase-${legacyFirebaseMatch[1]}`;
+          if (/\/node_modules\/(?:react|react-dom|react-router|react-router-dom|lucide-react)\//.test(normalizedId)) {
+            return 'app-shell-vendor';
           }
-
-          if (!id.includes('node_modules')) {
-            return undefined;
+          if (/\/apps\/app\/src\/lib\/(?:authService|profileService|profilePhotoService|appDataCache|appErrors|logger|telemetry|nativeRuntime|nativeRestDedup|nativeBackButton|pushNotificationRouting|workflowTiming|uxTiming|appLinks)\.(?:ts|tsx)$/.test(normalizedId)) {
+            return 'app-shell-auth';
           }
-
-          const packageRoot = normalizedId.split('/node_modules/')[1];
-          const packageName = packageRoot?.startsWith('@')
-            ? packageRoot.split('/').slice(0, 2).join('/')
-            : packageRoot?.split('/')[0];
-
-          if (!packageName) {
-            return 'vendor';
+          if (/\/apps\/app\/src\/lib\/(?:scheduleService|scheduleLogic|teamDetailService|homeService|homeLogic|chatService|chatLogic|parentToolsService|rosterAiImport|gameWrapupService|gameDayLineupBuilder|gameDayLineupPublish)\.(?:ts|tsx)$/.test(normalizedId)) {
+            return 'app-shell-team-data';
           }
-
-          return `vendor-${packageName.replace(/[\/]/g, '-')}`;
+          if (/\/js\/(?:db|firebase|firebase-runtime-config|firebase-app-check-rest|utils|legacyScheduleHelpers|roster-profile-fields)\.js$/.test(normalizedId)) {
+            return 'app-shell-legacy-data';
+          }
+          return undefined;
         }
       }
     }

--- a/docs/production-smoke-and-email-acceptance.md
+++ b/docs/production-smoke-and-email-acceptance.md
@@ -7,7 +7,8 @@ reuse a real family or roster for this suite.
 
 Store these values in the protected GitHub environment named `production-smoke`:
 
-- Secrets: `SMOKE_STAFF_EMAIL`, `SMOKE_STAFF_PASSWORD`,
+- Secrets: `SMOKE_ADMIN_EMAIL`, `SMOKE_ADMIN_PASSWORD`,
+  `SMOKE_STAFF_EMAIL`, `SMOKE_STAFF_PASSWORD`,
   `SMOKE_PARENT_EMAIL`, and `SMOKE_PARENT_PASSWORD`.
 - Required variables: `SMOKE_TEAM_ID`, `SMOKE_PLAYER_ID`,
   `SMOKE_GAME_ID`, `SMOKE_EVENT_ID`, and `SMOKE_REGISTRATION_FORM_ID`.
@@ -16,7 +17,8 @@ Store these values in the protected GitHub environment named `production-smoke`:
 - Optional variables: `SMOKE_CONVERSATION_ID`,
   `SMOKE_OPPORTUNITY_LISTING_ID`, and `SMOKE_OPPORTUNITY_INQUIRY_ID`.
 
-The staff account must be verified and have least-privilege owner/admin access to
+The admin account must be a dedicated platform administrator with no implicit
+team membership. The staff account must be verified and have least-privilege owner/admin access to
 the synthetic team. The parent account must be verified and linked to the smoke
 player and team. The smoke event must have a seeded RSVP and tracker
 configuration. The smoke team also needs one writable media album, a fee
@@ -51,11 +53,10 @@ are configured, the same workflow also runs:
 - fixture-backed staff, parent, notification, registration, fees, media,
   certificate, schedule, message, official, profile, and help views.
 
-Missing fixture-backed configuration is reported by name as a workflow warning
-and `not-configured` summary row; it does not convert successful baseline
-release probes into a false production outage. Once configured, any
-fixture-backed failure remains fail-closed. The nightly workflow remains the
-authoritative configuration and extended-coverage sentinel.
+Missing fixture-backed configuration blocks production deployment before any
+production credential is acquired. Post-deploy smoke independently validates
+the same contract and fails when a required role workflow is absent, skipped,
+or unsuccessful.
 
 The nightly workflow always runs the core read-only checks. Extended mutations
 are opt-in: set `SMOKE_EXTENDED_WRITES_ENABLED=1` only after the synthetic team

--- a/functions/index.js
+++ b/functions/index.js
@@ -110,7 +110,7 @@ const {
   PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY,
   buildPublicHomepageCandidateBatch,
   buildPublicHomepageGamesResponse,
-  serializeHomepageGame
+  serializePublicHomepageCandidates
 } = require('./public-homepage-games-core.cjs');
 const {
   buildCalendarFeedGamesQuery,
@@ -6506,38 +6506,6 @@ function getPublicHomepageTeamIds(game = {}) {
   ].map(normalizeTeamId).filter(Boolean))];
 }
 
-async function serializePublicHomepageCandidates(candidates, teamCache, category) {
-  const serialized = [];
-  for (const candidate of candidates) {
-    const teamIds = getPublicHomepageTeamIds(candidate);
-    for (const teamId of teamIds) {
-      if (!teamCache.has(teamId)) {
-        teamCache.set(teamId, getStrictPublicTeam(teamId).catch((error) => {
-          functions.logger.warn('Skipping a public homepage team that could not be resolved.', {
-            teamId,
-            error: error?.message || String(error)
-          });
-          return null;
-        }));
-      }
-      const team = await teamCache.get(teamId);
-      const game = team ? serializeHomepageGame(candidate, teamId, team) : null;
-      const categoryMatches = game && (
-        category === 'live'
-          ? game.status === 'live'
-          : category === 'replays'
-            ? game.status === 'completed'
-            : !['live', 'completed', 'cancelled'].includes(game.status)
-      );
-      if (categoryMatches) {
-        serialized.push(game);
-        break;
-      }
-    }
-  }
-  return serialized;
-}
-
 exports.publicHomepageGamesV1 = functions
   .runWith(fetchCalendarRuntime)
   .https
@@ -6553,19 +6521,37 @@ exports.publicHomepageGamesV1 = functions
         getPublicHomepageCandidateDocuments('sharedGames', category, now)
       ]));
       const teamCache = new Map();
-      const [live, upcoming, replays] = await Promise.all(categories.map((category, index) => (
-        serializePublicHomepageCandidates([
-          ...queryResults[index * 2].candidates,
-          ...queryResults[index * 2 + 1].candidates
-        ], teamCache, category)
+      const serializedResults = await Promise.all(categories.map((category, index) => (
+        serializePublicHomepageCandidates({
+          candidates: [
+            ...queryResults[index * 2].candidates,
+            ...queryResults[index * 2 + 1].candidates
+          ],
+          category,
+          getTeamIds: getPublicHomepageTeamIds,
+          getTeam(teamId) {
+            if (!teamCache.has(teamId)) {
+              teamCache.set(teamId, getStrictPublicTeam(teamId));
+            }
+            return teamCache.get(teamId);
+          },
+          onTeamError({ teamId, error }) {
+            functions.logger.warn('Skipping a public homepage team that could not be resolved.', {
+              teamId,
+              error: error?.message || String(error)
+            });
+          }
+        })
       )));
       const partialCategories = categories.filter((category, index) => (
-        queryResults[index * 2].truncated || queryResults[index * 2 + 1].truncated
+        queryResults[index * 2].truncated
+        || queryResults[index * 2 + 1].truncated
+        || serializedResults[index].partial
       ));
       const body = buildPublicHomepageGamesResponse({
-        live,
-        upcoming,
-        replays,
+        live: serializedResults[0].games,
+        upcoming: serializedResults[1].games,
+        replays: serializedResults[2].games,
         partialCategories,
         now
       });

--- a/functions/index.js
+++ b/functions/index.js
@@ -109,6 +109,7 @@ const {
 const {
   PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY,
   buildPublicHomepageGamesResponse,
+  limitPublicHomepageCandidates,
   serializeHomepageGame
 } = require('./public-homepage-games-core.cjs');
 const {
@@ -6477,15 +6478,20 @@ function buildPublicHomepageCandidateQuery(collectionName, category, now = new D
 async function getPublicHomepageCandidateDocuments(collectionName, category, now) {
   const snapshot = await buildPublicHomepageCandidateQuery(collectionName, category, now).get();
   if (snapshot.size > PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY) {
-    throw new Error(`Public homepage ${category} candidate scan limit exceeded.`);
+    functions.logger.warn('Truncating a public homepage candidate query at the scan limit.', {
+      collectionName,
+      category,
+      candidateLimit: PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY
+    });
   }
-  return snapshot.docs.map((docSnap) => ({
-    id: docSnap.id,
-    ...(docSnap.data() || {}),
-    _sharedGamePath: collectionName === 'sharedGames' ? docSnap.ref.path : null,
-    _teamId: collectionName === 'games' ? docSnap.ref?.parent?.parent?.id || '' : '',
-    isSharedGame: collectionName === 'sharedGames'
-  }));
+  return limitPublicHomepageCandidates(snapshot.docs)
+    .map((docSnap) => ({
+      id: docSnap.id,
+      ...(docSnap.data() || {}),
+      _sharedGamePath: collectionName === 'sharedGames' ? docSnap.ref.path : null,
+      _teamId: collectionName === 'games' ? docSnap.ref?.parent?.parent?.id || '' : '',
+      isSharedGame: collectionName === 'sharedGames'
+    }));
 }
 
 function getPublicHomepageTeamIds(game = {}) {

--- a/functions/index.js
+++ b/functions/index.js
@@ -108,8 +108,10 @@ const {
 } = require('./public-team-api-core.cjs');
 const {
   PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY,
+  PUBLIC_HOMEPAGE_MAX_UNIQUE_TEAM_LOOKUPS,
   buildPublicHomepageCandidateBatch,
   buildPublicHomepageGamesResponse,
+  buildPublicHomepageTeamIdBatch,
   serializePublicHomepageCandidates
 } = require('./public-homepage-games-core.cjs');
 const {
@@ -6498,12 +6500,14 @@ async function getPublicHomepageCandidateDocuments(collectionName, category, now
 }
 
 function getPublicHomepageTeamIds(game = {}) {
-  if (!game.isSharedGame) return game._teamId ? [game._teamId] : [];
-  return [...new Set([
+  if (!game.isSharedGame) {
+    return buildPublicHomepageTeamIdBatch([game._teamId]);
+  }
+  return buildPublicHomepageTeamIdBatch([
     game.homeTeamId,
     game.awayTeamId,
     ...(Array.isArray(game.teamIds) ? game.teamIds : [])
-  ].map(normalizeTeamId).filter(Boolean))];
+  ]);
 }
 
 exports.publicHomepageGamesV1 = functions
@@ -6521,6 +6525,10 @@ exports.publicHomepageGamesV1 = functions
         getPublicHomepageCandidateDocuments('sharedGames', category, now)
       ]));
       const teamCache = new Map();
+      const teamLookupBudget = {
+        seenTeamIds: new Set(),
+        maxUniqueTeamLookups: PUBLIC_HOMEPAGE_MAX_UNIQUE_TEAM_LOOKUPS
+      };
       const serializedResults = await Promise.all(categories.map((category, index) => (
         serializePublicHomepageCandidates({
           candidates: [
@@ -6529,6 +6537,7 @@ exports.publicHomepageGamesV1 = functions
           ],
           category,
           getTeamIds: getPublicHomepageTeamIds,
+          teamLookupBudget,
           getTeam(teamId) {
             if (!teamCache.has(teamId)) {
               teamCache.set(teamId, getStrictPublicTeam(teamId));

--- a/functions/index.js
+++ b/functions/index.js
@@ -107,6 +107,11 @@ const {
   serializePublicGame
 } = require('./public-team-api-core.cjs');
 const {
+  PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY,
+  buildPublicHomepageGamesResponse,
+  serializeHomepageGame
+} = require('./public-homepage-games-core.cjs');
+const {
   buildCalendarFeedGamesQuery,
   buildCalendarFeedRecurringMastersQuery
 } = require('./calendar-feed-window-core.cjs');
@@ -6425,6 +6430,135 @@ function sendPublicTeamApiSuccess(req, res, body) {
   }
   res.status(200).json(body);
 }
+
+function beginPublicHomepageGamesRequest(req, res) {
+  setPublicTeamApiCorsHeaders(res);
+  if (req.method === 'OPTIONS') {
+    res.status(204).end();
+    return { complete: true };
+  }
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    sendPublicTeamApiError(res, 405, 'method_not_allowed', 'Use GET or HEAD for this endpoint.');
+    return { complete: true };
+  }
+
+  const rateLimit = checkPublicTeamApiRateLimit(req);
+  res.set('X-RateLimit-Remaining', String(rateLimit.remaining));
+  if (!rateLimit.allowed) {
+    res.set('Retry-After', String(rateLimit.retryAfterSeconds));
+    sendPublicTeamApiError(res, 429, 'rate_limited', 'Too many requests. Please try again shortly.');
+    return { complete: true };
+  }
+  return { complete: false };
+}
+
+function buildPublicHomepageCandidateQuery(collectionName, category, now = new Date()) {
+  let query = firestore.collectionGroup(collectionName);
+  if (category === 'live') {
+    query = query.where('liveStatus', '==', 'live');
+  } else if (category === 'upcoming') {
+    const start = new Date(now);
+    start.setUTCHours(0, 0, 0, 0);
+    const end = new Date(start.getTime() + 7 * 24 * 60 * 60 * 1000);
+    query = query
+      .where('date', '>=', start)
+      .where('date', '<=', end)
+      .orderBy('date', 'asc');
+  } else {
+    const start = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+    query = query
+      .where('liveStatus', '==', 'completed')
+      .where('date', '>=', start)
+      .orderBy('date', 'desc');
+  }
+  return query.limit(PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY + 1);
+}
+
+async function getPublicHomepageCandidateDocuments(collectionName, category, now) {
+  const snapshot = await buildPublicHomepageCandidateQuery(collectionName, category, now).get();
+  if (snapshot.size > PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY) {
+    throw new Error(`Public homepage ${category} candidate scan limit exceeded.`);
+  }
+  return snapshot.docs.map((docSnap) => ({
+    id: docSnap.id,
+    ...(docSnap.data() || {}),
+    _sharedGamePath: collectionName === 'sharedGames' ? docSnap.ref.path : null,
+    _teamId: collectionName === 'games' ? docSnap.ref?.parent?.parent?.id || '' : '',
+    isSharedGame: collectionName === 'sharedGames'
+  }));
+}
+
+function getPublicHomepageTeamIds(game = {}) {
+  if (!game.isSharedGame) return game._teamId ? [game._teamId] : [];
+  return [...new Set([
+    game.homeTeamId,
+    game.awayTeamId,
+    ...(Array.isArray(game.teamIds) ? game.teamIds : [])
+  ].map(normalizeTeamId).filter(Boolean))];
+}
+
+async function serializePublicHomepageCandidates(candidates, teamCache, category) {
+  const serialized = [];
+  for (const candidate of candidates) {
+    const teamIds = getPublicHomepageTeamIds(candidate);
+    for (const teamId of teamIds) {
+      if (!teamCache.has(teamId)) {
+        teamCache.set(teamId, getStrictPublicTeam(teamId).catch((error) => {
+          functions.logger.warn('Skipping a public homepage team that could not be resolved.', {
+            teamId,
+            error: error?.message || String(error)
+          });
+          return null;
+        }));
+      }
+      const team = await teamCache.get(teamId);
+      const game = team ? serializeHomepageGame(candidate, teamId, team) : null;
+      const categoryMatches = game && (
+        category === 'live'
+          ? game.status === 'live'
+          : category === 'replays'
+            ? game.status === 'completed'
+            : !['live', 'completed', 'cancelled'].includes(game.status)
+      );
+      if (categoryMatches) {
+        serialized.push(game);
+        break;
+      }
+    }
+  }
+  return serialized;
+}
+
+exports.publicHomepageGamesV1 = functions
+  .runWith(fetchCalendarRuntime)
+  .https
+  .onRequest(async (req, res) => {
+    const request = beginPublicHomepageGamesRequest(req, res);
+    if (request.complete) return;
+
+    try {
+      const now = new Date();
+      const categories = ['live', 'upcoming', 'replays'];
+      const queryResults = await Promise.all(categories.flatMap((category) => [
+        getPublicHomepageCandidateDocuments('games', category, now),
+        getPublicHomepageCandidateDocuments('sharedGames', category, now)
+      ]));
+      const teamCache = new Map();
+      const [live, upcoming, replays] = await Promise.all(categories.map((category, index) => (
+        serializePublicHomepageCandidates([
+          ...queryResults[index * 2],
+          ...queryResults[index * 2 + 1]
+        ], teamCache, category)
+      )));
+      const body = buildPublicHomepageGamesResponse({ live, upcoming, replays, now });
+      sendPublicTeamApiSuccess(req, res, body);
+    } catch (error) {
+      functions.logger.error('Failed to build public homepage games response.', {
+        error: error?.message || String(error)
+      });
+      sendPublicTeamApiError(res, 500, 'unavailable', 'Public homepage games are temporarily unavailable.');
+    }
+  });
 
 exports.publicTeamRosterV1 = functions
   .runWith(fetchCalendarRuntime)

--- a/functions/index.js
+++ b/functions/index.js
@@ -108,8 +108,8 @@ const {
 } = require('./public-team-api-core.cjs');
 const {
   PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY,
+  buildPublicHomepageCandidateBatch,
   buildPublicHomepageGamesResponse,
-  limitPublicHomepageCandidates,
   serializeHomepageGame
 } = require('./public-homepage-games-core.cjs');
 const {
@@ -6477,21 +6477,24 @@ function buildPublicHomepageCandidateQuery(collectionName, category, now = new D
 
 async function getPublicHomepageCandidateDocuments(collectionName, category, now) {
   const snapshot = await buildPublicHomepageCandidateQuery(collectionName, category, now).get();
-  if (snapshot.size > PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY) {
+  const batch = buildPublicHomepageCandidateBatch(snapshot.docs);
+  if (batch.truncated) {
     functions.logger.warn('Truncating a public homepage candidate query at the scan limit.', {
       collectionName,
       category,
       candidateLimit: PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY
     });
   }
-  return limitPublicHomepageCandidates(snapshot.docs)
-    .map((docSnap) => ({
+  return {
+    truncated: batch.truncated,
+    candidates: batch.candidates.map((docSnap) => ({
       id: docSnap.id,
       ...(docSnap.data() || {}),
       _sharedGamePath: collectionName === 'sharedGames' ? docSnap.ref.path : null,
       _teamId: collectionName === 'games' ? docSnap.ref?.parent?.parent?.id || '' : '',
       isSharedGame: collectionName === 'sharedGames'
-    }));
+    }))
+  };
 }
 
 function getPublicHomepageTeamIds(game = {}) {
@@ -6552,11 +6555,20 @@ exports.publicHomepageGamesV1 = functions
       const teamCache = new Map();
       const [live, upcoming, replays] = await Promise.all(categories.map((category, index) => (
         serializePublicHomepageCandidates([
-          ...queryResults[index * 2],
-          ...queryResults[index * 2 + 1]
+          ...queryResults[index * 2].candidates,
+          ...queryResults[index * 2 + 1].candidates
         ], teamCache, category)
       )));
-      const body = buildPublicHomepageGamesResponse({ live, upcoming, replays, now });
+      const partialCategories = categories.filter((category, index) => (
+        queryResults[index * 2].truncated || queryResults[index * 2 + 1].truncated
+      ));
+      const body = buildPublicHomepageGamesResponse({
+        live,
+        upcoming,
+        replays,
+        partialCategories,
+        now
+      });
       sendPublicTeamApiSuccess(req, res, body);
     } catch (error) {
       functions.logger.error('Failed to build public homepage games response.', {

--- a/functions/public-homepage-games-core.cjs
+++ b/functions/public-homepage-games-core.cjs
@@ -1,5 +1,6 @@
 const {
   isStrictPublicTeam,
+  normalizeTeamId,
   serializePublicGame,
   serializePublicTeam
 } = require('./public-team-api-core.cjs');
@@ -7,6 +8,8 @@ const {
 const PUBLIC_HOMEPAGE_API_VERSION = 1;
 const PUBLIC_HOMEPAGE_RESULT_LIMIT = 6;
 const PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY = 120;
+const PUBLIC_HOMEPAGE_MAX_TEAM_IDS_PER_CANDIDATE = 2;
+const PUBLIC_HOMEPAGE_MAX_UNIQUE_TEAM_LOOKUPS = 240;
 
 function compactText(value, maxLength = 128) {
   if (typeof value !== 'string' && typeof value !== 'number') return '';
@@ -29,6 +32,16 @@ function buildPublicHomepageCandidateBatch(candidates = []) {
   return {
     candidates: limitPublicHomepageCandidates(safeCandidates),
     truncated: safeCandidates.length > PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY
+  };
+}
+
+function buildPublicHomepageTeamIdBatch(values = []) {
+  const validatedTeamIds = [...new Set(
+    (Array.isArray(values) ? values : []).map(normalizeTeamId).filter(Boolean)
+  )];
+  return {
+    teamIds: validatedTeamIds.slice(0, PUBLIC_HOMEPAGE_MAX_TEAM_IDS_PER_CANDIDATE),
+    truncated: validatedTeamIds.length > PUBLIC_HOMEPAGE_MAX_TEAM_IDS_PER_CANDIDATE
   };
 }
 
@@ -88,13 +101,30 @@ async function serializePublicHomepageCandidates({
   category,
   getTeamIds,
   getTeam,
+  teamLookupBudget = {
+    seenTeamIds: new Set(),
+    maxUniqueTeamLookups: PUBLIC_HOMEPAGE_MAX_UNIQUE_TEAM_LOOKUPS
+  },
   onTeamError = () => undefined
 } = {}) {
   const serialized = [];
   let partial = false;
   for (const candidate of candidates) {
-    const teamIds = getTeamIds(candidate);
+    const teamIdResult = getTeamIds(candidate);
+    const teamIds = Array.isArray(teamIdResult)
+      ? teamIdResult
+      : Array.isArray(teamIdResult?.teamIds) ? teamIdResult.teamIds : [];
+    if (!Array.isArray(teamIdResult) && teamIdResult?.truncated === true) {
+      partial = true;
+    }
     for (const teamId of teamIds) {
+      if (!teamLookupBudget.seenTeamIds.has(teamId)) {
+        if (teamLookupBudget.seenTeamIds.size >= teamLookupBudget.maxUniqueTeamLookups) {
+          partial = true;
+          continue;
+        }
+        teamLookupBudget.seenTeamIds.add(teamId);
+      }
       let team;
       try {
         team = await getTeam(teamId);
@@ -162,9 +192,12 @@ function buildPublicHomepageGamesResponse({
 module.exports = {
   PUBLIC_HOMEPAGE_API_VERSION,
   PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY,
+  PUBLIC_HOMEPAGE_MAX_TEAM_IDS_PER_CANDIDATE,
+  PUBLIC_HOMEPAGE_MAX_UNIQUE_TEAM_LOOKUPS,
   PUBLIC_HOMEPAGE_RESULT_LIMIT,
   buildPublicHomepageCandidateBatch,
   buildPublicHomepageGamesResponse,
+  buildPublicHomepageTeamIdBatch,
   limitPublicHomepageCandidates,
   projectSharedGameForPublicTeam,
   serializeHomepageGame,

--- a/functions/public-homepage-games-core.cjs
+++ b/functions/public-homepage-games-core.cjs
@@ -45,9 +45,18 @@ function buildPublicHomepageTeamIdBatch(values = []) {
   };
 }
 
+function buildSharedGameSyntheticId(sharedGamePath) {
+  if (typeof sharedGamePath !== 'string' || !sharedGamePath) {
+    throw new Error('sharedGamePath is required');
+  }
+  return `shared_${encodeURIComponent(sharedGamePath)}`;
+}
+
 function sharedGameSyntheticId(game = {}) {
-  const path = compactText(game._sharedGamePath || `sharedGames/${game.id}`, 512);
-  return `shared_${encodeURIComponent(path)}`;
+  const path = typeof game._sharedGamePath === 'string' && game._sharedGamePath
+    ? game._sharedGamePath
+    : game.id ? `sharedGames/${game.id}` : '';
+  return buildSharedGameSyntheticId(path);
 }
 
 function projectSharedGameForPublicTeam(game = {}, teamId) {
@@ -195,6 +204,7 @@ module.exports = {
   PUBLIC_HOMEPAGE_MAX_TEAM_IDS_PER_CANDIDATE,
   PUBLIC_HOMEPAGE_MAX_UNIQUE_TEAM_LOOKUPS,
   PUBLIC_HOMEPAGE_RESULT_LIMIT,
+  buildSharedGameSyntheticId,
   buildPublicHomepageCandidateBatch,
   buildPublicHomepageGamesResponse,
   buildPublicHomepageTeamIdBatch,

--- a/functions/public-homepage-games-core.cjs
+++ b/functions/public-homepage-games-core.cjs
@@ -83,6 +83,43 @@ function serializeHomepageGame(game = {}, teamId, team = {}) {
   };
 }
 
+async function serializePublicHomepageCandidates({
+  candidates = [],
+  category,
+  getTeamIds,
+  getTeam,
+  onTeamError = () => undefined
+} = {}) {
+  const serialized = [];
+  let partial = false;
+  for (const candidate of candidates) {
+    const teamIds = getTeamIds(candidate);
+    for (const teamId of teamIds) {
+      let team;
+      try {
+        team = await getTeam(teamId);
+      } catch (error) {
+        partial = true;
+        onTeamError({ teamId, error });
+        continue;
+      }
+      const game = team ? serializeHomepageGame(candidate, teamId, team) : null;
+      const categoryMatches = game && (
+        category === 'live'
+          ? game.status === 'live'
+          : category === 'replays'
+            ? game.status === 'completed'
+            : !['live', 'completed', 'cancelled'].includes(game.status)
+      );
+      if (categoryMatches) {
+        serialized.push(game);
+        break;
+      }
+    }
+  }
+  return { games: serialized, partial };
+}
+
 function dedupeAndLimit(games, limit, direction = 'asc') {
   const byKey = new Map();
   games.filter(Boolean).forEach((game) => {
@@ -130,5 +167,6 @@ module.exports = {
   buildPublicHomepageGamesResponse,
   limitPublicHomepageCandidates,
   projectSharedGameForPublicTeam,
-  serializeHomepageGame
+  serializeHomepageGame,
+  serializePublicHomepageCandidates
 };

--- a/functions/public-homepage-games-core.cjs
+++ b/functions/public-homepage-games-core.cjs
@@ -24,6 +24,14 @@ function limitPublicHomepageCandidates(candidates = []) {
   return candidates.slice(0, PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY);
 }
 
+function buildPublicHomepageCandidateBatch(candidates = []) {
+  const safeCandidates = Array.isArray(candidates) ? candidates : [];
+  return {
+    candidates: limitPublicHomepageCandidates(safeCandidates),
+    truncated: safeCandidates.length > PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY
+  };
+}
+
 function sharedGameSyntheticId(game = {}) {
   const path = compactText(game._sharedGamePath || `sharedGames/${game.id}`, 512);
   return `shared_${encodeURIComponent(path)}`;
@@ -92,15 +100,22 @@ function buildPublicHomepageGamesResponse({
   live = [],
   upcoming = [],
   replays = [],
+  partialCategories = [],
   limit = PUBLIC_HOMEPAGE_RESULT_LIMIT,
   now = new Date()
 } = {}) {
   const safeLimit = Number.isSafeInteger(limit) && limit > 0
     ? Math.min(limit, PUBLIC_HOMEPAGE_RESULT_LIMIT)
     : PUBLIC_HOMEPAGE_RESULT_LIMIT;
+  const safePartialCategories = [...new Set(
+    (Array.isArray(partialCategories) ? partialCategories : [])
+      .filter((category) => ['live', 'upcoming', 'replays'].includes(category))
+  )];
   return {
     version: PUBLIC_HOMEPAGE_API_VERSION,
     generatedAt: new Date(now).toISOString(),
+    partial: safePartialCategories.length > 0,
+    partialCategories: safePartialCategories,
     live: dedupeAndLimit(live, safeLimit),
     upcoming: dedupeAndLimit(upcoming, safeLimit),
     replays: dedupeAndLimit(replays, safeLimit, 'desc')
@@ -111,6 +126,7 @@ module.exports = {
   PUBLIC_HOMEPAGE_API_VERSION,
   PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY,
   PUBLIC_HOMEPAGE_RESULT_LIMIT,
+  buildPublicHomepageCandidateBatch,
   buildPublicHomepageGamesResponse,
   limitPublicHomepageCandidates,
   projectSharedGameForPublicTeam,

--- a/functions/public-homepage-games-core.cjs
+++ b/functions/public-homepage-games-core.cjs
@@ -1,0 +1,112 @@
+const {
+  isStrictPublicTeam,
+  serializePublicGame,
+  serializePublicTeam
+} = require('./public-team-api-core.cjs');
+
+const PUBLIC_HOMEPAGE_API_VERSION = 1;
+const PUBLIC_HOMEPAGE_RESULT_LIMIT = 6;
+const PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY = 120;
+
+function compactText(value, maxLength = 128) {
+  if (typeof value !== 'string' && typeof value !== 'number') return '';
+  return String(value).replace(/\s+/g, ' ').trim().slice(0, maxLength);
+}
+
+function finiteNonNegative(value) {
+  if (value === null || value === undefined || value === '') return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function sharedGameSyntheticId(game = {}) {
+  const path = compactText(game._sharedGamePath || `sharedGames/${game.id}`, 512);
+  return `shared_${encodeURIComponent(path)}`;
+}
+
+function projectSharedGameForPublicTeam(game = {}, teamId) {
+  const isHome = compactText(game.homeTeamId) === teamId;
+  const isAway = compactText(game.awayTeamId) === teamId;
+  if (!isHome && !isAway) return null;
+  return {
+    ...game,
+    id: sharedGameSyntheticId(game),
+    teamId,
+    isHome,
+    isSharedGame: true,
+    opponent: isHome
+      ? compactText(game.awayTeamName || game.awayPlaceholderName, 160) || 'TBD'
+      : compactText(game.homeTeamName || game.homePlaceholderName, 160) || 'TBD'
+  };
+}
+
+function serializeHomepageGame(game = {}, teamId, team = {}) {
+  if (!isStrictPublicTeam(team)) return null;
+  const projected = game.isSharedGame
+    ? projectSharedGameForPublicTeam(game, teamId)
+    : { ...game, teamId };
+  if (!projected) return null;
+  const serialized = serializePublicGame(projected);
+  if (!serialized) return null;
+
+  const homeScore = serialized.isHome ? serialized.teamScore : serialized.opponentScore;
+  const awayScore = serialized.isHome ? serialized.opponentScore : serialized.teamScore;
+  return {
+    id: serialized.id,
+    teamId,
+    opponent: serialized.opponent,
+    date: serialized.startsAt,
+    endsAt: serialized.endsAt,
+    location: serialized.location,
+    isHome: serialized.isHome,
+    status: serialized.status,
+    liveStatus: serialized.status,
+    homeScore,
+    awayScore,
+    liveViewerCount: finiteNonNegative(game.liveViewerCount),
+    videoUrl: serialized.videoUrl,
+    isSharedGame: projected.isSharedGame === true,
+    team: serializePublicTeam(teamId, team)
+  };
+}
+
+function dedupeAndLimit(games, limit, direction = 'asc') {
+  const byKey = new Map();
+  games.filter(Boolean).forEach((game) => {
+    const key = `${game.teamId}:${game.id}`;
+    if (!byKey.has(key)) byKey.set(key, game);
+  });
+  return [...byKey.values()]
+    .sort((left, right) => direction === 'desc'
+      ? right.date.localeCompare(left.date)
+      : left.date.localeCompare(right.date))
+    .slice(0, limit);
+}
+
+function buildPublicHomepageGamesResponse({
+  live = [],
+  upcoming = [],
+  replays = [],
+  limit = PUBLIC_HOMEPAGE_RESULT_LIMIT,
+  now = new Date()
+} = {}) {
+  const safeLimit = Number.isSafeInteger(limit) && limit > 0
+    ? Math.min(limit, PUBLIC_HOMEPAGE_RESULT_LIMIT)
+    : PUBLIC_HOMEPAGE_RESULT_LIMIT;
+  return {
+    version: PUBLIC_HOMEPAGE_API_VERSION,
+    generatedAt: new Date(now).toISOString(),
+    live: dedupeAndLimit(live, safeLimit),
+    upcoming: dedupeAndLimit(upcoming, safeLimit),
+    replays: dedupeAndLimit(replays, safeLimit, 'desc')
+  };
+}
+
+module.exports = {
+  PUBLIC_HOMEPAGE_API_VERSION,
+  PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY,
+  PUBLIC_HOMEPAGE_RESULT_LIMIT,
+  buildPublicHomepageGamesResponse,
+  projectSharedGameForPublicTeam,
+  serializeHomepageGame
+};

--- a/functions/public-homepage-games-core.cjs
+++ b/functions/public-homepage-games-core.cjs
@@ -19,6 +19,11 @@ function finiteNonNegative(value) {
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
 }
 
+function limitPublicHomepageCandidates(candidates = []) {
+  if (!Array.isArray(candidates)) return [];
+  return candidates.slice(0, PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY);
+}
+
 function sharedGameSyntheticId(game = {}) {
   const path = compactText(game._sharedGamePath || `sharedGames/${game.id}`, 512);
   return `shared_${encodeURIComponent(path)}`;
@@ -107,6 +112,7 @@ module.exports = {
   PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY,
   PUBLIC_HOMEPAGE_RESULT_LIMIT,
   buildPublicHomepageGamesResponse,
+  limitPublicHomepageCandidates,
   projectSharedGameForPublicTeam,
   serializeHomepageGame
 };

--- a/functions/test/public-homepage-games-core.test.cjs
+++ b/functions/test/public-homepage-games-core.test.cjs
@@ -2,6 +2,7 @@ const assert = require('node:assert/strict');
 const test = require('node:test');
 const {
   PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY,
+  buildPublicHomepageCandidateBatch,
   buildPublicHomepageGamesResponse,
   limitPublicHomepageCandidates,
   serializeHomepageGame
@@ -96,6 +97,26 @@ test('homepage candidate overflow truncates at the scan budget without failing d
   assert.equal(limited[0].id, 'candidate-0');
   assert.equal(limited.at(-1).id, 'candidate-119');
   assert.equal(candidates.length, 121);
+});
+
+test('mixed-visibility overflow is explicitly marked partial when a public candidate falls beyond the scan budget', () => {
+  const candidates = [
+    ...Array.from({ length: PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY }, (_, index) => ({
+      id: `private-${index}`,
+      visibility: 'private'
+    })),
+    { id: 'public-beyond-budget', visibility: 'public' }
+  ];
+  const batch = buildPublicHomepageCandidateBatch(candidates);
+  const response = buildPublicHomepageGamesResponse({
+    live: [],
+    partialCategories: batch.truncated ? ['live'] : []
+  });
+
+  assert.equal(batch.candidates.some((candidate) => candidate.id === 'public-beyond-budget'), false);
+  assert.equal(batch.truncated, true);
+  assert.equal(response.partial, true);
+  assert.deepEqual(response.partialCategories, ['live']);
 });
 
 test('shared games are projected from the selected public team perspective', () => {

--- a/functions/test/public-homepage-games-core.test.cjs
+++ b/functions/test/public-homepage-games-core.test.cjs
@@ -2,8 +2,10 @@ const assert = require('node:assert/strict');
 const test = require('node:test');
 const {
   PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY,
+  PUBLIC_HOMEPAGE_MAX_TEAM_IDS_PER_CANDIDATE,
   buildPublicHomepageCandidateBatch,
   buildPublicHomepageGamesResponse,
+  buildPublicHomepageTeamIdBatch,
   limitPublicHomepageCandidates,
   serializeHomepageGame,
   serializePublicHomepageCandidates
@@ -136,6 +138,66 @@ test('team lookup failures mark the affected homepage category partial', async (
   assert.equal(result.partial, true);
   assert.equal(errors.length, 1);
   assert.equal(errors[0].teamId, 'team-unavailable');
+});
+
+test('oversized shared-game team ID arrays are validated, capped, and marked partial', async () => {
+  const batch = buildPublicHomepageTeamIdBatch([
+    'team-home',
+    'team-away',
+    '../invalid',
+    'team-extra-1',
+    'team-extra-2',
+    'team-home'
+  ]);
+  const lookups = [];
+  const result = await serializePublicHomepageCandidates({
+    candidates: [{ id: 'shared-oversized' }],
+    category: 'live',
+    getTeamIds: () => batch,
+    getTeam: async (teamId) => {
+      lookups.push(teamId);
+      return null;
+    }
+  });
+
+  assert.equal(PUBLIC_HOMEPAGE_MAX_TEAM_IDS_PER_CANDIDATE, 2);
+  assert.deepEqual(batch.teamIds, ['team-home', 'team-away']);
+  assert.equal(batch.truncated, true);
+  assert.deepEqual(lookups, ['team-home', 'team-away']);
+  assert.deepEqual(result, { games: [], partial: true });
+});
+
+test('aggregate unique team lookup exhaustion marks only affected serialization partial', async () => {
+  const teamLookupBudget = {
+    seenTeamIds: new Set(),
+    maxUniqueTeamLookups: 3
+  };
+  const lookups = [];
+  const makeCandidate = (teamId) => ({
+    id: `game-${teamId}`,
+    _teamId: teamId,
+    date: '2026-07-28T18:00:00Z',
+    liveStatus: 'live'
+  });
+  const serialize = (teamIds) => serializePublicHomepageCandidates({
+    candidates: teamIds.map(makeCandidate),
+    category: 'live',
+    getTeamIds: (candidate) => [candidate._teamId],
+    getTeam: async (teamId) => {
+      lookups.push(teamId);
+      return publicTeam;
+    },
+    teamLookupBudget
+  });
+
+  const first = await serialize(['team-1', 'team-2']);
+  const affected = await serialize(['team-2', 'team-3', 'team-4']);
+
+  assert.equal(first.partial, false);
+  assert.equal(affected.partial, true);
+  assert.deepEqual(lookups, ['team-1', 'team-2', 'team-2', 'team-3']);
+  assert.deepEqual([...teamLookupBudget.seenTeamIds], ['team-1', 'team-2', 'team-3']);
+  assert.equal(affected.games.some((game) => game.teamId === 'team-4'), false);
 });
 
 test('private or missing teams remain an authoritative omission', async () => {

--- a/functions/test/public-homepage-games-core.test.cjs
+++ b/functions/test/public-homepage-games-core.test.cjs
@@ -5,7 +5,8 @@ const {
   buildPublicHomepageCandidateBatch,
   buildPublicHomepageGamesResponse,
   limitPublicHomepageCandidates,
-  serializeHomepageGame
+  serializeHomepageGame,
+  serializePublicHomepageCandidates
 } = require('../public-homepage-games-core.cjs');
 
 const publicTeam = {
@@ -117,6 +118,35 @@ test('mixed-visibility overflow is explicitly marked partial when a public candi
   assert.equal(batch.truncated, true);
   assert.equal(response.partial, true);
   assert.deepEqual(response.partialCategories, ['live']);
+});
+
+test('team lookup failures mark the affected homepage category partial', async () => {
+  const errors = [];
+  const result = await serializePublicHomepageCandidates({
+    candidates: [{ id: 'game-1', _teamId: 'team-unavailable' }],
+    category: 'live',
+    getTeamIds: (candidate) => [candidate._teamId],
+    getTeam: async () => {
+      throw new Error('transient team read failure');
+    },
+    onTeamError: (failure) => errors.push(failure)
+  });
+
+  assert.deepEqual(result.games, []);
+  assert.equal(result.partial, true);
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0].teamId, 'team-unavailable');
+});
+
+test('private or missing teams remain an authoritative omission', async () => {
+  const result = await serializePublicHomepageCandidates({
+    candidates: [{ id: 'game-1', _teamId: 'team-private' }],
+    category: 'live',
+    getTeamIds: (candidate) => [candidate._teamId],
+    getTeam: async () => null
+  });
+
+  assert.deepEqual(result, { games: [], partial: false });
 });
 
 test('shared games are projected from the selected public team perspective', () => {

--- a/functions/test/public-homepage-games-core.test.cjs
+++ b/functions/test/public-homepage-games-core.test.cjs
@@ -1,0 +1,109 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY,
+  buildPublicHomepageGamesResponse,
+  serializeHomepageGame
+} = require('../public-homepage-games-core.cjs');
+
+const publicTeam = {
+  id: 'team-public',
+  name: 'Public Tigers',
+  sport: 'Soccer',
+  isPublic: true,
+  active: true,
+  ownerEmail: 'private@example.com'
+};
+
+test('homepage serializer exposes only public game and team fields', () => {
+  const game = serializeHomepageGame({
+    id: 'game-1',
+    date: '2026-07-28T18:00:00Z',
+    opponent: 'Falcons',
+    liveStatus: 'live',
+    homeScore: 3,
+    awayScore: 2,
+    liveViewerCount: 12,
+    assignments: [{ email: 'private@example.com' }],
+    notes: 'private note'
+  }, 'team-public', publicTeam);
+
+  assert.deepEqual(game, {
+    id: 'game-1',
+    teamId: 'team-public',
+    opponent: 'Falcons',
+    date: '2026-07-28T18:00:00.000Z',
+    endsAt: null,
+    location: '',
+    isHome: true,
+    status: 'live',
+    liveStatus: 'live',
+    homeScore: 3,
+    awayScore: 2,
+    liveViewerCount: 12,
+    videoUrl: null,
+    isSharedGame: false,
+    team: {
+      id: 'team-public',
+      name: 'Public Tigers',
+      sport: 'Soccer',
+      photoUrl: null
+    }
+  });
+  const json = JSON.stringify(game);
+  assert.equal(json.includes('ownerEmail'), false);
+  assert.equal(json.includes('assignments'), false);
+  assert.equal(json.includes('private note'), false);
+});
+
+test('homepage serializer rejects private teams and unsafe games', () => {
+  assert.equal(serializeHomepageGame(
+    { id: 'game-1', date: '2026-07-28T18:00:00Z' },
+    'team-private',
+    { ...publicTeam, isPublic: false }
+  ), null);
+  assert.equal(serializeHomepageGame(
+    { id: 'game-1', date: '2026-07-28T18:00:00Z', visibility: 'private' },
+    'team-public',
+    publicTeam
+  ), null);
+});
+
+test('homepage response sorts, deduplicates, and enforces the public result cap', () => {
+  const games = Array.from({ length: 8 }, (_, index) => ({
+    id: `game-${index}`,
+    teamId: 'team-public',
+    date: `2026-07-${String(index + 10).padStart(2, '0')}T18:00:00.000Z`
+  }));
+  const response = buildPublicHomepageGamesResponse({
+    live: [games[1], games[1]],
+    upcoming: [...games].reverse(),
+    replays: games
+  });
+
+  assert.equal(response.live.length, 1);
+  assert.deepEqual(response.upcoming.map((game) => game.id), games.slice(0, 6).map((game) => game.id));
+  assert.deepEqual(response.replays.map((game) => game.id), [...games].reverse().slice(0, 6).map((game) => game.id));
+  assert.equal(PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY, 120);
+});
+
+test('shared games are projected from the selected public team perspective', () => {
+  const game = serializeHomepageGame({
+    id: 'shared-1',
+    _sharedGamePath: 'events/event-1/sharedGames/shared-1',
+    date: '2026-07-28T18:00:00Z',
+    homeTeamId: 'team-public',
+    homeTeamName: 'Public Tigers',
+    awayTeamId: 'team-away',
+    awayTeamName: 'Falcons',
+    homeScore: 4,
+    awayScore: 1,
+    isSharedGame: true
+  }, 'team-public', publicTeam);
+
+  assert.equal(game.teamId, 'team-public');
+  assert.equal(game.opponent, 'Falcons');
+  assert.equal(game.homeScore, 4);
+  assert.equal(game.isSharedGame, true);
+  assert.match(game.id, /^shared_/);
+});

--- a/functions/test/public-homepage-games-core.test.cjs
+++ b/functions/test/public-homepage-games-core.test.cjs
@@ -3,6 +3,7 @@ const test = require('node:test');
 const {
   PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY,
   PUBLIC_HOMEPAGE_MAX_TEAM_IDS_PER_CANDIDATE,
+  buildSharedGameSyntheticId,
   buildPublicHomepageCandidateBatch,
   buildPublicHomepageGamesResponse,
   buildPublicHomepageTeamIdBatch,
@@ -212,9 +213,10 @@ test('private or missing teams remain an authoritative omission', async () => {
 });
 
 test('shared games are projected from the selected public team perspective', () => {
+  const sharedGamePath = 'events/event with spaces/sharedGames/shared-1';
   const game = serializeHomepageGame({
     id: 'shared-1',
-    _sharedGamePath: 'events/event-1/sharedGames/shared-1',
+    _sharedGamePath: sharedGamePath,
     date: '2026-07-28T18:00:00Z',
     homeTeamId: 'team-public',
     homeTeamName: 'Public Tigers',
@@ -229,5 +231,9 @@ test('shared games are projected from the selected public team perspective', () 
   assert.equal(game.opponent, 'Falcons');
   assert.equal(game.homeScore, 4);
   assert.equal(game.isSharedGame, true);
-  assert.match(game.id, /^shared_/);
+  assert.equal(game.id, buildSharedGameSyntheticId(sharedGamePath));
+  assert.equal(
+    decodeURIComponent(game.id.slice('shared_'.length)),
+    sharedGamePath
+  );
 });

--- a/functions/test/public-homepage-games-core.test.cjs
+++ b/functions/test/public-homepage-games-core.test.cjs
@@ -3,6 +3,7 @@ const test = require('node:test');
 const {
   PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY,
   buildPublicHomepageGamesResponse,
+  limitPublicHomepageCandidates,
   serializeHomepageGame
 } = require('../public-homepage-games-core.cjs');
 
@@ -85,6 +86,16 @@ test('homepage response sorts, deduplicates, and enforces the public result cap'
   assert.deepEqual(response.upcoming.map((game) => game.id), games.slice(0, 6).map((game) => game.id));
   assert.deepEqual(response.replays.map((game) => game.id), [...games].reverse().slice(0, 6).map((game) => game.id));
   assert.equal(PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY, 120);
+});
+
+test('homepage candidate overflow truncates at the scan budget without failing discovery', () => {
+  const candidates = Array.from({ length: 121 }, (_, index) => ({ id: `candidate-${index}` }));
+  const limited = limitPublicHomepageCandidates(candidates);
+
+  assert.equal(limited.length, PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY);
+  assert.equal(limited[0].id, 'candidate-0');
+  assert.equal(limited.at(-1).id, 'candidate-119');
+  assert.equal(candidates.length, 121);
 });
 
 test('shared games are projected from the selected public team perspective', () => {

--- a/functions/test/public-homepage-games-handler-contract.test.cjs
+++ b/functions/test/public-homepage-games-handler-contract.test.cjs
@@ -1,0 +1,33 @@
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const { join } = require('node:path');
+const test = require('node:test');
+
+const source = readFileSync(join(__dirname, '..', 'index.js'), 'utf8');
+
+test('exports a bounded and cached public homepage games handler', () => {
+  const start = source.indexOf('function beginPublicHomepageGamesRequest');
+  const end = source.indexOf('exports.publicTeamRosterV1', start);
+  const handler = source.slice(start, end);
+
+  assert.match(handler, /exports\.publicHomepageGamesV1 = functions/);
+  assert.match(handler, /collectionGroup\(collectionName\)/);
+  assert.match(handler, /PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY \+ 1/);
+  assert.match(handler, /candidate scan limit exceeded/);
+  assert.match(handler, /getStrictPublicTeam\(teamId\)/);
+  assert.match(handler, /serializeHomepageGame\(candidate, teamId, team\)/);
+  assert.match(handler, /buildPublicHomepageGamesResponse/);
+  assert.match(handler, /sendPublicTeamApiSuccess/);
+  assert.match(handler, /checkPublicTeamApiRateLimit/);
+});
+
+test('homepage endpoint fails closed for unsupported methods and query failures', () => {
+  const start = source.indexOf('function beginPublicHomepageGamesRequest');
+  const end = source.indexOf('exports.publicTeamRosterV1', start);
+  const handler = source.slice(start, end);
+
+  assert.match(handler, /method_not_allowed/);
+  assert.match(handler, /rate_limited/);
+  assert.match(handler, /sendPublicTeamApiError\(res, 500, 'unavailable'/);
+  assert.doesNotMatch(handler, /res\.status\(200\).*error/s);
+});

--- a/functions/test/public-homepage-games-handler-contract.test.cjs
+++ b/functions/test/public-homepage-games-handler-contract.test.cjs
@@ -17,7 +17,8 @@ test('exports a bounded and cached public homepage games handler', () => {
   assert.match(handler, /Truncating a public homepage candidate query at the scan limit/);
   assert.doesNotMatch(handler, /candidate scan limit exceeded/);
   assert.match(handler, /getStrictPublicTeam\(teamId\)/);
-  assert.match(handler, /serializeHomepageGame\(candidate, teamId, team\)/);
+  assert.match(handler, /serializePublicHomepageCandidates\(\{/);
+  assert.match(handler, /serializedResults\[index\]\.partial/);
   assert.match(handler, /buildPublicHomepageGamesResponse/);
   assert.match(handler, /partialCategories/);
   assert.match(handler, /sendPublicTeamApiSuccess/);

--- a/functions/test/public-homepage-games-handler-contract.test.cjs
+++ b/functions/test/public-homepage-games-handler-contract.test.cjs
@@ -13,7 +13,9 @@ test('exports a bounded and cached public homepage games handler', () => {
   assert.match(handler, /exports\.publicHomepageGamesV1 = functions/);
   assert.match(handler, /collectionGroup\(collectionName\)/);
   assert.match(handler, /PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY \+ 1/);
-  assert.match(handler, /candidate scan limit exceeded/);
+  assert.match(handler, /limitPublicHomepageCandidates\(snapshot\.docs\)/);
+  assert.match(handler, /Truncating a public homepage candidate query at the scan limit/);
+  assert.doesNotMatch(handler, /candidate scan limit exceeded/);
   assert.match(handler, /getStrictPublicTeam\(teamId\)/);
   assert.match(handler, /serializeHomepageGame\(candidate, teamId, team\)/);
   assert.match(handler, /buildPublicHomepageGamesResponse/);

--- a/functions/test/public-homepage-games-handler-contract.test.cjs
+++ b/functions/test/public-homepage-games-handler-contract.test.cjs
@@ -17,6 +17,9 @@ test('exports a bounded and cached public homepage games handler', () => {
   assert.match(handler, /Truncating a public homepage candidate query at the scan limit/);
   assert.doesNotMatch(handler, /candidate scan limit exceeded/);
   assert.match(handler, /getStrictPublicTeam\(teamId\)/);
+  assert.match(handler, /buildPublicHomepageTeamIdBatch\(\[/);
+  assert.match(handler, /PUBLIC_HOMEPAGE_MAX_UNIQUE_TEAM_LOOKUPS/);
+  assert.match(handler, /teamLookupBudget/);
   assert.match(handler, /serializePublicHomepageCandidates\(\{/);
   assert.match(handler, /serializedResults\[index\]\.partial/);
   assert.match(handler, /buildPublicHomepageGamesResponse/);

--- a/functions/test/public-homepage-games-handler-contract.test.cjs
+++ b/functions/test/public-homepage-games-handler-contract.test.cjs
@@ -13,12 +13,13 @@ test('exports a bounded and cached public homepage games handler', () => {
   assert.match(handler, /exports\.publicHomepageGamesV1 = functions/);
   assert.match(handler, /collectionGroup\(collectionName\)/);
   assert.match(handler, /PUBLIC_HOMEPAGE_MAX_CANDIDATES_PER_QUERY \+ 1/);
-  assert.match(handler, /limitPublicHomepageCandidates\(snapshot\.docs\)/);
+  assert.match(handler, /buildPublicHomepageCandidateBatch\(snapshot\.docs\)/);
   assert.match(handler, /Truncating a public homepage candidate query at the scan limit/);
   assert.doesNotMatch(handler, /candidate scan limit exceeded/);
   assert.match(handler, /getStrictPublicTeam\(teamId\)/);
   assert.match(handler, /serializeHomepageGame\(candidate, teamId, team\)/);
   assert.match(handler, /buildPublicHomepageGamesResponse/);
+  assert.match(handler, /partialCategories/);
   assert.match(handler, /sendPublicTeamApiSuccess/);
   assert.match(handler, /checkPublicTeamApiRateLimit/);
 });

--- a/functions/test/public-homepage-games-index-contract.test.cjs
+++ b/functions/test/public-homepage-games-index-contract.test.cjs
@@ -1,0 +1,54 @@
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const { join } = require('node:path');
+const test = require('node:test');
+
+const indexConfig = JSON.parse(readFileSync(
+  join(__dirname, '..', '..', 'firestore.indexes.json'),
+  'utf8'
+));
+
+function hasComposite(collectionGroup, expectedFields) {
+  return indexConfig.indexes.some((index) => (
+    index.collectionGroup === collectionGroup
+    && index.queryScope === 'COLLECTION_GROUP'
+    && expectedFields.every((expected, position) => (
+      index.fields[position]?.fieldPath === expected.fieldPath
+      && index.fields[position]?.order === expected.order
+    ))
+    && index.fields.length === expectedFields.length
+  ));
+}
+
+function hasCollectionGroupFieldOrder(collectionGroup, fieldPath, order) {
+  return indexConfig.fieldOverrides.some((override) => (
+    override.collectionGroup === collectionGroup
+    && override.fieldPath === fieldPath
+    && override.indexes.some((index) => (
+      index.queryScope === 'COLLECTION_GROUP' && index.order === order
+    ))
+  ));
+}
+
+test('homepage collection-group query shapes have deployed index definitions', () => {
+  for (const collectionGroup of ['games', 'sharedGames']) {
+    assert.equal(
+      hasComposite(collectionGroup, [
+        { fieldPath: 'liveStatus', order: 'ASCENDING' },
+        { fieldPath: 'date', order: 'DESCENDING' }
+      ]),
+      true,
+      `${collectionGroup} replay query needs liveStatus/date composite index`
+    );
+    assert.equal(
+      hasCollectionGroupFieldOrder(collectionGroup, 'date', 'ASCENDING'),
+      true,
+      `${collectionGroup} upcoming query needs ascending collection-group date index`
+    );
+    assert.equal(
+      hasCollectionGroupFieldOrder(collectionGroup, 'date', 'DESCENDING'),
+      true,
+      `${collectionGroup} replay query needs descending collection-group date index`
+    );
+  }
+});

--- a/index.html
+++ b/index.html
@@ -653,7 +653,7 @@
   <script type="module">
     import { checkAuth, getRedirectUrl } from './js/auth.js?v=135';
     import { renderHeader, formatDate, formatTime } from './js/utils.js?v=18';
-    import { getPublicHomepageGames } from './js/public-homepage-games.js?v=1';
+    import { getPublicHomepageGames } from './js/public-homepage-games.js?v=2';
     import { initHomepage } from './js/homepage.js?v=5';
 
     initHomepage({

--- a/index.html
+++ b/index.html
@@ -653,17 +653,15 @@
   <script type="module">
     import { checkAuth, getRedirectUrl } from './js/auth.js?v=135';
     import { renderHeader, formatDate, formatTime } from './js/utils.js?v=18';
-    import { getUpcomingLiveGames, getLiveGamesNow, getRecentLiveTrackedGames } from './js/db.js?v=127';
-    import { initHomepage } from './js/homepage.js?v=4';
+    import { getPublicHomepageGames } from './js/public-homepage-games.js?v=1';
+    import { initHomepage } from './js/homepage.js?v=5';
 
     initHomepage({
       document,
       checkAuth,
       getRedirectUrl,
       renderHeader,
-      getLiveGamesNow,
-      getUpcomingLiveGames,
-      getRecentLiveTrackedGames,
+      getHomepageGames: getPublicHomepageGames,
       formatDate,
       formatTime
     });

--- a/js/certificates/assets.js
+++ b/js/certificates/assets.js
@@ -1,4 +1,4 @@
-import { imageStorage, requireImageAuth } from '../firebase-images.js?v=10';
+import { imageStorage, requireImageAuth } from '../firebase-images.js?v=11';
 import {
     db,
     collection,

--- a/js/db.js
+++ b/js/db.js
@@ -96,7 +96,7 @@ import {
     isSharedGameSyntheticId,
     mergeGamesForTeam,
     projectSharedGameForTeam
-} from './shared-games.js?v=1';
+} from './shared-games.js?v=2';
 import {
     normalizeAthleteProfileDraft,
     collectAthleteProfileMediaCleanupPaths,

--- a/js/db.js
+++ b/js/db.js
@@ -34,7 +34,7 @@ import {
     getDownloadURL,
     deleteObject
 } from './firebase.js?v=23';
-import { imageStorage, ensureImageAuth, requireImageAuth } from './firebase-images.js?v=10';
+import { imageStorage, ensureImageAuth, requireImageAuth } from './firebase-images.js?v=11';
 import { uploadBytesResumable } from './vendor/firebase-storage.js';
 import { buildDrillDiagramUploadPaths } from './drill-upload-paths.js?v=2';
 import { buildChatAttachmentFallbackPath, buildGameClipFallbackPath, buildStatSheetFallbackPath } from './fallback-media-paths.js?v=2';

--- a/js/firebase-app-check.js
+++ b/js/firebase-app-check.js
@@ -4,7 +4,7 @@ import {
     getToken,
     initializeAppCheck
 } from './vendor/firebase-app-check.js';
-import { resolveAppCheckRuntimeConfig } from './firebase-runtime-config.js?v=14';
+import { resolveAppCheckRuntimeConfig } from './firebase-runtime-config.js?v=15';
 import { registerPrimaryAppCheckContext } from './firebase-app-check-rest.js?v=1';
 
 export {

--- a/js/firebase-app-check.js
+++ b/js/firebase-app-check.js
@@ -4,7 +4,7 @@ import {
     getToken,
     initializeAppCheck
 } from './vendor/firebase-app-check.js';
-import { resolveAppCheckRuntimeConfig } from './firebase-runtime-config.js?v=13';
+import { resolveAppCheckRuntimeConfig } from './firebase-runtime-config.js?v=14';
 import { registerPrimaryAppCheckContext } from './firebase-app-check-rest.js?v=1';
 
 export {

--- a/js/firebase-app-check.js
+++ b/js/firebase-app-check.js
@@ -4,7 +4,7 @@ import {
     getToken,
     initializeAppCheck
 } from './vendor/firebase-app-check.js';
-import { resolveAppCheckRuntimeConfig } from './firebase-runtime-config.js?v=11';
+import { resolveAppCheckRuntimeConfig } from './firebase-runtime-config.js?v=12';
 import { registerPrimaryAppCheckContext } from './firebase-app-check-rest.js?v=1';
 
 export {

--- a/js/firebase-app-check.js
+++ b/js/firebase-app-check.js
@@ -4,7 +4,7 @@ import {
     getToken,
     initializeAppCheck
 } from './vendor/firebase-app-check.js';
-import { resolveAppCheckRuntimeConfig } from './firebase-runtime-config.js?v=12';
+import { resolveAppCheckRuntimeConfig } from './firebase-runtime-config.js?v=13';
 import { registerPrimaryAppCheckContext } from './firebase-app-check-rest.js?v=1';
 
 export {

--- a/js/firebase-app-check.js
+++ b/js/firebase-app-check.js
@@ -4,7 +4,7 @@ import {
     getToken,
     initializeAppCheck
 } from './vendor/firebase-app-check.js';
-import { resolveAppCheckRuntimeConfig } from './firebase-runtime-config.js?v=15';
+import { resolveAppCheckRuntimeConfig } from './firebase-runtime-config.js?v=16';
 import { registerPrimaryAppCheckContext } from './firebase-app-check-rest.js?v=1';
 
 export {

--- a/js/firebase-images.js
+++ b/js/firebase-images.js
@@ -1,7 +1,7 @@
 import { initializeApp, getApps } from "./vendor/firebase-app.js";
 import { getStorage } from "./vendor/firebase-storage.js";
 import { getAuth, signInAnonymously, onAuthStateChanged, setPersistence, browserLocalPersistence } from "./vendor/firebase-auth.js";
-import { resolveImageFirebaseConfig } from "./firebase-runtime-config.js?v=15";
+import { resolveImageFirebaseConfig } from "./firebase-runtime-config.js?v=16";
 
 const imgConfig = resolveImageFirebaseConfig();
 

--- a/js/firebase-images.js
+++ b/js/firebase-images.js
@@ -1,7 +1,7 @@
 import { initializeApp, getApps } from "./vendor/firebase-app.js";
 import { getStorage } from "./vendor/firebase-storage.js";
 import { getAuth, signInAnonymously, onAuthStateChanged, setPersistence, browserLocalPersistence } from "./vendor/firebase-auth.js";
-import { resolveImageFirebaseConfig } from "./firebase-runtime-config.js?v=14";
+import { resolveImageFirebaseConfig } from "./firebase-runtime-config.js?v=15";
 
 const imgConfig = resolveImageFirebaseConfig();
 

--- a/js/firebase-images.js
+++ b/js/firebase-images.js
@@ -1,7 +1,7 @@
 import { initializeApp, getApps } from "./vendor/firebase-app.js";
 import { getStorage } from "./vendor/firebase-storage.js";
 import { getAuth, signInAnonymously, onAuthStateChanged, setPersistence, browserLocalPersistence } from "./vendor/firebase-auth.js";
-import { resolveImageFirebaseConfig } from "./firebase-runtime-config.js?v=12";
+import { resolveImageFirebaseConfig } from "./firebase-runtime-config.js?v=13";
 
 const imgConfig = resolveImageFirebaseConfig();
 

--- a/js/firebase-images.js
+++ b/js/firebase-images.js
@@ -1,7 +1,7 @@
 import { initializeApp, getApps } from "./vendor/firebase-app.js";
 import { getStorage } from "./vendor/firebase-storage.js";
 import { getAuth, signInAnonymously, onAuthStateChanged, setPersistence, browserLocalPersistence } from "./vendor/firebase-auth.js";
-import { resolveImageFirebaseConfig } from "./firebase-runtime-config.js?v=11";
+import { resolveImageFirebaseConfig } from "./firebase-runtime-config.js?v=12";
 
 const imgConfig = resolveImageFirebaseConfig();
 

--- a/js/firebase-images.js
+++ b/js/firebase-images.js
@@ -1,7 +1,7 @@
 import { initializeApp, getApps } from "./vendor/firebase-app.js";
 import { getStorage } from "./vendor/firebase-storage.js";
 import { getAuth, signInAnonymously, onAuthStateChanged, setPersistence, browserLocalPersistence } from "./vendor/firebase-auth.js";
-import { resolveImageFirebaseConfig } from "./firebase-runtime-config.js?v=13";
+import { resolveImageFirebaseConfig } from "./firebase-runtime-config.js?v=14";
 
 const imgConfig = resolveImageFirebaseConfig();
 

--- a/js/firebase-runtime-config.js
+++ b/js/firebase-runtime-config.js
@@ -220,56 +220,58 @@ export async function resolvePrimaryFirebaseConfig() {
         : globalThis.location?.protocol;
     const canonicalProductionHost = isCanonicalProductionHostname(runtimeHostname);
     const nativeRuntime = isNativeRuntimeProtocol(runtimeProtocol);
-    const remoteConfig = await fetchAllPlaysRuntimeConfig();
-    const remoteFirebaseConfig = normalizeFirebaseConfig(
-        remoteConfig.firebase || remoteConfig.firebasePrimary
-    );
-    const rejectedProductionRuntimeConfig = Boolean(
-        remoteFirebaseConfig
-        && !canonicalProductionHost
-        && !nativeRuntime
-        && isBundledProductionFirebaseConfig(remoteFirebaseConfig)
-    );
-    if (
-        remoteFirebaseConfig
-        && (
-            canonicalProductionHost
-            || nativeRuntime
-            || !isBundledProductionFirebaseConfig(remoteFirebaseConfig)
-        )
-    ) {
-        return remoteFirebaseConfig;
-    }
 
     if (nativeRuntime) {
         return { ...DEFAULT_PRIMARY_FIREBASE_CONFIG };
     }
 
     const localDevelopmentHost = runtimeHostname === 'localhost' || runtimeHostname === '127.0.0.1';
-    const localOrUnresolvedHost = !runtimeHostname || localDevelopmentHost;
-    const canUseHostingInit = !runtimeHostname
-        || localDevelopmentHost
-        || runtimeHostname.endsWith('.web.app')
-        || runtimeHostname.endsWith('.firebaseapp.com');
-    if (!canUseHostingInit) {
-        if (canonicalProductionHost) {
-            return { ...DEFAULT_PRIMARY_FIREBASE_CONFIG };
-        }
-        throw new Error('Firebase config is unavailable for this non-production host.');
+    const firebaseHostingHost = Boolean(
+        runtimeHostname?.endsWith('.web.app')
+        || runtimeHostname?.endsWith('.firebaseapp.com')
+    );
+
+    if (canonicalProductionHost) {
+        const remoteConfig = await fetchAllPlaysRuntimeConfig();
+        const remoteFirebaseConfig = normalizeFirebaseConfig(
+            remoteConfig.firebase || remoteConfig.firebasePrimary
+        );
+        return remoteFirebaseConfig || { ...DEFAULT_PRIMARY_FIREBASE_CONFIG };
     }
 
-    try {
-        return await fetchFirebaseConfigFromHosting();
-    } catch (error) {
-        if (
-            !canonicalProductionHost
-            && !(localOrUnresolvedHost && !rejectedProductionRuntimeConfig)
-        ) {
-            throw error;
+    if (!runtimeHostname || localDevelopmentHost || firebaseHostingHost) {
+        try {
+            return await fetchFirebaseConfigFromHosting();
+        } catch (hostingError) {
+            if (firebaseHostingHost) {
+                throw hostingError;
+            }
+
+            const remoteConfig = await fetchAllPlaysRuntimeConfig();
+            const remoteFirebaseConfig = normalizeFirebaseConfig(
+                remoteConfig.firebase || remoteConfig.firebasePrimary
+            );
+            if (
+                remoteFirebaseConfig
+                && !isBundledProductionFirebaseConfig(remoteFirebaseConfig)
+            ) {
+                return remoteFirebaseConfig;
+            }
+            throw hostingError;
         }
-        console.warn('Falling back to bundled Firebase config.', error);
-        return { ...DEFAULT_PRIMARY_FIREBASE_CONFIG };
     }
+
+    const remoteConfig = await fetchAllPlaysRuntimeConfig();
+    const remoteFirebaseConfig = normalizeFirebaseConfig(
+        remoteConfig.firebase || remoteConfig.firebasePrimary
+    );
+    if (
+        remoteFirebaseConfig
+        && !isBundledProductionFirebaseConfig(remoteFirebaseConfig)
+    ) {
+        return remoteFirebaseConfig;
+    }
+    throw new Error('Firebase config is unavailable for this non-production host.');
 }
 
 export function resolveImageFirebaseConfig() {

--- a/js/firebase-runtime-config.js
+++ b/js/firebase-runtime-config.js
@@ -204,14 +204,6 @@ async function fetchFirebaseConfigFromHosting() {
 }
 
 export async function resolvePrimaryFirebaseConfig() {
-    const globalConfig = readGlobalConfig();
-    const inlineConfig = normalizeFirebaseConfig(
-        globalConfig.firebase || globalConfig.firebasePrimary || readWindowGlobal('ALLPLAYS_FIREBASE_CONFIG')
-    );
-    if (inlineConfig) {
-        return inlineConfig;
-    }
-
     const runtimeHostname = typeof window !== 'undefined'
         ? window.location?.hostname
         : globalThis.location?.hostname;
@@ -220,6 +212,21 @@ export async function resolvePrimaryFirebaseConfig() {
         : globalThis.location?.protocol;
     const canonicalProductionHost = isCanonicalProductionHostname(runtimeHostname);
     const nativeRuntime = isNativeRuntimeProtocol(runtimeProtocol);
+    const globalConfig = readGlobalConfig();
+    const inlineConfig = normalizeFirebaseConfig(
+        globalConfig.firebase || globalConfig.firebasePrimary || readWindowGlobal('ALLPLAYS_FIREBASE_CONFIG')
+    );
+    if (
+        inlineConfig
+        && (
+            !isBundledProductionFirebaseConfig(inlineConfig)
+            || canonicalProductionHost
+            || nativeRuntime
+            || !runtimeHostname
+        )
+    ) {
+        return inlineConfig;
+    }
 
     if (nativeRuntime) {
         return { ...DEFAULT_PRIMARY_FIREBASE_CONFIG };

--- a/js/firebase-runtime-config.js
+++ b/js/firebase-runtime-config.js
@@ -26,6 +26,9 @@ const DEFAULT_IMAGE_FIREBASE_CONFIG = {
     appId: '1:340859680438:web:4d00f571e8531907a11817',
     measurementId: 'G-FRVND6NT3C'
 };
+let runtimeConfigFetchPromise = null;
+let runtimeConfigFetchKey = '';
+let runtimeConfigFetchImplementation = null;
 
 function readGlobalConfig() {
     return (typeof window !== 'undefined' && window.__ALLPLAYS_CONFIG__ && typeof window.__ALLPLAYS_CONFIG__ === 'object')
@@ -114,19 +117,36 @@ function runtimeConfigCandidates() {
 }
 
 async function fetchAllPlaysRuntimeConfig() {
-    for (const url of runtimeConfigCandidates()) {
-        try {
-            const response = await fetch(url, { cache: 'no-store' });
-            if (!response.ok) continue;
-            const payload = await response.json();
-            if (payload && typeof payload === 'object') {
-                return payload;
-            }
-        } catch (_error) {
-            // Runtime config is optional until App Check console rollout is complete.
-        }
+    const candidates = runtimeConfigCandidates();
+    const fetchImplementation = globalThis.fetch;
+    const fetchKey = candidates.join('|');
+    if (
+        runtimeConfigFetchPromise
+        && runtimeConfigFetchKey === fetchKey
+        && runtimeConfigFetchImplementation === fetchImplementation
+    ) {
+        return runtimeConfigFetchPromise;
     }
-    return {};
+
+    runtimeConfigFetchKey = fetchKey;
+    runtimeConfigFetchImplementation = fetchImplementation;
+    runtimeConfigFetchPromise = (async () => {
+        if (typeof fetchImplementation !== 'function') return {};
+        for (const url of candidates) {
+            try {
+                const response = await fetchImplementation(url, { cache: 'no-store' });
+                if (!response.ok) continue;
+                const payload = await response.json();
+                if (payload && typeof payload === 'object') {
+                    return payload;
+                }
+            } catch (_error) {
+                // Runtime config is optional until App Check console rollout is complete.
+            }
+        }
+        return {};
+    })();
+    return runtimeConfigFetchPromise;
 }
 
 function normalizeFirebaseConfig(rawConfig) {
@@ -171,19 +191,37 @@ async function fetchFirebaseConfigFromHosting() {
 }
 
 export async function resolvePrimaryFirebaseConfig() {
-    try {
-        const hostedConfig = await fetchFirebaseConfigFromHosting();
-        return hostedConfig;
-    } catch (error) {
-        const globalConfig = readGlobalConfig();
-        const inlineConfig = normalizeFirebaseConfig(
-            globalConfig.firebase || globalConfig.firebasePrimary || readWindowGlobal('ALLPLAYS_FIREBASE_CONFIG')
-        );
-        if (inlineConfig) {
-            console.warn('Falling back to inline Firebase config after hosted init lookup failed.', error);
-            return inlineConfig;
-        }
+    const globalConfig = readGlobalConfig();
+    const inlineConfig = normalizeFirebaseConfig(
+        globalConfig.firebase || globalConfig.firebasePrimary || readWindowGlobal('ALLPLAYS_FIREBASE_CONFIG')
+    );
+    if (inlineConfig) {
+        return inlineConfig;
+    }
 
+    const remoteConfig = await fetchAllPlaysRuntimeConfig();
+    const remoteFirebaseConfig = normalizeFirebaseConfig(
+        remoteConfig.firebase || remoteConfig.firebasePrimary
+    );
+    if (remoteFirebaseConfig) {
+        return remoteFirebaseConfig;
+    }
+
+    const runtimeHostname = typeof window !== 'undefined'
+        ? window.location?.hostname
+        : globalThis.location?.hostname;
+    const canUseHostingInit = !runtimeHostname
+        || runtimeHostname === 'localhost'
+        || runtimeHostname === '127.0.0.1'
+        || runtimeHostname.endsWith('.web.app')
+        || runtimeHostname.endsWith('.firebaseapp.com');
+    if (!canUseHostingInit) {
+        return { ...DEFAULT_PRIMARY_FIREBASE_CONFIG };
+    }
+
+    try {
+        return await fetchFirebaseConfigFromHosting();
+    } catch (error) {
         console.warn('Falling back to bundled Firebase config.', error);
         return { ...DEFAULT_PRIMARY_FIREBASE_CONFIG };
     }

--- a/js/firebase-runtime-config.js
+++ b/js/firebase-runtime-config.js
@@ -203,6 +203,14 @@ async function fetchFirebaseConfigFromHosting() {
     return normalized;
 }
 
+async function fetchNonProductionFirebaseConfigFromHosting() {
+    const config = await fetchFirebaseConfigFromHosting();
+    if (isBundledProductionFirebaseConfig(config)) {
+        throw new Error('Firebase Hosting init config points to production Firebase on a non-production host.');
+    }
+    return config;
+}
+
 export async function resolvePrimaryFirebaseConfig() {
     const runtimeHostname = typeof window !== 'undefined'
         ? window.location?.hostname
@@ -248,7 +256,7 @@ export async function resolvePrimaryFirebaseConfig() {
 
     if (!runtimeHostname || localDevelopmentHost || firebaseHostingHost) {
         try {
-            return await fetchFirebaseConfigFromHosting();
+            return await fetchNonProductionFirebaseConfigFromHosting();
         } catch (hostingError) {
             if (firebaseHostingHost) {
                 throw hostingError;

--- a/js/firebase-runtime-config.js
+++ b/js/firebase-runtime-config.js
@@ -2,6 +2,7 @@ const FIREBASE_INIT_JSON_URL = '/__/firebase/init.json';
 const ALLPLAYS_RUNTIME_CONFIG_PATH = '.well-known/allplays-runtime-config.json';
 const REQUIRED_FIREBASE_FIELDS = ['apiKey', 'authDomain', 'projectId', 'messagingSenderId', 'appId'];
 const OPTIONAL_FIREBASE_FIELDS = ['storageBucket', 'measurementId'];
+const CANONICAL_PRODUCTION_HOSTNAMES = new Set(['allplays.ai', 'www.allplays.ai']);
 const DEFAULT_PRIMARY_FIREBASE_CONFIG = {
     apiKey: 'AIzaSyDoixIoKJuUVWdmImwjYRTthjKOv2mU0Jc',
     authDomain: 'game-flow-c6311.firebaseapp.com',
@@ -167,6 +168,18 @@ function normalizeFirebaseConfig(rawConfig) {
     return hasRequiredFields ? normalized : null;
 }
 
+function isCanonicalProductionHostname(hostname) {
+    return CANONICAL_PRODUCTION_HOSTNAMES.has(String(hostname || '').trim().toLowerCase());
+}
+
+function isBundledProductionFirebaseConfig(config) {
+    return config?.projectId === DEFAULT_PRIMARY_FIREBASE_CONFIG.projectId;
+}
+
+function isNativeRuntimeProtocol(protocol) {
+    return protocol === 'capacitor:' || protocol === 'ionic:';
+}
+
 async function fetchFirebaseConfigFromHosting() {
     const baseUrl = (typeof window !== 'undefined' && window.location && window.location.origin)
         ? window.location.origin
@@ -199,29 +212,61 @@ export async function resolvePrimaryFirebaseConfig() {
         return inlineConfig;
     }
 
+    const runtimeHostname = typeof window !== 'undefined'
+        ? window.location?.hostname
+        : globalThis.location?.hostname;
+    const runtimeProtocol = typeof window !== 'undefined'
+        ? window.location?.protocol
+        : globalThis.location?.protocol;
+    const canonicalProductionHost = isCanonicalProductionHostname(runtimeHostname);
+    const nativeRuntime = isNativeRuntimeProtocol(runtimeProtocol);
     const remoteConfig = await fetchAllPlaysRuntimeConfig();
     const remoteFirebaseConfig = normalizeFirebaseConfig(
         remoteConfig.firebase || remoteConfig.firebasePrimary
     );
-    if (remoteFirebaseConfig) {
+    const rejectedProductionRuntimeConfig = Boolean(
+        remoteFirebaseConfig
+        && !canonicalProductionHost
+        && !nativeRuntime
+        && isBundledProductionFirebaseConfig(remoteFirebaseConfig)
+    );
+    if (
+        remoteFirebaseConfig
+        && (
+            canonicalProductionHost
+            || nativeRuntime
+            || !isBundledProductionFirebaseConfig(remoteFirebaseConfig)
+        )
+    ) {
         return remoteFirebaseConfig;
     }
 
-    const runtimeHostname = typeof window !== 'undefined'
-        ? window.location?.hostname
-        : globalThis.location?.hostname;
+    if (nativeRuntime) {
+        return { ...DEFAULT_PRIMARY_FIREBASE_CONFIG };
+    }
+
+    const localDevelopmentHost = runtimeHostname === 'localhost' || runtimeHostname === '127.0.0.1';
+    const localOrUnresolvedHost = !runtimeHostname || localDevelopmentHost;
     const canUseHostingInit = !runtimeHostname
-        || runtimeHostname === 'localhost'
-        || runtimeHostname === '127.0.0.1'
+        || localDevelopmentHost
         || runtimeHostname.endsWith('.web.app')
         || runtimeHostname.endsWith('.firebaseapp.com');
     if (!canUseHostingInit) {
-        return { ...DEFAULT_PRIMARY_FIREBASE_CONFIG };
+        if (canonicalProductionHost) {
+            return { ...DEFAULT_PRIMARY_FIREBASE_CONFIG };
+        }
+        throw new Error('Firebase config is unavailable for this non-production host.');
     }
 
     try {
         return await fetchFirebaseConfigFromHosting();
     } catch (error) {
+        if (
+            !canonicalProductionHost
+            && !(localOrUnresolvedHost && !rejectedProductionRuntimeConfig)
+        ) {
+            throw error;
+        }
         console.warn('Falling back to bundled Firebase config.', error);
         return { ...DEFAULT_PRIMARY_FIREBASE_CONFIG };
     }

--- a/js/firebase-runtime-config.js
+++ b/js/firebase-runtime-config.js
@@ -257,6 +257,9 @@ export async function resolvePrimaryFirebaseConfig() {
             ) {
                 return remoteFirebaseConfig;
             }
+            if (!runtimeHostname || localDevelopmentHost) {
+                return { ...DEFAULT_PRIMARY_FIREBASE_CONFIG };
+            }
             throw hostingError;
         }
     }

--- a/js/firebase-runtime-config.js
+++ b/js/firebase-runtime-config.js
@@ -236,22 +236,26 @@ export async function resolvePrimaryFirebaseConfig() {
         : globalThis.location?.protocol;
     const canonicalProductionHost = isCanonicalProductionHostname(runtimeHostname);
     const productionFirebaseHostingHost = isProductionFirebaseHostingHostname(runtimeHostname);
+    const productionRuntimeHost = canonicalProductionHost || productionFirebaseHostingHost;
     const nativeRuntime = isNativeRuntimeProtocol(runtimeProtocol);
     const globalConfig = readGlobalConfig();
     const inlineConfig = normalizeFirebaseConfig(
         globalConfig.firebase || globalConfig.firebasePrimary || readWindowGlobal('ALLPLAYS_FIREBASE_CONFIG')
     );
-    if (
-        inlineConfig
-        && (
+    if (inlineConfig) {
+        if (productionRuntimeHost) {
+            if (!isBundledProductionFirebaseConfig(inlineConfig)) {
+                throw new Error('Firebase config does not match the production Firebase project.');
+            }
+            return inlineConfig;
+        }
+        if (
             !isBundledProductionFirebaseConfig(inlineConfig)
-            || canonicalProductionHost
-            || productionFirebaseHostingHost
             || nativeRuntime
             || !runtimeHostname
-        )
-    ) {
-        return inlineConfig;
+        ) {
+            return inlineConfig;
+        }
     }
 
     if (nativeRuntime) {
@@ -269,6 +273,12 @@ export async function resolvePrimaryFirebaseConfig() {
         const remoteFirebaseConfig = normalizeFirebaseConfig(
             remoteConfig.firebase || remoteConfig.firebasePrimary
         );
+        if (
+            remoteFirebaseConfig
+            && !isBundledProductionFirebaseConfig(remoteFirebaseConfig)
+        ) {
+            throw new Error('Firebase runtime config does not match the production Firebase project.');
+        }
         return remoteFirebaseConfig || { ...DEFAULT_PRIMARY_FIREBASE_CONFIG };
     }
 

--- a/js/firebase-runtime-config.js
+++ b/js/firebase-runtime-config.js
@@ -3,6 +3,10 @@ const ALLPLAYS_RUNTIME_CONFIG_PATH = '.well-known/allplays-runtime-config.json';
 const REQUIRED_FIREBASE_FIELDS = ['apiKey', 'authDomain', 'projectId', 'messagingSenderId', 'appId'];
 const OPTIONAL_FIREBASE_FIELDS = ['storageBucket', 'measurementId'];
 const CANONICAL_PRODUCTION_HOSTNAMES = new Set(['allplays.ai', 'www.allplays.ai']);
+const PRODUCTION_FIREBASE_HOSTING_HOSTNAMES = new Set([
+    'game-flow-c6311.web.app',
+    'game-flow-c6311.firebaseapp.com'
+]);
 const DEFAULT_PRIMARY_FIREBASE_CONFIG = {
     apiKey: 'AIzaSyDoixIoKJuUVWdmImwjYRTthjKOv2mU0Jc',
     authDomain: 'game-flow-c6311.firebaseapp.com',
@@ -172,6 +176,10 @@ function isCanonicalProductionHostname(hostname) {
     return CANONICAL_PRODUCTION_HOSTNAMES.has(String(hostname || '').trim().toLowerCase());
 }
 
+function isProductionFirebaseHostingHostname(hostname) {
+    return PRODUCTION_FIREBASE_HOSTING_HOSTNAMES.has(String(hostname || '').trim().toLowerCase());
+}
+
 function isBundledProductionFirebaseConfig(config) {
     return config?.projectId === DEFAULT_PRIMARY_FIREBASE_CONFIG.projectId;
 }
@@ -211,6 +219,14 @@ async function fetchNonProductionFirebaseConfigFromHosting() {
     return config;
 }
 
+async function fetchProductionFirebaseConfigFromHosting() {
+    const config = await fetchFirebaseConfigFromHosting();
+    if (!isBundledProductionFirebaseConfig(config)) {
+        throw new Error('Firebase Hosting init config does not match the production Firebase project.');
+    }
+    return config;
+}
+
 export async function resolvePrimaryFirebaseConfig() {
     const runtimeHostname = typeof window !== 'undefined'
         ? window.location?.hostname
@@ -219,6 +235,7 @@ export async function resolvePrimaryFirebaseConfig() {
         ? window.location?.protocol
         : globalThis.location?.protocol;
     const canonicalProductionHost = isCanonicalProductionHostname(runtimeHostname);
+    const productionFirebaseHostingHost = isProductionFirebaseHostingHostname(runtimeHostname);
     const nativeRuntime = isNativeRuntimeProtocol(runtimeProtocol);
     const globalConfig = readGlobalConfig();
     const inlineConfig = normalizeFirebaseConfig(
@@ -229,6 +246,7 @@ export async function resolvePrimaryFirebaseConfig() {
         && (
             !isBundledProductionFirebaseConfig(inlineConfig)
             || canonicalProductionHost
+            || productionFirebaseHostingHost
             || nativeRuntime
             || !runtimeHostname
         )
@@ -252,6 +270,10 @@ export async function resolvePrimaryFirebaseConfig() {
             remoteConfig.firebase || remoteConfig.firebasePrimary
         );
         return remoteFirebaseConfig || { ...DEFAULT_PRIMARY_FIREBASE_CONFIG };
+    }
+
+    if (productionFirebaseHostingHost) {
+        return fetchProductionFirebaseConfigFromHosting();
     }
 
     if (!runtimeHostname || localDevelopmentHost || firebaseHostingHost) {

--- a/js/firebase-runtime-config.js
+++ b/js/firebase-runtime-config.js
@@ -257,8 +257,11 @@ export async function resolvePrimaryFirebaseConfig() {
             ) {
                 return remoteFirebaseConfig;
             }
-            if (!runtimeHostname || localDevelopmentHost) {
+            if (!runtimeHostname) {
                 return { ...DEFAULT_PRIMARY_FIREBASE_CONFIG };
+            }
+            if (localDevelopmentHost) {
+                throw new Error('Firebase config is unavailable for local development. Configure an explicit non-production Firebase project.');
             }
             throw hostingError;
         }

--- a/js/firebase.js
+++ b/js/firebase.js
@@ -53,7 +53,7 @@ import {
 import { getStorage, ref, uploadBytes, getDownloadURL, deleteObject } from "./vendor/firebase-storage.js";
 import { getFunctions, httpsCallable } from "./vendor/firebase-functions.js";
 import { initializePrimaryAppCheck } from "./firebase-app-check.js?v=2";
-import { resolvePrimaryFirebaseConfig } from "./firebase-runtime-config.js?v=12";
+import { resolvePrimaryFirebaseConfig } from "./firebase-runtime-config.js?v=13";
 
 const firebaseConfig = await resolvePrimaryFirebaseConfig();
 

--- a/js/firebase.js
+++ b/js/firebase.js
@@ -53,7 +53,7 @@ import {
 import { getStorage, ref, uploadBytes, getDownloadURL, deleteObject } from "./vendor/firebase-storage.js";
 import { getFunctions, httpsCallable } from "./vendor/firebase-functions.js";
 import { initializePrimaryAppCheck } from "./firebase-app-check.js?v=2";
-import { resolvePrimaryFirebaseConfig } from "./firebase-runtime-config.js?v=13";
+import { resolvePrimaryFirebaseConfig } from "./firebase-runtime-config.js?v=14";
 
 const firebaseConfig = await resolvePrimaryFirebaseConfig();
 

--- a/js/firebase.js
+++ b/js/firebase.js
@@ -53,7 +53,7 @@ import {
 import { getStorage, ref, uploadBytes, getDownloadURL, deleteObject } from "./vendor/firebase-storage.js";
 import { getFunctions, httpsCallable } from "./vendor/firebase-functions.js";
 import { initializePrimaryAppCheck } from "./firebase-app-check.js?v=2";
-import { resolvePrimaryFirebaseConfig } from "./firebase-runtime-config.js?v=15";
+import { resolvePrimaryFirebaseConfig } from "./firebase-runtime-config.js?v=16";
 
 const firebaseConfig = await resolvePrimaryFirebaseConfig();
 

--- a/js/firebase.js
+++ b/js/firebase.js
@@ -53,7 +53,7 @@ import {
 import { getStorage, ref, uploadBytes, getDownloadURL, deleteObject } from "./vendor/firebase-storage.js";
 import { getFunctions, httpsCallable } from "./vendor/firebase-functions.js";
 import { initializePrimaryAppCheck } from "./firebase-app-check.js?v=2";
-import { resolvePrimaryFirebaseConfig } from "./firebase-runtime-config.js?v=14";
+import { resolvePrimaryFirebaseConfig } from "./firebase-runtime-config.js?v=15";
 
 const firebaseConfig = await resolvePrimaryFirebaseConfig();
 

--- a/js/firebase.js
+++ b/js/firebase.js
@@ -53,7 +53,7 @@ import {
 import { getStorage, ref, uploadBytes, getDownloadURL, deleteObject } from "./vendor/firebase-storage.js";
 import { getFunctions, httpsCallable } from "./vendor/firebase-functions.js";
 import { initializePrimaryAppCheck } from "./firebase-app-check.js?v=2";
-import { resolvePrimaryFirebaseConfig } from "./firebase-runtime-config.js?v=11";
+import { resolvePrimaryFirebaseConfig } from "./firebase-runtime-config.js?v=12";
 
 const firebaseConfig = await resolvePrimaryFirebaseConfig();
 

--- a/js/homepage.js
+++ b/js/homepage.js
@@ -50,6 +50,10 @@ function renderTeamAvatar(game) {
     return `<div class="w-10 h-10 rounded-full bg-primary-100 flex items-center justify-center text-primary-600 font-bold">${teamInitial}</div>`;
 }
 
+function renderPartialNotice(message) {
+    return `<div class="col-span-full rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900" role="status" data-homepage-partial>${escapeHtml(message)}</div>`;
+}
+
 function applyRequestAccessCta(cta) {
     if (!cta) {
         return;
@@ -86,6 +90,7 @@ export async function loadLiveGames({
     container,
     getLiveGamesNow,
     getUpcomingLiveGames,
+    getPartialCategories = async () => [],
     formatDate,
     formatTime,
     logger = console
@@ -111,6 +116,10 @@ export async function loadLiveGames({
         }
 
         upcomingGames = upcomingGames.filter(isVisibleUpcomingHomepageGame);
+        const partialCategories = await getPartialCategories();
+        const partialNotice = partialCategories.includes('live') || partialCategories.includes('upcoming')
+            ? renderPartialNotice('Showing available games. Some live or upcoming games may be missing.')
+            : '';
 
         const combined = [
             ...liveGames.map((game) => ({ ...game, isLive: true })),
@@ -118,11 +127,11 @@ export async function loadLiveGames({
         ].slice(0, 6);
 
         if (combined.length === 0) {
-            container.innerHTML = '<div class="text-center py-8 text-gray-500 col-span-full">No upcoming live games scheduled</div>';
+            container.innerHTML = `${partialNotice}<div class="text-center py-8 text-gray-500 col-span-full">No upcoming live games scheduled</div>`;
             return;
         }
 
-        container.innerHTML = combined.map((game) => `
+        container.innerHTML = partialNotice + combined.map((game) => `
           <a href="${buildLiveGameHref(game)}"
              class="block bg-white rounded-xl shadow hover:shadow-lg transition border border-gray-200 p-5 ${game.isLive ? 'ring-2 ring-red-500' : ''}">
             ${game.isLive ? `
@@ -156,6 +165,7 @@ export async function loadLiveGames({
 export async function loadPastGames({
     container,
     getRecentLiveTrackedGames,
+    getPartialCategories = async () => [],
     formatDate,
     logger = console
 }) {
@@ -166,12 +176,16 @@ export async function loadPastGames({
     try {
         const pastGamesResult = await getRecentLiveTrackedGames(6);
         const pastGames = Array.isArray(pastGamesResult) ? pastGamesResult : [];
+        const partialCategories = await getPartialCategories();
+        const partialNotice = partialCategories.includes('replays')
+            ? renderPartialNotice('Showing available replays. Some recent replays may be missing.')
+            : '';
         if (pastGames.length === 0) {
-            container.innerHTML = '<div class="text-center py-8 text-gray-500 col-span-full">No recent replays available</div>';
+            container.innerHTML = `${partialNotice}<div class="text-center py-8 text-gray-500 col-span-full">No recent replays available</div>`;
             return;
         }
 
-        container.innerHTML = pastGames.map((game) => `
+        container.innerHTML = partialNotice + pastGames.map((game) => `
           <a href="${buildLiveGameHref(game, true)}"
              class="block bg-white rounded-xl shadow hover:shadow-lg transition border border-gray-200 p-5">
             <div class="flex items-center gap-3 mb-3">
@@ -218,6 +232,13 @@ export async function initHomepage({
     const replayGamesLoader = homepageGamesPromise
         ? () => homepageGamesPromise.then((payload) => payload.replays || [])
         : getRecentLiveTrackedGames;
+    const partialCategoriesLoader = homepageGamesPromise
+        ? () => homepageGamesPromise.then((payload) => (
+            payload.partial === true && Array.isArray(payload.partialCategories)
+                ? payload.partialCategories
+                : []
+        ))
+        : async () => [];
 
     checkAuth((user) => {
         renderHeader(document.getElementById('header-container'), user);
@@ -230,6 +251,7 @@ export async function initHomepage({
             container: document.getElementById('live-games-list'),
             getLiveGamesNow: liveGamesLoader,
             getUpcomingLiveGames: upcomingGamesLoader,
+            getPartialCategories: partialCategoriesLoader,
             formatDate,
             formatTime,
             logger
@@ -237,6 +259,7 @@ export async function initHomepage({
         loadPastGames({
             container: document.getElementById('past-games-list'),
             getRecentLiveTrackedGames: replayGamesLoader,
+            getPartialCategories: partialCategoriesLoader,
             formatDate,
             logger
         })

--- a/js/homepage.js
+++ b/js/homepage.js
@@ -200,11 +200,24 @@ export async function initHomepage({
     getLiveGamesNow,
     getUpcomingLiveGames,
     getRecentLiveTrackedGames,
+    getHomepageGames,
     formatDate,
     formatTime,
     logger = console
 }) {
     const heroCta = document.getElementById('hero-cta');
+    const homepageGamesPromise = typeof getHomepageGames === 'function'
+        ? Promise.resolve().then(() => getHomepageGames())
+        : null;
+    const liveGamesLoader = homepageGamesPromise
+        ? () => homepageGamesPromise.then((payload) => payload.live || [])
+        : getLiveGamesNow;
+    const upcomingGamesLoader = homepageGamesPromise
+        ? () => homepageGamesPromise.then((payload) => payload.upcoming || [])
+        : getUpcomingLiveGames;
+    const replayGamesLoader = homepageGamesPromise
+        ? () => homepageGamesPromise.then((payload) => payload.replays || [])
+        : getRecentLiveTrackedGames;
 
     checkAuth((user) => {
         renderHeader(document.getElementById('header-container'), user);
@@ -215,15 +228,15 @@ export async function initHomepage({
     await Promise.all([
         loadLiveGames({
             container: document.getElementById('live-games-list'),
-            getLiveGamesNow,
-            getUpcomingLiveGames,
+            getLiveGamesNow: liveGamesLoader,
+            getUpcomingLiveGames: upcomingGamesLoader,
             formatDate,
             formatTime,
             logger
         }),
         loadPastGames({
             container: document.getElementById('past-games-list'),
-            getRecentLiveTrackedGames,
+            getRecentLiveTrackedGames: replayGamesLoader,
             formatDate,
             logger
         })

--- a/js/public-homepage-games.js
+++ b/js/public-homepage-games.js
@@ -22,6 +22,10 @@ export async function getPublicHomepageGames({
         throw new Error('Public homepage games response is invalid.');
     }
     return {
+        partial: payload.partial === true,
+        partialCategories: Array.isArray(payload.partialCategories)
+            ? payload.partialCategories.filter((category) => ['live', 'upcoming', 'replays'].includes(category))
+            : [],
         live: Array.isArray(payload.live) ? payload.live : [],
         upcoming: Array.isArray(payload.upcoming) ? payload.upcoming : [],
         replays: Array.isArray(payload.replays) ? payload.replays : []

--- a/js/public-homepage-games.js
+++ b/js/public-homepage-games.js
@@ -1,0 +1,29 @@
+export const PUBLIC_HOMEPAGE_GAMES_URL = 'https://us-central1-game-flow-c6311.cloudfunctions.net/publicHomepageGamesV1';
+
+export async function getPublicHomepageGames({
+    fetchImpl = globalThis.fetch,
+    signal,
+    url = PUBLIC_HOMEPAGE_GAMES_URL
+} = {}) {
+    if (typeof fetchImpl !== 'function') {
+        throw new Error('Public homepage games transport is unavailable.');
+    }
+
+    const response = await fetchImpl(url, {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+        signal
+    });
+    if (!response.ok) {
+        throw new Error(`Public homepage games request failed (${response.status}).`);
+    }
+    const payload = await response.json();
+    if (!payload || typeof payload !== 'object') {
+        throw new Error('Public homepage games response is invalid.');
+    }
+    return {
+        live: Array.isArray(payload.live) ? payload.live : [],
+        upcoming: Array.isArray(payload.upcoming) ? payload.upcoming : [],
+        replays: Array.isArray(payload.replays) ? payload.replays : []
+    };
+}

--- a/js/public-homepage-games.js
+++ b/js/public-homepage-games.js
@@ -1,25 +1,68 @@
 export const PUBLIC_HOMEPAGE_GAMES_URL = 'https://us-central1-game-flow-c6311.cloudfunctions.net/publicHomepageGamesV1';
+export const PUBLIC_HOMEPAGE_REQUEST_TIMEOUT_MS = 10_000;
 
 export async function getPublicHomepageGames({
     fetchImpl = globalThis.fetch,
     signal,
+    timeoutMs = PUBLIC_HOMEPAGE_REQUEST_TIMEOUT_MS,
     url = PUBLIC_HOMEPAGE_GAMES_URL
 } = {}) {
     if (typeof fetchImpl !== 'function') {
         throw new Error('Public homepage games transport is unavailable.');
     }
 
-    const response = await fetchImpl(url, {
-        method: 'GET',
-        headers: { Accept: 'application/json' },
-        signal
+    const timeout = Number.isFinite(timeoutMs) && timeoutMs > 0
+        ? timeoutMs
+        : PUBLIC_HOMEPAGE_REQUEST_TIMEOUT_MS;
+    const requestController = new AbortController();
+    let timeoutId;
+    let rejectAbort;
+    const abortPromise = new Promise((_, reject) => {
+        rejectAbort = reject;
     });
-    if (!response.ok) {
-        throw new Error(`Public homepage games request failed (${response.status}).`);
+    const abortRequest = (error) => {
+        if (!requestController.signal.aborted) {
+            requestController.abort(error);
+        }
+        rejectAbort(error);
+    };
+    const handleExternalAbort = () => {
+        abortRequest(signal?.reason instanceof Error
+            ? signal.reason
+            : new Error('Public homepage games request was aborted.'));
+    };
+
+    if (signal?.aborted) {
+        handleExternalAbort();
+    } else {
+        signal?.addEventListener('abort', handleExternalAbort, { once: true });
+        timeoutId = setTimeout(() => {
+            abortRequest(new Error('Public homepage games request timed out.'));
+        }, timeout);
     }
-    const payload = await response.json();
-    if (!payload || typeof payload !== 'object') {
-        throw new Error('Public homepage games response is invalid.');
+
+    const requestPromise = (async () => {
+        const response = await fetchImpl(url, {
+            method: 'GET',
+            headers: { Accept: 'application/json' },
+            signal: requestController.signal
+        });
+        if (!response.ok) {
+            throw new Error(`Public homepage games request failed (${response.status}).`);
+        }
+        const payload = await response.json();
+        if (!payload || typeof payload !== 'object') {
+            throw new Error('Public homepage games response is invalid.');
+        }
+        return payload;
+    })();
+
+    let payload;
+    try {
+        payload = await Promise.race([requestPromise, abortPromise]);
+    } finally {
+        clearTimeout(timeoutId);
+        signal?.removeEventListener('abort', handleExternalAbort);
     }
     return {
         partial: payload.partial === true,

--- a/js/shared-games.js
+++ b/js/shared-games.js
@@ -35,7 +35,18 @@ export function decodeSharedGameSyntheticId(gameId) {
     const prefix = gameId.startsWith(SHARED_GAME_ID_PREFIX)
         ? SHARED_GAME_ID_PREFIX
         : LEGACY_SHARED_GAME_ID_PREFIX;
-    return decodeURIComponent(gameId.slice(prefix.length));
+    let sharedGamePath;
+    try {
+        sharedGamePath = decodeURIComponent(gameId.slice(prefix.length));
+    } catch (_error) {
+        return null;
+    }
+    const segments = sharedGamePath.split('/');
+    const isSharedGameDocumentPath = segments.length >= 2
+        && segments.length % 2 === 0
+        && segments.every(Boolean)
+        && segments.at(-2) === 'sharedGames';
+    return isSharedGameDocumentPath ? sharedGamePath : null;
 }
 
 export function projectSharedGameForTeam(sharedGame, teamId) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "app:check-bundle-size": "node scripts/check-app-bundle-size.mjs",
     "serve:firebase": "firebase emulators:start --only hosting --project demo-allplays",
     "app:dev": "npm --prefix apps/app run dev",
-    "app:build": "npm --prefix apps/app run build && node scripts/verify-app-bundle-visualizer.mjs",
+    "app:build": "npm --prefix apps/app run build && node scripts/verify-app-bundle-visualizer.mjs && npm run app:check-bundle-size",
     "app:preview": "npm --prefix apps/app run preview",
     "app:validate-performance-measurements": "node scripts/validate-app-performance-measurements.mjs",
     "mobile:serve": "npm run app:dev",

--- a/scripts/check-app-bundle-size.mjs
+++ b/scripts/check-app-bundle-size.mjs
@@ -1,3 +1,4 @@
+import { gzipSync } from 'node:zlib';
 import { readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
@@ -5,8 +6,12 @@ import process from 'node:process';
 const repoRoot = process.cwd();
 const distDir = path.resolve(repoRoot, process.env.APP_DIST_DIR || 'apps/app/dist');
 const indexHtmlPath = path.join(distDir, 'index.html');
-const defaultEntryBudgetBytes = 1_420_000;
-const entryBudgetBytes = parsePositiveInteger(process.env.APP_ENTRY_CHUNK_LIMIT_BYTES) || defaultEntryBudgetBytes;
+const budgets = {
+  entryBytes: parsePositiveInteger(process.env.APP_ENTRY_CHUNK_LIMIT_BYTES) || 1_420_000,
+  initialGzipBytes: parsePositiveInteger(process.env.APP_INITIAL_GZIP_LIMIT_BYTES) || 600 * 1024,
+  initialFiles: parsePositiveInteger(process.env.APP_INITIAL_FILE_LIMIT) || 40,
+  modulePreloads: parsePositiveInteger(process.env.APP_MODULE_PRELOAD_LIMIT) || 20
+};
 
 const indexHtml = await readFile(indexHtmlPath, 'utf8').catch((error) => {
   throw new Error(`Unable to read app build output at ${indexHtmlPath}: ${error.message}`);
@@ -17,20 +22,69 @@ if (!entryScriptMatch) {
   throw new Error(`Unable to find the app entry chunk in ${indexHtmlPath}. Run npm run app:build first.`);
 }
 
-const entryChunkPath = path.resolve(distDir, entryScriptMatch[1].replace(/^\.\//, ''));
+const entryChunkRelativePath = normalizeAssetPath(entryScriptMatch[1]);
+const entryChunkPath = path.resolve(distDir, entryChunkRelativePath);
 const entryChunkStats = await stat(entryChunkPath).catch((error) => {
   throw new Error(`Unable to read app entry chunk at ${entryChunkPath}: ${error.message}`);
 });
+const initialAssets = new Set(
+  [...indexHtml.matchAll(/(?:src|href)=["']([^"']+\.(?:js|css))["']/gi)]
+    .map((match) => normalizeAssetPath(match[1]))
+);
+await collectStaticImports(entryChunkRelativePath, initialAssets);
 
-const entrySizeBytes = entryChunkStats.size;
-const entryBudgetKb = bytesToKb(entryBudgetBytes);
-const entrySizeKb = bytesToKb(entrySizeBytes);
-
-if (entrySizeBytes > entryBudgetBytes) {
-  throw new Error(`App entry chunk is ${entrySizeKb} KB, over the ${entryBudgetKb} KB budget. Update the bundle or intentionally raise APP_ENTRY_CHUNK_LIMIT_BYTES.`);
+let initialGzipBytes = 0;
+for (const relativePath of initialAssets) {
+  const contents = await readFile(path.join(distDir, relativePath));
+  initialGzipBytes += gzipSync(contents).length;
 }
 
-console.log(`App entry chunk ${path.relative(repoRoot, entryChunkPath)} is ${entrySizeKb} KB, within the ${entryBudgetKb} KB budget.`);
+const measurements = {
+  entryBytes: entryChunkStats.size,
+  initialGzipBytes,
+  initialFiles: initialAssets.size,
+  modulePreloads: (indexHtml.match(/\bmodulepreload\b/gi) || []).length
+};
+const failures = [];
+
+checkBudget('entry chunk', measurements.entryBytes, budgets.entryBytes, 'bytes', failures);
+checkBudget('initial static payload (gzip)', measurements.initialGzipBytes, budgets.initialGzipBytes, 'bytes', failures);
+checkBudget('initial asset count', measurements.initialFiles, budgets.initialFiles, 'files', failures);
+checkBudget('HTML modulepreload count', measurements.modulePreloads, budgets.modulePreloads, 'preloads', failures);
+
+if (failures.length > 0) {
+  throw new Error(`App cold-start budget failed:\n- ${failures.join('\n- ')}`);
+}
+
+console.log(
+  `App cold-start budget passed: entry ${bytesToKb(measurements.entryBytes)} KB; `
+  + `${measurements.initialFiles} initial assets / ${bytesToKb(measurements.initialGzipBytes)} KB gzip; `
+  + `${measurements.modulePreloads} modulepreloads.`
+);
+
+async function collectStaticImports(relativePath, collected) {
+  const source = await readFile(path.join(distDir, relativePath), 'utf8');
+  const importPattern = /(?:from|import)\s*["'](\.\/[^"']+\.js)["']/g;
+  for (const match of source.matchAll(importPattern)) {
+    const dependency = path.posix.normalize(path.posix.join(path.posix.dirname(relativePath), match[1]));
+    if (collected.has(dependency)) continue;
+    collected.add(dependency);
+    await collectStaticImports(dependency, collected);
+  }
+}
+
+function normalizeAssetPath(assetPath) {
+  return assetPath.replace(/[?#].*$/, '').replace(/^\.?\//, '');
+}
+
+function checkBudget(label, actual, limit, unit, failures) {
+  if (actual > limit) {
+    const display = unit === 'bytes'
+      ? `${bytesToKb(actual)} KB > ${bytesToKb(limit)} KB`
+      : `${actual} ${unit} > ${limit} ${unit}`;
+    failures.push(`${label}: ${display}`);
+  }
+}
 
 function parsePositiveInteger(value) {
   const parsed = Number.parseInt(String(value || ''), 10);

--- a/scripts/stage-pages-bundle.mjs
+++ b/scripts/stage-pages-bundle.mjs
@@ -59,6 +59,19 @@ const primaryFirebaseRuntimeConfig = {
     appId: '1:982493478258:web:1f942c420cef6c40e8b1eb',
     measurementId: 'G-VTLSFV4PHW'
 };
+const previewSmokeFirebaseRuntimeConfig = {
+    apiKey: 'preview-smoke-key',
+    authDomain: 'allplays-preview-smoke.firebaseapp.com',
+    projectId: 'allplays-preview-smoke',
+    messagingSenderId: '123456789',
+    appId: '1:123456789:web:previewsmoke'
+};
+
+export function resolveStagedFirebaseRuntimeConfig(target) {
+    return target === 'preview-smoke'
+        ? previewSmokeFirebaseRuntimeConfig
+        : primaryFirebaseRuntimeConfig;
+}
 const pagesMetaUnsupportedDirectives = new Set(['frame-ancestors']);
 const widgetScoreboardRelativePath = 'widget-scoreboard.html';
 
@@ -234,10 +247,13 @@ export function injectPagesSecurityMeta(destinationDir, { rootDir = defaultRootD
     };
 }
 
-export function createAppCheckRuntimeConfig(siteKey, { enforcementReady = false } = {}) {
+export function createAppCheckRuntimeConfig(
+    siteKey,
+    { enforcementReady = false, firebaseConfig = primaryFirebaseRuntimeConfig } = {}
+) {
     if (!isAppCheckEnforcementReady(enforcementReady)) {
         return {
-            firebase: primaryFirebaseRuntimeConfig,
+            firebase: firebaseConfig,
             appCheck: {
                 enabled: false,
                 isTokenAutoRefreshEnabled: true
@@ -253,7 +269,7 @@ export function createAppCheckRuntimeConfig(siteKey, { enforcementReady = false 
     }
 
     return {
-        firebase: primaryFirebaseRuntimeConfig,
+        firebase: firebaseConfig,
         appCheck: {
             enabled: true,
             recaptchaEnterpriseSiteKey: normalizedSiteKey,
@@ -262,12 +278,19 @@ export function createAppCheckRuntimeConfig(siteKey, { enforcementReady = false 
     };
 }
 
-export function writeAppCheckRuntimeConfig(destinationDir, siteKey, { enforcementReady = false } = {}) {
+export function writeAppCheckRuntimeConfig(
+    destinationDir,
+    siteKey,
+    { enforcementReady = false, firebaseConfig = primaryFirebaseRuntimeConfig } = {}
+) {
     const outputPath = path.join(destinationDir, appCheckRuntimeConfigRelativePath);
     fs.mkdirSync(path.dirname(outputPath), { recursive: true });
     fs.writeFileSync(
         outputPath,
-        `${JSON.stringify(createAppCheckRuntimeConfig(siteKey, { enforcementReady }), null, 2)}\n`
+        `${JSON.stringify(createAppCheckRuntimeConfig(
+            siteKey,
+            { enforcementReady, firebaseConfig }
+        ), null, 2)}\n`
     );
     return outputPath;
 }
@@ -352,6 +375,9 @@ export function stagePagesBundle(destinationDir, { rootDir = defaultRootDir } = 
         {
             enforcementReady: isAppCheckEnforcementReady(
                 process.env.ALLPLAYS_APP_CHECK_ENFORCEMENT_READY
+            ),
+            firebaseConfig: resolveStagedFirebaseRuntimeConfig(
+                process.env.ALLPLAYS_FIREBASE_RUNTIME_TARGET
             )
         }
     );

--- a/scripts/stage-pages-bundle.mjs
+++ b/scripts/stage-pages-bundle.mjs
@@ -50,6 +50,15 @@ const excludedPublicClaimPaths = new Set([
 ]);
 
 const appCheckRuntimeConfigRelativePath = path.join('.well-known', 'allplays-runtime-config.json');
+const primaryFirebaseRuntimeConfig = {
+    apiKey: 'AIzaSyDoixIoKJuUVWdmImwjYRTthjKOv2mU0Jc',
+    authDomain: 'game-flow-c6311.firebaseapp.com',
+    projectId: 'game-flow-c6311',
+    storageBucket: 'game-flow-c6311.firebasestorage.app',
+    messagingSenderId: '982493478258',
+    appId: '1:982493478258:web:1f942c420cef6c40e8b1eb',
+    measurementId: 'G-VTLSFV4PHW'
+};
 const pagesMetaUnsupportedDirectives = new Set(['frame-ancestors']);
 const widgetScoreboardRelativePath = 'widget-scoreboard.html';
 
@@ -228,6 +237,7 @@ export function injectPagesSecurityMeta(destinationDir, { rootDir = defaultRootD
 export function createAppCheckRuntimeConfig(siteKey, { enforcementReady = false } = {}) {
     if (!isAppCheckEnforcementReady(enforcementReady)) {
         return {
+            firebase: primaryFirebaseRuntimeConfig,
             appCheck: {
                 enabled: false,
                 isTokenAutoRefreshEnabled: true
@@ -243,6 +253,7 @@ export function createAppCheckRuntimeConfig(siteKey, { enforcementReady = false 
     }
 
     return {
+        firebase: primaryFirebaseRuntimeConfig,
         appCheck: {
             enabled: true,
             recaptchaEnterpriseSiteKey: normalizedSiteKey,

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -235,6 +235,13 @@ export function validateFirebaseDeployWorkloadIdentity(workflow, label) {
     // that behavior for environment-like identifiers so constructs such as
     // GOOGLE_"APPLICATION"_CREDENTIALS cannot bypass the static-key guard.
     const normalizedCredentialPolicyText = scalarPolicyText
+        // Production role-smoke accounts are application test fixtures, not
+        // Google/Firebase deployment credentials. Keep this allowlist exact so
+        // generic secrets and credential-shaped values remain forbidden.
+        .replace(
+            /\$\{\{\s*secrets\.SMOKE_(?:ADMIN|STAFF|PARENT)_(?:EMAIL|PASSWORD)\s*\}\}/g,
+            ''
+        )
         .replace(/(["'])([A-Z0-9_]*)\1/gi, '$2')
         .replace(/(?<=[A-Z0-9_])["'](?=[A-Z0-9_])/gi, '');
     const forbiddenScalarPatterns = [

--- a/tests/coverage/feature-coverage-map.json
+++ b/tests/coverage/feature-coverage-map.json
@@ -772,6 +772,7 @@
                 "listPublicOpportunities",
                 "listPublicOpportunityReports",
                 "moderatePublicOpportunity",
+                "publicHomepageGamesV1",
                 "publicTeamGamesV1",
                 "publicTeamRosterV1",
                 "renewPublicOpportunity",
@@ -782,6 +783,8 @@
             "unitTests": [
                 "functions/test/public-team-api-core.test.cjs",
                 "functions/test/public-team-api-handler-contract.test.cjs",
+                "functions/test/public-homepage-games-core.test.cjs",
+                "functions/test/public-homepage-games-handler-contract.test.cjs",
                 "tests/unit/public-opportunities-core.test.js",
                 "tests/unit/public-opportunities-functions-source.test.js",
                 "tests/unit/public-opportunities-rules.test.js"

--- a/tests/setupTests.js
+++ b/tests/setupTests.js
@@ -1,0 +1,12 @@
+if (typeof window !== 'undefined') {
+    window.__ALLPLAYS_CONFIG__ = {
+        ...window.__ALLPLAYS_CONFIG__,
+        firebase: window.__ALLPLAYS_CONFIG__?.firebase || {
+            apiKey: 'test-api-key',
+            authDomain: 'test-allplays.firebaseapp.com',
+            projectId: 'test-allplays',
+            messagingSenderId: '123456789',
+            appId: 'test-app-id'
+        }
+    };
+}

--- a/tests/smoke/app-admin-core.spec.js
+++ b/tests/smoke/app-admin-core.spec.js
@@ -1,0 +1,48 @@
+import { expect, test } from '@playwright/test';
+import {
+    collectAppRuntimeIssues,
+    createAuthenticatedStorageState,
+    getAppSmokeConfig,
+    openAuthenticatedAppRoute,
+    redactSmokeDiagnostic
+} from './helpers/app-auth.js';
+
+const config = getAppSmokeConfig();
+const enabled = Boolean(config.appBaseUrl) &&
+    ['production', 'extended-production'].includes(process.env.SMOKE_SUITE || '');
+const secrets = [config.adminEmail, config.adminPassword];
+
+test.skip(!enabled, 'Platform-admin workflow runs only in production smoke');
+test.describe.configure({ mode: 'serial' });
+
+let adminStorageState;
+
+test.beforeAll(async ({ browser }) => {
+    expect(config.adminEmail, 'SMOKE_ADMIN_EMAIL is required').toBeTruthy();
+    expect(config.adminPassword, 'SMOKE_ADMIN_PASSWORD is required').toBeTruthy();
+    adminStorageState = await createAuthenticatedStorageState(browser, {
+        appBaseUrl: config.appBaseUrl,
+        email: config.adminEmail,
+        password: config.adminPassword,
+        roleLabel: 'platform admin'
+    });
+});
+
+test('platform admin Home loads without a platform-wide team fanout', async ({ browser }) => {
+    const context = await browser.newContext({
+        storageState: adminStorageState,
+        serviceWorkers: 'block'
+    });
+    const page = await context.newPage();
+    const issues = collectAppRuntimeIssues(page, secrets);
+    const startedAt = Date.now();
+    try {
+        await openAuthenticatedAppRoute(page, config.appBaseUrl, '/home', {
+            heading: 'Your day'
+        });
+        expect(Date.now() - startedAt, 'Platform-admin Home should become usable within 20 seconds').toBeLessThan(20_000);
+        expect(issues.map((issue) => redactSmokeDiagnostic(issue, secrets))).toEqual([]);
+    } finally {
+        await context.close();
+    }
+});

--- a/tests/smoke/app-production-bootstrap.spec.js
+++ b/tests/smoke/app-production-bootstrap.spec.js
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 const appBootUrl = process.env.SMOKE_APP_BOOT_URL || '';
+const previewSmokeRuntime = process.env.SMOKE_EXPECTED_FIREBASE_RUNTIME_TARGET === 'preview-smoke';
 test.skip(!appBootUrl, 'SMOKE_APP_BOOT_URL is required for production app boot smoke tests');
 
 function appUrl(hashPath = '/auth') {
@@ -18,6 +19,12 @@ test('production React app boots from deployed /app bundle', async ({ page }) =>
     const stylesheetResponses = [];
 
     page.on('pageerror', (error) => {
+        if (
+            previewSmokeRuntime
+            && /Installations:.*API key not valid/i.test(error.message)
+        ) {
+            return;
+        }
         fatalErrors.push(error.message);
     });
 

--- a/tests/smoke/firebase-auth-bootstrap.spec.js
+++ b/tests/smoke/firebase-auth-bootstrap.spec.js
@@ -2,7 +2,12 @@ import { test, expect } from '@playwright/test';
 import { createBootIssueCollector } from './helpers/boot-path.js';
 
 const appBaseUrl = process.env.SMOKE_APP_BASE_URL || process.env.SMOKE_APP_BOOT_URL || '';
+const usesSyntheticPreviewFirebase = process.env.SMOKE_EXPECTED_FIREBASE_RUNTIME_TARGET === 'preview-smoke';
 test.skip(!appBaseUrl, 'SMOKE_APP_BASE_URL or SMOKE_APP_BOOT_URL is required');
+test.skip(
+    usesSyntheticPreviewFirebase,
+    'Real Firebase bootstrap probes require a valid Firebase runtime identity'
+);
 
 function appUrl(route) {
     const url = new URL(appBaseUrl);

--- a/tests/smoke/helpers/app-auth.js
+++ b/tests/smoke/helpers/app-auth.js
@@ -9,6 +9,8 @@ const sensitivePatterns = [
 export function getAppSmokeConfig() {
     return {
         appBaseUrl: process.env.SMOKE_APP_BASE_URL || process.env.SMOKE_APP_BOOT_URL || '',
+        adminEmail: process.env.SMOKE_ADMIN_EMAIL || '',
+        adminPassword: process.env.SMOKE_ADMIN_PASSWORD || '',
         staffEmail: process.env.SMOKE_STAFF_EMAIL || process.env.SMOKE_AUTH_EMAIL || '',
         staffPassword: process.env.SMOKE_STAFF_PASSWORD || process.env.SMOKE_AUTH_PASSWORD || '',
         parentEmail: process.env.SMOKE_PARENT_EMAIL || process.env.SMOKE_AUTH_EMAIL || '',

--- a/tests/smoke/homepage-discovery.spec.js
+++ b/tests/smoke/homepage-discovery.spec.js
@@ -28,48 +28,43 @@ async function installHomepageModuleMocks(page) {
             return;
         }
 
-        if (url.pathname.endsWith('/js/db.js')) {
+        if (url.pathname.endsWith('/js/public-homepage-games.js')) {
             await route.fulfill({
                 contentType: 'application/javascript',
                 body: `
-                    function timestamp(isoValue) {
-                        return { toDate() { return new Date(isoValue); } };
-                    }
-                    export async function getLiveGamesNow() {
-                        return [{
+                    export async function getPublicHomepageGames() {
+                        return {
+                          live: [{
                             id: 'smoke-live-1',
                             teamId: 'smoke-team-live',
                             opponent: 'Falcons',
-                            date: timestamp('2026-04-10T23:00:00.000Z'),
+                            date: '2026-04-10T23:00:00.000Z',
                             homeScore: 21,
                             awayScore: 17,
                             liveViewerCount: 3,
                             liveStatus: 'live',
                             team: { id: 'smoke-team-live', name: 'Smoke Tigers', photoUrl: '' }
-                        }];
-                    }
-                    export async function getUpcomingLiveGames() {
-                        return [{
+                          }],
+                          upcoming: [{
                             id: 'smoke-upcoming-1',
                             teamId: 'smoke-team-upcoming',
                             opponent: 'Owls',
-                            date: timestamp('2026-04-11T20:30:00.000Z'),
+                            date: '2026-04-11T20:30:00.000Z',
                             status: 'scheduled',
                             liveStatus: 'scheduled',
                             team: { id: 'smoke-team-upcoming', name: 'Smoke Panthers', photoUrl: '' }
-                        }];
-                    }
-                    export async function getRecentLiveTrackedGames() {
-                        return [{
+                          }],
+                          replays: [{
                             id: 'smoke-replay-1',
                             teamId: 'smoke-team-replay',
                             opponent: 'Bears',
-                            date: timestamp('2026-04-09T01:15:00.000Z'),
+                            date: '2026-04-09T01:15:00.000Z',
                             homeScore: 44,
                             awayScore: 41,
                             liveStatus: 'completed',
                             team: { id: 'smoke-team-replay', name: 'Smoke Wolves', photoUrl: '' }
-                        }];
+                          }]
+                        };
                     }
                 `
             });

--- a/tests/smoke/homepage-discovery.spec.js
+++ b/tests/smoke/homepage-discovery.spec.js
@@ -34,6 +34,8 @@ async function installHomepageModuleMocks(page) {
                 body: `
                     export async function getPublicHomepageGames() {
                         return {
+                          partial: true,
+                          partialCategories: ['live', 'replays'],
                           live: [{
                             id: 'smoke-live-1',
                             teamId: 'smoke-team-live',
@@ -108,6 +110,7 @@ test('homepage resolves live/upcoming and replay discovery cards', async ({ page
     });
     await expect(page.locator('#live-games-list')).toContainText('Smoke Tigers');
     await expect(page.locator('#live-games-list')).toContainText('Smoke Panthers');
+    await expect(page.locator('#live-games-list')).toContainText('Some live or upcoming games may be missing.');
     await expect(page.locator('#live-games-list a[href="live-game.html?teamId=smoke-team-live&gameId=smoke-live-1"]')).toHaveCount(1);
     await expect(page.locator('#live-games-list a[href="live-game.html?teamId=smoke-team-upcoming&gameId=smoke-upcoming-1"]')).toHaveCount(1);
 
@@ -117,5 +120,6 @@ test('homepage resolves live/upcoming and replay discovery cards', async ({ page
         ctaPattern: /Watch Replay/
     });
     await expect(page.locator('#past-games-list')).toContainText('Smoke Wolves');
+    await expect(page.locator('#past-games-list')).toContainText('Some recent replays may be missing.');
     await expect(page.locator('#past-games-list a[href="live-game.html?teamId=smoke-team-replay&gameId=smoke-replay-1&replay=true"]')).toHaveCount(1);
 });

--- a/tests/smoke/pages-staged-artifact.spec.js
+++ b/tests/smoke/pages-staged-artifact.spec.js
@@ -4,7 +4,8 @@ import path from 'node:path';
 import {
     createAppCheckRuntimeConfig,
     isAppCheckEnforcementReady,
-    readPagesSecurityMetaPolicies
+    readPagesSecurityMetaPolicies,
+    resolveStagedFirebaseRuntimeConfig
 } from '../../scripts/stage-pages-bundle.mjs';
 
 const stagedArtifactEnabled = process.env.SMOKE_PAGES_STAGED_ARTIFACT === 'true';
@@ -12,6 +13,8 @@ const expectedEnforcementReady = isAppCheckEnforcementReady(
     process.env.SMOKE_EXPECTED_APP_CHECK_ENFORCEMENT_READY
 );
 const expectedSiteKey = process.env.SMOKE_EXPECTED_APP_CHECK_SITE_KEY || '';
+const expectedFirebaseRuntimeTarget = process.env.SMOKE_EXPECTED_FIREBASE_RUNTIME_TARGET || '';
+const previewSmokeRuntime = expectedFirebaseRuntimeTarget === 'preview-smoke';
 const securityPolicies = readPagesSecurityMetaPolicies(path.resolve(import.meta.dirname, '../..'));
 
 test.describe('exact staged GitHub Pages artifact', () => {
@@ -26,7 +29,8 @@ test.describe('exact staged GitHub Pages artifact', () => {
         expect(runtimeConfigResponse.status()).toBe(200);
         const runtimeConfig = await runtimeConfigResponse.json();
         expect(runtimeConfig).toEqual(createAppCheckRuntimeConfig(expectedSiteKey, {
-            enforcementReady: expectedEnforcementReady
+            enforcementReady: expectedEnforcementReady,
+            firebaseConfig: resolveStagedFirebaseRuntimeConfig(expectedFirebaseRuntimeTarget)
         }));
         if (expectedEnforcementReady) {
             expect(expectedSiteKey).toMatch(/^[A-Za-z0-9_-]{10,200}$/);
@@ -64,6 +68,12 @@ test.describe('exact staged GitHub Pages artifact', () => {
         const externalAttestationRequests = [];
 
         page.on('pageerror', (error) => {
+            if (
+                previewSmokeRuntime
+                && /Installations:.*API key not valid/i.test(error.message)
+            ) {
+                return;
+            }
             fatalErrors.push(error.message);
         });
         page.on('requestfailed', (request) => {

--- a/tests/smoke/pages-staged-artifact.spec.js
+++ b/tests/smoke/pages-staged-artifact.spec.js
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/test';
 import path from 'node:path';
 
 import {
+    createAppCheckRuntimeConfig,
     isAppCheckEnforcementReady,
     readPagesSecurityMetaPolicies
 } from '../../scripts/stage-pages-bundle.mjs';
@@ -24,22 +25,11 @@ test.describe('exact staged GitHub Pages artifact', () => {
         const runtimeConfigResponse = await request.get('/.well-known/allplays-runtime-config.json');
         expect(runtimeConfigResponse.status()).toBe(200);
         const runtimeConfig = await runtimeConfigResponse.json();
+        expect(runtimeConfig).toEqual(createAppCheckRuntimeConfig(expectedSiteKey, {
+            enforcementReady: expectedEnforcementReady
+        }));
         if (expectedEnforcementReady) {
-            expect(runtimeConfig).toEqual({
-                appCheck: {
-                    enabled: true,
-                    recaptchaEnterpriseSiteKey: expectedSiteKey,
-                    isTokenAutoRefreshEnabled: true
-                }
-            });
             expect(expectedSiteKey).toMatch(/^[A-Za-z0-9_-]{10,200}$/);
-        } else {
-            expect(runtimeConfig).toEqual({
-                appCheck: {
-                    enabled: false,
-                    isTokenAutoRefreshEnabled: true
-                }
-            });
         }
 
         for (const path of [

--- a/tests/smoke/static-hosting-bootstrap.spec.js
+++ b/tests/smoke/static-hosting-bootstrap.spec.js
@@ -62,6 +62,12 @@ test.describe('preview boot smoke pages', () => {
             await assertPageBootsWithoutFatalErrors(page, {
                 baseURL,
                 ...definition,
+                expectedAttributes: (
+                    previewSmokeRuntime
+                    && definition.name === 'player details without game context'
+                )
+                    ? []
+                    : definition.expectedAttributes,
                 ignoredConsoleErrors: [
                     ...(definition.ignoredConsoleErrors || []),
                     ...previewRuntimeIgnoredErrors

--- a/tests/smoke/static-hosting-bootstrap.spec.js
+++ b/tests/smoke/static-hosting-bootstrap.spec.js
@@ -1,4 +1,5 @@
 import { test } from '@playwright/test';
+import { PUBLIC_HOMEPAGE_GAMES_URL } from '../../js/public-homepage-games.js';
 import { assertPageBootsWithoutFatalErrors } from './helpers/boot-path.js';
 import {
     getAuthenticatedSmokePages,
@@ -18,9 +19,27 @@ async function loginWithPassword(page, baseURL, email, password) {
 
 const smokeContext = getSmokeContext();
 
+async function stubHomepageEndpointForBootIsolation(page) {
+    await page.route(PUBLIC_HOMEPAGE_GAMES_URL, async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                version: 1,
+                live: [],
+                upcoming: [],
+                replays: []
+            })
+        });
+    });
+}
+
 test.describe('public smoke pages', () => {
     for (const definition of getPublicSmokePages()) {
         test(`${definition.name} renders`, async ({ page, baseURL }) => {
+            if (definition.name === 'homepage') {
+                await stubHomepageEndpointForBootIsolation(page);
+            }
             await assertPageBootsWithoutFatalErrors(page, {
                 baseURL,
                 ...definition

--- a/tests/smoke/static-hosting-bootstrap.spec.js
+++ b/tests/smoke/static-hosting-bootstrap.spec.js
@@ -18,6 +18,10 @@ async function loginWithPassword(page, baseURL, email, password) {
 }
 
 const smokeContext = getSmokeContext();
+const previewSmokeRuntime = process.env.SMOKE_EXPECTED_FIREBASE_RUNTIME_TARGET === 'preview-smoke';
+const previewRuntimeIgnoredErrors = previewSmokeRuntime
+    ? [/Installations:.*API key not valid/i]
+    : [];
 
 async function stubHomepageEndpointForBootIsolation(page) {
     await page.route(PUBLIC_HOMEPAGE_GAMES_URL, async (route) => {
@@ -42,7 +46,11 @@ test.describe('public smoke pages', () => {
             }
             await assertPageBootsWithoutFatalErrors(page, {
                 baseURL,
-                ...definition
+                ...definition,
+                ignoredConsoleErrors: [
+                    ...(definition.ignoredConsoleErrors || []),
+                    ...previewRuntimeIgnoredErrors
+                ]
             });
         });
     }
@@ -53,14 +61,21 @@ test.describe('preview boot smoke pages', () => {
         test(`${definition.name} boots without fatal runtime errors`, async ({ page, baseURL }) => {
             await assertPageBootsWithoutFatalErrors(page, {
                 baseURL,
-                ...definition
+                ...definition,
+                ignoredConsoleErrors: [
+                    ...(definition.ignoredConsoleErrors || []),
+                    ...previewRuntimeIgnoredErrors
+                ]
             });
         });
     }
 });
 
 test.describe('authenticated smoke pages', () => {
-    test.skip(!smokeContext.authEmail || !smokeContext.authPassword, 'SMOKE_AUTH_EMAIL and SMOKE_AUTH_PASSWORD are required');
+    test.skip(
+        previewSmokeRuntime || !smokeContext.authEmail || !smokeContext.authPassword,
+        'Authenticated smoke requires a configured non-isolated Firebase runtime.'
+    );
     test.setTimeout(300_000);
 
     test('authenticated coach and parent pages render', async ({ page, baseURL }) => {

--- a/tests/unit/access-code-validation.test.js
+++ b/tests/unit/access-code-validation.test.js
@@ -47,7 +47,7 @@ vi.mock('../../js/firebase.js?v=23', () => ({
 
 vi.mock('../../js/firebase.js?v=22', async () => import('../../js/firebase.js?v=23'));
 
-vi.mock('../../js/firebase-images.js?v=10', () => ({
+vi.mock('../../js/firebase-images.js?v=11', () => ({
     imageStorage: {},
     ensureImageAuth: vi.fn(),
     requireImageAuth: vi.fn()

--- a/tests/unit/admin-user-search-db.test.js
+++ b/tests/unit/admin-user-search-db.test.js
@@ -56,7 +56,7 @@ vi.mock('../../js/firebase.js?v=23', () => ({
     deleteObject: vi.fn()
 }));
 
-vi.mock('../../js/firebase-images.js?v=10', () => ({
+vi.mock('../../js/firebase-images.js?v=11', () => ({
     imageStorage: {},
     ensureImageAuth: vi.fn(),
     requireImageAuth: vi.fn()

--- a/tests/unit/app-bundle-size-script.test.js
+++ b/tests/unit/app-bundle-size-script.test.js
@@ -1,0 +1,66 @@
+import {
+    mkdirSync,
+    mkdtempSync,
+    rmSync,
+    writeFileSync
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const tempDirs = [];
+
+afterEach(() => {
+    tempDirs.splice(0).forEach((directory) => rmSync(directory, { recursive: true, force: true }));
+});
+
+describe('app cold-start bundle budget', () => {
+    it('recursively counts minified static imports in file and gzip totals', () => {
+        const distDir = mkdtempSync(path.join(tmpdir(), 'allplays-app-budget-'));
+        tempDirs.push(distDir);
+        mkdirSync(path.join(distDir, 'assets'));
+        writeFileSync(
+            path.join(distDir, 'index.html'),
+            '<script type="module" src="./assets/index-fixture.js"></script>'
+        );
+        writeFileSync(
+            path.join(distDir, 'assets', 'index-fixture.js'),
+            'import"./setup.js";export{x}from"./chunk.js";'
+        );
+        writeFileSync(
+            path.join(distDir, 'assets', 'setup.js'),
+            'import"./nested.js";export const setup="abcdefghijklmnopqrstuvwxyz0123456789";'
+        );
+        writeFileSync(
+            path.join(distDir, 'assets', 'chunk.js'),
+            'export const x="ABCDEFGHIJKLMNOPQRSTUVWXYZ9876543210";'
+        );
+        writeFileSync(
+            path.join(distDir, 'assets', 'nested.js'),
+            'export const nested="qwertyuiopasdfghjklzxcvbnm2468013579";'
+        );
+
+        const result = spawnSync(
+            process.execPath,
+            ['scripts/check-app-bundle-size.mjs'],
+            {
+                cwd: path.resolve(import.meta.dirname, '../..'),
+                encoding: 'utf8',
+                env: {
+                    ...process.env,
+                    APP_DIST_DIR: distDir,
+                    APP_ENTRY_CHUNK_LIMIT_BYTES: '10000',
+                    APP_INITIAL_GZIP_LIMIT_BYTES: '100',
+                    APP_INITIAL_FILE_LIMIT: '2',
+                    APP_MODULE_PRELOAD_LIMIT: '10'
+                }
+            }
+        );
+        const output = `${result.stdout}\n${result.stderr}`;
+
+        expect(result.status).not.toBe(0);
+        expect(output).toContain('initial static payload (gzip)');
+        expect(output).toContain('initial asset count: 4 files > 2 files');
+    });
+});

--- a/tests/unit/app-performance-measurement-initiative-source-contract.test.js
+++ b/tests/unit/app-performance-measurement-initiative-source-contract.test.js
@@ -45,7 +45,7 @@ describe('app performance measurement initiative source contract', () => {
     });
 
     it('keeps app preview and bundle budget commands available for baseline captures', () => {
-        expect(packageSource).toContain('"app:build": "npm --prefix apps/app run build && node scripts/verify-app-bundle-visualizer.mjs"');
+        expect(packageSource).toContain('"app:build": "npm --prefix apps/app run build && node scripts/verify-app-bundle-visualizer.mjs && npm run app:check-bundle-size"');
         expect(packageSource).toContain('"app:preview": "npm --prefix apps/app run preview"');
         expect(packageSource).toContain('"app:check-bundle-size": "node scripts/check-app-bundle-size.mjs"');
         expect(packageSource).toContain('"app:validate-performance-measurements": "node scripts/validate-app-performance-measurements.mjs"');
@@ -53,10 +53,12 @@ describe('app performance measurement initiative source contract', () => {
         expect(ciSource).toContain('Validate app performance evidence when present');
         expect(ciSource).toContain('npm run app:validate-performance-measurements -- docs/app-performance-measurements.json');
 
-        expect(bundleSizeScriptSource).toContain("const defaultEntryBudgetBytes = 1_420_000;");
+        expect(bundleSizeScriptSource).toContain('entryBytes: parsePositiveInteger(process.env.APP_ENTRY_CHUNK_LIMIT_BYTES) || 1_420_000');
         expect(bundleSizeScriptSource).toContain('process.env.APP_ENTRY_CHUNK_LIMIT_BYTES');
+        expect(bundleSizeScriptSource).toContain('process.env.APP_INITIAL_GZIP_LIMIT_BYTES');
+        expect(bundleSizeScriptSource).toContain('process.env.APP_MODULE_PRELOAD_LIMIT');
         expect(bundleSizeScriptSource).toContain('Unable to find the app entry chunk');
-        expect(bundleSizeScriptSource).toContain('App entry chunk ${path.relative(repoRoot, entryChunkPath)} is ${entrySizeKb} KB');
+        expect(bundleSizeScriptSource).toContain('App cold-start budget passed');
 
         [
             'desktop-web',

--- a/tests/unit/app-vite-config.test.ts
+++ b/tests/unit/app-vite-config.test.ts
@@ -1,5 +1,4 @@
 import { readFileSync } from 'node:fs';
-import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import appViteConfig from '../../apps/app/vite.config.ts';
@@ -14,19 +13,23 @@ const resolvedAppViteConfig = typeof appViteConfig === 'function'
     : await appViteConfig;
 
 describe('app Vite config', () => {
-    it('keeps app source in the entry chunk', () => {
+    it('keeps lazy routes out of the HTML module-preload fanout', () => {
+        const resolveDependencies = resolvedAppViteConfig.build?.modulePreload &&
+            typeof resolvedAppViteConfig.build.modulePreload === 'object'
+            ? resolvedAppViteConfig.build.modulePreload.resolveDependencies
+            : undefined;
+
+        expect(resolveDependencies?.('index.js', ['route-a.js', 'route-b.js'], {
+            hostId: 'index.html',
+            hostType: 'html'
+        })).toEqual([]);
+        expect(resolveDependencies?.('route-a.js', ['shared.js'], {
+            hostId: 'route-a.js',
+            hostType: 'js'
+        })).toEqual(['shared.js']);
         const manualChunks = resolvedAppViteConfig.build?.rollupOptions?.output?.manualChunks;
-
-        expect(manualChunks?.('/workspace/apps/app/src/main.tsx')).toBeUndefined();
-    });
-
-    it('splits node_modules packages into stable vendor chunks', () => {
-        const manualChunks = resolvedAppViteConfig.build?.rollupOptions?.output?.manualChunks;
-        const reactModule = path.join('/workspace', 'node_modules', 'react', 'index.js');
-        const scopedModule = path.join('/workspace', 'node_modules', '@capacitor', 'core', 'dist', 'index.js');
-
-        expect(manualChunks?.(reactModule)).toBe('vendor-react');
-        expect(manualChunks?.(scopedModule)).toBe('vendor-@capacitor-core');
+        expect(manualChunks?.('/workspace/node_modules/lucide-react/dist/cjs/lucide-react.js')).toBe('app-shell-vendor');
+        expect(manualChunks?.('/workspace/node_modules/@sentry/browser/build/npm/esm/index.js')).toBeUndefined();
     });
 
     it('exposes the legacy JS directory through the @legacy alias', () => {

--- a/tests/unit/certificates-assets.test.js
+++ b/tests/unit/certificates-assets.test.js
@@ -9,7 +9,7 @@ const mocks = vi.hoisted(() => ({
     ref: vi.fn()
 }));
 
-vi.mock('../../js/firebase-images.js?v=10', () => ({
+vi.mock('../../js/firebase-images.js?v=11', () => ({
     imageStorage: {},
     requireImageAuth: mocks.requireImageAuth
 }));

--- a/tests/unit/db-team-access-query-resilience.test.js
+++ b/tests/unit/db-team-access-query-resilience.test.js
@@ -49,7 +49,7 @@ vi.mock('../../js/firebase.js?v=23', () => ({
 
 vi.mock('../../js/firebase.js?v=22', async () => import('../../js/firebase.js?v=23'));
 
-vi.mock('../../js/firebase-images.js?v=10', () => ({
+vi.mock('../../js/firebase-images.js?v=11', () => ({
   imageStorage: {},
   ensureImageAuth: vi.fn(),
   requireImageAuth: vi.fn()

--- a/tests/unit/db-update-team-registration-provider-clear.test.js
+++ b/tests/unit/db-update-team-registration-provider-clear.test.js
@@ -43,7 +43,7 @@ vi.mock('../../js/firebase.js?v=23', () => ({
 
 vi.mock('../../js/firebase.js?v=22', async () => import('../../js/firebase.js?v=23'));
 
-vi.mock('../../js/firebase-images.js?v=10', () => ({
+vi.mock('../../js/firebase-images.js?v=11', () => ({
     imageStorage: {},
     ensureImageAuth: vi.fn(),
     requireImageAuth: vi.fn()

--- a/tests/unit/discover-public-teams-search-pagination.test.js
+++ b/tests/unit/discover-public-teams-search-pagination.test.js
@@ -50,7 +50,7 @@ vi.mock('../../js/firebase.js?v=23', () => ({
 
 vi.mock('../../js/firebase.js?v=22', async () => import('../../js/firebase.js?v=23'));
 
-vi.mock('../../js/firebase-images.js?v=10', () => ({
+vi.mock('../../js/firebase-images.js?v=11', () => ({
     imageStorage: {},
     ensureImageAuth: vi.fn(),
     requireImageAuth: vi.fn()

--- a/tests/unit/firebase-firestore-init.test.js
+++ b/tests/unit/firebase-firestore-init.test.js
@@ -84,7 +84,7 @@ vi.mock('../../js/firebase-app-check.js?v=2', () => ({
     initializePrimaryAppCheck: vi.fn(async () => ({ state: 'skipped' }))
 }));
 
-vi.mock('../../js/firebase-runtime-config.js?v=15', () => ({
+vi.mock('../../js/firebase-runtime-config.js?v=16', () => ({
     resolvePrimaryFirebaseConfig: vi.fn(async () => ({
         apiKey: 'test-key',
         authDomain: 'example.test',

--- a/tests/unit/firebase-firestore-init.test.js
+++ b/tests/unit/firebase-firestore-init.test.js
@@ -84,7 +84,7 @@ vi.mock('../../js/firebase-app-check.js?v=2', () => ({
     initializePrimaryAppCheck: vi.fn(async () => ({ state: 'skipped' }))
 }));
 
-vi.mock('../../js/firebase-runtime-config.js?v=11', () => ({
+vi.mock('../../js/firebase-runtime-config.js?v=12', () => ({
     resolvePrimaryFirebaseConfig: vi.fn(async () => ({
         apiKey: 'test-key',
         authDomain: 'example.test',

--- a/tests/unit/firebase-firestore-init.test.js
+++ b/tests/unit/firebase-firestore-init.test.js
@@ -84,7 +84,7 @@ vi.mock('../../js/firebase-app-check.js?v=2', () => ({
     initializePrimaryAppCheck: vi.fn(async () => ({ state: 'skipped' }))
 }));
 
-vi.mock('../../js/firebase-runtime-config.js?v=12', () => ({
+vi.mock('../../js/firebase-runtime-config.js?v=13', () => ({
     resolvePrimaryFirebaseConfig: vi.fn(async () => ({
         apiKey: 'test-key',
         authDomain: 'example.test',
@@ -110,7 +110,7 @@ describe('firebase firestore initialization', () => {
         });
         firestoreMocks.getFirestore.mockReturnValue(existingDb);
 
-        const module = await import('../../js/firebase.js?v=22');
+        const module = await import('../../js/firebase.js?v=23');
 
         expect(module.db).toBe(existingDb);
         expect(firestoreMocks.initializeFirestore).toHaveBeenCalledTimes(1);

--- a/tests/unit/firebase-firestore-init.test.js
+++ b/tests/unit/firebase-firestore-init.test.js
@@ -84,7 +84,7 @@ vi.mock('../../js/firebase-app-check.js?v=2', () => ({
     initializePrimaryAppCheck: vi.fn(async () => ({ state: 'skipped' }))
 }));
 
-vi.mock('../../js/firebase-runtime-config.js?v=14', () => ({
+vi.mock('../../js/firebase-runtime-config.js?v=15', () => ({
     resolvePrimaryFirebaseConfig: vi.fn(async () => ({
         apiKey: 'test-key',
         authDomain: 'example.test',

--- a/tests/unit/firebase-firestore-init.test.js
+++ b/tests/unit/firebase-firestore-init.test.js
@@ -84,7 +84,7 @@ vi.mock('../../js/firebase-app-check.js?v=2', () => ({
     initializePrimaryAppCheck: vi.fn(async () => ({ state: 'skipped' }))
 }));
 
-vi.mock('../../js/firebase-runtime-config.js?v=13', () => ({
+vi.mock('../../js/firebase-runtime-config.js?v=14', () => ({
     resolvePrimaryFirebaseConfig: vi.fn(async () => ({
         apiKey: 'test-key',
         authDomain: 'example.test',

--- a/tests/unit/firebase-runtime-config.test.js
+++ b/tests/unit/firebase-runtime-config.test.js
@@ -82,6 +82,31 @@ describe('firebase runtime config', () => {
         });
     });
 
+    it('rejects production Firebase returned by local hosting init', async () => {
+        resetGlobals();
+        globalThis.window.location = {
+            origin: 'http://localhost:3000',
+            protocol: 'http:',
+            hostname: 'localhost',
+            pathname: '/'
+        };
+        globalThis.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                apiKey: 'production-key',
+                authDomain: 'game-flow-c6311.firebaseapp.com',
+                projectId: 'game-flow-c6311',
+                messagingSenderId: '982493478258',
+                appId: 'production-app'
+            })
+        });
+
+        await expect(resolvePrimaryFirebaseConfig()).rejects.toThrow(
+            'Firebase config is unavailable for local development. Configure an explicit non-production Firebase project.'
+        );
+        expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    });
+
     it('uses an explicit non-production runtime fallback for isolated local preview smoke', async () => {
         resetGlobals();
         globalThis.window.location = {
@@ -199,6 +224,31 @@ describe('firebase runtime config', () => {
             'https://allplays-preview.web.app/__/firebase/init.json',
             { cache: 'no-store' }
         );
+    });
+
+    it('rejects production Firebase returned by Firebase Hosting preview init', async () => {
+        resetGlobals();
+        globalThis.window.location = {
+            origin: 'https://game-flow-c6311--preview.web.app',
+            protocol: 'https:',
+            hostname: 'game-flow-c6311--preview.web.app',
+            pathname: '/app/'
+        };
+        globalThis.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                apiKey: 'production-key',
+                authDomain: 'game-flow-c6311.firebaseapp.com',
+                projectId: 'game-flow-c6311',
+                messagingSenderId: '982493478258',
+                appId: 'production-app'
+            })
+        });
+
+        await expect(resolvePrimaryFirebaseConfig()).rejects.toThrow(
+            'Firebase Hosting init config points to production Firebase on a non-production host.'
+        );
+        expect(globalThis.fetch).toHaveBeenCalledOnce();
     });
 
     it('does not let a different non-production runtime file override a Firebase host identity', async () => {

--- a/tests/unit/firebase-runtime-config.test.js
+++ b/tests/unit/firebase-runtime-config.test.js
@@ -117,7 +117,7 @@ describe('firebase runtime config', () => {
         expect(globalThis.fetch).toHaveBeenCalledTimes(2);
     });
 
-    it('keeps the bundled fallback when local hosting and runtime config are unavailable', async () => {
+    it('fails closed when local hosting and runtime config are unavailable', async () => {
         resetGlobals();
         globalThis.window.location = {
             origin: 'http://localhost:3000',
@@ -130,9 +130,41 @@ describe('firebase runtime config', () => {
             status: 404
         });
 
-        const config = await resolvePrimaryFirebaseConfig();
+        await expect(resolvePrimaryFirebaseConfig()).rejects.toThrow(
+            'Firebase config is unavailable for local development. Configure an explicit non-production Firebase project.'
+        );
+        expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    });
 
-        expect(config.projectId).toBe('game-flow-c6311');
+    it('fails closed when localhost runtime config points at production Firebase', async () => {
+        resetGlobals();
+        globalThis.window.location = {
+            origin: 'http://127.0.0.1:4173',
+            protocol: 'http:',
+            hostname: '127.0.0.1',
+            pathname: '/app/'
+        };
+        globalThis.fetch = vi.fn(async (url) => {
+            if (url.endsWith('/__/firebase/init.json')) {
+                return { ok: false, status: 404 };
+            }
+            return {
+                ok: true,
+                json: async () => ({
+                    firebase: {
+                        apiKey: 'production-key',
+                        authDomain: 'game-flow-c6311.firebaseapp.com',
+                        projectId: 'game-flow-c6311',
+                        messagingSenderId: '982493478258',
+                        appId: 'production-app'
+                    }
+                })
+            };
+        });
+
+        await expect(resolvePrimaryFirebaseConfig()).rejects.toThrow(
+            'Firebase config is unavailable for local development. Configure an explicit non-production Firebase project.'
+        );
         expect(globalThis.fetch).toHaveBeenCalledTimes(2);
     });
 

--- a/tests/unit/firebase-runtime-config.test.js
+++ b/tests/unit/firebase-runtime-config.test.js
@@ -279,6 +279,63 @@ describe('firebase runtime config', () => {
         expect(globalThis.fetch).toHaveBeenCalledOnce();
     });
 
+    it.each([
+        'allplays.ai',
+        'www.allplays.ai',
+        'game-flow-c6311.web.app',
+        'game-flow-c6311.firebaseapp.com'
+    ])('rejects inline non-production Firebase config on production host %s', async (hostname) => {
+        resetGlobals();
+        globalThis.window.location = {
+            origin: `https://${hostname}`,
+            protocol: 'https:',
+            hostname,
+            pathname: '/app/'
+        };
+        globalThis.window.__ALLPLAYS_CONFIG__ = {
+            firebase: {
+                apiKey: 'preview-key',
+                authDomain: 'allplays-preview.firebaseapp.com',
+                projectId: 'allplays-preview',
+                messagingSenderId: '456',
+                appId: 'preview-app'
+            }
+        };
+        globalThis.fetch = vi.fn();
+
+        await expect(resolvePrimaryFirebaseConfig()).rejects.toThrow(
+            'Firebase config does not match the production Firebase project.'
+        );
+        expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-production Firebase from the canonical production runtime file', async () => {
+        resetGlobals();
+        globalThis.window.location = {
+            origin: 'https://allplays.ai',
+            protocol: 'https:',
+            hostname: 'allplays.ai',
+            pathname: '/app/'
+        };
+        globalThis.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                firebase: {
+                    apiKey: 'preview-key',
+                    authDomain: 'allplays-preview.firebaseapp.com',
+                    projectId: 'allplays-preview',
+                    messagingSenderId: '456',
+                    appId: 'preview-app'
+                }
+            })
+        });
+
+        await expect(resolvePrimaryFirebaseConfig()).rejects.toThrow(
+            'Firebase runtime config does not match the production Firebase project.'
+        );
+        expect(globalThis.fetch).toHaveBeenCalledOnce();
+    });
+
     it('rejects a non-production project returned by an official production Firebase alias', async () => {
         resetGlobals();
         globalThis.window.location = {
@@ -634,10 +691,10 @@ describe('firebase runtime config', () => {
             json: async () => ({
                 firebase: {
                     apiKey: 'runtime-key',
-                    authDomain: 'runtime.firebaseapp.com',
-                    projectId: 'runtime-project',
-                    messagingSenderId: '123',
-                    appId: 'runtime-app'
+                    authDomain: 'game-flow-c6311.firebaseapp.com',
+                    projectId: 'game-flow-c6311',
+                    messagingSenderId: '982493478258',
+                    appId: 'production-runtime-app'
                 },
                 appCheck: { enabled: false }
             })
@@ -648,7 +705,7 @@ describe('firebase runtime config', () => {
             resolveAppCheckRuntimeConfig()
         ]);
 
-        expect(firebaseConfig.projectId).toBe('runtime-project');
+        expect(firebaseConfig.projectId).toBe('game-flow-c6311');
         expect(appCheckConfig.enabled).toBe(false);
         expect(globalThis.fetch).toHaveBeenCalledOnce();
         expect(globalThis.fetch).not.toHaveBeenCalledWith(

--- a/tests/unit/firebase-runtime-config.test.js
+++ b/tests/unit/firebase-runtime-config.test.js
@@ -313,6 +313,12 @@ describe('firebase runtime config', () => {
 
     it('prefers explicit inline firebase config without making a network request', async () => {
         resetGlobals();
+        globalThis.window.location = {
+            origin: 'http://localhost:3000',
+            protocol: 'http:',
+            hostname: 'localhost',
+            pathname: '/'
+        };
         globalThis.window.__ALLPLAYS_CONFIG__ = {
             firebase: {
                 apiKey: 'inline-key',
@@ -346,6 +352,12 @@ describe('firebase runtime config', () => {
 
     it('falls back to inline config before bundled defaults when hosted init lookup fails', async () => {
         resetGlobals();
+        globalThis.window.location = {
+            origin: 'http://localhost:3000',
+            protocol: 'http:',
+            hostname: 'localhost',
+            pathname: '/'
+        };
         globalThis.window.__ALLPLAYS_CONFIG__ = {
             firebase: {
                 apiKey: 'inline-key',
@@ -368,6 +380,90 @@ describe('firebase runtime config', () => {
             projectId: 'inline-allplays',
             appId: 'inline-app'
         });
+    });
+
+    it('rejects inline production Firebase config on localhost', async () => {
+        resetGlobals();
+        globalThis.window.location = {
+            origin: 'http://localhost:3000',
+            protocol: 'http:',
+            hostname: 'localhost',
+            pathname: '/'
+        };
+        globalThis.window.__ALLPLAYS_CONFIG__ = {
+            firebase: {
+                apiKey: 'production-key',
+                authDomain: 'game-flow-c6311.firebaseapp.com',
+                projectId: 'game-flow-c6311',
+                messagingSenderId: '982493478258',
+                appId: 'production-app'
+            }
+        };
+        globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 });
+
+        await expect(resolvePrimaryFirebaseConfig()).rejects.toThrow(
+            'Firebase config is unavailable for local development. Configure an explicit non-production Firebase project.'
+        );
+        expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects inline production Firebase config on a custom preview host', async () => {
+        resetGlobals();
+        globalThis.window.location = {
+            origin: 'https://preview.example.com',
+            protocol: 'https:',
+            hostname: 'preview.example.com',
+            pathname: '/'
+        };
+        globalThis.window.__ALLPLAYS_CONFIG__ = {
+            firebase: {
+                apiKey: 'production-key',
+                authDomain: 'game-flow-c6311.firebaseapp.com',
+                projectId: 'game-flow-c6311',
+                messagingSenderId: '982493478258',
+                appId: 'production-app'
+            }
+        };
+        globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 });
+
+        await expect(resolvePrimaryFirebaseConfig()).rejects.toThrow(
+            'Firebase config is unavailable for this non-production host.'
+        );
+        expect(globalThis.fetch).toHaveBeenCalledOnce();
+    });
+
+    it('ignores inline production Firebase config on a Firebase Hosting preview', async () => {
+        resetGlobals();
+        globalThis.window.location = {
+            origin: 'https://allplays-preview.web.app',
+            protocol: 'https:',
+            hostname: 'allplays-preview.web.app',
+            pathname: '/'
+        };
+        globalThis.window.__ALLPLAYS_CONFIG__ = {
+            firebase: {
+                apiKey: 'production-key',
+                authDomain: 'game-flow-c6311.firebaseapp.com',
+                projectId: 'game-flow-c6311',
+                messagingSenderId: '982493478258',
+                appId: 'production-app'
+            }
+        };
+        globalThis.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                apiKey: 'preview-key',
+                authDomain: 'allplays-preview.firebaseapp.com',
+                projectId: 'allplays-preview',
+                messagingSenderId: '456',
+                appId: 'preview-app'
+            })
+        });
+
+        await expect(resolvePrimaryFirebaseConfig()).resolves.toMatchObject({
+            projectId: 'allplays-preview'
+        });
+        expect(globalThis.fetch).toHaveBeenCalledOnce();
     });
 
     it('returns the bundled image firebase config when no inline image config is present', () => {

--- a/tests/unit/firebase-runtime-config.test.js
+++ b/tests/unit/firebase-runtime-config.test.js
@@ -38,6 +38,11 @@ describe('firebase runtime config', () => {
 
     it('falls back to the bundled primary firebase config when hosting init is unavailable', async () => {
         resetGlobals();
+        globalThis.window.location = {
+            origin: 'https://allplays.ai',
+            hostname: 'allplays.ai',
+            pathname: '/'
+        };
         globalThis.fetch = vi.fn().mockResolvedValue({
             ok: false,
             status: 404
@@ -51,7 +56,7 @@ describe('firebase runtime config', () => {
         // project and broke Installations/FCM/Performance wherever the fallback ran.
         expect(config.appId).toBe('1:982493478258:web:1f942c420cef6c40e8b1eb');
         expect(config.messagingSenderId).toBe('982493478258');
-        expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+        expect(globalThis.fetch).toHaveBeenCalledOnce();
     });
 
     it('keeps hosted demo firebase config when served through local Firebase hosting', async () => {
@@ -75,6 +80,99 @@ describe('firebase runtime config', () => {
             projectId: 'demo-allplays',
             appId: 'demo-app'
         });
+    });
+
+    it('ignores a production runtime file on a non-production Firebase host', async () => {
+        resetGlobals();
+        globalThis.window.location = {
+            origin: 'https://allplays-preview.web.app',
+            hostname: 'allplays-preview.web.app',
+            pathname: '/app/'
+        };
+        globalThis.fetch = vi.fn(async (url) => {
+            if (url.endsWith('/.well-known/allplays-runtime-config.json')) {
+                return {
+                    ok: true,
+                    json: async () => ({
+                        firebase: {
+                            apiKey: 'production-key',
+                            authDomain: 'game-flow-c6311.firebaseapp.com',
+                            projectId: 'game-flow-c6311',
+                            messagingSenderId: '982493478258',
+                            appId: 'production-app'
+                        }
+                    })
+                };
+            }
+            if (url.endsWith('/__/firebase/init.json')) {
+                return {
+                    ok: true,
+                    json: async () => ({
+                        apiKey: 'preview-key',
+                        authDomain: 'allplays-preview.firebaseapp.com',
+                        projectId: 'allplays-preview',
+                        messagingSenderId: '456',
+                        appId: 'preview-app'
+                    })
+                };
+            }
+            throw new Error(`Unexpected URL: ${url}`);
+        });
+
+        const config = await resolvePrimaryFirebaseConfig();
+
+        expect(config.projectId).toBe('allplays-preview');
+        expect(globalThis.fetch).toHaveBeenNthCalledWith(
+            1,
+            'https://allplays-preview.web.app/.well-known/allplays-runtime-config.json',
+            { cache: 'no-store' }
+        );
+        expect(globalThis.fetch).toHaveBeenNthCalledWith(
+            2,
+            'https://allplays-preview.web.app/__/firebase/init.json',
+            { cache: 'no-store' }
+        );
+    });
+
+    it('fails closed when a non-production host has only the bundled production config', async () => {
+        resetGlobals();
+        globalThis.window.location = {
+            origin: 'https://preview.example.com',
+            hostname: 'preview.example.com',
+            pathname: '/'
+        };
+        globalThis.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                firebase: {
+                    apiKey: 'production-key',
+                    authDomain: 'game-flow-c6311.firebaseapp.com',
+                    projectId: 'game-flow-c6311',
+                    messagingSenderId: '982493478258',
+                    appId: 'production-app'
+                }
+            })
+        });
+
+        await expect(resolvePrimaryFirebaseConfig()).rejects.toThrow(
+            'Firebase config is unavailable for this non-production host.'
+        );
+    });
+
+    it('keeps the bundled config available to the packaged native app', async () => {
+        resetGlobals();
+        globalThis.window.location = {
+            origin: 'capacitor://localhost',
+            protocol: 'capacitor:',
+            hostname: 'localhost',
+            pathname: '/app/'
+        };
+        globalThis.fetch = vi.fn();
+
+        const config = await resolvePrimaryFirebaseConfig();
+
+        expect(config.projectId).toBe('game-flow-c6311');
+        expect(globalThis.fetch).not.toHaveBeenCalled();
     });
 
     it('prefers explicit inline firebase config without making a network request', async () => {
@@ -234,7 +332,7 @@ describe('firebase runtime config', () => {
     it('keeps every legacy browser importer on the explicit runtime-config cache contract', () => {
         for (const importer of ['firebase.js', 'firebase-images.js', 'firebase-app-check.js']) {
             const source = readFileSync(new URL(`../../js/${importer}`, import.meta.url), 'utf8');
-            expect(source).toContain('firebase-runtime-config.js?v=13');
+            expect(source).toContain('firebase-runtime-config.js?v=14');
         }
     });
 

--- a/tests/unit/firebase-runtime-config.test.js
+++ b/tests/unit/firebase-runtime-config.test.js
@@ -117,6 +117,25 @@ describe('firebase runtime config', () => {
         expect(globalThis.fetch).toHaveBeenCalledTimes(2);
     });
 
+    it('keeps the bundled fallback when local hosting and runtime config are unavailable', async () => {
+        resetGlobals();
+        globalThis.window.location = {
+            origin: 'http://localhost:3000',
+            protocol: 'http:',
+            hostname: 'localhost',
+            pathname: '/'
+        };
+        globalThis.fetch = vi.fn().mockResolvedValue({
+            ok: false,
+            status: 404
+        });
+
+        const config = await resolvePrimaryFirebaseConfig();
+
+        expect(config.projectId).toBe('game-flow-c6311');
+        expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    });
+
     it('uses host-specific init before any runtime file on a non-production Firebase host', async () => {
         resetGlobals();
         globalThis.window.location = {
@@ -417,7 +436,7 @@ describe('firebase runtime config', () => {
     it('keeps every legacy browser importer on the explicit runtime-config cache contract', () => {
         for (const importer of ['firebase.js', 'firebase-images.js', 'firebase-app-check.js']) {
             const source = readFileSync(new URL(`../../js/${importer}`, import.meta.url), 'utf8');
-            expect(source).toContain('firebase-runtime-config.js?v=15');
+            expect(source).toContain('firebase-runtime-config.js?v=16');
         }
     });
 

--- a/tests/unit/firebase-runtime-config.test.js
+++ b/tests/unit/firebase-runtime-config.test.js
@@ -234,7 +234,7 @@ describe('firebase runtime config', () => {
     it('keeps every legacy browser importer on the explicit runtime-config cache contract', () => {
         for (const importer of ['firebase.js', 'firebase-images.js', 'firebase-app-check.js']) {
             const source = readFileSync(new URL(`../../js/${importer}`, import.meta.url), 'utf8');
-            expect(source).toContain('firebase-runtime-config.js?v=12');
+            expect(source).toContain('firebase-runtime-config.js?v=13');
         }
     });
 

--- a/tests/unit/firebase-runtime-config.test.js
+++ b/tests/unit/firebase-runtime-config.test.js
@@ -82,7 +82,42 @@ describe('firebase runtime config', () => {
         });
     });
 
-    it('ignores a production runtime file on a non-production Firebase host', async () => {
+    it('uses an explicit non-production runtime fallback for isolated local preview smoke', async () => {
+        resetGlobals();
+        globalThis.window.location = {
+            origin: 'http://127.0.0.1:4173',
+            protocol: 'http:',
+            hostname: '127.0.0.1',
+            pathname: '/app/'
+        };
+        globalThis.fetch = vi.fn(async (url) => {
+            if (url.endsWith('/__/firebase/init.json')) {
+                return { ok: false, status: 404 };
+            }
+            if (url.endsWith('/.well-known/allplays-runtime-config.json')) {
+                return {
+                    ok: true,
+                    json: async () => ({
+                        firebase: {
+                            apiKey: 'preview-smoke-key',
+                            authDomain: 'allplays-preview-smoke.firebaseapp.com',
+                            projectId: 'allplays-preview-smoke',
+                            messagingSenderId: '123456789',
+                            appId: 'preview-smoke-app'
+                        }
+                    })
+                };
+            }
+            throw new Error(`Unexpected URL: ${url}`);
+        });
+
+        const config = await resolvePrimaryFirebaseConfig();
+
+        expect(config.projectId).toBe('allplays-preview-smoke');
+        expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses host-specific init before any runtime file on a non-production Firebase host', async () => {
         resetGlobals();
         globalThis.window.location = {
             origin: 'https://allplays-preview.web.app',
@@ -90,20 +125,6 @@ describe('firebase runtime config', () => {
             pathname: '/app/'
         };
         globalThis.fetch = vi.fn(async (url) => {
-            if (url.endsWith('/.well-known/allplays-runtime-config.json')) {
-                return {
-                    ok: true,
-                    json: async () => ({
-                        firebase: {
-                            apiKey: 'production-key',
-                            authDomain: 'game-flow-c6311.firebaseapp.com',
-                            projectId: 'game-flow-c6311',
-                            messagingSenderId: '982493478258',
-                            appId: 'production-app'
-                        }
-                    })
-                };
-            }
             if (url.endsWith('/__/firebase/init.json')) {
                 return {
                     ok: true,
@@ -122,13 +143,77 @@ describe('firebase runtime config', () => {
         const config = await resolvePrimaryFirebaseConfig();
 
         expect(config.projectId).toBe('allplays-preview');
-        expect(globalThis.fetch).toHaveBeenNthCalledWith(
-            1,
-            'https://allplays-preview.web.app/.well-known/allplays-runtime-config.json',
+        expect(globalThis.fetch).toHaveBeenCalledOnce();
+        expect(globalThis.fetch).toHaveBeenCalledWith(
+            'https://allplays-preview.web.app/__/firebase/init.json',
             { cache: 'no-store' }
         );
-        expect(globalThis.fetch).toHaveBeenNthCalledWith(
-            2,
+    });
+
+    it('does not let a different non-production runtime file override a Firebase host identity', async () => {
+        resetGlobals();
+        globalThis.window.location = {
+            origin: 'https://allplays-preview.web.app',
+            hostname: 'allplays-preview.web.app',
+            pathname: '/app/'
+        };
+        globalThis.fetch = vi.fn(async (url) => {
+            if (url.endsWith('/__/firebase/init.json')) {
+                return {
+                    ok: true,
+                    json: async () => ({
+                        apiKey: 'preview-key',
+                        authDomain: 'allplays-preview.firebaseapp.com',
+                        projectId: 'allplays-preview',
+                        messagingSenderId: '456',
+                        appId: 'preview-app'
+                    })
+                };
+            }
+            if (url.endsWith('/.well-known/allplays-runtime-config.json')) {
+                return {
+                    ok: true,
+                    json: async () => ({
+                        firebase: {
+                            apiKey: 'other-key',
+                            authDomain: 'other-preview.firebaseapp.com',
+                            projectId: 'other-preview',
+                            messagingSenderId: '789',
+                            appId: 'other-preview-app'
+                        }
+                    })
+                };
+            }
+            throw new Error(`Unexpected URL: ${url}`);
+        });
+
+        const config = await resolvePrimaryFirebaseConfig();
+
+        expect(config.projectId).toBe('allplays-preview');
+        expect(globalThis.fetch).toHaveBeenCalledOnce();
+        expect(globalThis.fetch).not.toHaveBeenCalledWith(
+            'https://allplays-preview.web.app/.well-known/allplays-runtime-config.json',
+            expect.anything()
+        );
+    });
+
+    it('fails closed instead of using a runtime fallback when Firebase host init is unavailable', async () => {
+        resetGlobals();
+        globalThis.window.location = {
+            origin: 'https://allplays-preview.web.app',
+            hostname: 'allplays-preview.web.app',
+            pathname: '/app/'
+        };
+        globalThis.fetch = vi.fn().mockResolvedValue({
+            ok: false,
+            status: 503
+        });
+
+        await expect(resolvePrimaryFirebaseConfig()).rejects.toThrow(
+            'Firebase config request failed (503)'
+        );
+        expect(globalThis.fetch).toHaveBeenCalledOnce();
+        expect(globalThis.fetch).toHaveBeenCalledWith(
             'https://allplays-preview.web.app/__/firebase/init.json',
             { cache: 'no-store' }
         );
@@ -332,7 +417,7 @@ describe('firebase runtime config', () => {
     it('keeps every legacy browser importer on the explicit runtime-config cache contract', () => {
         for (const importer of ['firebase.js', 'firebase-images.js', 'firebase-app-check.js']) {
             const source = readFileSync(new URL(`../../js/${importer}`, import.meta.url), 'utf8');
-            expect(source).toContain('firebase-runtime-config.js?v=14');
+            expect(source).toContain('firebase-runtime-config.js?v=15');
         }
     });
 

--- a/tests/unit/firebase-runtime-config.test.js
+++ b/tests/unit/firebase-runtime-config.test.js
@@ -51,7 +51,7 @@ describe('firebase runtime config', () => {
         // project and broke Installations/FCM/Performance wherever the fallback ran.
         expect(config.appId).toBe('1:982493478258:web:1f942c420cef6c40e8b1eb');
         expect(config.messagingSenderId).toBe('982493478258');
-        expect(globalThis.fetch).toHaveBeenCalledOnce();
+        expect(globalThis.fetch).toHaveBeenCalledTimes(2);
     });
 
     it('keeps hosted demo firebase config when served through local Firebase hosting', async () => {
@@ -77,7 +77,7 @@ describe('firebase runtime config', () => {
         });
     });
 
-    it('prefers hosted firebase config over inline config when both are present', async () => {
+    it('prefers explicit inline firebase config without making a network request', async () => {
         resetGlobals();
         globalThis.window.__ALLPLAYS_CONFIG__ = {
             firebase: {
@@ -102,11 +102,12 @@ describe('firebase runtime config', () => {
         const config = await resolvePrimaryFirebaseConfig();
 
         expect(config).toMatchObject({
-            apiKey: 'hosted-key',
-            authDomain: 'hosted-allplays.firebaseapp.com',
-            projectId: 'hosted-allplays',
-            appId: 'hosted-app'
+            apiKey: 'inline-key',
+            authDomain: 'inline-allplays.firebaseapp.com',
+            projectId: 'inline-allplays',
+            appId: 'inline-app'
         });
+        expect(globalThis.fetch).not.toHaveBeenCalled();
     });
 
     it('falls back to inline config before bundled defaults when hosted init lookup fails', async () => {
@@ -188,6 +189,41 @@ describe('firebase runtime config', () => {
         );
     });
 
+    it('shares one allplays.ai runtime request across Firebase and App Check startup', async () => {
+        resetGlobals();
+        globalThis.window.location = {
+            origin: 'https://allplays.ai',
+            hostname: 'allplays.ai',
+            pathname: '/app/'
+        };
+        globalThis.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                firebase: {
+                    apiKey: 'runtime-key',
+                    authDomain: 'runtime.firebaseapp.com',
+                    projectId: 'runtime-project',
+                    messagingSenderId: '123',
+                    appId: 'runtime-app'
+                },
+                appCheck: { enabled: false }
+            })
+        });
+
+        const [firebaseConfig, appCheckConfig] = await Promise.all([
+            resolvePrimaryFirebaseConfig(),
+            resolveAppCheckRuntimeConfig()
+        ]);
+
+        expect(firebaseConfig.projectId).toBe('runtime-project');
+        expect(appCheckConfig.enabled).toBe(false);
+        expect(globalThis.fetch).toHaveBeenCalledOnce();
+        expect(globalThis.fetch).not.toHaveBeenCalledWith(
+            'https://allplays.ai/__/firebase/init.json',
+            expect.anything()
+        );
+    });
+
     it('does not expose the repository through a Vite-analyzable import-meta URL', () => {
         const source = readFileSync(new URL('../../js/firebase-runtime-config.js', import.meta.url), 'utf8');
 
@@ -198,7 +234,7 @@ describe('firebase runtime config', () => {
     it('keeps every legacy browser importer on the explicit runtime-config cache contract', () => {
         for (const importer of ['firebase.js', 'firebase-images.js', 'firebase-app-check.js']) {
             const source = readFileSync(new URL(`../../js/${importer}`, import.meta.url), 'utf8');
-            expect(source).toContain('firebase-runtime-config.js?v=11');
+            expect(source).toContain('firebase-runtime-config.js?v=12');
         }
     });
 

--- a/tests/unit/firebase-runtime-config.test.js
+++ b/tests/unit/firebase-runtime-config.test.js
@@ -251,6 +251,59 @@ describe('firebase runtime config', () => {
         expect(globalThis.fetch).toHaveBeenCalledOnce();
     });
 
+    it.each([
+        'game-flow-c6311.web.app',
+        'game-flow-c6311.firebaseapp.com'
+    ])('accepts production Firebase hosted init on the official alias %s', async (hostname) => {
+        resetGlobals();
+        globalThis.window.location = {
+            origin: `https://${hostname}`,
+            protocol: 'https:',
+            hostname,
+            pathname: '/app/'
+        };
+        globalThis.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                apiKey: 'production-key',
+                authDomain: 'game-flow-c6311.firebaseapp.com',
+                projectId: 'game-flow-c6311',
+                messagingSenderId: '982493478258',
+                appId: 'production-app'
+            })
+        });
+
+        await expect(resolvePrimaryFirebaseConfig()).resolves.toMatchObject({
+            projectId: 'game-flow-c6311'
+        });
+        expect(globalThis.fetch).toHaveBeenCalledOnce();
+    });
+
+    it('rejects a non-production project returned by an official production Firebase alias', async () => {
+        resetGlobals();
+        globalThis.window.location = {
+            origin: 'https://game-flow-c6311.web.app',
+            protocol: 'https:',
+            hostname: 'game-flow-c6311.web.app',
+            pathname: '/app/'
+        };
+        globalThis.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                apiKey: 'preview-key',
+                authDomain: 'allplays-preview.firebaseapp.com',
+                projectId: 'allplays-preview',
+                messagingSenderId: '456',
+                appId: 'preview-app'
+            })
+        });
+
+        await expect(resolvePrimaryFirebaseConfig()).rejects.toThrow(
+            'Firebase Hosting init config does not match the production Firebase project.'
+        );
+        expect(globalThis.fetch).toHaveBeenCalledOnce();
+    });
+
     it('does not let a different non-production runtime file override a Firebase host identity', async () => {
         resetGlobals();
         globalThis.window.location = {

--- a/tests/unit/homepage-index.test.js
+++ b/tests/unit/homepage-index.test.js
@@ -73,6 +73,7 @@ async function runHomepage({
     liveError = null,
     upcomingError = null,
     replayError = null,
+    homepageGames = null,
     getRedirectUrl = () => 'dashboard.html',
     formatDate = (value) => `DATE:${value}`,
     formatTime = (value) => `TIME:${value}`
@@ -107,6 +108,9 @@ async function runHomepage({
             }
             return replayGames;
         },
+        getHomepageGames: homepageGames
+            ? async () => homepageGames
+            : undefined,
         formatDate,
         formatTime,
         logger: {
@@ -316,6 +320,27 @@ describe('homepage index workflow', () => {
 
         expect(elements.get('past-games-list').innerHTML).not.toContain('Loading replays...');
         expect(elements.get('past-games-list').textContent).toBe('No recent replays available');
+    });
+
+    it('renders category-level incomplete-result notices from the public homepage response', async () => {
+        const { elements } = await runHomepage({
+            homepageGames: {
+                partial: true,
+                partialCategories: ['live', 'replays'],
+                live: [],
+                upcoming: [],
+                replays: []
+            }
+        });
+
+        expect(elements.get('live-games-list').textContent).toContain(
+            'Showing available games. Some live or upcoming games may be missing.'
+        );
+        expect(elements.get('live-games-list').textContent).toContain('No upcoming live games scheduled');
+        expect(elements.get('past-games-list').textContent).toContain(
+            'Showing available replays. Some recent replays may be missing.'
+        );
+        expect(elements.get('past-games-list').textContent).toContain('No recent replays available');
     });
 
     it('replaces loading placeholders with exact error fallback copy when replay loading fails', async () => {

--- a/tests/unit/homepage-index.test.js
+++ b/tests/unit/homepage-index.test.js
@@ -2,6 +2,11 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import { initHomepage } from '../../js/homepage.js';
+import { getPublicHomepageGames } from '../../js/public-homepage-games.js';
+import {
+    buildSharedGameSyntheticId,
+    decodeSharedGameSyntheticId
+} from '../../js/shared-games.js';
 
 class MockElement {
     constructor(id = '') {
@@ -74,6 +79,7 @@ async function runHomepage({
     upcomingError = null,
     replayError = null,
     homepageGames = null,
+    homepageGamesLoader = null,
     getRedirectUrl = () => 'dashboard.html',
     formatDate = (value) => `DATE:${value}`,
     formatTime = (value) => `TIME:${value}`
@@ -108,9 +114,9 @@ async function runHomepage({
             }
             return replayGames;
         },
-        getHomepageGames: homepageGames
+        getHomepageGames: homepageGamesLoader || (homepageGames
             ? async () => homepageGames
-            : undefined,
+            : undefined),
         formatDate,
         formatTime,
         logger: {
@@ -130,7 +136,7 @@ describe('homepage index workflow', () => {
         expect(homepageHtml).toContain('mailto:paul@paulsnider.net?subject=ALL%20PLAYS%20Access%20Request');
         expect(homepageHtml).toContain('Request Access');
         expect(homepageHtml).toContain("./js/homepage.js?v=5");
-        expect(homepageHtml).toContain("./js/public-homepage-games.js?v=1");
+        expect(homepageHtml).toContain("./js/public-homepage-games.js?v=2");
         expect(homepageHtml).not.toMatch(/import\s+\{[^}]*getLiveGamesNow[^}]*\}\s+from\s+'\.\/js\/db\.js/);
     });
 
@@ -341,6 +347,61 @@ describe('homepage index workflow', () => {
             'Showing available replays. Some recent replays may be missing.'
         );
         expect(elements.get('past-games-list').textContent).toContain('No recent replays available');
+    });
+
+    it('routes shared live, upcoming, and replay cards through the shared-game resolver contract', async () => {
+        const paths = {
+            live: 'organizations/org 1/sharedGames/live 1',
+            upcoming: 'tournaments/tournament-1/sharedGames/upcoming-1',
+            replay: 'events/event-1/sharedGames/replay-1'
+        };
+        const makeSharedGame = (category, teamId) => createGame({
+            id: buildSharedGameSyntheticId(paths[category]),
+            teamId,
+            isSharedGame: true
+        });
+        const { elements } = await runHomepage({
+            homepageGames: {
+                live: [makeSharedGame('live', 'team-live')],
+                upcoming: [makeSharedGame('upcoming', 'team-upcoming')],
+                replays: [makeSharedGame('replay', 'team-replay')]
+            }
+        });
+
+        const hrefs = [
+            ...elements.get('live-games-list').innerHTML.matchAll(/href="([^"]+)"/g),
+            ...elements.get('past-games-list').innerHTML.matchAll(/href="([^"]+)"/g)
+        ].map((match) => match[1]);
+
+        expect(hrefs).toHaveLength(3);
+        expect(hrefs[0]).toContain(`gameId=${encodeURIComponent(buildSharedGameSyntheticId(paths.live))}`);
+        expect(hrefs[1]).toContain(`gameId=${encodeURIComponent(buildSharedGameSyntheticId(paths.upcoming))}`);
+        expect(hrefs[2]).toContain(`gameId=${encodeURIComponent(buildSharedGameSyntheticId(paths.replay))}`);
+        expect(hrefs[2]).toContain('&replay=true');
+
+        hrefs.forEach((href, index) => {
+            const gameId = new URL(href, 'https://allplays.ai/').searchParams.get('gameId');
+            expect(decodeSharedGameSyntheticId(gameId)).toBe(Object.values(paths)[index]);
+        });
+    });
+
+    it('replaces both discovery loading sections with errors when the endpoint stalls', async () => {
+        vi.useFakeTimers();
+        try {
+            const homepage = runHomepage({
+                homepageGamesLoader: () => getPublicHomepageGames({
+                    fetchImpl: () => new Promise(() => {}),
+                    timeoutMs: 25
+                })
+            });
+            await vi.advanceTimersByTimeAsync(25);
+            const { elements } = await homepage;
+
+            expect(elements.get('live-games-list').textContent).toBe('Unable to load games');
+            expect(elements.get('past-games-list').textContent).toBe('Unable to load replays');
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
     it('replaces loading placeholders with exact error fallback copy when replay loading fails', async () => {

--- a/tests/unit/homepage-index.test.js
+++ b/tests/unit/homepage-index.test.js
@@ -125,7 +125,9 @@ describe('homepage index workflow', () => {
         expect(homepageHtml).not.toContain('login.html#signup');
         expect(homepageHtml).toContain('mailto:paul@paulsnider.net?subject=ALL%20PLAYS%20Access%20Request');
         expect(homepageHtml).toContain('Request Access');
-        expect(homepageHtml).toContain("./js/homepage.js?v=4");
+        expect(homepageHtml).toContain("./js/homepage.js?v=5");
+        expect(homepageHtml).toContain("./js/public-homepage-games.js?v=1");
+        expect(homepageHtml).not.toMatch(/import\s+\{[^}]*getLiveGamesNow[^}]*\}\s+from\s+'\.\/js\/db\.js/);
     });
 
     it('routes coach users to the team dashboard CTA, deduplicates live and upcoming games, and preserves replay links', async () => {

--- a/tests/unit/invite-parent-permission-fallback.test.js
+++ b/tests/unit/invite-parent-permission-fallback.test.js
@@ -52,7 +52,7 @@ vi.mock('../../js/firebase.js?v=23', () => ({
 
 vi.mock('../../js/firebase.js?v=22', async () => import('../../js/firebase.js?v=23'));
 
-vi.mock('../../js/firebase-images.js?v=10', () => ({
+vi.mock('../../js/firebase-images.js?v=11', () => ({
     imageStorage: {},
     ensureImageAuth: vi.fn(),
     requireImageAuth: vi.fn()

--- a/tests/unit/pages-bundle-staging.test.js
+++ b/tests/unit/pages-bundle-staging.test.js
@@ -9,6 +9,7 @@ import {
     injectPagesSecurityMeta,
     isAppCheckEnforcementReady,
     readPagesSecurityMetaPolicies,
+    resolveStagedFirebaseRuntimeConfig,
     stagePagesBundle,
     toPagesMetaCsp,
     writeAppCheckRuntimeConfig
@@ -18,6 +19,7 @@ import { writeFirebaseHostingConfig } from '../../scripts/write-firebase-hosting
 const tempDirs = [];
 const originalSiteKey = process.env.ALLPLAYS_APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY;
 const originalEnforcementReady = process.env.ALLPLAYS_APP_CHECK_ENFORCEMENT_READY;
+const originalFirebaseRuntimeTarget = process.env.ALLPLAYS_FIREBASE_RUNTIME_TARGET;
 
 function makeTempDir() {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'allplays-pages-bundle-'));
@@ -68,6 +70,7 @@ function makePagesSecurityFirebaseConfig() {
 beforeEach(() => {
     delete process.env.ALLPLAYS_APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY;
     delete process.env.ALLPLAYS_APP_CHECK_ENFORCEMENT_READY;
+    delete process.env.ALLPLAYS_FIREBASE_RUNTIME_TARGET;
 });
 
 afterEach(() => {
@@ -78,9 +81,20 @@ afterEach(() => {
     else process.env.ALLPLAYS_APP_CHECK_RECAPTCHA_ENTERPRISE_SITE_KEY = originalSiteKey;
     if (originalEnforcementReady === undefined) delete process.env.ALLPLAYS_APP_CHECK_ENFORCEMENT_READY;
     else process.env.ALLPLAYS_APP_CHECK_ENFORCEMENT_READY = originalEnforcementReady;
+    if (originalFirebaseRuntimeTarget === undefined) delete process.env.ALLPLAYS_FIREBASE_RUNTIME_TARGET;
+    else process.env.ALLPLAYS_FIREBASE_RUNTIME_TARGET = originalFirebaseRuntimeTarget;
 });
 
 describe('pages bundle staging', () => {
+    it('uses a non-production Firebase identity only for the explicit preview smoke target', () => {
+        expect(resolveStagedFirebaseRuntimeConfig('preview-smoke').projectId)
+            .toBe('allplays-preview-smoke');
+        expect(resolveStagedFirebaseRuntimeConfig(undefined).projectId)
+            .toBe('game-flow-c6311');
+        expect(resolveStagedFirebaseRuntimeConfig('unexpected').projectId)
+            .toBe('game-flow-c6311');
+    });
+
     it('keeps raw static hosting fail-open without a configured App Check key', () => {
         const repoRoot = path.resolve(import.meta.dirname, '../..');
         const runtimeConfigPath = path.join(

--- a/tests/unit/pages-bundle-staging.test.js
+++ b/tests/unit/pages-bundle-staging.test.js
@@ -90,7 +90,7 @@ describe('pages bundle staging', () => {
         );
         const runtimeConfig = JSON.parse(fs.readFileSync(runtimeConfigPath, 'utf8'));
 
-        expect(runtimeConfig).toEqual({
+        expect(runtimeConfig).toMatchObject({
             appCheck: {
                 enabled: false,
                 isTokenAutoRefreshEnabled: true
@@ -309,7 +309,7 @@ describe('pages bundle staging', () => {
         expect(JSON.parse(fs.readFileSync(
             path.join(destinationDir, '.well-known', 'allplays-runtime-config.json'),
             'utf8'
-        ))).toEqual({
+        ))).toMatchObject({
             appCheck: {
                 enabled: false,
                 isTokenAutoRefreshEnabled: true
@@ -372,7 +372,7 @@ describe('pages bundle staging', () => {
         const config = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
 
         expect(outputPath).toBe(path.join(destinationDir, '.well-known', 'allplays-runtime-config.json'));
-        expect(config).toEqual({
+        expect(config).toMatchObject({
             appCheck: {
                 enabled: false,
                 isTokenAutoRefreshEnabled: true
@@ -402,7 +402,7 @@ describe('pages bundle staging', () => {
         );
         const config = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
 
-        expect(config).toEqual({
+        expect(config).toMatchObject({
             appCheck: {
                 enabled: true,
                 recaptchaEnterpriseSiteKey: 'public-enterprise-site-key_123',
@@ -444,7 +444,7 @@ describe('pages bundle staging', () => {
         );
 
         expect(outputPath).toBe(runtimeConfigPath);
-        expect(JSON.parse(fs.readFileSync(runtimeConfigPath, 'utf8'))).toEqual({
+        expect(JSON.parse(fs.readFileSync(runtimeConfigPath, 'utf8'))).toMatchObject({
             appCheck: {
                 enabled: false,
                 isTokenAutoRefreshEnabled: true

--- a/tests/unit/practice-attendance-roster-size.test.js
+++ b/tests/unit/practice-attendance-roster-size.test.js
@@ -49,7 +49,7 @@ vi.mock('../../js/firebase.js?v=23', () => ({
 
 vi.mock('../../js/firebase.js?v=22', async () => import('../../js/firebase.js?v=23'));
 
-vi.mock('../../js/firebase-images.js?v=10', () => ({
+vi.mock('../../js/firebase-images.js?v=11', () => ({
     imageStorage: {},
     ensureImageAuth: vi.fn(),
     requireImageAuth: vi.fn()

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -633,7 +633,7 @@ else:
         expect(fs.existsSync(path.join(extractedSite, 'firebase.json'))).toBe(false);
         expect(JSON.parse(
             fs.readFileSync(path.join(extractedSite, '.well-known', 'allplays-runtime-config.json'), 'utf8')
-        )).toEqual({
+        )).toMatchObject({
             appCheck: {
                 enabled: true,
                 recaptchaEnterpriseSiteKey: 'public-preview-site-key_123',

--- a/tests/unit/preview-smoke-workflow.test.js
+++ b/tests/unit/preview-smoke-workflow.test.js
@@ -9,6 +9,10 @@ const integrationWorkflow = readFileSync(
     new URL('../../.github/workflows/pr-integration.yml', import.meta.url),
     'utf8'
 );
+const firebaseAuthBootstrapSmoke = readFileSync(
+    new URL('../smoke/firebase-auth-bootstrap.spec.js', import.meta.url),
+    'utf8'
+);
 
 describe('preview-smoke CI workflow', () => {
     it('is called by the consolidated code-head workflow without label-churn runs', () => {
@@ -93,5 +97,15 @@ describe('preview-smoke CI workflow', () => {
             'apps/app/public/.well-known/allplays-runtime-config.json'
         );
         expect(devServerStep).toContain('npm --prefix apps/app run dev');
+    });
+
+    it('does not run real Firebase bootstrap probes against the synthetic preview identity', () => {
+        expect(workflow).toContain('SMOKE_EXPECTED_FIREBASE_RUNTIME_TARGET: preview-smoke');
+        expect(firebaseAuthBootstrapSmoke).toContain(
+            "process.env.SMOKE_EXPECTED_FIREBASE_RUNTIME_TARGET === 'preview-smoke'"
+        );
+        expect(firebaseAuthBootstrapSmoke).toContain(
+            'Real Firebase bootstrap probes require a valid Firebase runtime identity'
+        );
     });
 });

--- a/tests/unit/preview-smoke-workflow.test.js
+++ b/tests/unit/preview-smoke-workflow.test.js
@@ -78,4 +78,20 @@ describe('preview-smoke CI workflow', () => {
 
         expect(gate).toContain('if: ${{ always() && !cancelled() }}');
     });
+
+    it('serves the isolated staged Firebase config to the React dev server', () => {
+        const devServerStep = workflow.slice(
+            workflow.indexOf('      - name: Start React app dev server'),
+            workflow.indexOf('      - name: Wait for local smoke servers')
+        );
+
+        expect(devServerStep).toContain('mkdir -p apps/app/public/.well-known');
+        expect(devServerStep).toContain(
+            '"$RUNNER_TEMP/allplays-pages/.well-known/allplays-runtime-config.json"'
+        );
+        expect(devServerStep).toContain(
+            'apps/app/public/.well-known/allplays-runtime-config.json'
+        );
+        expect(devServerStep).toContain('npm --prefix apps/app run dev');
+    });
 });

--- a/tests/unit/production-smoke-config-gate.test.js
+++ b/tests/unit/production-smoke-config-gate.test.js
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const deployWorkflow = readFileSync('.github/workflows/deploy-prod.yml', 'utf8');
+const postDeployWorkflow = readFileSync('.github/workflows/post-deploy-smoke.yml', 'utf8');
+
+describe('production role-smoke gate', () => {
+    it('blocks preparation before production credentials when role fixtures are missing', () => {
+        expect(deployWorkflow).toContain('validate-production-smoke-config:');
+        expect(deployWorkflow).toContain('environment:\n      name: production-smoke');
+        expect(deployWorkflow).toContain('SMOKE_ADMIN_EMAIL: ${{ secrets.SMOKE_ADMIN_EMAIL }}');
+        expect(deployWorkflow).toContain('SMOKE_STAFF_EMAIL: ${{ secrets.SMOKE_STAFF_EMAIL }}');
+        expect(deployWorkflow).toContain('SMOKE_PARENT_EMAIL: ${{ secrets.SMOKE_PARENT_EMAIL }}');
+        expect(deployWorkflow).toContain('Missing protected configuration names: $missing_csv');
+        expect(deployWorkflow).toContain('needs: [unit-tests, regression-guards, validate-production-smoke-config]');
+        expect(deployWorkflow.indexOf('validate-production-smoke-config:')).toBeLessThan(
+            deployWorkflow.indexOf('  prepare-deploy:')
+        );
+    });
+
+    it('does not allow post-deploy role workflows to be reported as skipped success', () => {
+        expect(postDeployWorkflow).toContain('Fixture-backed production smoke not configured');
+        expect(postDeployWorkflow).toContain('CORE_CONFIGURED');
+        expect(postDeployWorkflow).toContain(
+            'if [[ "$CORE_CONFIGURED" != "true" || "$CORE_OUTCOME" != "success" ]]; then'
+        );
+        expect(postDeployWorkflow).not.toContain('not-configured ($CORE_MISSING)');
+    });
+});

--- a/tests/unit/public-homepage-games-client.test.js
+++ b/tests/unit/public-homepage-games-client.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
     PUBLIC_HOMEPAGE_GAMES_URL,
+    PUBLIC_HOMEPAGE_REQUEST_TIMEOUT_MS,
     getPublicHomepageGames
 } from '../../js/public-homepage-games.js';
 
@@ -38,5 +39,53 @@ describe('public homepage games client', () => {
         await expect(getPublicHomepageGames({ fetchImpl })).rejects.toThrow(
             'Public homepage games request failed (503).'
         );
+    });
+
+    it('aborts and rejects a non-settling request at the internal deadline', async () => {
+        vi.useFakeTimers();
+        let requestSignal;
+        const fetchImpl = vi.fn((_url, options) => {
+            requestSignal = options.signal;
+            return new Promise(() => {});
+        });
+
+        try {
+            const request = getPublicHomepageGames({ fetchImpl, timeoutMs: 25 });
+            const rejection = expect(request).rejects.toThrow(
+                'Public homepage games request timed out.'
+            );
+            await vi.advanceTimersByTimeAsync(25);
+
+            await rejection;
+            expect(requestSignal.aborted).toBe(true);
+            expect(PUBLIC_HOMEPAGE_REQUEST_TIMEOUT_MS).toBe(10_000);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('keeps the deadline active while reading a stalled response body', async () => {
+        vi.useFakeTimers();
+        let requestSignal;
+        const fetchImpl = vi.fn(async (_url, options) => {
+            requestSignal = options.signal;
+            return {
+                ok: true,
+                json: () => new Promise(() => {})
+            };
+        });
+
+        try {
+            const request = getPublicHomepageGames({ fetchImpl, timeoutMs: 25 });
+            const rejection = expect(request).rejects.toThrow(
+                'Public homepage games request timed out.'
+            );
+            await vi.advanceTimersByTimeAsync(25);
+
+            await rejection;
+            expect(requestSignal.aborted).toBe(true);
+        } finally {
+            vi.useRealTimers();
+        }
     });
 });

--- a/tests/unit/public-homepage-games-client.test.js
+++ b/tests/unit/public-homepage-games-client.test.js
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    PUBLIC_HOMEPAGE_GAMES_URL,
+    getPublicHomepageGames
+} from '../../js/public-homepage-games.js';
+
+describe('public homepage games client', () => {
+    it('loads one sanitized discovery payload from the bounded public endpoint', async () => {
+        const fetchImpl = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            live: [{ id: 'live-1' }],
+            upcoming: [{ id: 'upcoming-1' }],
+            replays: [{ id: 'replay-1' }],
+            privateInternalField: 'ignored'
+        }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' }
+        }));
+
+        await expect(getPublicHomepageGames({ fetchImpl })).resolves.toEqual({
+            live: [{ id: 'live-1' }],
+            upcoming: [{ id: 'upcoming-1' }],
+            replays: [{ id: 'replay-1' }]
+        });
+        expect(fetchImpl).toHaveBeenCalledOnce();
+        expect(fetchImpl).toHaveBeenCalledWith(PUBLIC_HOMEPAGE_GAMES_URL, expect.objectContaining({
+            method: 'GET',
+            headers: { Accept: 'application/json' }
+        }));
+    });
+
+    it('fails explicitly instead of falling back to unauthorized Firestore queries', async () => {
+        const fetchImpl = vi.fn().mockResolvedValue(new Response('{}', { status: 503 }));
+
+        await expect(getPublicHomepageGames({ fetchImpl })).rejects.toThrow(
+            'Public homepage games request failed (503).'
+        );
+    });
+});

--- a/tests/unit/public-homepage-games-client.test.js
+++ b/tests/unit/public-homepage-games-client.test.js
@@ -10,6 +10,8 @@ describe('public homepage games client', () => {
             live: [{ id: 'live-1' }],
             upcoming: [{ id: 'upcoming-1' }],
             replays: [{ id: 'replay-1' }],
+            partial: true,
+            partialCategories: ['live', 'invalid'],
             privateInternalField: 'ignored'
         }), {
             status: 200,
@@ -17,6 +19,8 @@ describe('public homepage games client', () => {
         }));
 
         await expect(getPublicHomepageGames({ fetchImpl })).resolves.toEqual({
+            partial: true,
+            partialCategories: ['live'],
             live: [{ id: 'live-1' }],
             upcoming: [{ id: 'upcoming-1' }],
             replays: [{ id: 'replay-1' }]

--- a/tests/unit/scoped-fallback-uploads.test.js
+++ b/tests/unit/scoped-fallback-uploads.test.js
@@ -68,7 +68,7 @@ vi.mock('../../js/firebase.js?v=23', () => ({
 
 vi.mock('../../js/firebase.js?v=22', async () => import('../../js/firebase.js?v=23'));
 
-vi.mock('../../js/firebase-images.js?v=10', () => ({
+vi.mock('../../js/firebase-images.js?v=11', () => ({
     imageStorage: 'image-storage',
     ensureImageAuth: imageAuthMocks.ensureImageAuth,
     requireImageAuth: imageAuthMocks.requireImageAuth

--- a/tests/unit/shared-games.test.js
+++ b/tests/unit/shared-games.test.js
@@ -17,6 +17,13 @@ describe('shared game projection', () => {
         expect(decodeSharedGameSyntheticId(`shared::${encodeURIComponent(sharedPath)}`)).toBe(sharedPath);
     });
 
+    it('rejects malformed or non-shared document paths at the route boundary', () => {
+        expect(decodeSharedGameSyntheticId('shared_%E0%A4%A')).toBeNull();
+        expect(decodeSharedGameSyntheticId(buildSharedGameSyntheticId('teams/team-1'))).toBeNull();
+        expect(decodeSharedGameSyntheticId(buildSharedGameSyntheticId('sharedGames'))).toBeNull();
+        expect(decodeSharedGameSyntheticId(buildSharedGameSyntheticId('sharedGames/game-1/events'))).toBeNull();
+    });
+
     it('projects a centrally owned shared game into the home team schedule', () => {
         const shared = {
             id: 'game-100',

--- a/tests/unit/smoke-candidate-host.test.js
+++ b/tests/unit/smoke-candidate-host.test.js
@@ -64,7 +64,7 @@ describe('candidate host public smoke', () => {
     it('keeps the expected runtime configuration paused without the rollout-ready gate', () => {
         expect(getExpectedRuntimeConfig({
             siteKey: ' public-site-key_123 '
-        })).toEqual({
+        })).toMatchObject({
             appCheck: {
                 enabled: false,
                 isTokenAutoRefreshEnabled: true
@@ -76,7 +76,7 @@ describe('candidate host public smoke', () => {
         expect(getExpectedRuntimeConfig({
             siteKey: ' public-site-key_123 ',
             enforcementReady: true
-        })).toEqual({
+        })).toMatchObject({
             appCheck: {
                 enabled: true,
                 recaptchaEnterpriseSiteKey: 'public-site-key_123',

--- a/tests/unit/team-media-db-ordering.test.js
+++ b/tests/unit/team-media-db-ordering.test.js
@@ -104,7 +104,7 @@ vi.mock('../../js/firebase.js?v=23', () => ({
 
 vi.mock('../../js/firebase.js?v=22', async () => import('../../js/firebase.js?v=23'));
 
-vi.mock('../../js/firebase-images.js?v=10', () => ({
+vi.mock('../../js/firebase-images.js?v=11', () => ({
     imageStorage: {},
     ensureImageAuth: vi.fn(),
     requireImageAuth: vi.fn()

--- a/track-statsheet.html
+++ b/track-statsheet.html
@@ -204,7 +204,7 @@
     import { renderHeader, renderFooter, getUrlParams, escapeHtml, formatDate } from './js/utils.js?v=18';
     import { checkAuth } from './js/auth.js?v=135';
     import { renderTeamAdminBanner } from './js/team-admin-banner.js';
-    import { ensureImageAuth, getImageAuthError } from './js/firebase-images.js?v=10';
+    import { ensureImageAuth, getImageAuthError } from './js/firebase-images.js?v=11';
     import { validateTrackStatsheetApplyRows, buildTrackStatsheetApplyPlan } from './js/track-statsheet-apply.js?v=5';
     import { getApp } from './js/vendor/firebase-app.js';
     import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from './js/vendor/firebase-ai.js';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -54,7 +54,7 @@ export default defineConfig({
     dedupe: ['react', 'react-dom', 'react-router-dom']
   },
   test: {
-    setupFiles: './tests/setupTests.js',
+    setupFiles: path.resolve(workspaceRoot, 'tests/setupTests.js'),
     // Never run tests from nested git worktrees (e.g. `.claude/worktrees/*`,
     // agent worktrees). They are separate checkouts whose test files would
     // otherwise be globbed in and fail on environment-specific issues.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -54,6 +54,7 @@ export default defineConfig({
     dedupe: ['react', 'react-dom', 'react-router-dom']
   },
   test: {
+    setupFiles: './tests/setupTests.js',
     // Never run tests from nested git worktrees (e.g. `.claude/worktrees/*`,
     // agent worktrees). They are separate checkouts whose test files would
     // otherwise be globbed in and fail on environment-specific issues.


### PR DESCRIPTION
## What changed

- Stop platform-admin authorization from turning Home into a platform-wide team and schedule fanout.
- Move legacy homepage live/upcoming/replay discovery behind a bounded, rate-limited public Cloud Function with strict public-team serialization.
- Reduce React cold-start fanout, defer per-user cache modules until sign-out, share Firebase runtime configuration startup, and enforce entry/preload/gzip budgets in `app:build`.
- Improve native authentication messages for offline, timeout, and unreachable-service failures.
- Make production smoke configuration fail closed and add a dedicated platform-admin Home smoke check.

## Root cause

The instability had multiple amplifiers: platform admins could trigger global Home reads, the public homepage queried Firestore directly across collections, app startup eagerly loaded route and AI/data dependencies, and production smoke could report success when protected role fixtures were absent. Together these made a backend or configuration problem look like a broad platform hang and allowed gaps in release validation.

## Impact

Home reads are scoped to actual team membership, public discovery has a server-owned privacy and query budget boundary, and the initial app graph falls from 95 preloads / roughly 721 KB gzip to 0 preloads / 13 initial assets / 376.6 KB gzip. Deployments now stop before mutation when required role smoke fixtures are missing.

## Validation

- `npm test` — 5,205 passed, 121 skipped
- `cd apps/app && npm test -- --run` — 1,547 passed
- `cd functions && npm test` — 371 passed
- `npm run app:build` — passed; 13 initial assets, 376.6 KB gzip, 0 modulepreloads
- Focused homepage Playwright smoke — passed
- Full local Playwright smoke with explicit legacy and Vite origins — 236 passed, 26 production-only skipped, 1 expected pre-deploy failure

The remaining pre-deploy smoke failure is the legacy homepage calling `publicHomepageGamesV1`; the endpoint returns 404 until this PR deploys the new function. The dedicated endpoint-mocked homepage discovery smoke passes. After deployment, protected `production-smoke` configuration must include the required fixture IDs and distinct admin/staff/parent credentials.