### PR TITLE
Add officials smoke fixture maintenance

### DIFF
--- a/.github/workflows/production-smoke-fixture.yml
+++ b/.github/workflows/production-smoke-fixture.yml
@@ -1,0 +1,50 @@
+name: production-smoke-fixture
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Audit or repair the dedicated officials smoke fixture
+        required: true
+        default: audit
+        type: choice
+        options:
+          - audit
+          - repair
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-smoke-fixture
+  cancel-in-progress: false
+
+jobs:
+  maintain-officials-fixture:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment:
+      name: production-smoke
+
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 22
+
+      - name: Audit or repair officials smoke fixture
+        run: node scripts/maintain-production-smoke-official-fixture.mjs
+        env:
+          SMOKE_FIXTURE_MODE: ${{ inputs.mode }}
+          SMOKE_APP_BASE_URL: https://allplays.ai/app/
+          SMOKE_TEAM_ID: ${{ vars.SMOKE_TEAM_ID }}
+          SMOKE_GAME_ID: ${{ vars.SMOKE_GAME_ID }}
+          SMOKE_STAFF_EMAIL: ${{ secrets.SMOKE_STAFF_EMAIL }}
+          SMOKE_STAFF_PASSWORD: ${{ secrets.SMOKE_STAFF_PASSWORD }}

