### PR TITLE
Allow team-scoped officials access

### DIFF
--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -1733,6 +1733,7 @@ describe('official assignments app service', () => {
 
   it('allows an eligible team participant to view requested-team open slots without an official directory link', async () => {
     vi.mocked(getDocs).mockResolvedValue({ docs: [] } as any);
+    vi.mocked(getTeam).mockResolvedValue(null as any);
     vi.mocked(getGames).mockResolvedValue([
       {
         id: 'game-open',
@@ -1759,6 +1760,7 @@ describe('official assignments app service', () => {
         canClaim: true
       })
     ]);
+    expect(getTeam).toHaveBeenCalledWith('team-alpha', { includeInactive: true });
   });
 
   it('delegates accept, decline, and claim writes to legacy officiating actions', async () => {

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -1731,6 +1731,36 @@ describe('official assignments app service', () => {
     expect(getGames).toHaveBeenCalledWith('team-alpha', { startDate: expect.any(Date) });
   });
 
+  it('allows an eligible team participant to view requested-team open slots without an official directory link', async () => {
+    vi.mocked(getDocs).mockResolvedValue({ docs: [] } as any);
+    vi.mocked(getGames).mockResolvedValue([
+      {
+        id: 'game-open',
+        date: futureDate,
+        opponent: 'Falcons',
+        location: 'Field 4',
+        officiatingSelfAssignmentEnabled: true,
+        officiatingSlots: [
+          { id: 'line', position: 'Line Judge', status: 'open' }
+        ]
+      }
+    ] as any);
+
+    const result = await loadOfficialAssignments(user, { teamId: 'team-alpha' });
+
+    expect(result.hasAccess).toBe(true);
+    expect(result.teamIds).toEqual(['team-alpha']);
+    expect(result.assignments).toEqual([
+      expect.objectContaining({
+        kind: 'open',
+        teamId: 'team-alpha',
+        gameId: 'game-open',
+        slotId: 'line',
+        canClaim: true
+      })
+    ]);
+  });
+
   it('delegates accept, decline, and claim writes to legacy officiating actions', async () => {
     const item = {
       kind: 'assigned',

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -6704,7 +6704,10 @@ export async function loadOfficialAssignments(user: AuthUser, options: { teamId?
 
     return {
       teamId,
-      hasAccess: linkedTeamIds.includes(teamId) || (requestedTeamId === teamId && assignments.some((item) => item.kind === 'assigned')),
+      hasAccess: linkedTeamIds.includes(teamId) || (
+        requestedTeamId === teamId &&
+        (canClaim || assignments.some((item) => item.kind === 'assigned'))
+      ),
       assignments
     };
   }));

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -6579,14 +6579,19 @@ function isUpcomingOfficialGame(game: any, now = new Date()) {
   return Boolean(date && date.getTime() >= now.getTime() && status !== 'cancelled' && status !== 'canceled');
 }
 
-function isEligibleOpenOfficiatingSlotParticipant(team: any = {}, userProfile: Record<string, any> = {}, user: AuthUser) {
+function isEligibleOpenOfficiatingSlotParticipant(
+  team: any = {},
+  userProfile: Record<string, any> = {},
+  user: AuthUser,
+  requestedTeamId = compactString(team?.id)
+) {
   const uid = compactString(user?.uid);
   const email = normalizeOfficialLinkEmail(user?.email || '');
   if (!uid) return false;
   if (team?.ownerId === uid) return true;
   if (email && Array.isArray(team?.adminEmails) && team.adminEmails.map((value: unknown) => normalizeOfficialLinkEmail(value)).includes(email)) return true;
   if (userProfile?.isAdmin === true) return true;
-  if (Array.isArray(userProfile?.parentTeamIds) && userProfile.parentTeamIds.includes(team?.id)) return true;
+  if (requestedTeamId && Array.isArray(userProfile?.parentTeamIds) && userProfile.parentTeamIds.includes(requestedTeamId)) return true;
   return false;
 }
 
@@ -6658,7 +6663,12 @@ export async function loadOfficialAssignments(user: AuthUser, options: { teamId?
       getTeam(teamId, { includeInactive: true }).catch(() => null),
       getGames(teamId, { startDate: officialGamesSince }).catch(() => [])
     ]);
-    const canClaim = isEligibleOpenOfficiatingSlotParticipant(team || {}, userProfile as Record<string, any>, user);
+    const canClaim = isEligibleOpenOfficiatingSlotParticipant(
+      team || {},
+      userProfile as Record<string, any>,
+      user,
+      teamId
+    );
     const teamName = compactString(team?.name) || 'Team';
 
     const assignments = (Array.isArray(games) ? games : [])

--- a/tests/smoke/app-authenticated-core.spec.js
+++ b/tests/smoke/app-authenticated-core.spec.js
@@ -103,8 +103,15 @@ test('staff account reaches every critical app workflow with smoke fixtures', as
         await expect(page.getByRole('button', { name: 'Photo', exact: true })).toBeVisible({ timeout: 20_000 });
         await expect(page.locator('main')).not.toContainText('No albums are available yet.');
         await openAuthenticatedAppRoute(page, config.appBaseUrl, `${teamPath}/certificates`, { heading: 'Awards studio' });
-        await openAuthenticatedAppRoute(page, config.appBaseUrl, '/officials', { heading: 'Assignments' });
-        await expect(page.locator('main')).not.toContainText('No upcoming assignments');
+        await openAuthenticatedAppRoute(
+            page,
+            config.appBaseUrl,
+            `/officials?teamId=${encodeURIComponent(config.teamId)}`,
+            {
+                heading: 'Assignments',
+                requiredHref: `/schedule/${encodeURIComponent(config.teamId)}/${encodeURIComponent(config.gameId)}`
+            }
+        );
         await openAuthenticatedAppRoute(page, config.appBaseUrl, '/profile/settings');
         await openAuthenticatedAppRoute(page, config.appBaseUrl, '/help', { heading: 'Find guides without leaving the app' });
         await assertNotificationInbox(page);

--- a/tests/unit/production-smoke-auth-setup-timeout.test.js
+++ b/tests/unit/production-smoke-auth-setup-timeout.test.js
@@ -91,6 +91,16 @@ describe('production smoke authenticated setup timeout', () => {
         );
     });
 
+    it('keeps the officials workflow team-scoped and backed by the seeded game', () => {
+        expect(authenticatedCore).toContain(
+            '`/officials?teamId=${encodeURIComponent(config.teamId)}`'
+        );
+        expect(authenticatedCore).toContain(
+            'requiredHref: `/schedule/${encodeURIComponent(config.teamId)}/${encodeURIComponent(config.gameId)}`'
+        );
+        expect(authenticatedCore).not.toContain("openAuthenticatedAppRoute(page, config.appBaseUrl, '/officials'");
+    });
+
     it('asserts the initial authenticated Home route without navigating to the current URL', () => {
         const routeAssertions = [
             "assertAuthenticatedAppRoute(page, '/home'",


### PR DESCRIPTION
## What changed
- allow a requested team officials view when the signed-in user already satisfies the existing open-slot eligibility rules
- preserve officials route context in the production staff smoke and require the seeded game deep link
- add service and smoke-contract regression coverage

## Why
Exact-SHA production smoke run 30477333005 reached the staff officials workflow and exposed a redirect to Home. The staff smoke user was an eligible owner/admin for the synthetic team but had no separate officials-directory link, so the service computed claimable open slots and then denied the page that displayed them.

## Safety
- access is limited to an explicitly requested team
- eligibility reuses the existing owner/admin/platform-admin/parent-team predicate
- Firestore rules and all assignment mutation authorization remain unchanged
- production smoke remains read-only

## Validation
- npm run test:app -- src/lib/scheduleService.test.ts (139 passed)
- npx vitest run tests/unit/production-smoke-auth-setup-timeout.test.js --reporter=verbose (8 passed)
- npm run test:app (1,552 passed)
- npm test, isolated (5,246 passed; 121 skipped)
- npm run app:build (passed, including visualizer and bundle budget)
- git diff --check (passed)