### PR TITLE
Avoid hanging authenticated smoke reload

### DIFF
--- a/tests/smoke/helpers/app-auth.js
+++ b/tests/smoke/helpers/app-auth.js
@@ -109,9 +109,9 @@ export async function createAuthenticatedStorageState(browser, credentials) {
     const page = await context.newPage();
     try {
         await signInToApp(page, credentials);
-        await page.reload({ waitUntil: 'domcontentloaded' });
-        await expect(page.locator('main')).toBeVisible({ timeout: 20_000 });
-        await expect.poll(() => new URL(page.url()).hash).not.toMatch(/^#\/auth(?:\?|$)/);
+        // Consumers restore this state in a fresh context before opening protected routes.
+        // Avoid reloading the signed-in page here: canonical production navigation can
+        // remain pending even after Firebase auth and the protected Home UI are ready.
         return await context.storageState({ indexedDB: true });
     } finally {
         await context.close();

--- a/tests/unit/production-smoke-auth-setup-timeout.test.js
+++ b/tests/unit/production-smoke-auth-setup-timeout.test.js
@@ -17,4 +17,14 @@ describe('production smoke authenticated setup timeout', () => {
             );
         }
     });
+
+    it('captures Firebase persistence without reloading the signed-in production page', () => {
+        const storageStateHelper = helper.slice(
+            helper.indexOf('export async function createAuthenticatedStorageState'),
+            helper.indexOf('export async function openAuthenticatedAppRoute')
+        );
+
+        expect(storageStateHelper).toContain('context.storageState({ indexedDB: true })');
+        expect(storageStateHelper).not.toContain('page.reload(');
+    });
 });


### PR DESCRIPTION
## Summary

- capture Firebase auth IndexedDB state immediately after the successful protected landing
- restore that state in the fresh browser contexts already used by every role workflow
- remove the redundant canonical-host reload that remained pending after Home was ready
- add a regression contract that prevents storage-state setup from reintroducing `page.reload()`

## Root cause

Production run [30460009067](https://github.com/pauljsnider/allplays/actions/runs/30460009067) proved the prior 30-second setup-budget fix worked, but both credentialed setup hooks then exhausted the full three-minute budget at the same `page.reload({ waitUntil: 'domcontentloaded' })` call. Browser logs showed Firebase authentication and protected Home rendering had already completed. The reload was redundant because every consuming test restores the captured state into a new browser context before opening protected routes; the parent role test also retains an explicit refresh-persistence assertion.

## Validation

- focused regression: 2 tests passed
- Playwright discovery: all 4 admin/staff/parent/cross-role core tests discovered
- `npm test`: 708 files passed, 5,238 tests passed, 121 skipped
- `git diff --check`

## Production safety

This changes smoke-test state capture only. It does not alter application behavior, credentials, fixture data, permissions, production writes, or workflow assertions. Extended production writes remain disabled.