--- a/scripts/maintain-production-smoke-official-fixture.mjs
+++ b/scripts/maintain-production-smoke-official-fixture.mjs
@@ -23,6 +23,7 @@ function getSlotFields(value) {
 function isUnassignedOpenSlot(value) {
     const fields = getSlotFields(value);
     return getStringField(fields, 'status') === 'open' &&
+        Boolean(getStringField(fields, 'position').trim()) &&
         !getStringField(fields, 'officialUserId') &&
         !getStringField(fields, 'officialEmail') &&
         !getStringField(fields, 'officialName');

--- a/scripts/maintain-production-smoke-official-fixture.mjs
+++ b/scripts/maintain-production-smoke-official-fixture.mjs
@@ -1,0 +1,176 @@
+import { pathToFileURL } from 'node:url';
+import {
+    createFirebaseRestSession,
+    getFirestoreDocument,
+    patchFirestoreDocumentFields
+} from '../tests/smoke/helpers/firebase-rest.js';
+
+export const officialFixtureDate = '2099-01-01T18:00:00.000Z';
+export const officialFixtureSlotId = 'allplays-smoke-official-v1';
+
+function getStringField(fields, fieldName) {
+    return String(fields?.[fieldName]?.stringValue || '');
+}
+
+function getArrayValues(field) {
+    return Array.isArray(field?.arrayValue?.values) ? field.arrayValue.values : [];
+}
+
+function getSlotFields(value) {
+    return value?.mapValue?.fields || {};
+}
+
+function isUnassignedOpenSlot(value) {
+    const fields = getSlotFields(value);
+    return getStringField(fields, 'status') === 'open' &&
+        !getStringField(fields, 'officialUserId') &&
+        !getStringField(fields, 'officialEmail') &&
+        !getStringField(fields, 'officialName');
+}
+
+function getGameDate(fields) {
+    const value = fields?.date || {};
+    return String(value.timestampValue || value.stringValue || '');
+}
+
+function getGameStatus(fields) {
+    return getStringField(fields, 'status').trim().toLowerCase();
+}
+
+export function assertSmokeFixtureIdentifier(value, label) {
+    if (!/^allplays-smoke-[A-Za-z0-9_-]+$/.test(String(value || ''))) {
+        throw new Error(`${label} must identify a dedicated AllPlays smoke fixture`);
+    }
+}
+
+export function inspectOfficialFixture(document, now = new Date()) {
+    const fields = document?.fields || {};
+    const dateValue = getGameDate(fields);
+    const date = dateValue ? new Date(dateValue) : null;
+    const status = getGameStatus(fields);
+    const slots = getArrayValues(fields.officiatingSlots);
+    const openSlotCount = slots.filter(isUnassignedOpenSlot).length;
+    const isUpcoming = Boolean(date && Number.isFinite(date.getTime()) && date.getTime() > now.getTime());
+    const isCancelled = status === 'cancelled' || status === 'canceled';
+
+    return {
+        ready: fields.officiatingSelfAssignmentEnabled?.booleanValue === true &&
+            isUpcoming &&
+            !isCancelled &&
+            openSlotCount > 0,
+        isUpcoming,
+        isCancelled,
+        openSlotCount,
+        selfAssignmentEnabled: fields.officiatingSelfAssignmentEnabled?.booleanValue === true
+    };
+}
+
+function buildFixtureSlot() {
+    return {
+        mapValue: {
+            fields: {
+                id: { stringValue: officialFixtureSlotId },
+                position: { stringValue: 'Smoke official' },
+                status: { stringValue: 'open' },
+                scheduleReviewRequired: { booleanValue: false }
+            }
+        }
+    };
+}
+
+export function buildOfficialFixturePatch(document, now = new Date()) {
+    const fields = document?.fields || {};
+    const slots = getArrayValues(fields.officiatingSlots);
+    const inspection = inspectOfficialFixture(document, now);
+    const nextSlots = inspection.openSlotCount > 0
+        ? slots
+        : [
+            ...slots.filter(
+                (value) => getStringField(getSlotFields(value), 'id') !== officialFixtureSlotId
+            ),
+            buildFixtureSlot()
+        ];
+    const patch = {
+        officiatingSelfAssignmentEnabled: { booleanValue: true },
+        officiatingSlots: { arrayValue: { values: nextSlots } }
+    };
+
+    if (!inspection.isUpcoming) {
+        patch.date = { timestampValue: officialFixtureDate };
+    }
+    if (inspection.isCancelled) {
+        patch.status = { stringValue: 'scheduled' };
+    }
+
+    return { fields: patch };
+}
+
+function isAuthorizedFixtureManager(teamDocument, session, staffEmail) {
+    const fields = teamDocument?.fields || {};
+    if (getStringField(fields, 'ownerId') === session.localId) return true;
+    const normalizedEmail = String(staffEmail || '').trim().toLowerCase();
+    return getArrayValues(fields.adminEmails)
+        .map((value) => String(value?.stringValue || '').trim().toLowerCase())
+        .includes(normalizedEmail);
+}
+
+async function main() {
+    const mode = String(process.env.SMOKE_FIXTURE_MODE || 'audit').trim().toLowerCase();
+    if (!['audit', 'repair'].includes(mode)) {
+        throw new Error('SMOKE_FIXTURE_MODE must be audit or repair');
+    }
+
+    const appBaseUrl = String(process.env.SMOKE_APP_BASE_URL || '').trim();
+    const teamId = String(process.env.SMOKE_TEAM_ID || '').trim();
+    const gameId = String(process.env.SMOKE_GAME_ID || '').trim();
+    const staffEmail = String(process.env.SMOKE_STAFF_EMAIL || '').trim();
+    const staffPassword = String(process.env.SMOKE_STAFF_PASSWORD || '');
+    if (!appBaseUrl || !teamId || !gameId || !staffEmail || !staffPassword) {
+        throw new Error('Protected production smoke fixture configuration is incomplete');
+    }
+    assertSmokeFixtureIdentifier(teamId, 'Team ID');
+    assertSmokeFixtureIdentifier(gameId, 'Game ID');
+
+    const session = await createFirebaseRestSession({
+        appBaseUrl,
+        email: staffEmail,
+        password: staffPassword
+    });
+    const teamDocument = await getFirestoreDocument(session, `teams/${teamId}`);
+    if (!teamDocument || !isAuthorizedFixtureManager(teamDocument, session, staffEmail)) {
+        throw new Error('The staff smoke account is not an owner or administrator of the fixture team');
+    }
+
+    const gamePath = `teams/${teamId}/games/${gameId}`;
+    const gameDocument = await getFirestoreDocument(session, gamePath);
+    if (!gameDocument) {
+        throw new Error('The officials smoke game fixture does not exist');
+    }
+    let inspection = inspectOfficialFixture(gameDocument);
+
+    if (mode === 'repair' && !inspection.ready) {
+        const patch = buildOfficialFixturePatch(gameDocument);
+        await patchFirestoreDocumentFields(session, gamePath, patch.fields, {
+            updateTime: String(gameDocument.updateTime || '')
+        });
+        const repairedDocument = await getFirestoreDocument(session, gamePath);
+        inspection = inspectOfficialFixture(repairedDocument);
+    }
+
+    if (!inspection.ready) {
+        throw new Error(
+            `Officials fixture is not ready (upcoming=${inspection.isUpcoming}, ` +
+            `self-assignment=${inspection.selfAssignmentEnabled}, open-slots=${inspection.openSlotCount}, ` +
+            `cancelled=${inspection.isCancelled})`
+        );
+    }
+
+    console.log(`Officials fixture ${mode} passed with ${inspection.openSlotCount} open slot(s).`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main().catch((error) => {
+        console.error(`Production smoke officials fixture failed: ${error?.message || 'Unknown error'}`);
+        process.exitCode = 1;
+    });
+}

--- a/tests/smoke/helpers/firebase-rest.js
+++ b/tests/smoke/helpers/firebase-rest.js
@@ -161,6 +161,39 @@ export async function getFirestoreDocument(session, documentPath) {
     return readJson(response, 'Firestore smoke document read');
 }
 
+export async function patchFirestoreDocumentFields(
+    session,
+    documentPath,
+    fields,
+    { updateTime = '' } = {}
+) {
+    const fieldEntries = Object.entries(fields || {});
+    if (!fieldEntries.length) {
+        throw new Error('Firestore smoke patch requires at least one field');
+    }
+    const url = new URL(
+        `${firestoreApiOrigin}/v1/projects/${encodeURIComponent(session.projectId)}/databases/(default)/documents/${encodeDocumentPath(documentPath)}`
+    );
+    fieldEntries
+        .map(([fieldPath]) => fieldPath)
+        .sort()
+        .forEach((fieldPath) => url.searchParams.append('updateMask.fieldPaths', fieldPath));
+    if (updateTime) {
+        url.searchParams.set('currentDocument.updateTime', updateTime);
+    }
+    const response = await fetch(url, {
+        method: 'PATCH',
+        headers: {
+            authorization: `Bearer ${session.idToken}`,
+            'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+            fields: Object.fromEntries(fieldEntries)
+        })
+    });
+    return readJson(response, 'Firestore smoke document patch');
+}
+
 export async function restoreFirestoreDocument(session, documentPath, originalDocument) {
     if (!originalDocument) {
         await deleteFirestoreDocument(session, documentPath);

--- a/tests/unit/production-smoke-official-fixture.test.js
+++ b/tests/unit/production-smoke-official-fixture.test.js
@@ -1,0 +1,181 @@
+import { readFileSync } from 'node:fs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+    assertSmokeFixtureIdentifier,
+    buildOfficialFixturePatch,
+    inspectOfficialFixture,
+    officialFixtureDate,
+    officialFixtureSlotId
+} from '../../scripts/maintain-production-smoke-official-fixture.mjs';
+import { patchFirestoreDocumentFields } from '../smoke/helpers/firebase-rest.js';
+
+const workflowSource = readFileSync('.github/workflows/production-smoke-fixture.yml', 'utf8');
+
+function buildDocument({
+    date = '2025-01-01T18:00:00.000Z',
+    enabled = false,
+    slots = [],
+    status = 'cancelled'
+} = {}) {
+    return {
+        updateTime: '2026-07-29T18:00:00.000Z',
+        fields: {
+            date: { timestampValue: date },
+            officiatingSelfAssignmentEnabled: { booleanValue: enabled },
+            officiatingSlots: { arrayValue: { values: slots } },
+            status: { stringValue: status }
+        }
+    };
+}
+
+describe('production officials smoke fixture maintenance', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('rejects identifiers outside the dedicated smoke namespace', () => {
+        expect(() => assertSmokeFixtureIdentifier('allplays-smoke-team-v1', 'Team ID')).not.toThrow();
+        expect(() => assertSmokeFixtureIdentifier('real-team', 'Team ID')).toThrow(
+            'Team ID must identify a dedicated AllPlays smoke fixture'
+        );
+    });
+
+    it('builds a deterministic repair without replacing unrelated game fields', () => {
+        const document = buildDocument();
+        const patch = buildOfficialFixturePatch(document, new Date('2026-07-29T18:00:00.000Z'));
+
+        expect(patch.fields).toEqual({
+            date: { timestampValue: officialFixtureDate },
+            officiatingSelfAssignmentEnabled: { booleanValue: true },
+            officiatingSlots: {
+                arrayValue: {
+                    values: [
+                        {
+                            mapValue: {
+                                fields: {
+                                    id: { stringValue: officialFixtureSlotId },
+                                    position: { stringValue: 'Smoke official' },
+                                    scheduleReviewRequired: { booleanValue: false },
+                                    status: { stringValue: 'open' }
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            status: { stringValue: 'scheduled' }
+        });
+        expect(Object.keys(patch.fields)).not.toContain('opponent');
+    });
+
+    it('recognizes an upcoming self-assignable unclaimed official slot as ready', () => {
+        const document = buildDocument({
+            date: officialFixtureDate,
+            enabled: true,
+            status: 'scheduled',
+            slots: [
+                {
+                    mapValue: {
+                        fields: {
+                            id: { stringValue: officialFixtureSlotId },
+                            position: { stringValue: 'Smoke official' },
+                            status: { stringValue: 'open' }
+                        }
+                    }
+                }
+            ]
+        });
+
+        expect(inspectOfficialFixture(document, new Date('2026-07-29T18:00:00.000Z'))).toEqual({
+            ready: true,
+            isUpcoming: true,
+            isCancelled: false,
+            openSlotCount: 1,
+            selfAssignmentEnabled: true
+        });
+        expect(buildOfficialFixturePatch(document).fields).toEqual({
+            officiatingSelfAssignmentEnabled: { booleanValue: true },
+            officiatingSlots: document.fields.officiatingSlots
+        });
+    });
+
+    it('does not count an assigned open-looking slot as claimable', () => {
+        const document = buildDocument({
+            date: officialFixtureDate,
+            enabled: true,
+            status: 'scheduled',
+            slots: [
+                {
+                    mapValue: {
+                        fields: {
+                            id: { stringValue: 'assigned-slot' },
+                            officialUserId: { stringValue: 'assigned-user' },
+                            status: { stringValue: 'open' }
+                        }
+                    }
+                }
+            ]
+        });
+
+        expect(inspectOfficialFixture(document).openSlotCount).toBe(0);
+        const slots = buildOfficialFixturePatch(document).fields.officiatingSlots.arrayValue.values;
+        expect(slots).toHaveLength(2);
+        expect(slots[1].mapValue.fields.id.stringValue).toBe(officialFixtureSlotId);
+    });
+
+    it('patches only the named fields with an optimistic concurrency precondition', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+            ok: true,
+            json: vi.fn().mockResolvedValue({ fields: {} })
+        });
+
+        await patchFirestoreDocumentFields(
+            {
+                projectId: 'smoke-project',
+                idToken: 'redacted-token'
+            },
+            'teams/allplays-smoke-team-v1/games/allplays-smoke-game-v1',
+            {
+                officiatingSlots: { arrayValue: { values: [] } },
+                officiatingSelfAssignmentEnabled: { booleanValue: true }
+            },
+            { updateTime: '2026-07-29T18:00:00.000Z' }
+        );
+
+        expect(fetchMock).toHaveBeenCalledOnce();
+        const [requestUrl, request] = fetchMock.mock.calls[0];
+        const url = new URL(requestUrl);
+        expect(url.searchParams.getAll('updateMask.fieldPaths')).toEqual([
+            'officiatingSelfAssignmentEnabled',
+            'officiatingSlots'
+        ]);
+        expect(url.searchParams.get('currentDocument.updateTime')).toBe(
+            '2026-07-29T18:00:00.000Z'
+        );
+        expect(request).toMatchObject({
+            method: 'PATCH',
+            headers: {
+                authorization: 'Bearer redacted-token',
+                'content-type': 'application/json'
+            }
+        });
+        expect(JSON.parse(request.body)).toEqual({
+            fields: {
+                officiatingSlots: { arrayValue: { values: [] } },
+                officiatingSelfAssignmentEnabled: { booleanValue: true }
+            }
+        });
+    });
+
+    it('keeps production fixture credentials on an exact default-branch manual workflow', () => {
+        expect(workflowSource).toContain('workflow_dispatch:');
+        expect(workflowSource).not.toContain('pull_request:');
+        expect(workflowSource).toContain("if: github.ref == 'refs/heads/master'");
+        expect(workflowSource).toContain('ref: ${{ github.sha }}');
+        expect(workflowSource).toContain('persist-credentials: false');
+        expect(workflowSource).toContain('permissions:\n  contents: read');
+        expect(workflowSource).toContain('environment:\n      name: production-smoke');
+        expect(workflowSource).toContain('SMOKE_FIXTURE_MODE: ${{ inputs.mode }}');
+        expect(workflowSource).not.toContain('run: ${{ inputs.mode }}');
+    });
+});

--- a/tests/unit/production-smoke-official-fixture.test.js
+++ b/tests/unit/production-smoke-official-fixture.test.js
@@ -123,6 +123,30 @@ describe('production officials smoke fixture maintenance', () => {
         expect(slots[1].mapValue.fields.id.stringValue).toBe(officialFixtureSlotId);
     });
 
+    it('repairs an open-looking slot that application normalization drops without a position', () => {
+        const document = buildDocument({
+            date: officialFixtureDate,
+            enabled: true,
+            status: 'scheduled',
+            slots: [
+                {
+                    mapValue: {
+                        fields: {
+                            id: { stringValue: 'malformed-slot' },
+                            position: { stringValue: '   ' },
+                            status: { stringValue: 'open' }
+                        }
+                    }
+                }
+            ]
+        });
+
+        expect(inspectOfficialFixture(document).openSlotCount).toBe(0);
+        const slots = buildOfficialFixturePatch(document).fields.officiatingSlots.arrayValue.values;
+        expect(slots).toHaveLength(2);
+        expect(slots[1].mapValue.fields.position.stringValue).toBe('Smoke official');
+    });
+
     it('patches only the named fields with an optimistic concurrency precondition', async () => {
         const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
             ok: true,


### PR DESCRIPTION
## What changed
- add a manual production-smoke workflow that audits or repairs the dedicated officials game fixture
- require an exact default-branch SHA, protected smoke credentials, smoke-namespaced IDs, and staff ownership/admin access
- patch only date/status/officiating fields with an optimistic update-time precondition
- add reusable field-scoped Firestore REST patching and deterministic unit coverage

## Why
Exact-SHA production smoke run 30480278094 proved the officials access fix reached the Assignments page, then failed because the long-lived synthetic game did not contain a rendered open assignment. The smoke correctly rejected an empty officials workflow. This adds a controlled way to repair that pre-seeded smoke-owned record without making post-deploy smoke itself write to production.

## Safety
- workflow_dispatch only; no pull-request or scheduled trigger
- refuses any team/game ID outside the allplays-smoke namespace
- runs only on refs/heads/master and checks out github.sha exactly
- production-smoke environment secrets; read-only repository token
- verifies the smoke staff account owns/administers the synthetic team
- preserves unrelated game fields and uses currentDocument.updateTime
- audit is the default; repair must be selected explicitly

## Validation
- focused fixture and core-smoke contracts: 14 passed
- npm test: 5,252 passed; 121 skipped
- node syntax checks passed
- git diff --check passed
- GitHub Actions threat-model review: no findings