### PR TITLE
Wait for hydrated smoke fixture links

### DIFF
--- a/tests/smoke/helpers/app-auth.js
+++ b/tests/smoke/helpers/app-auth.js
@@ -195,10 +195,15 @@ export async function assertAuthenticatedAppRoute(page, route, options = {}) {
     const body = await page.locator('body').innerText();
     for (const pattern of forbidden) expect(body).not.toMatch(pattern);
     if (requiredHref) {
-        const found = await page.locator('a').evaluateAll((links, expected) => (
-            links.some((link) => String(link.getAttribute('href') || '').includes(String(expected)))
-        ), requiredHref);
-        expect(found, `Expected a meaningful fixture link containing ${requiredHref}`).toBe(true);
+        await expect.poll(
+            () => page.locator('a').evaluateAll((links, expected) => (
+                links.some((link) => String(link.getAttribute('href') || '').includes(String(expected)))
+            ), requiredHref),
+            {
+                timeout: 25_000,
+                message: `Expected a meaningful fixture link containing ${requiredHref}`
+            }
+        ).toBe(true);
     }
 }
 

--- a/tests/unit/production-smoke-auth-setup-timeout.test.js
+++ b/tests/unit/production-smoke-auth-setup-timeout.test.js
@@ -101,6 +101,20 @@ describe('production smoke authenticated setup timeout', () => {
         expect(authenticatedCore).not.toContain("openAuthenticatedAppRoute(page, config.appBaseUrl, '/officials'");
     });
 
+    it('waits for asynchronously hydrated fixture links before failing a route', () => {
+        const routeHelper = helper.slice(
+            helper.indexOf('export async function assertAuthenticatedAppRoute'),
+            helper.indexOf('export async function openAuthenticatedAppRoute')
+        );
+
+        expect(routeHelper).toContain('await expect.poll(');
+        expect(routeHelper).toContain('timeout: 25_000');
+        expect(routeHelper).toContain(
+            'message: `Expected a meaningful fixture link containing ${requiredHref}`'
+        );
+        expect(routeHelper).not.toContain('const found = await');
+    });
+
     it('asserts the initial authenticated Home route without navigating to the current URL', () => {
         const routeAssertions = [
             "assertAuthenticatedAppRoute(page, '/home'",


### PR DESCRIPTION
## What changed

- poll required meaningful-link assertions for up to the existing 25-second route hydration budget
- retain immediate heading, forbidden-error, and route checks
- add a source regression that prevents reverting to a single eager link snapshot

## Why

Exact-SHA production validation proved the synthetic officials fixture is healthy through the protected REST audit, but the browser smoke checked the Officials link immediately after the static `Assignments` heading appeared. The async assignment query had not rendered yet, so the staff workflow failed after roughly one second and prevented the parent/boundary tests from running.

## Validation

- focused authenticated smoke helper contracts: 9/9 passed
- full root suite: 710 files passed, 3 skipped; 5,255 tests passed, 121 skipped
- syntax and diff checks passed
- exact production baseline on the prior head: 25/25 passed
- fixture repair and independent audit: one normalized open slot

No production data or application behavior changes.