### PR TITLE
Disambiguate media smoke action

### DIFF
--- a/tests/smoke/app-authenticated-core.spec.js
+++ b/tests/smoke/app-authenticated-core.spec.js
@@ -100,7 +100,7 @@ test('staff account reaches every critical app workflow with smoke fixtures', as
         await expect(page.getByText('Participant details', { exact: true })).toBeVisible({ timeout: 20_000 });
         await expect(page.locator('main')).not.toContainText('No applications are available for this form yet.');
         await openAuthenticatedAppRoute(page, config.appBaseUrl, `${teamPath}/media`);
-        await expect(page.getByRole('button', { name: 'Photo' })).toBeVisible({ timeout: 20_000 });
+        await expect(page.getByRole('button', { name: 'Photo', exact: true })).toBeVisible({ timeout: 20_000 });
         await expect(page.locator('main')).not.toContainText('No albums are available yet.');
         await openAuthenticatedAppRoute(page, config.appBaseUrl, `${teamPath}/certificates`, { heading: 'Awards studio' });
         await openAuthenticatedAppRoute(page, config.appBaseUrl, '/officials', { heading: 'Assignments' });

--- a/tests/unit/production-smoke-auth-setup-timeout.test.js
+++ b/tests/unit/production-smoke-auth-setup-timeout.test.js
@@ -85,6 +85,12 @@ describe('production smoke authenticated setup timeout', () => {
         expect(authenticatedCore).toContain('withAuthenticatedPage(parentWorkflowSession');
     });
 
+    it('selects the singular media action without matching the plural media filter', () => {
+        expect(authenticatedCore).toContain(
+            "getByRole('button', { name: 'Photo', exact: true })"
+        );
+    });
+
     it('asserts the initial authenticated Home route without navigating to the current URL', () => {
         const routeAssertions = [
             "assertAuthenticatedAppRoute(page, '/home'",


### PR DESCRIPTION
## What changed

- Match the singular `Photo` media action exactly so it cannot also select the plural `Photos` filter.
- Add a source-contract regression for the exact accessible-name locator.

## Why

Exact-SHA production smoke run [30475508529](https://github.com/pauljsnider/allplays/actions/runs/30475508529) confirmed the authenticated setup hang is fixed and the platform-admin workflow passes. It then exposed this strict-mode locator ambiguity on the staff media page.

## Validation

- Focused production-smoke contract: 7/7 passed
- `npm test` — 709 files passed, 3 skipped; 5,245 tests passed, 121 skipped
- Affected Playwright discovery — 4 tests in 2 files
- Remaining role locators audited for the same ambiguity
- `git diff --check`

## Production safety

Smoke assertion only. No application behavior, credentials, fixtures, Firebase data, or extended-write settings changed.