### PR TITLE
Send app origin for smoke authentication

### DIFF
--- a/tests/smoke/helpers/firebase-rest.js
+++ b/tests/smoke/helpers/firebase-rest.js
@@ -34,6 +34,7 @@ async function loadFirebaseSmokeConfig(appBaseUrl) {
 }
 
 export async function createFirebaseRestSession({ appBaseUrl, email, password }) {
+    const appOrigin = new URL(appBaseUrl).origin;
     const config = await loadFirebaseSmokeConfig(appBaseUrl);
     if (!config.apiKey || !config.projectId) {
         throw new Error('Firebase smoke configuration is incomplete');
@@ -43,7 +44,10 @@ export async function createFirebaseRestSession({ appBaseUrl, email, password })
         `${identityToolkitOrigin}/v1/accounts:signInWithPassword?key=${encodeURIComponent(config.apiKey)}`,
         {
             method: 'POST',
-            headers: { 'content-type': 'application/json' },
+            headers: {
+                'content-type': 'application/json',
+                referer: `${appOrigin}/`
+            },
             body: JSON.stringify({
                 email,
                 password,

--- a/tests/unit/production-smoke-official-fixture.test.js
+++ b/tests/unit/production-smoke-official-fixture.test.js
@@ -236,6 +236,10 @@ describe('production officials smoke fixture maintenance', () => {
         expect(fetchMock.mock.calls[2][0]).toBe(
             'https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=runtime-api-key'
         );
+        expect(fetchMock.mock.calls[2][1].headers).toEqual({
+            'content-type': 'application/json',
+            referer: 'https://allplays.ai/'
+        });
         expect(JSON.parse(fetchMock.mock.calls[2][1].body)).toEqual({
             email: 'smoke@example.com',
             password: 'exact password',


### PR DESCRIPTION
## What changed

- derive the expected browser referrer from `SMOKE_APP_BASE_URL`
- include that canonical origin when the REST smoke helper signs in through Firebase Identity Toolkit
- assert the exact canonical referrer in the production bootstrap regression

## Why

The protected read-only fixture audit reached Firebase Auth after #4248, but the production web API key correctly rejected a server request with an empty referrer. A dummy-credential probe confirmed `PERMISSION_DENIED` without the app origin and normal credential validation with `https://allplays.ai/`. This preserves the existing API-key restriction and does not change cloud configuration.

## Validation

- dummy credentials only: empty referrer rejected; canonical app referrer reached normal `EMAIL_NOT_FOUND` validation
- focused fixture/bootstrap contracts: 8/8 passed
- full root suite: 710 files passed, 3 skipped; 5,254 tests passed, 121 skipped
- syntax and diff checks passed

No production data mutation has run. After landing, the fixture will be validated audit → repair → audit.