### PR TITLE
Expose production smoke auth failures

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -88,6 +88,15 @@ jobs:
           SMOKE_AUTH_EMAIL: ${{ secrets.SMOKE_AUTH_EMAIL }}
           SMOKE_AUTH_PASSWORD: ${{ secrets.SMOKE_AUTH_PASSWORD }}
 
+      - name: Upload redacted candidate authentication diagnostic
+        if: always() && steps.firebase_auth.outcome == 'failure'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: candidate-auth-redacted-diagnostic-${{ github.event.workflow_run.head_sha }}
+          path: test-results/**/candidate-auth-diagnostic.json
+          if-no-files-found: warn
+          retention-days: 7
+
       - name: Inspect fixture-backed smoke readiness
         id: core_config
         env:
@@ -188,6 +197,7 @@ jobs:
           tests/smoke/app-authenticated-core.spec.js
           --config=playwright.smoke.config.js
           --project=smoke
+          --workers=1
           --reporter=line
         env:
           SMOKE_APP_BOOT_URL: https://allplays.ai/app/
@@ -207,15 +217,6 @@ jobs:
           SMOKE_STAFF_PASSWORD: ${{ secrets.SMOKE_STAFF_PASSWORD }}
           SMOKE_PARENT_EMAIL: ${{ secrets.SMOKE_PARENT_EMAIL }}
           SMOKE_PARENT_PASSWORD: ${{ secrets.SMOKE_PARENT_PASSWORD }}
-
-      - name: Upload redacted candidate authentication diagnostic
-        if: always() && steps.firebase_auth.outcome == 'failure'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: candidate-auth-redacted-diagnostic-${{ github.event.workflow_run.head_sha }}
-          path: test-results/**/candidate-auth-diagnostic.json
-          if-no-files-found: warn
-          retention-days: 7
 
       - name: Aggregate production smoke signals
         if: always()

--- a/.github/workflows/scheduled-prod-smoke.yml
+++ b/.github/workflows/scheduled-prod-smoke.yml
@@ -51,6 +51,7 @@ jobs:
           tests/smoke/app-authenticated-extended.spec.js
           --config=playwright.smoke.config.js
           --project=smoke
+          --workers=1
           --reporter=line
         env:
           SMOKE_BASE_URL: https://allplays.ai

