### PR TITLE
Keep production smoke auth sessions live

### DIFF
--- a/tests/smoke/app-admin-core.spec.js
+++ b/tests/smoke/app-admin-core.spec.js
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 import {
     AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS,
     collectAppRuntimeIssues,
-    createAuthenticatedStorageState,
+    createAuthenticatedAppSession,
     getAppSmokeConfig,
     openAuthenticatedAppRoute,
     redactSmokeDiagnostic
@@ -16,26 +16,20 @@ const secrets = [config.adminEmail, config.adminPassword];
 test.skip(!enabled, 'Platform-admin workflow runs only in production smoke');
 test.describe.configure({ mode: 'serial' });
 
-let adminStorageState;
-
-test.beforeAll(async ({ browser }) => {
+test.beforeAll(async () => {
     test.setTimeout(AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS);
     expect(config.adminEmail, 'SMOKE_ADMIN_EMAIL is required').toBeTruthy();
     expect(config.adminPassword, 'SMOKE_ADMIN_PASSWORD is required').toBeTruthy();
-    adminStorageState = await createAuthenticatedStorageState(browser, {
+});
+
+test('platform admin Home loads without a platform-wide team fanout', async ({ browser }) => {
+    test.setTimeout(60_000);
+    const { context, page } = await createAuthenticatedAppSession(browser, {
         appBaseUrl: config.appBaseUrl,
         email: config.adminEmail,
         password: config.adminPassword,
         roleLabel: 'platform admin'
     });
-});
-
-test('platform admin Home loads without a platform-wide team fanout', async ({ browser }) => {
-    const context = await browser.newContext({
-        storageState: adminStorageState,
-        serviceWorkers: 'block'
-    });
-    const page = await context.newPage();
     const issues = collectAppRuntimeIssues(page, secrets);
     const startedAt = Date.now();
     try {

--- a/tests/smoke/app-admin-core.spec.js
+++ b/tests/smoke/app-admin-core.spec.js
@@ -16,29 +16,31 @@ const secrets = [config.adminEmail, config.adminPassword];
 test.skip(!enabled, 'Platform-admin workflow runs only in production smoke');
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async () => {
+let adminSession;
+
+test.beforeAll(async ({ browser }) => {
     test.setTimeout(AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS);
     expect(config.adminEmail, 'SMOKE_ADMIN_EMAIL is required').toBeTruthy();
     expect(config.adminPassword, 'SMOKE_ADMIN_PASSWORD is required').toBeTruthy();
-});
-
-test('platform admin Home loads without a platform-wide team fanout', async ({ browser }) => {
-    test.setTimeout(60_000);
-    const { context, page } = await createAuthenticatedAppSession(browser, {
+    adminSession = await createAuthenticatedAppSession(browser, {
         appBaseUrl: config.appBaseUrl,
         email: config.adminEmail,
         password: config.adminPassword,
         roleLabel: 'platform admin'
     });
+});
+
+test.afterAll(async () => {
+    await adminSession?.context.close();
+});
+
+test('platform admin Home loads without a platform-wide team fanout', async () => {
+    const { page } = adminSession;
     const issues = collectAppRuntimeIssues(page, secrets);
     const startedAt = Date.now();
-    try {
-        await openAuthenticatedAppRoute(page, config.appBaseUrl, '/home', {
-            heading: 'Your day'
-        });
-        expect(Date.now() - startedAt, 'Platform-admin Home should become usable within 20 seconds').toBeLessThan(20_000);
-        expect(issues.map((issue) => redactSmokeDiagnostic(issue, secrets))).toEqual([]);
-    } finally {
-        await context.close();
-    }
+    await openAuthenticatedAppRoute(page, config.appBaseUrl, '/home', {
+        heading: 'Your day'
+    });
+    expect(Date.now() - startedAt, 'Platform-admin Home should become usable within 20 seconds').toBeLessThan(20_000);
+    expect(issues.map((issue) => redactSmokeDiagnostic(issue, secrets))).toEqual([]);
 });

--- a/tests/smoke/app-admin-core.spec.js
+++ b/tests/smoke/app-admin-core.spec.js
@@ -2,7 +2,6 @@ import { expect, test } from '@playwright/test';
 import {
     AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS,
     assertAuthenticatedAppRoute,
-    collectAppRuntimeIssues,
     createAuthenticatedAppSession,
     getAppSmokeConfig,
     redactSmokeDiagnostic
@@ -35,12 +34,13 @@ test.afterAll(async () => {
 });
 
 test('platform admin Home loads without a platform-wide team fanout', async () => {
-    const { page } = adminSession;
-    const issues = collectAppRuntimeIssues(page, secrets);
-    const startedAt = Date.now();
+    const { page, issues, authenticatedHomeStartedAt } = adminSession;
     await assertAuthenticatedAppRoute(page, '/home', {
         heading: 'Your day'
     });
-    expect(Date.now() - startedAt, 'Platform-admin Home should become usable within 20 seconds').toBeLessThan(20_000);
+    expect(
+        Date.now() - authenticatedHomeStartedAt,
+        'Platform-admin Home should become usable within 20 seconds of authentication'
+    ).toBeLessThan(20_000);
     expect(issues.map((issue) => redactSmokeDiagnostic(issue, secrets))).toEqual([]);
 });

--- a/tests/smoke/app-admin-core.spec.js
+++ b/tests/smoke/app-admin-core.spec.js
@@ -1,10 +1,10 @@
 import { expect, test } from '@playwright/test';
 import {
     AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS,
+    assertAuthenticatedAppRoute,
     collectAppRuntimeIssues,
     createAuthenticatedAppSession,
     getAppSmokeConfig,
-    openAuthenticatedAppRoute,
     redactSmokeDiagnostic
 } from './helpers/app-auth.js';
 
@@ -38,7 +38,7 @@ test('platform admin Home loads without a platform-wide team fanout', async () =
     const { page } = adminSession;
     const issues = collectAppRuntimeIssues(page, secrets);
     const startedAt = Date.now();
-    await openAuthenticatedAppRoute(page, config.appBaseUrl, '/home', {
+    await assertAuthenticatedAppRoute(page, '/home', {
         heading: 'Your day'
     });
     expect(Date.now() - startedAt, 'Platform-admin Home should become usable within 20 seconds').toBeLessThan(20_000);

--- a/tests/smoke/app-authenticated-core.spec.js
+++ b/tests/smoke/app-authenticated-core.spec.js
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 import {
     AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS,
+    assertAuthenticatedAppRoute,
     assertNotificationInbox,
     buildAppSmokeUrl,
     collectAppRuntimeIssues,
@@ -84,7 +85,7 @@ test('staff account reaches every critical app workflow with smoke fixtures', as
     test.setTimeout(240_000);
     await withAuthenticatedPage(staffSession, async (page) => {
         const teamPath = `/teams/${encodeURIComponent(config.teamId)}`;
-        await openAuthenticatedAppRoute(page, config.appBaseUrl, '/home', { heading: 'Your day' });
+        await assertAuthenticatedAppRoute(page, '/home', { heading: 'Your day' });
         await openAuthenticatedAppRoute(page, config.appBaseUrl, '/teams', { requiredHref: teamPath });
         await openAuthenticatedAppRoute(page, config.appBaseUrl, teamPath);
         await openAuthenticatedAppRoute(page, config.appBaseUrl, `${teamPath}?tab=roster`, {
@@ -123,7 +124,7 @@ test('parent account reaches every critical family workflow with linked fixtures
     test.setTimeout(210_000);
     await withAuthenticatedPage(parentWorkflowSession, async (page) => {
         const playerPath = `/players/${encodeURIComponent(config.teamId)}/${encodeURIComponent(config.playerId)}`;
-        await openAuthenticatedAppRoute(page, config.appBaseUrl, '/home', {
+        await assertAuthenticatedAppRoute(page, '/home', {
             heading: 'Your day',
             requiredHref: playerPath
         });

--- a/tests/smoke/app-authenticated-core.spec.js
+++ b/tests/smoke/app-authenticated-core.spec.js
@@ -43,24 +43,26 @@ test.beforeAll(async ({ browser }) => {
         'Staff and parent smoke accounts must be distinct for cross-role access checks'
     ).not.toBe(config.parentEmail.trim().toLowerCase());
 
-    staffSession = await createAuthenticatedAppSession(browser, {
-        appBaseUrl: config.appBaseUrl,
-        email: config.staffEmail,
-        password: config.staffPassword,
-        roleLabel: 'staff'
-    });
-    parentWorkflowSession = await createAuthenticatedAppSession(browser, {
-        appBaseUrl: config.appBaseUrl,
-        email: config.parentEmail,
-        password: config.parentPassword,
-        roleLabel: 'parent'
-    });
-    parentBoundarySession = await createAuthenticatedAppSession(browser, {
-        appBaseUrl: config.appBaseUrl,
-        email: config.parentEmail,
-        password: config.parentPassword,
-        roleLabel: 'parent'
-    });
+    [staffSession, parentWorkflowSession, parentBoundarySession] = await Promise.all([
+        createAuthenticatedAppSession(browser, {
+            appBaseUrl: config.appBaseUrl,
+            email: config.staffEmail,
+            password: config.staffPassword,
+            roleLabel: 'staff'
+        }),
+        createAuthenticatedAppSession(browser, {
+            appBaseUrl: config.appBaseUrl,
+            email: config.parentEmail,
+            password: config.parentPassword,
+            roleLabel: 'parent'
+        }),
+        createAuthenticatedAppSession(browser, {
+            appBaseUrl: config.appBaseUrl,
+            email: config.parentEmail,
+            password: config.parentPassword,
+            roleLabel: 'parent'
+        })
+    ]);
 });
 
 test.afterAll(async () => {

--- a/tests/smoke/app-authenticated-core.spec.js
+++ b/tests/smoke/app-authenticated-core.spec.js
@@ -23,7 +23,11 @@ const secretValues = [
 test.skip(!enabled, 'Credentialed core workflows run only in production or extended-production smoke');
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async () => {
+let staffSession;
+let parentWorkflowSession;
+let parentBoundarySession;
+
+test.beforeAll(async ({ browser }) => {
     test.setTimeout(AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS);
     for (const [name, value] of Object.entries({
         SMOKE_TEAM_ID: config.teamId,
@@ -38,27 +42,45 @@ test.beforeAll(async () => {
         config.staffEmail.trim().toLowerCase(),
         'Staff and parent smoke accounts must be distinct for cross-role access checks'
     ).not.toBe(config.parentEmail.trim().toLowerCase());
-});
 
-async function withAuthenticatedPage(browser, credentials, callback) {
-    const { context, page } = await createAuthenticatedAppSession(browser, credentials);
-    const issues = collectAppRuntimeIssues(page, secretValues);
-    try {
-        await callback(page);
-        expect(issues.map((issue) => redactSmokeDiagnostic(issue, secretValues))).toEqual([]);
-    } finally {
-        await context.close();
-    }
-}
-
-test('staff account reaches every critical app workflow with smoke fixtures', async ({ browser }) => {
-    test.setTimeout(240_000);
-    await withAuthenticatedPage(browser, {
+    staffSession = await createAuthenticatedAppSession(browser, {
         appBaseUrl: config.appBaseUrl,
         email: config.staffEmail,
         password: config.staffPassword,
         roleLabel: 'staff'
-    }, async (page) => {
+    });
+    parentWorkflowSession = await createAuthenticatedAppSession(browser, {
+        appBaseUrl: config.appBaseUrl,
+        email: config.parentEmail,
+        password: config.parentPassword,
+        roleLabel: 'parent'
+    });
+    parentBoundarySession = await createAuthenticatedAppSession(browser, {
+        appBaseUrl: config.appBaseUrl,
+        email: config.parentEmail,
+        password: config.parentPassword,
+        roleLabel: 'parent'
+    });
+});
+
+test.afterAll(async () => {
+    await Promise.all([
+        staffSession?.context.close(),
+        parentWorkflowSession?.context.close(),
+        parentBoundarySession?.context.close()
+    ]);
+});
+
+async function withAuthenticatedPage(session, callback) {
+    const { page } = session;
+    const issues = collectAppRuntimeIssues(page, secretValues);
+    await callback(page);
+    expect(issues.map((issue) => redactSmokeDiagnostic(issue, secretValues))).toEqual([]);
+}
+
+test('staff account reaches every critical app workflow with smoke fixtures', async () => {
+    test.setTimeout(240_000);
+    await withAuthenticatedPage(staffSession, async (page) => {
         const teamPath = `/teams/${encodeURIComponent(config.teamId)}`;
         await openAuthenticatedAppRoute(page, config.appBaseUrl, '/home', { heading: 'Your day' });
         await openAuthenticatedAppRoute(page, config.appBaseUrl, '/teams', { requiredHref: teamPath });
@@ -95,14 +117,9 @@ test('staff account reaches every critical app workflow with smoke fixtures', as
     });
 });
 
-test('parent account reaches every critical family workflow with linked fixtures', async ({ browser }) => {
+test('parent account reaches every critical family workflow with linked fixtures', async () => {
     test.setTimeout(210_000);
-    await withAuthenticatedPage(browser, {
-        appBaseUrl: config.appBaseUrl,
-        email: config.parentEmail,
-        password: config.parentPassword,
-        roleLabel: 'parent'
-    }, async (page) => {
+    await withAuthenticatedPage(parentWorkflowSession, async (page) => {
         const playerPath = `/players/${encodeURIComponent(config.teamId)}/${encodeURIComponent(config.playerId)}`;
         await openAuthenticatedAppRoute(page, config.appBaseUrl, '/home', {
             heading: 'Your day',
@@ -135,14 +152,8 @@ test('parent account reaches every critical family workflow with linked fixtures
     });
 });
 
-test('role boundaries, logout, refresh persistence, and signed-out rejection hold', async ({ browser }) => {
-    test.setTimeout(90_000);
-    await withAuthenticatedPage(browser, {
-        appBaseUrl: config.appBaseUrl,
-        email: config.parentEmail,
-        password: config.parentPassword,
-        roleLabel: 'parent'
-    }, async (page) => {
+test('role boundaries, logout, refresh persistence, and signed-out rejection hold', async () => {
+    await withAuthenticatedPage(parentBoundarySession, async (page) => {
         await page.goto(buildAppSmokeUrl(config.appBaseUrl, `/teams/${encodeURIComponent(config.teamId)}/fees`));
         await expect(page.getByText(/Admin access required|Only team owners|access denied/i).first()).toBeVisible({ timeout: 25_000 });
 

--- a/tests/smoke/app-authenticated-core.spec.js
+++ b/tests/smoke/app-authenticated-core.spec.js
@@ -4,7 +4,7 @@ import {
     assertNotificationInbox,
     buildAppSmokeUrl,
     collectAppRuntimeIssues,
-    createAuthenticatedStorageState,
+    createAuthenticatedAppSession,
     getAppSmokeConfig,
     openAuthenticatedAppRoute,
     redactSmokeDiagnostic
@@ -23,10 +23,7 @@ const secretValues = [
 test.skip(!enabled, 'Credentialed core workflows run only in production or extended-production smoke');
 test.describe.configure({ mode: 'serial' });
 
-let staffStorageState;
-let parentStorageState;
-
-test.beforeAll(async ({ browser }) => {
+test.beforeAll(async () => {
     test.setTimeout(AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS);
     for (const [name, value] of Object.entries({
         SMOKE_TEAM_ID: config.teamId,
@@ -41,27 +38,10 @@ test.beforeAll(async ({ browser }) => {
         config.staffEmail.trim().toLowerCase(),
         'Staff and parent smoke accounts must be distinct for cross-role access checks'
     ).not.toBe(config.parentEmail.trim().toLowerCase());
-
-    staffStorageState = await createAuthenticatedStorageState(browser, {
-        appBaseUrl: config.appBaseUrl,
-        email: config.staffEmail,
-        password: config.staffPassword,
-        roleLabel: 'staff'
-    });
-    parentStorageState = await createAuthenticatedStorageState(browser, {
-        appBaseUrl: config.appBaseUrl,
-        email: config.parentEmail,
-        password: config.parentPassword,
-        roleLabel: 'parent'
-    });
 });
 
-async function withAuthenticatedPage(browser, storageState, callback) {
-    const context = await browser.newContext({
-        storageState,
-        serviceWorkers: 'block'
-    });
-    const page = await context.newPage();
+async function withAuthenticatedPage(browser, credentials, callback) {
+    const { context, page } = await createAuthenticatedAppSession(browser, credentials);
     const issues = collectAppRuntimeIssues(page, secretValues);
     try {
         await callback(page);
@@ -73,7 +53,12 @@ async function withAuthenticatedPage(browser, storageState, callback) {
 
 test('staff account reaches every critical app workflow with smoke fixtures', async ({ browser }) => {
     test.setTimeout(240_000);
-    await withAuthenticatedPage(browser, staffStorageState, async (page) => {
+    await withAuthenticatedPage(browser, {
+        appBaseUrl: config.appBaseUrl,
+        email: config.staffEmail,
+        password: config.staffPassword,
+        roleLabel: 'staff'
+    }, async (page) => {
         const teamPath = `/teams/${encodeURIComponent(config.teamId)}`;
         await openAuthenticatedAppRoute(page, config.appBaseUrl, '/home', { heading: 'Your day' });
         await openAuthenticatedAppRoute(page, config.appBaseUrl, '/teams', { requiredHref: teamPath });
@@ -112,7 +97,12 @@ test('staff account reaches every critical app workflow with smoke fixtures', as
 
 test('parent account reaches every critical family workflow with linked fixtures', async ({ browser }) => {
     test.setTimeout(210_000);
-    await withAuthenticatedPage(browser, parentStorageState, async (page) => {
+    await withAuthenticatedPage(browser, {
+        appBaseUrl: config.appBaseUrl,
+        email: config.parentEmail,
+        password: config.parentPassword,
+        roleLabel: 'parent'
+    }, async (page) => {
         const playerPath = `/players/${encodeURIComponent(config.teamId)}/${encodeURIComponent(config.playerId)}`;
         await openAuthenticatedAppRoute(page, config.appBaseUrl, '/home', {
             heading: 'Your day',
@@ -146,7 +136,13 @@ test('parent account reaches every critical family workflow with linked fixtures
 });
 
 test('role boundaries, logout, refresh persistence, and signed-out rejection hold', async ({ browser }) => {
-    await withAuthenticatedPage(browser, parentStorageState, async (page) => {
+    test.setTimeout(90_000);
+    await withAuthenticatedPage(browser, {
+        appBaseUrl: config.appBaseUrl,
+        email: config.parentEmail,
+        password: config.parentPassword,
+        roleLabel: 'parent'
+    }, async (page) => {
         await page.goto(buildAppSmokeUrl(config.appBaseUrl, `/teams/${encodeURIComponent(config.teamId)}/fees`));
         await expect(page.getByText(/Admin access required|Only team owners|access denied/i).first()).toBeVisible({ timeout: 25_000 });
 

--- a/tests/smoke/app-authenticated-core.spec.js
+++ b/tests/smoke/app-authenticated-core.spec.js
@@ -4,7 +4,6 @@ import {
     assertAuthenticatedAppRoute,
     assertNotificationInbox,
     buildAppSmokeUrl,
-    collectAppRuntimeIssues,
     createAuthenticatedAppSession,
     getAppSmokeConfig,
     openAuthenticatedAppRoute,
@@ -75,8 +74,7 @@ test.afterAll(async () => {
 });
 
 async function withAuthenticatedPage(session, callback) {
-    const { page } = session;
-    const issues = collectAppRuntimeIssues(page, secretValues);
+    const { page, issues } = session;
     await callback(page);
     expect(issues.map((issue) => redactSmokeDiagnostic(issue, secretValues))).toEqual([]);
 }

--- a/tests/smoke/app-authenticated-extended.spec.js
+++ b/tests/smoke/app-authenticated-extended.spec.js
@@ -34,10 +34,14 @@ const secretValues = [
 test.skip(!extendedEnabled, 'SMOKE_EXTENDED_WRITES=1 is required');
 test.describe.configure({ mode: 'serial' });
 
+let staffSession;
+let parentNotificationSession;
+let parentWriteSession;
+let parentReadOnlySession;
 let staffRestSession;
 let parentRestSession;
 
-test.beforeAll(async () => {
+test.beforeAll(async ({ browser }) => {
     test.setTimeout(AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS);
     for (const [name, value] of Object.entries({
         SMOKE_RUN_ID: runId,
@@ -59,6 +63,30 @@ test.beforeAll(async () => {
         'Staff and parent smoke accounts must be distinct for cross-role access checks'
     ).not.toBe(config.parentEmail.trim().toLowerCase());
 
+    staffSession = await createAuthenticatedAppSession(browser, {
+        appBaseUrl: config.appBaseUrl,
+        email: config.staffEmail,
+        password: config.staffPassword,
+        roleLabel: 'staff'
+    });
+    parentNotificationSession = await createAuthenticatedAppSession(browser, {
+        appBaseUrl: config.appBaseUrl,
+        email: config.parentEmail,
+        password: config.parentPassword,
+        roleLabel: 'parent'
+    });
+    parentWriteSession = await createAuthenticatedAppSession(browser, {
+        appBaseUrl: config.appBaseUrl,
+        email: config.parentEmail,
+        password: config.parentPassword,
+        roleLabel: 'parent'
+    });
+    parentReadOnlySession = await createAuthenticatedAppSession(browser, {
+        appBaseUrl: config.appBaseUrl,
+        email: config.parentEmail,
+        password: config.parentPassword,
+        roleLabel: 'parent'
+    });
     [staffRestSession, parentRestSession] = await Promise.all([
         createFirebaseRestSession({
             appBaseUrl: config.appBaseUrl,
@@ -73,15 +101,20 @@ test.beforeAll(async () => {
     ]);
 });
 
-async function withAuthenticatedPage(browser, credentials, callback) {
-    const { context, page } = await createAuthenticatedAppSession(browser, credentials);
+test.afterAll(async () => {
+    await Promise.all([
+        staffSession?.context.close(),
+        parentNotificationSession?.context.close(),
+        parentWriteSession?.context.close(),
+        parentReadOnlySession?.context.close()
+    ]);
+});
+
+async function withAuthenticatedPage(session, callback) {
+    const { page } = session;
     const issues = collectAppRuntimeIssues(page, secretValues);
-    try {
-        await callback(page);
-        expect(issues.map((issue) => redactSmokeDiagnostic(issue, secretValues))).toEqual([]);
-    } finally {
-        await context.close();
-    }
+    await callback(page);
+    expect(issues.map((issue) => redactSmokeDiagnostic(issue, secretValues))).toEqual([]);
 }
 
 async function openRoute(page, route) {
@@ -90,7 +123,7 @@ async function openRoute(page, route) {
     await expect.poll(() => new URL(page.url()).hash, { timeout: 20_000 }).toContain(`#${route.split('?')[0]}`);
 }
 
-test('staff smoke writes are deterministic and removed after validation', async ({ browser }) => {
+test('staff smoke writes are deterministic and removed after validation', async () => {
     test.setTimeout(300_000);
     const playerName = `${smokePrefix}-player`;
     const opponentName = `${smokePrefix}-opponent`;
@@ -139,12 +172,7 @@ test('staff smoke writes are deterministic and removed after validation', async 
     ];
 
     try {
-        await withAuthenticatedPage(browser, {
-            appBaseUrl: config.appBaseUrl,
-            email: config.staffEmail,
-            password: config.staffPassword,
-            roleLabel: 'staff'
-        }, async (page) => {
+        await withAuthenticatedPage(staffSession, async (page) => {
             await openRoute(page, `/teams/${encodeURIComponent(config.teamId)}?tab=roster`);
             await page.getByRole('button', { name: 'Add player' }).click();
             await page.getByPlaceholder('Player name').fill(playerName);
@@ -243,12 +271,7 @@ test('staff smoke writes are deterministic and removed after validation', async 
             await expect(page.getByText('Media item deleted.')).toBeVisible({ timeout: 25_000 });
         });
 
-        await withAuthenticatedPage(browser, {
-            appBaseUrl: config.appBaseUrl,
-            email: config.parentEmail,
-            password: config.parentPassword,
-            roleLabel: 'parent'
-        }, async (page) => {
+        await withAuthenticatedPage(parentNotificationSession, async (page) => {
             await openRoute(page, '/home');
             await page.getByRole('button', { name: 'Notifications' }).first().click();
             const inbox = page.getByRole('dialog', { name: 'Notifications' });
@@ -266,7 +289,7 @@ test('staff smoke writes are deterministic and removed after validation', async 
     }
 });
 
-test('parent smoke writes restore or remove every touched record', async ({ browser }) => {
+test('parent smoke writes restore or remove every touched record', async () => {
     test.setTimeout(240_000);
     const rideNote = `${smokePrefix}-ride`;
     const shareLabel = `${smokePrefix}-share`;
@@ -307,12 +330,7 @@ test('parent smoke writes restore or remove every touched record', async ({ brow
     ];
 
     try {
-        await withAuthenticatedPage(browser, {
-            appBaseUrl: config.appBaseUrl,
-            email: config.parentEmail,
-            password: config.parentPassword,
-            roleLabel: 'parent'
-        }, async (page) => {
+        await withAuthenticatedPage(parentWriteSession, async (page) => {
             await openRoute(
                 page,
                 `/schedule/${encodeURIComponent(config.teamId)}/${encodeURIComponent(config.eventId)}?childId=${encodeURIComponent(config.playerId)}&section=availability`
@@ -359,14 +377,8 @@ test('parent smoke writes restore or remove every touched record', async ({ brow
     }
 });
 
-test('read-only fixtures cover registrations, fees, opportunities, and notification deep links', async ({ browser }) => {
-    test.setTimeout(90_000);
-    await withAuthenticatedPage(browser, {
-        appBaseUrl: config.appBaseUrl,
-        email: config.parentEmail,
-        password: config.parentPassword,
-        roleLabel: 'parent'
-    }, async (page) => {
+test('read-only fixtures cover registrations, fees, opportunities, and notification deep links', async () => {
+    await withAuthenticatedPage(parentReadOnlySession, async (page) => {
         await openRoute(page, '/parent-tools/registrations');
         await expect(page.getByText('Registrations', { exact: true })).toBeVisible();
         await expect(page.locator(`a[href*="${config.registrationFormId}"]`).first()).toBeVisible({ timeout: 20_000 });

--- a/tests/smoke/app-authenticated-extended.spec.js
+++ b/tests/smoke/app-authenticated-extended.spec.js
@@ -3,7 +3,6 @@ import {
     AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS,
     assertAuthenticatedAppRoute,
     buildAppSmokeUrl,
-    collectAppRuntimeIssues,
     createAuthenticatedAppSession,
     getAppSmokeConfig,
     redactSmokeDiagnostic
@@ -119,8 +118,7 @@ test.afterAll(async () => {
 });
 
 async function withAuthenticatedPage(session, callback) {
-    const { page } = session;
-    const issues = collectAppRuntimeIssues(page, secretValues);
+    const { page, issues } = session;
     await callback(page);
     expect(issues.map((issue) => redactSmokeDiagnostic(issue, secretValues))).toEqual([]);
 }

--- a/tests/smoke/app-authenticated-extended.spec.js
+++ b/tests/smoke/app-authenticated-extended.spec.js
@@ -3,7 +3,7 @@ import {
     AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS,
     buildAppSmokeUrl,
     collectAppRuntimeIssues,
-    createAuthenticatedStorageState,
+    createAuthenticatedAppSession,
     getAppSmokeConfig,
     redactSmokeDiagnostic
 } from './helpers/app-auth.js';
@@ -34,12 +34,10 @@ const secretValues = [
 test.skip(!extendedEnabled, 'SMOKE_EXTENDED_WRITES=1 is required');
 test.describe.configure({ mode: 'serial' });
 
-let staffStorageState;
-let parentStorageState;
 let staffRestSession;
 let parentRestSession;
 
-test.beforeAll(async ({ browser }) => {
+test.beforeAll(async () => {
     test.setTimeout(AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS);
     for (const [name, value] of Object.entries({
         SMOKE_RUN_ID: runId,
@@ -61,20 +59,6 @@ test.beforeAll(async ({ browser }) => {
         'Staff and parent smoke accounts must be distinct for cross-role access checks'
     ).not.toBe(config.parentEmail.trim().toLowerCase());
 
-    [staffStorageState, parentStorageState] = await Promise.all([
-        createAuthenticatedStorageState(browser, {
-            appBaseUrl: config.appBaseUrl,
-            email: config.staffEmail,
-            password: config.staffPassword,
-            roleLabel: 'staff'
-        }),
-        createAuthenticatedStorageState(browser, {
-            appBaseUrl: config.appBaseUrl,
-            email: config.parentEmail,
-            password: config.parentPassword,
-            roleLabel: 'parent'
-        })
-    ]);
     [staffRestSession, parentRestSession] = await Promise.all([
         createFirebaseRestSession({
             appBaseUrl: config.appBaseUrl,
@@ -89,12 +73,8 @@ test.beforeAll(async ({ browser }) => {
     ]);
 });
 
-async function withAuthenticatedPage(browser, storageState, callback) {
-    const context = await browser.newContext({
-        storageState,
-        serviceWorkers: 'block'
-    });
-    const page = await context.newPage();
+async function withAuthenticatedPage(browser, credentials, callback) {
+    const { context, page } = await createAuthenticatedAppSession(browser, credentials);
     const issues = collectAppRuntimeIssues(page, secretValues);
     try {
         await callback(page);
@@ -159,7 +139,12 @@ test('staff smoke writes are deterministic and removed after validation', async 
     ];
 
     try {
-        await withAuthenticatedPage(browser, staffStorageState, async (page) => {
+        await withAuthenticatedPage(browser, {
+            appBaseUrl: config.appBaseUrl,
+            email: config.staffEmail,
+            password: config.staffPassword,
+            roleLabel: 'staff'
+        }, async (page) => {
             await openRoute(page, `/teams/${encodeURIComponent(config.teamId)}?tab=roster`);
             await page.getByRole('button', { name: 'Add player' }).click();
             await page.getByPlaceholder('Player name').fill(playerName);
@@ -258,7 +243,12 @@ test('staff smoke writes are deterministic and removed after validation', async 
             await expect(page.getByText('Media item deleted.')).toBeVisible({ timeout: 25_000 });
         });
 
-        await withAuthenticatedPage(browser, parentStorageState, async (page) => {
+        await withAuthenticatedPage(browser, {
+            appBaseUrl: config.appBaseUrl,
+            email: config.parentEmail,
+            password: config.parentPassword,
+            roleLabel: 'parent'
+        }, async (page) => {
             await openRoute(page, '/home');
             await page.getByRole('button', { name: 'Notifications' }).first().click();
             const inbox = page.getByRole('dialog', { name: 'Notifications' });
@@ -317,7 +307,12 @@ test('parent smoke writes restore or remove every touched record', async ({ brow
     ];
 
     try {
-        await withAuthenticatedPage(browser, parentStorageState, async (page) => {
+        await withAuthenticatedPage(browser, {
+            appBaseUrl: config.appBaseUrl,
+            email: config.parentEmail,
+            password: config.parentPassword,
+            roleLabel: 'parent'
+        }, async (page) => {
             await openRoute(
                 page,
                 `/schedule/${encodeURIComponent(config.teamId)}/${encodeURIComponent(config.eventId)}?childId=${encodeURIComponent(config.playerId)}&section=availability`
@@ -365,7 +360,13 @@ test('parent smoke writes restore or remove every touched record', async ({ brow
 });
 
 test('read-only fixtures cover registrations, fees, opportunities, and notification deep links', async ({ browser }) => {
-    await withAuthenticatedPage(browser, parentStorageState, async (page) => {
+    test.setTimeout(90_000);
+    await withAuthenticatedPage(browser, {
+        appBaseUrl: config.appBaseUrl,
+        email: config.parentEmail,
+        password: config.parentPassword,
+        roleLabel: 'parent'
+    }, async (page) => {
         await openRoute(page, '/parent-tools/registrations');
         await expect(page.getByText('Registrations', { exact: true })).toBeVisible();
         await expect(page.locator(`a[href*="${config.registrationFormId}"]`).first()).toBeVisible({ timeout: 20_000 });

--- a/tests/smoke/app-authenticated-extended.spec.js
+++ b/tests/smoke/app-authenticated-extended.spec.js
@@ -63,31 +63,38 @@ test.beforeAll(async ({ browser }) => {
         'Staff and parent smoke accounts must be distinct for cross-role access checks'
     ).not.toBe(config.parentEmail.trim().toLowerCase());
 
-    staffSession = await createAuthenticatedAppSession(browser, {
-        appBaseUrl: config.appBaseUrl,
-        email: config.staffEmail,
-        password: config.staffPassword,
-        roleLabel: 'staff'
-    });
-    parentNotificationSession = await createAuthenticatedAppSession(browser, {
-        appBaseUrl: config.appBaseUrl,
-        email: config.parentEmail,
-        password: config.parentPassword,
-        roleLabel: 'parent'
-    });
-    parentWriteSession = await createAuthenticatedAppSession(browser, {
-        appBaseUrl: config.appBaseUrl,
-        email: config.parentEmail,
-        password: config.parentPassword,
-        roleLabel: 'parent'
-    });
-    parentReadOnlySession = await createAuthenticatedAppSession(browser, {
-        appBaseUrl: config.appBaseUrl,
-        email: config.parentEmail,
-        password: config.parentPassword,
-        roleLabel: 'parent'
-    });
-    [staffRestSession, parentRestSession] = await Promise.all([
+    [
+        staffSession,
+        parentNotificationSession,
+        parentWriteSession,
+        parentReadOnlySession,
+        staffRestSession,
+        parentRestSession
+    ] = await Promise.all([
+        createAuthenticatedAppSession(browser, {
+            appBaseUrl: config.appBaseUrl,
+            email: config.staffEmail,
+            password: config.staffPassword,
+            roleLabel: 'staff'
+        }),
+        createAuthenticatedAppSession(browser, {
+            appBaseUrl: config.appBaseUrl,
+            email: config.parentEmail,
+            password: config.parentPassword,
+            roleLabel: 'parent'
+        }),
+        createAuthenticatedAppSession(browser, {
+            appBaseUrl: config.appBaseUrl,
+            email: config.parentEmail,
+            password: config.parentPassword,
+            roleLabel: 'parent'
+        }),
+        createAuthenticatedAppSession(browser, {
+            appBaseUrl: config.appBaseUrl,
+            email: config.parentEmail,
+            password: config.parentPassword,
+            roleLabel: 'parent'
+        }),
         createFirebaseRestSession({
             appBaseUrl: config.appBaseUrl,
             email: config.staffEmail,

--- a/tests/smoke/app-authenticated-extended.spec.js
+++ b/tests/smoke/app-authenticated-extended.spec.js
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 import {
     AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS,
+    assertAuthenticatedAppRoute,
     buildAppSmokeUrl,
     collectAppRuntimeIssues,
     createAuthenticatedAppSession,
@@ -279,7 +280,7 @@ test('staff smoke writes are deterministic and removed after validation', async 
         });
 
         await withAuthenticatedPage(parentNotificationSession, async (page) => {
-            await openRoute(page, '/home');
+            await assertAuthenticatedAppRoute(page, '/home');
             await page.getByRole('button', { name: 'Notifications' }).first().click();
             const inbox = page.getByRole('dialog', { name: 'Notifications' });
             await expect(inbox).toBeVisible();

--- a/tests/smoke/helpers/app-auth.js
+++ b/tests/smoke/helpers/app-auth.js
@@ -118,13 +118,12 @@ export async function createAuthenticatedAppSession(browser, credentials) {
     }
 }
 
-export async function openAuthenticatedAppRoute(page, appBaseUrl, route, options = {}) {
+export async function assertAuthenticatedAppRoute(page, route, options = {}) {
     const {
         heading,
         forbidden = [/Unable to load/i, /\bnot found\b/i, /temporarily unavailable/i],
         requiredHref = ''
     } = options;
-    await page.goto(buildAppSmokeUrl(appBaseUrl, route), { waitUntil: 'domcontentloaded' });
     await expect.poll(() => new URL(page.url()).hash, { timeout: 20_000 }).toContain(`#${route.split('?')[0]}`);
     await expect(page.locator('main')).toBeVisible({ timeout: 20_000 });
     if (heading) {
@@ -140,6 +139,11 @@ export async function openAuthenticatedAppRoute(page, appBaseUrl, route, options
         ), requiredHref);
         expect(found, `Expected a meaningful fixture link containing ${requiredHref}`).toBe(true);
     }
+}
+
+export async function openAuthenticatedAppRoute(page, appBaseUrl, route, options = {}) {
+    await page.goto(buildAppSmokeUrl(appBaseUrl, route), { waitUntil: 'domcontentloaded' });
+    await assertAuthenticatedAppRoute(page, route, options);
 }
 
 export async function assertNotificationInbox(page) {

--- a/tests/smoke/helpers/app-auth.js
+++ b/tests/smoke/helpers/app-auth.js
@@ -91,6 +91,7 @@ export async function signInToApp(page, { appBaseUrl, email, password, roleLabel
     await expect(page.getByRole('heading', { name: 'Sign in' })).toBeVisible({ timeout: 20_000 });
     await page.getByLabel('Email').fill(email);
     await page.getByLabel('Password', { exact: true }).fill(password);
+    const authenticatedHomeStartedAt = Date.now();
     await page.getByRole('button', { name: 'Sign in' }).last().click();
     await expect.poll(() => new URL(page.url()).hash, {
         message: `${roleLabel} remained in the authentication flow`,
@@ -99,6 +100,7 @@ export async function signInToApp(page, { appBaseUrl, email, password, roleLabel
     await expect(page.locator('main')).toBeVisible({ timeout: 15_000 });
     await page.getByLabel('Password', { exact: true }).fill('').catch(() => {});
     await page.getByLabel('Email').fill('').catch(() => {});
+    return { authenticatedHomeStartedAt };
 }
 
 export async function createAuthenticatedAppSession(browser, credentials) {
@@ -107,11 +109,12 @@ export async function createAuthenticatedAppSession(browser, credentials) {
         recordVideo: undefined
     });
     const page = await context.newPage();
+    const issues = collectAppRuntimeIssues(page, [credentials.email, credentials.password]);
     try {
-        await signInToApp(page, credentials);
+        const timing = await signInToApp(page, credentials);
         // Keep the authenticated context live. Exporting Firebase's IndexedDB-backed
         // persistence can remain pending after Auth and Home are already usable.
-        return { context, page };
+        return { context, page, issues, ...timing };
     } catch (error) {
         await context.close();
         throw error;

--- a/tests/smoke/helpers/app-auth.js
+++ b/tests/smoke/helpers/app-auth.js
@@ -101,7 +101,7 @@ export async function signInToApp(page, { appBaseUrl, email, password, roleLabel
     await page.getByLabel('Email').fill('').catch(() => {});
 }
 
-export async function createAuthenticatedStorageState(browser, credentials) {
+export async function createAuthenticatedAppSession(browser, credentials) {
     const context = await browser.newContext({
         serviceWorkers: 'block',
         recordVideo: undefined
@@ -109,12 +109,12 @@ export async function createAuthenticatedStorageState(browser, credentials) {
     const page = await context.newPage();
     try {
         await signInToApp(page, credentials);
-        // Consumers restore this state in a fresh context before opening protected routes.
-        // Avoid reloading the signed-in page here: canonical production navigation can
-        // remain pending even after Firebase auth and the protected Home UI are ready.
-        return await context.storageState({ indexedDB: true });
-    } finally {
+        // Keep the authenticated context live. Exporting Firebase's IndexedDB-backed
+        // persistence can remain pending after Auth and Home are already usable.
+        return { context, page };
+    } catch (error) {
         await context.close();
+        throw error;
     }
 }
 

--- a/tests/unit/production-smoke-auth-setup-timeout.test.js
+++ b/tests/unit/production-smoke-auth-setup-timeout.test.js
@@ -13,18 +13,26 @@ describe('production smoke authenticated setup timeout', () => {
         for (const source of [authenticatedCore, adminCore, authenticatedExtended]) {
             expect(source).toContain('AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS');
             expect(source).toMatch(
-                /test\.beforeAll\(async \(\{ browser \}\) => \{\s+test\.setTimeout\(AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS\);/
+                /test\.beforeAll\(async \(\) => \{\s+test\.setTimeout\(AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS\);/
             );
         }
     });
 
-    it('captures Firebase persistence without reloading the signed-in production page', () => {
-        const storageStateHelper = helper.slice(
-            helper.indexOf('export async function createAuthenticatedStorageState'),
+    it('keeps Firebase authentication in a live context without serializing IndexedDB state', () => {
+        const authenticatedSessionHelper = helper.slice(
+            helper.indexOf('export async function createAuthenticatedAppSession'),
             helper.indexOf('export async function openAuthenticatedAppRoute')
         );
 
-        expect(storageStateHelper).toContain('context.storageState({ indexedDB: true })');
-        expect(storageStateHelper).not.toContain('page.reload(');
+        expect(authenticatedSessionHelper).toContain('await signInToApp(page, credentials);');
+        expect(authenticatedSessionHelper).toContain('return { context, page };');
+        expect(authenticatedSessionHelper).not.toContain('storageState(');
+        expect(authenticatedSessionHelper).not.toContain('page.reload(');
+
+        for (const source of [authenticatedCore, adminCore, authenticatedExtended]) {
+            expect(source).toContain('createAuthenticatedAppSession');
+            expect(source).not.toContain('createAuthenticatedStorageState');
+            expect(source).not.toContain('storageState:');
+        }
     });
 });

--- a/tests/unit/production-smoke-auth-setup-timeout.test.js
+++ b/tests/unit/production-smoke-auth-setup-timeout.test.js
@@ -39,8 +39,13 @@ describe('production smoke authenticated setup timeout', () => {
             helper.indexOf('export async function openAuthenticatedAppRoute')
         );
 
-        expect(authenticatedSessionHelper).toContain('await signInToApp(page, credentials);');
-        expect(authenticatedSessionHelper).toContain('return { context, page };');
+        expect(authenticatedSessionHelper).toContain(
+            'const issues = collectAppRuntimeIssues(page, [credentials.email, credentials.password]);'
+        );
+        expect(authenticatedSessionHelper.indexOf('collectAppRuntimeIssues(')).toBeLessThan(
+            authenticatedSessionHelper.indexOf('signInToApp(')
+        );
+        expect(authenticatedSessionHelper).toContain('return { context, page, issues, ...timing };');
         expect(authenticatedSessionHelper).not.toContain('storageState(');
         expect(authenticatedSessionHelper).not.toContain('page.reload(');
 
@@ -70,5 +75,12 @@ describe('production smoke authenticated setup timeout', () => {
         expect(helper).toMatch(
             /export async function openAuthenticatedAppRoute[\s\S]*?page\.goto\([\s\S]*?await assertAuthenticatedAppRoute\(page, route, options\);/
         );
+    });
+
+    it('measures the initial admin Home transition from before the sign-in action', () => {
+        expect(helper).toMatch(
+            /const authenticatedHomeStartedAt = Date\.now\(\);\s+await page\.getByRole\('button', \{ name: 'Sign in' \}\)/
+        );
+        expect(adminCore).toContain('Date.now() - authenticatedHomeStartedAt');
     });
 });

--- a/tests/unit/production-smoke-auth-setup-timeout.test.js
+++ b/tests/unit/production-smoke-auth-setup-timeout.test.js
@@ -23,6 +23,14 @@ describe('production smoke authenticated setup timeout', () => {
             expect(boundedSetup).toContain('createAuthenticatedAppSession(browser, {');
             expect(source).toMatch(/test\.afterAll\(async \(\) => \{[\s\S]*?context\.close\(\)/);
         }
+
+        for (const source of [authenticatedCore, authenticatedExtended]) {
+            const boundedSetup = source.slice(
+                source.indexOf('test.beforeAll('),
+                source.indexOf('test.afterAll(')
+            );
+            expect(boundedSetup).toContain('await Promise.all([');
+        }
     });
 
     it('keeps Firebase authentication in a live context without serializing IndexedDB state', () => {

--- a/tests/unit/production-smoke-auth-setup-timeout.test.js
+++ b/tests/unit/production-smoke-auth-setup-timeout.test.js
@@ -13,8 +13,15 @@ describe('production smoke authenticated setup timeout', () => {
         for (const source of [authenticatedCore, adminCore, authenticatedExtended]) {
             expect(source).toContain('AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS');
             expect(source).toMatch(
-                /test\.beforeAll\(async \(\) => \{\s+test\.setTimeout\(AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS\);/
+                /test\.beforeAll\(async \(\{ browser \}\) => \{\s+test\.setTimeout\(AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS\);/
             );
+
+            const boundedSetup = source.slice(
+                source.indexOf('test.beforeAll('),
+                source.indexOf('test.afterAll(')
+            );
+            expect(boundedSetup).toContain('createAuthenticatedAppSession(browser, {');
+            expect(source).toMatch(/test\.afterAll\(async \(\) => \{[\s\S]*?context\.close\(\)/);
         }
     });
 

--- a/tests/unit/production-smoke-auth-setup-timeout.test.js
+++ b/tests/unit/production-smoke-auth-setup-timeout.test.js
@@ -50,4 +50,25 @@ describe('production smoke authenticated setup timeout', () => {
             expect(source).not.toContain('storageState:');
         }
     });
+
+    it('asserts the initial authenticated Home route without navigating to the current URL', () => {
+        const routeAssertions = [
+            "assertAuthenticatedAppRoute(page, '/home'",
+            "assertAuthenticatedAppRoute(page, '/home'",
+            "assertAuthenticatedAppRoute(page, '/home'"
+        ];
+
+        for (const [source, assertion] of [
+            [adminCore, routeAssertions[0]],
+            [authenticatedCore, routeAssertions[1]],
+            [authenticatedExtended, routeAssertions[2]]
+        ]) {
+            expect(source).toContain(assertion);
+            expect(source).not.toContain("openAuthenticatedAppRoute(page, config.appBaseUrl, '/home'");
+        }
+
+        expect(helper).toMatch(
+            /export async function openAuthenticatedAppRoute[\s\S]*?page\.goto\([\s\S]*?await assertAuthenticatedAppRoute\(page, route, options\);/
+        );
+    });
 });


### PR DESCRIPTION
## Summary
- replace Playwright IndexedDB storage-state export with live isolated authenticated contexts
- authenticate each admin, staff, parent, and extended workflow in the context that exercises it
- retain explicit refresh persistence, logout, signed-out rejection, redacted diagnostics, and bounded timeouts

## Why
Production run 30463041863 proved Firebase authentication and protected Home rendering succeeded, but Playwright context.storageState({ indexedDB: true }) stayed pending until both 180-second setup hooks expired. Keeping the already-authenticated context removes that test-runner serialization deadlock without changing product code or production data.

## Validation
- npx vitest run tests/unit/production-smoke-auth-setup-timeout.test.js --reporter=verbose
- npx playwright test tests/smoke/app-admin-core.spec.js tests/smoke/app-authenticated-core.spec.js tests/smoke/app-authenticated-extended.spec.js --config=playwright.smoke.config.js --project=smoke --list
- npm test (708 files; 5,238 passed; 121 skipped)
- git diff --check

## Production safety
- smoke-harness-only change
- no production data mutation
- role credentials remain GitHub environment secrets and are not logged
- extended production writes remain disabled