### PR TITLE
Allow credentialed smoke setup to finish

### DIFF
--- a/tests/smoke/app-admin-core.spec.js
+++ b/tests/smoke/app-admin-core.spec.js
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import {
+    AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS,
     collectAppRuntimeIssues,
     createAuthenticatedStorageState,
     getAppSmokeConfig,
@@ -18,6 +19,7 @@ test.describe.configure({ mode: 'serial' });
 let adminStorageState;
 
 test.beforeAll(async ({ browser }) => {
+    test.setTimeout(AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS);
     expect(config.adminEmail, 'SMOKE_ADMIN_EMAIL is required').toBeTruthy();
     expect(config.adminPassword, 'SMOKE_ADMIN_PASSWORD is required').toBeTruthy();
     adminStorageState = await createAuthenticatedStorageState(browser, {

--- a/tests/smoke/app-authenticated-core.spec.js
+++ b/tests/smoke/app-authenticated-core.spec.js
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import {
+    AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS,
     assertNotificationInbox,
     buildAppSmokeUrl,
     collectAppRuntimeIssues,
@@ -26,6 +27,7 @@ let staffStorageState;
 let parentStorageState;
 
 test.beforeAll(async ({ browser }) => {
+    test.setTimeout(AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS);
     for (const [name, value] of Object.entries({
         SMOKE_TEAM_ID: config.teamId,
         SMOKE_PLAYER_ID: config.playerId,

--- a/tests/smoke/app-authenticated-extended.spec.js
+++ b/tests/smoke/app-authenticated-extended.spec.js
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import {
+    AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS,
     buildAppSmokeUrl,
     collectAppRuntimeIssues,
     createAuthenticatedStorageState,
@@ -39,6 +40,7 @@ let staffRestSession;
 let parentRestSession;
 
 test.beforeAll(async ({ browser }) => {
+    test.setTimeout(AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS);
     for (const [name, value] of Object.entries({
         SMOKE_RUN_ID: runId,
         SMOKE_APP_BASE_URL: config.appBaseUrl,

--- a/tests/smoke/helpers/app-auth.js
+++ b/tests/smoke/helpers/app-auth.js
@@ -1,5 +1,7 @@
 import { expect } from '@playwright/test';
 
+export const AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS = 180_000;
+
 const sensitivePatterns = [
     /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
     /\b(?:oobCode|code|token|apiKey|recipientId|registrationId)=([^&#\s]+)/gi,

--- a/tests/unit/production-smoke-auth-setup-timeout.test.js
+++ b/tests/unit/production-smoke-auth-setup-timeout.test.js
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const helper = readFileSync('tests/smoke/helpers/app-auth.js', 'utf8');
+const authenticatedCore = readFileSync('tests/smoke/app-authenticated-core.spec.js', 'utf8');
+const adminCore = readFileSync('tests/smoke/app-admin-core.spec.js', 'utf8');
+const authenticatedExtended = readFileSync('tests/smoke/app-authenticated-extended.spec.js', 'utf8');
+
+describe('production smoke authenticated setup timeout', () => {
+    it('uses an explicit bounded setup budget for every credentialed role suite', () => {
+        expect(helper).toContain('export const AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS = 180_000;');
+
+        for (const source of [authenticatedCore, adminCore, authenticatedExtended]) {
+            expect(source).toContain('AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS');
+            expect(source).toMatch(
+                /test\.beforeAll\(async \(\{ browser \}\) => \{\s+test\.setTimeout\(AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS\);/
+            );
+        }
+    });
+});


### PR DESCRIPTION
## Summary

- give every credentialed production smoke `beforeAll` hook a shared, bounded three-minute setup budget
- keep route, fixture-content, runtime-error, and role-boundary assertions unchanged
- cover the post-deploy core suite, platform-admin suite, and scheduled extended suite
- add a regression contract that prevents the suites from falling back to Playwright's 30-second default

## Root cause

Production run [30457814678](https://github.com/pauljsnider/allplays/actions/runs/30457814678) passed the candidate login and all 25 canonical baseline tests. The credentialed role suite then timed out both setup hooks at exactly 30 seconds while creating authenticated storage state, before two workflows could start. The final aggregator correctly failed closed.

## Validation

- `npx vitest run tests/unit/production-smoke-auth-setup-timeout.test.js --reporter=verbose`
- Playwright discovery for the admin/staff/parent core specs: 4 tests discovered
- `npm test`: 708 files passed, 5,237 tests passed, 121 skipped
- `git diff --check`

## Production safety

This changes test setup timing only. It does not change production application code, fixture data, credentials, write permissions, or assertion behavior. Scheduled extended writes remain disabled in the protected production-smoke environment.