### PR TITLE
Let authenticated smoke setup return

### DIFF
--- a/tests/smoke/helpers/app-auth.js
+++ b/tests/smoke/helpers/app-auth.js
@@ -119,8 +119,6 @@ export async function signInToApp(page, { appBaseUrl, email, password, roleLabel
         }).not.toMatch(/^#\/(?:auth|verify-pending)(?:\?|$)/);
         stage = 'waiting for the authenticated shell';
         await expect(page.locator('main')).toBeVisible({ timeout: 20_000 });
-        await page.getByLabel('Password', { exact: true }).fill('').catch(() => {});
-        await page.getByLabel('Email').fill('').catch(() => {});
         return { authenticatedHomeStartedAt };
     } catch (error) {
         throw new Error(

--- a/tests/unit/production-smoke-auth-setup-timeout.test.js
+++ b/tests/unit/production-smoke-auth-setup-timeout.test.js
@@ -61,6 +61,16 @@ describe('production smoke authenticated setup timeout', () => {
         }
     });
 
+    it('returns immediately after authenticated navigation without waiting for vanished credential fields', () => {
+        const signInHelper = helper.slice(
+            helper.indexOf('export async function signInToApp'),
+            helper.indexOf('async function closeBrowserContextBounded')
+        );
+
+        expect(signInHelper).toContain('return { authenticatedHomeStartedAt };');
+        expect(signInHelper).not.toContain(".fill('')");
+    });
+
     it('limits credential concurrency in the core post-deploy workflow', () => {
         const workflow = readFileSync('.github/workflows/post-deploy-smoke.yml', 'utf8');
         const scheduledWorkflow = readFileSync('.github/workflows/scheduled-prod-smoke.yml', 'utf8');


### PR DESCRIPTION
## What changed

- Remove two unbounded best-effort credential-field clears after authentication has already navigated away from the form.
- Add a regression contract requiring successful authenticated setup to return without waiting on vanished inputs.

## Why

Exact-SHA production smoke run [30473025981](https://github.com/pauljsnider/allplays/actions/runs/30473025981) proved candidate auth, fixture readiness, and the 25-route baseline passed, but both role-suite `beforeAll` hooks consumed their full 240-second budget. The post-navigation `.fill("")` calls targeted inputs that no longer existed and inherited an unlimited Playwright action timeout.

## Validation

- `npx vitest run tests/unit/production-smoke-auth-setup-timeout.test.js tests/unit/app-auth-smoke-helper.test.js --reporter=verbose` — 8/8 passed
- `npm test` — 709 files passed, 3 skipped; 5,244 tests passed, 121 skipped
- Affected Playwright discovery — 4 tests in 2 files
- `git diff --check`

## Production safety

Smoke harness only. No application behavior, credentials, fixtures, Firebase data, or extended-write settings changed.