### PR TITLE
Fix production smoke Firebase bootstrap

### DIFF
--- a/tests/smoke/helpers/firebase-rest.js
+++ b/tests/smoke/helpers/firebase-rest.js
@@ -17,12 +17,24 @@ async function readJson(response, operation) {
     return response.json();
 }
 
-export async function createFirebaseRestSession({ appBaseUrl, email, password }) {
+async function loadFirebaseSmokeConfig(appBaseUrl) {
     const origin = new URL(appBaseUrl).origin;
-    const configResponse = await fetch(`${origin}/__/firebase/init.json`, {
+    const hostingResponse = await fetch(`${origin}/__/firebase/init.json`, {
         headers: { accept: 'application/json' }
     });
-    const config = await readJson(configResponse, 'Firebase smoke configuration load');
+    if (hostingResponse.ok) {
+        return hostingResponse.json();
+    }
+
+    const runtimeResponse = await fetch(`${origin}/.well-known/allplays-runtime-config.json`, {
+        headers: { accept: 'application/json' }
+    });
+    const runtimeConfig = await readJson(runtimeResponse, 'AllPlays smoke runtime configuration load');
+    return runtimeConfig.firebase || runtimeConfig.firebasePrimary || {};
+}
+
+export async function createFirebaseRestSession({ appBaseUrl, email, password }) {
+    const config = await loadFirebaseSmokeConfig(appBaseUrl);
     if (!config.apiKey || !config.projectId) {
         throw new Error('Firebase smoke configuration is incomplete');
     }

--- a/tests/unit/production-smoke-official-fixture.test.js
+++ b/tests/unit/production-smoke-official-fixture.test.js
@@ -7,7 +7,10 @@ import {
     officialFixtureDate,
     officialFixtureSlotId
 } from '../../scripts/maintain-production-smoke-official-fixture.mjs';
-import { patchFirestoreDocumentFields } from '../smoke/helpers/firebase-rest.js';
+import {
+    createFirebaseRestSession,
+    patchFirestoreDocumentFields
+} from '../smoke/helpers/firebase-rest.js';
 
 const workflowSource = readFileSync('.github/workflows/production-smoke-fixture.yml', 'utf8');
 
@@ -188,6 +191,55 @@ describe('production officials smoke fixture maintenance', () => {
                 officiatingSlots: { arrayValue: { values: [] } },
                 officiatingSelfAssignmentEnabled: { booleanValue: true }
             }
+        });
+    });
+
+    it('loads canonical-host Firebase configuration from the AllPlays runtime fallback', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch')
+            .mockResolvedValueOnce({
+                ok: false,
+                status: 404
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: vi.fn().mockResolvedValue({
+                    firebase: {
+                        apiKey: 'runtime-api-key',
+                        projectId: 'runtime-project',
+                        storageBucket: 'runtime-bucket'
+                    }
+                })
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: vi.fn().mockResolvedValue({
+                    idToken: 'redacted-token',
+                    localId: 'smoke-user'
+                })
+            });
+
+        await expect(createFirebaseRestSession({
+            appBaseUrl: 'https://allplays.ai/app/',
+            email: 'smoke@example.com',
+            password: 'exact password'
+        })).resolves.toEqual({
+            projectId: 'runtime-project',
+            storageBucket: 'runtime-bucket',
+            idToken: 'redacted-token',
+            localId: 'smoke-user'
+        });
+
+        expect(fetchMock.mock.calls[0][0]).toBe('https://allplays.ai/__/firebase/init.json');
+        expect(fetchMock.mock.calls[1][0]).toBe(
+            'https://allplays.ai/.well-known/allplays-runtime-config.json'
+        );
+        expect(fetchMock.mock.calls[2][0]).toBe(
+            'https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=runtime-api-key'
+        );
+        expect(JSON.parse(fetchMock.mock.calls[2][1].body)).toEqual({
+            email: 'smoke@example.com',
+            password: 'exact password',
+            returnSecureToken: true
         });
     });
 


### PR DESCRIPTION
## What changed

- fall back from the Firebase Hosting init endpoint to the canonical AllPlays runtime-config endpoint
- preserve the existing Firebase Hosting bootstrap for preview and local smoke targets
- add regression coverage for the production `allplays.ai/app/` configuration and exact password forwarding

## Why

The first protected officials-fixture audit failed safely before any write because `allplays.ai/__/firebase/init.json` is intentionally unavailable. The production app resolves Firebase through `.well-known/allplays-runtime-config.json`; the REST smoke helper now follows the same contract.

## Validation

- `npx vitest run tests/unit/production-smoke-official-fixture.test.js --reporter=verbose` (8/8)
- `npm test` (710 files passed, 3 skipped; 5,254 tests passed, 121 skipped)
- `node --check tests/smoke/helpers/firebase-rest.js`
- `git diff --check`

The failed audit made no production data changes. After this PR lands, the fixture sequence will be rerun as audit → repair → audit before exact-SHA production smoke.