--- a/tests/smoke/app-admin-core.spec.js
+++ b/tests/smoke/app-admin-core.spec.js
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/test';
 import {
     AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS,
     assertAuthenticatedAppRoute,
+    closeAuthenticatedAppSession,
     createAuthenticatedAppSession,
     getAppSmokeConfig,
     redactSmokeDiagnostic
@@ -30,7 +31,7 @@ test.beforeAll(async ({ browser }) => {
 });
 
 test.afterAll(async () => {
-    await adminSession?.context.close();
+    await closeAuthenticatedAppSession(adminSession);
 });
 
 test('platform admin Home loads without a platform-wide team fanout', async () => {

--- a/tests/smoke/app-authenticated-core.spec.js
+++ b/tests/smoke/app-authenticated-core.spec.js
@@ -4,7 +4,8 @@ import {
     assertAuthenticatedAppRoute,
     assertNotificationInbox,
     buildAppSmokeUrl,
-    createAuthenticatedAppSession,
+    closeAuthenticatedAppSession,
+    createAuthenticatedAppSessions,
     getAppSmokeConfig,
     openAuthenticatedAppRoute,
     redactSmokeDiagnostic
@@ -25,7 +26,6 @@ test.describe.configure({ mode: 'serial' });
 
 let staffSession;
 let parentWorkflowSession;
-let parentBoundarySession;
 
 test.beforeAll(async ({ browser }) => {
     test.setTimeout(AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS);
@@ -43,33 +43,26 @@ test.beforeAll(async ({ browser }) => {
         'Staff and parent smoke accounts must be distinct for cross-role access checks'
     ).not.toBe(config.parentEmail.trim().toLowerCase());
 
-    [staffSession, parentWorkflowSession, parentBoundarySession] = await Promise.all([
-        createAuthenticatedAppSession(browser, {
+    [staffSession, parentWorkflowSession] = await createAuthenticatedAppSessions(browser, [
+        {
             appBaseUrl: config.appBaseUrl,
             email: config.staffEmail,
             password: config.staffPassword,
             roleLabel: 'staff'
-        }),
-        createAuthenticatedAppSession(browser, {
+        },
+        {
             appBaseUrl: config.appBaseUrl,
             email: config.parentEmail,
             password: config.parentPassword,
             roleLabel: 'parent'
-        }),
-        createAuthenticatedAppSession(browser, {
-            appBaseUrl: config.appBaseUrl,
-            email: config.parentEmail,
-            password: config.parentPassword,
-            roleLabel: 'parent'
-        })
+        }
     ]);
 });
 
 test.afterAll(async () => {
     await Promise.all([
-        staffSession?.context.close(),
-        parentWorkflowSession?.context.close(),
-        parentBoundarySession?.context.close()
+        closeAuthenticatedAppSession(staffSession),
+        closeAuthenticatedAppSession(parentWorkflowSession)
     ]);
 });
 
@@ -154,7 +147,7 @@ test('parent account reaches every critical family workflow with linked fixtures
 });
 
 test('role boundaries, logout, refresh persistence, and signed-out rejection hold', async () => {
-    await withAuthenticatedPage(parentBoundarySession, async (page) => {
+    await withAuthenticatedPage(parentWorkflowSession, async (page) => {
         await page.goto(buildAppSmokeUrl(config.appBaseUrl, `/teams/${encodeURIComponent(config.teamId)}/fees`));
         await expect(page.getByText(/Admin access required|Only team owners|access denied/i).first()).toBeVisible({ timeout: 25_000 });
 

--- a/tests/smoke/app-authenticated-extended.spec.js
+++ b/tests/smoke/app-authenticated-extended.spec.js
@@ -3,7 +3,8 @@ import {
     AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS,
     assertAuthenticatedAppRoute,
     buildAppSmokeUrl,
-    createAuthenticatedAppSession,
+    closeAuthenticatedAppSession,
+    createAuthenticatedAppSessions,
     getAppSmokeConfig,
     redactSmokeDiagnostic
 } from './helpers/app-auth.js';
@@ -63,38 +64,33 @@ test.beforeAll(async ({ browser }) => {
         'Staff and parent smoke accounts must be distinct for cross-role access checks'
     ).not.toBe(config.parentEmail.trim().toLowerCase());
 
-    [
-        staffSession,
-        parentNotificationSession,
-        parentWriteSession,
-        parentReadOnlySession,
-        staffRestSession,
-        parentRestSession
-    ] = await Promise.all([
-        createAuthenticatedAppSession(browser, {
-            appBaseUrl: config.appBaseUrl,
-            email: config.staffEmail,
-            password: config.staffPassword,
-            roleLabel: 'staff'
-        }),
-        createAuthenticatedAppSession(browser, {
-            appBaseUrl: config.appBaseUrl,
-            email: config.parentEmail,
-            password: config.parentPassword,
-            roleLabel: 'parent'
-        }),
-        createAuthenticatedAppSession(browser, {
-            appBaseUrl: config.appBaseUrl,
-            email: config.parentEmail,
-            password: config.parentPassword,
-            roleLabel: 'parent'
-        }),
-        createAuthenticatedAppSession(browser, {
-            appBaseUrl: config.appBaseUrl,
-            email: config.parentEmail,
-            password: config.parentPassword,
-            roleLabel: 'parent'
-        }),
+    const [uiSessions, nextStaffRestSession, nextParentRestSession] = await Promise.all([
+        createAuthenticatedAppSessions(browser, [
+            {
+                appBaseUrl: config.appBaseUrl,
+                email: config.staffEmail,
+                password: config.staffPassword,
+                roleLabel: 'staff'
+            },
+            {
+                appBaseUrl: config.appBaseUrl,
+                email: config.parentEmail,
+                password: config.parentPassword,
+                roleLabel: 'parent notifications'
+            },
+            {
+                appBaseUrl: config.appBaseUrl,
+                email: config.parentEmail,
+                password: config.parentPassword,
+                roleLabel: 'parent writes'
+            },
+            {
+                appBaseUrl: config.appBaseUrl,
+                email: config.parentEmail,
+                password: config.parentPassword,
+                roleLabel: 'parent read-only'
+            }
+        ]),
         createFirebaseRestSession({
             appBaseUrl: config.appBaseUrl,
             email: config.staffEmail,
@@ -106,14 +102,22 @@ test.beforeAll(async ({ browser }) => {
             password: config.parentPassword
         })
     ]);
+    [
+        staffSession,
+        parentNotificationSession,
+        parentWriteSession,
+        parentReadOnlySession
+    ] = uiSessions;
+    staffRestSession = nextStaffRestSession;
+    parentRestSession = nextParentRestSession;
 });
 
 test.afterAll(async () => {
     await Promise.all([
-        staffSession?.context.close(),
-        parentNotificationSession?.context.close(),
-        parentWriteSession?.context.close(),
-        parentReadOnlySession?.context.close()
+        closeAuthenticatedAppSession(staffSession),
+        closeAuthenticatedAppSession(parentNotificationSession),
+        closeAuthenticatedAppSession(parentWriteSession),
+        closeAuthenticatedAppSession(parentReadOnlySession)
     ]);
 });
 

--- a/tests/smoke/candidate-host-auth.spec.js
+++ b/tests/smoke/candidate-host-auth.spec.js
@@ -43,7 +43,7 @@ async function writeRedactedDiagnostic(page, testInfo, failure) {
 }
 
 test('candidate host accepts authentication and loads a protected landing page', async ({ page }, testInfo) => {
-    test.setTimeout(45_000);
+    test.setTimeout(90_000);
     try {
         expect(authEmail, 'SMOKE_STAFF_EMAIL or SMOKE_AUTH_EMAIL is required for candidate-host auth smoke').toBeTruthy();
         expect(authPassword, 'SMOKE_STAFF_PASSWORD or SMOKE_AUTH_PASSWORD is required for candidate-host auth smoke').toBeTruthy();
@@ -51,7 +51,7 @@ test('candidate host accepts authentication and loads a protected landing page',
         await test.step(`authenticate at ${candidateHostUrl}`, async () => {
             await page.goto(candidateUrl('/app/#/auth'), { waitUntil: 'domcontentloaded' });
             await expect(page.getByRole('heading', { name: 'Sign in' }), `Authentication form did not load at candidate URL ${candidateHostUrl}`)
-                .toBeVisible({ timeout: 10_000 });
+                .toBeVisible({ timeout: 30_000 });
             await page.getByLabel('Email').fill(authEmail);
             await page.getByLabel('Password', { exact: true }).fill(authPassword);
             const submitButton = page.getByRole('button', { name: 'Sign in' }).last();

--- a/tests/smoke/helpers/app-auth.js
+++ b/tests/smoke/helpers/app-auth.js
@@ -1,6 +1,7 @@
 import { expect } from '@playwright/test';
 
-export const AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS = 180_000;
+export const AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS = 240_000;
+const AUTHENTICATED_CONTEXT_CLOSE_TIMEOUT_MS = 5_000;
 
 const sensitivePatterns = [
     /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
@@ -59,6 +60,16 @@ function safeRequestLabel(requestUrl) {
     }
 }
 
+function safePageLabel(pageUrl) {
+    try {
+        const parsed = new URL(pageUrl);
+        const route = parsed.hash.split('?')[0];
+        return `${parsed.origin}${parsed.pathname}${route}`;
+    } catch {
+        return '[invalid-url]';
+    }
+}
+
 export function collectAppRuntimeIssues(page, secrets = []) {
     const issues = [];
     page.on('pageerror', (error) => {
@@ -87,20 +98,47 @@ export async function signInToApp(page, { appBaseUrl, email, password, roleLabel
     expect(email, `${roleLabel} smoke email is required`).toBeTruthy();
     expect(password, `${roleLabel} smoke password is required`).toBeTruthy();
 
-    await page.goto(buildAppSmokeUrl(appBaseUrl, '/auth'), { waitUntil: 'domcontentloaded' });
-    await expect(page.getByRole('heading', { name: 'Sign in' })).toBeVisible({ timeout: 20_000 });
-    await page.getByLabel('Email').fill(email);
-    await page.getByLabel('Password', { exact: true }).fill(password);
-    const authenticatedHomeStartedAt = Date.now();
-    await page.getByRole('button', { name: 'Sign in' }).last().click();
-    await expect.poll(() => new URL(page.url()).hash, {
-        message: `${roleLabel} remained in the authentication flow`,
-        timeout: 25_000
-    }).not.toMatch(/^#\/(?:auth|verify-pending)(?:\?|$)/);
-    await expect(page.locator('main')).toBeVisible({ timeout: 15_000 });
-    await page.getByLabel('Password', { exact: true }).fill('').catch(() => {});
-    await page.getByLabel('Email').fill('').catch(() => {});
-    return { authenticatedHomeStartedAt };
+    let stage = 'opening the sign-in page';
+    try {
+        await page.goto(buildAppSmokeUrl(appBaseUrl, '/auth'), {
+            waitUntil: 'domcontentloaded',
+            timeout: 45_000
+        });
+        stage = 'waiting for the sign-in form';
+        await expect(page.getByRole('heading', { name: 'Sign in' })).toBeVisible({ timeout: 30_000 });
+        stage = 'filling credentials';
+        await page.getByLabel('Email').fill(email, { timeout: 15_000 });
+        await page.getByLabel('Password', { exact: true }).fill(password, { timeout: 15_000 });
+        const authenticatedHomeStartedAt = Date.now();
+        stage = 'submitting credentials';
+        await page.getByRole('button', { name: 'Sign in' }).last().click({ timeout: 20_000 });
+        stage = 'waiting for the authenticated route';
+        await expect.poll(() => new URL(page.url()).hash, {
+            message: `${roleLabel} remained in the authentication flow`,
+            timeout: 40_000
+        }).not.toMatch(/^#\/(?:auth|verify-pending)(?:\?|$)/);
+        stage = 'waiting for the authenticated shell';
+        await expect(page.locator('main')).toBeVisible({ timeout: 20_000 });
+        await page.getByLabel('Password', { exact: true }).fill('').catch(() => {});
+        await page.getByLabel('Email').fill('').catch(() => {});
+        return { authenticatedHomeStartedAt };
+    } catch (error) {
+        throw new Error(
+            `${roleLabel} smoke authentication failed while ${stage} at ${safePageLabel(page.url())}: ` +
+            redactSmokeDiagnostic(error?.message, [email, password])
+        );
+    }
+}
+
+async function closeBrowserContextBounded(context) {
+    let timeoutId;
+    await Promise.race([
+        context.close().catch(() => {}),
+        new Promise((resolve) => {
+            timeoutId = setTimeout(resolve, AUTHENTICATED_CONTEXT_CLOSE_TIMEOUT_MS);
+        })
+    ]);
+    clearTimeout(timeoutId);
 }
 
 export async function createAuthenticatedAppSession(browser, credentials) {
@@ -116,9 +154,31 @@ export async function createAuthenticatedAppSession(browser, credentials) {
         // persistence can remain pending after Auth and Home are already usable.
         return { context, page, issues, ...timing };
     } catch (error) {
-        await context.close();
+        await closeBrowserContextBounded(context);
         throw error;
     }
+}
+
+export async function createAuthenticatedAppSessions(browser, credentialsList) {
+    const results = await Promise.allSettled(
+        credentialsList.map((credentials) => createAuthenticatedAppSession(browser, credentials))
+    );
+    const sessions = results
+        .filter((result) => result.status === 'fulfilled')
+        .map((result) => result.value);
+    const failures = results
+        .filter((result) => result.status === 'rejected')
+        .map((result) => String(result.reason?.message || result.reason));
+
+    if (failures.length > 0) {
+        await Promise.all(sessions.map((session) => closeBrowserContextBounded(session.context)));
+        throw new Error(`Authenticated smoke session setup failed: ${failures.join('; ')}`);
+    }
+    return sessions;
+}
+
+export async function closeAuthenticatedAppSession(session) {
+    if (session?.context) await closeBrowserContextBounded(session.context);
 }
 
 export async function assertAuthenticatedAppRoute(page, route, options = {}) {

--- a/tests/unit/app-auth-smoke-helper.test.js
+++ b/tests/unit/app-auth-smoke-helper.test.js
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { closeAuthenticatedAppSession } from '../../tests/smoke/helpers/app-auth.js';
+
+describe('authenticated smoke session cleanup', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('does not let a pending browser-context close hide the authentication failure', async () => {
+        vi.useFakeTimers();
+        const context = {
+            close: vi.fn(() => new Promise(() => {}))
+        };
+        let settled = false;
+        const cleanup = closeAuthenticatedAppSession({ context }).then(() => {
+            settled = true;
+        });
+
+        await vi.advanceTimersByTimeAsync(4_999);
+        expect(settled).toBe(false);
+        await vi.advanceTimersByTimeAsync(1);
+        await cleanup;
+
+        expect(settled).toBe(true);
+        expect(context.close).toHaveBeenCalledOnce();
+    });
+
+    it('still awaits a context that closes normally', async () => {
+        const context = {
+            close: vi.fn().mockResolvedValue(undefined)
+        };
+
+        await closeAuthenticatedAppSession({ context });
+
+        expect(context.close).toHaveBeenCalledOnce();
+    });
+});

--- a/tests/unit/candidate-host-auth-smoke.test.js
+++ b/tests/unit/candidate-host-auth-smoke.test.js
@@ -31,7 +31,14 @@ describe('candidate-host authenticated smoke coverage', () => {
         expect(spec).toContain("expect(landingUrl.hash).not.toMatch(/^#\\/auth");
         expect(spec).toContain("testInfo.outputPath('candidate-auth-diagnostic.json')");
         expect(spec).toContain('redactDiagnosticText');
+        expect(spec).toContain('test.setTimeout(90_000)');
+        expect(spec).toContain("toBeVisible({ timeout: 30_000 })");
         expect(spec).not.toContain('page.screenshot');
+
+        const diagnosticUpload = workflow.indexOf('Upload redacted candidate authentication diagnostic');
+        const baseline = workflow.indexOf('Run production smoke baseline');
+        expect(diagnosticUpload).toBeGreaterThan(-1);
+        expect(diagnosticUpload).toBeLessThan(baseline);
     });
 
     it('does not enable App Check enforcement for candidate authentication', () => {

--- a/tests/unit/production-smoke-auth-setup-timeout.test.js
+++ b/tests/unit/production-smoke-auth-setup-timeout.test.js
@@ -8,7 +8,7 @@ const authenticatedExtended = readFileSync('tests/smoke/app-authenticated-extend
 
 describe('production smoke authenticated setup timeout', () => {
     it('uses an explicit bounded setup budget for every credentialed role suite', () => {
-        expect(helper).toContain('export const AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS = 180_000;');
+        expect(helper).toContain('export const AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS = 240_000;');
 
         for (const source of [authenticatedCore, adminCore, authenticatedExtended]) {
             expect(source).toContain('AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS');
@@ -20,8 +20,8 @@ describe('production smoke authenticated setup timeout', () => {
                 source.indexOf('test.beforeAll('),
                 source.indexOf('test.afterAll(')
             );
-            expect(boundedSetup).toContain('createAuthenticatedAppSession(browser, {');
-            expect(source).toMatch(/test\.afterAll\(async \(\) => \{[\s\S]*?context\.close\(\)/);
+            expect(boundedSetup).toMatch(/createAuthenticatedAppSession(?:s)?\(browser,/);
+            expect(source).toMatch(/test\.afterAll\(async \(\) => \{[\s\S]*?closeAuthenticatedAppSession\(/);
         }
 
         for (const source of [authenticatedCore, authenticatedExtended]) {
@@ -29,7 +29,7 @@ describe('production smoke authenticated setup timeout', () => {
                 source.indexOf('test.beforeAll('),
                 source.indexOf('test.afterAll(')
             );
-            expect(boundedSetup).toContain('await Promise.all([');
+            expect(boundedSetup).toContain('createAuthenticatedAppSessions(browser, [');
         }
     });
 
@@ -46,6 +46,11 @@ describe('production smoke authenticated setup timeout', () => {
             authenticatedSessionHelper.indexOf('signInToApp(')
         );
         expect(authenticatedSessionHelper).toContain('return { context, page, issues, ...timing };');
+        expect(authenticatedSessionHelper).toContain('Promise.allSettled(');
+        expect(authenticatedSessionHelper).toContain('closeBrowserContextBounded(context)');
+        expect(helper).toContain('smoke authentication failed while ${stage}');
+        expect(helper).toContain('AUTHENTICATED_CONTEXT_CLOSE_TIMEOUT_MS = 5_000');
+        expect(helper).toContain('timeoutId = setTimeout(resolve, AUTHENTICATED_CONTEXT_CLOSE_TIMEOUT_MS)');
         expect(authenticatedSessionHelper).not.toContain('storageState(');
         expect(authenticatedSessionHelper).not.toContain('page.reload(');
 
@@ -54,6 +59,20 @@ describe('production smoke authenticated setup timeout', () => {
             expect(source).not.toContain('createAuthenticatedStorageState');
             expect(source).not.toContain('storageState:');
         }
+    });
+
+    it('limits credential concurrency in the core post-deploy workflow', () => {
+        const workflow = readFileSync('.github/workflows/post-deploy-smoke.yml', 'utf8');
+        const scheduledWorkflow = readFileSync('.github/workflows/scheduled-prod-smoke.yml', 'utf8');
+
+        expect(workflow).toMatch(
+            /tests\/smoke\/app-admin-core\.spec\.js[\s\S]*?tests\/smoke\/app-authenticated-core\.spec\.js[\s\S]*?--workers=1/
+        );
+        expect(scheduledWorkflow).toMatch(
+            /tests\/smoke\/app-admin-core\.spec\.js[\s\S]*?tests\/smoke\/app-authenticated-core\.spec\.js[\s\S]*?--workers=1/
+        );
+        expect(authenticatedCore).not.toContain('parentBoundarySession');
+        expect(authenticatedCore).toContain('withAuthenticatedPage(parentWorkflowSession');
     });
 
     it('asserts the initial authenticated Home route without navigating to the current URL', () => {
@@ -79,7 +98,7 @@ describe('production smoke authenticated setup timeout', () => {
 
     it('measures the initial admin Home transition from before the sign-in action', () => {
         expect(helper).toMatch(
-            /const authenticatedHomeStartedAt = Date\.now\(\);\s+await page\.getByRole\('button', \{ name: 'Sign in' \}\)/
+            /const authenticatedHomeStartedAt = Date\.now\(\);[\s\S]*?await page\.getByRole\('button', \{ name: 'Sign in' \}\)/
         );
         expect(adminCore).toContain('Date.now() - authenticatedHomeStartedAt');
     });


### PR DESCRIPTION
## What changed
- bound browser-context cleanup so a failed production sign-in reports its redacted stage error instead of hanging the entire setup hook
- reduce core auth fan-out, reuse the parent session safely, and run credentialed suites with one Playwright worker
- allow a 30-second cold auth-form boot and preserve candidate diagnostics before later Playwright runs clean the output directory
- retain independent candidate, baseline, fixture, and role-workflow aggregation without enabling extended writes

## Why
Exact production run [30469936204](https://github.com/pauljsnider/allplays/actions/runs/30469936204) passed fixture readiness and the 25-test baseline, but candidate auth missed a 10-second cold-start budget and the core suites hid their real sign-in error behind an unbounded context close until both 180-second hooks expired.

## Validation
- `npm test -- --run`: 709 files passed, 5,243 tests passed, 121 skipped
- focused auth/workflow regressions: 11 passed
- Playwright discovery: 8 affected credentialed/candidate tests listed
- `git diff --check`
- GitHub Actions hardening review: no findings (trusted master checkout, least-privilege permissions, SHA-pinned actions, no unsafe event interpolation)

## Production safety
- no application behavior or Firebase records changed
- no credentials, tokens, URLs with action codes, screenshots, traces, or video are emitted
- extended production writes remain disabled