### PR TITLE
Repair parent production smoke fixture links

### DIFF
--- a/.github/workflows/production-smoke-fixture.yml
+++ b/.github/workflows/production-smoke-fixture.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: Audit or repair the dedicated officials smoke fixture
+        description: Audit or repair the dedicated production smoke fixtures
         required: true
         default: audit
         type: choice
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  maintain-officials-fixture:
+  maintain-production-fixtures:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -48,3 +48,17 @@ jobs:
           SMOKE_GAME_ID: ${{ vars.SMOKE_GAME_ID }}
           SMOKE_STAFF_EMAIL: ${{ secrets.SMOKE_STAFF_EMAIL }}
           SMOKE_STAFF_PASSWORD: ${{ secrets.SMOKE_STAFF_PASSWORD }}
+
+      - name: Audit or repair parent smoke fixture
+        run: node scripts/maintain-production-smoke-parent-fixture.mjs
+        env:
+          SMOKE_FIXTURE_MODE: ${{ inputs.mode }}
+          SMOKE_APP_BASE_URL: https://allplays.ai/app/
+          SMOKE_TEAM_ID: ${{ vars.SMOKE_TEAM_ID }}
+          SMOKE_PLAYER_ID: ${{ vars.SMOKE_PLAYER_ID }}
+          SMOKE_ADMIN_EMAIL: ${{ secrets.SMOKE_ADMIN_EMAIL }}
+          SMOKE_ADMIN_PASSWORD: ${{ secrets.SMOKE_ADMIN_PASSWORD }}
+          SMOKE_STAFF_EMAIL: ${{ secrets.SMOKE_STAFF_EMAIL }}
+          SMOKE_STAFF_PASSWORD: ${{ secrets.SMOKE_STAFF_PASSWORD }}
+          SMOKE_PARENT_EMAIL: ${{ secrets.SMOKE_PARENT_EMAIL }}
+          SMOKE_PARENT_PASSWORD: ${{ secrets.SMOKE_PARENT_PASSWORD }}

--- a/scripts/maintain-production-smoke-parent-fixture.mjs
+++ b/scripts/maintain-production-smoke-parent-fixture.mjs
@@ -34,7 +34,7 @@ function isParentLink(value, teamId, playerId) {
 
 function isActiveRosterPlayer(document) {
     const fields = document?.fields || {};
-    const status = getStringField(fields, 'status').trim().toLowerCase();
+    const status = getStringField(fields, 'status');
     return getBooleanField(fields, 'active') !== false &&
         getBooleanField(fields, 'archived') !== true &&
         (!status || status === 'active');

--- a/scripts/maintain-production-smoke-parent-fixture.mjs
+++ b/scripts/maintain-production-smoke-parent-fixture.mjs
@@ -1,0 +1,265 @@
+import { pathToFileURL } from 'node:url';
+import {
+    createFirebaseRestSession,
+    getFirestoreDocument,
+    patchFirestoreDocumentFields
+} from '../tests/smoke/helpers/firebase-rest.js';
+import { assertSmokeFixtureIdentifier } from './maintain-production-smoke-official-fixture.mjs';
+
+function getStringField(fields, fieldName) {
+    return String(fields?.[fieldName]?.stringValue || '');
+}
+
+function getArrayValues(field) {
+    return Array.isArray(field?.arrayValue?.values) ? field.arrayValue.values : [];
+}
+
+function getMapFields(value) {
+    return value?.mapValue?.fields || {};
+}
+
+function getBooleanField(fields, fieldName) {
+    return fields?.[fieldName]?.booleanValue;
+}
+
+function hasStringValue(field, expected) {
+    return getArrayValues(field).some((value) => String(value?.stringValue || '') === expected);
+}
+
+function isParentLink(value, teamId, playerId) {
+    const fields = getMapFields(value);
+    return getStringField(fields, 'teamId') === teamId &&
+        getStringField(fields, 'playerId') === playerId;
+}
+
+function isActiveRosterPlayer(document) {
+    const fields = document?.fields || {};
+    const status = getStringField(fields, 'status').trim().toLowerCase();
+    return getBooleanField(fields, 'active') !== false &&
+        getBooleanField(fields, 'archived') !== true &&
+        (!status || status === 'active');
+}
+
+export function inspectParentFixture(userDocument, playerDocument, teamId, playerId) {
+    const fields = userDocument?.fields || {};
+    const playerKey = `${teamId}::${playerId}`;
+    const hasParentOf = getArrayValues(fields.parentOf)
+        .some((value) => isParentLink(value, teamId, playerId));
+    const hasParentTeamId = hasStringValue(fields.parentTeamIds, teamId);
+    const hasParentPlayerKey = hasStringValue(fields.parentPlayerKeys, playerKey);
+    const playerExists = Boolean(playerDocument);
+    const playerActive = playerExists && isActiveRosterPlayer(playerDocument);
+
+    return {
+        ready: hasParentOf && hasParentTeamId && hasParentPlayerKey && playerActive,
+        hasParentOf,
+        hasParentTeamId,
+        hasParentPlayerKey,
+        playerExists,
+        playerActive
+    };
+}
+
+function buildStringArray(values) {
+    return {
+        arrayValue: {
+            values: values.map((value) => ({ stringValue: value }))
+        }
+    };
+}
+
+function uniqueStrings(field, requiredValue) {
+    return [
+        ...new Set([
+            ...getArrayValues(field).map((value) => String(value?.stringValue || '')).filter(Boolean),
+            requiredValue
+        ])
+    ];
+}
+
+function buildParentLink(teamId, playerId, teamName, playerName) {
+    return {
+        mapValue: {
+            fields: {
+                teamId: { stringValue: teamId },
+                teamName: { stringValue: teamName },
+                playerId: { stringValue: playerId },
+                playerName: { stringValue: playerName }
+            }
+        }
+    };
+}
+
+export function buildParentMembershipPatch(
+    userDocument,
+    { teamId, playerId, teamName = 'Smoke Team', playerName = 'Smoke Player' }
+) {
+    const fields = userDocument?.fields || {};
+    const parentOf = [
+        ...getArrayValues(fields.parentOf)
+            .filter((value) => !isParentLink(value, teamId, playerId)),
+        buildParentLink(teamId, playerId, teamName, playerName)
+    ];
+
+    return {
+        fields: {
+            parentOf: { arrayValue: { values: parentOf } },
+            parentTeamIds: buildStringArray(uniqueStrings(fields.parentTeamIds, teamId)),
+            parentPlayerKeys: buildStringArray(
+                uniqueStrings(fields.parentPlayerKeys, `${teamId}::${playerId}`)
+            )
+        }
+    };
+}
+
+export function buildActivePlayerPatch() {
+    return {
+        fields: {
+            active: { booleanValue: true },
+            archived: { booleanValue: false },
+            status: { stringValue: 'active' }
+        }
+    };
+}
+
+function isAuthorizedFixtureManager(teamDocument, session, staffEmail) {
+    const fields = teamDocument?.fields || {};
+    if (getStringField(fields, 'ownerId') === session.localId) return true;
+    const normalizedEmail = String(staffEmail || '').trim().toLowerCase();
+    return getArrayValues(fields.adminEmails)
+        .map((value) => String(value?.stringValue || '').trim().toLowerCase())
+        .includes(normalizedEmail);
+}
+
+function isGlobalAdmin(userDocument) {
+    return getBooleanField(userDocument?.fields || {}, 'isAdmin') === true;
+}
+
+function getDisplayName(document, fallback) {
+    const fields = document?.fields || {};
+    return getStringField(fields, 'name').trim() ||
+        getStringField(fields, 'displayName').trim() ||
+        fallback;
+}
+
+async function main() {
+    const mode = String(process.env.SMOKE_FIXTURE_MODE || 'audit').trim().toLowerCase();
+    if (!['audit', 'repair'].includes(mode)) {
+        throw new Error('SMOKE_FIXTURE_MODE must be audit or repair');
+    }
+
+    const appBaseUrl = String(process.env.SMOKE_APP_BASE_URL || '').trim();
+    const teamId = String(process.env.SMOKE_TEAM_ID || '').trim();
+    const playerId = String(process.env.SMOKE_PLAYER_ID || '').trim();
+    const adminEmail = String(process.env.SMOKE_ADMIN_EMAIL || '').trim();
+    const adminPassword = String(process.env.SMOKE_ADMIN_PASSWORD || '');
+    const staffEmail = String(process.env.SMOKE_STAFF_EMAIL || '').trim();
+    const staffPassword = String(process.env.SMOKE_STAFF_PASSWORD || '');
+    const parentEmail = String(process.env.SMOKE_PARENT_EMAIL || '').trim();
+    const parentPassword = String(process.env.SMOKE_PARENT_PASSWORD || '');
+    if (
+        !appBaseUrl || !teamId || !playerId ||
+        !adminEmail || !adminPassword ||
+        !staffEmail || !staffPassword ||
+        !parentEmail || !parentPassword
+    ) {
+        throw new Error('Protected production smoke parent fixture configuration is incomplete');
+    }
+    assertSmokeFixtureIdentifier(teamId, 'Team ID');
+    assertSmokeFixtureIdentifier(playerId, 'Player ID');
+
+    const [adminSession, staffSession, parentSession] = await Promise.all([
+        createFirebaseRestSession({
+            appBaseUrl,
+            email: adminEmail,
+            password: adminPassword
+        }),
+        createFirebaseRestSession({
+            appBaseUrl,
+            email: staffEmail,
+            password: staffPassword
+        }),
+        createFirebaseRestSession({
+            appBaseUrl,
+            email: parentEmail,
+            password: parentPassword
+        })
+    ]);
+
+    const [adminDocument, teamDocument] = await Promise.all([
+        getFirestoreDocument(adminSession, `users/${adminSession.localId}`),
+        getFirestoreDocument(staffSession, `teams/${teamId}`)
+    ]);
+    if (!adminDocument || !isGlobalAdmin(adminDocument)) {
+        throw new Error('The admin smoke account is not authorized to maintain fixture membership');
+    }
+    if (!teamDocument || !isAuthorizedFixtureManager(teamDocument, staffSession, staffEmail)) {
+        throw new Error('The staff smoke account is not an owner or administrator of the fixture team');
+    }
+
+    const playerPath = `teams/${teamId}/players/${playerId}`;
+    const parentPath = `users/${parentSession.localId}`;
+    let [playerDocument, parentDocument] = await Promise.all([
+        getFirestoreDocument(staffSession, playerPath),
+        getFirestoreDocument(parentSession, parentPath)
+    ]);
+    if (!playerDocument) {
+        throw new Error('The parent smoke player fixture does not exist');
+    }
+    if (!parentDocument) {
+        throw new Error('The parent smoke user profile does not exist');
+    }
+
+    let inspection = inspectParentFixture(parentDocument, playerDocument, teamId, playerId);
+    if (mode === 'repair' && !inspection.ready) {
+        if (!inspection.playerActive) {
+            await patchFirestoreDocumentFields(
+                staffSession,
+                playerPath,
+                buildActivePlayerPatch().fields,
+                { updateTime: String(playerDocument.updateTime || '') }
+            );
+        }
+        if (
+            !inspection.hasParentOf ||
+            !inspection.hasParentTeamId ||
+            !inspection.hasParentPlayerKey
+        ) {
+            const membershipPatch = buildParentMembershipPatch(parentDocument, {
+                teamId,
+                playerId,
+                teamName: getDisplayName(teamDocument, 'Smoke Team'),
+                playerName: getDisplayName(playerDocument, 'Smoke Player')
+            });
+            await patchFirestoreDocumentFields(
+                adminSession,
+                parentPath,
+                membershipPatch.fields,
+                { updateTime: String(parentDocument.updateTime || '') }
+            );
+        }
+
+        [playerDocument, parentDocument] = await Promise.all([
+            getFirestoreDocument(staffSession, playerPath),
+            getFirestoreDocument(parentSession, parentPath)
+        ]);
+        inspection = inspectParentFixture(parentDocument, playerDocument, teamId, playerId);
+    }
+
+    if (!inspection.ready) {
+        throw new Error(
+            `Parent fixture is not ready (parent-link=${inspection.hasParentOf}, ` +
+            `team-link=${inspection.hasParentTeamId}, player-key=${inspection.hasParentPlayerKey}, ` +
+            `player-exists=${inspection.playerExists}, player-active=${inspection.playerActive})`
+        );
+    }
+
+    console.log(`Parent fixture ${mode} passed with a linked active player.`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main().catch((error) => {
+        console.error(`Production smoke parent fixture failed: ${error?.message || 'Unknown error'}`);
+        process.exitCode = 1;
+    });
+}

--- a/tests/unit/production-smoke-parent-fixture.test.js
+++ b/tests/unit/production-smoke-parent-fixture.test.js
@@ -1,0 +1,163 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+    buildActivePlayerPatch,
+    buildParentMembershipPatch,
+    inspectParentFixture
+} from '../../scripts/maintain-production-smoke-parent-fixture.mjs';
+
+const workflowSource = readFileSync('.github/workflows/production-smoke-fixture.yml', 'utf8');
+
+function mapValue(fields) {
+    return { mapValue: { fields } };
+}
+
+function stringArray(values) {
+    return {
+        arrayValue: {
+            values: values.map((value) => ({ stringValue: value }))
+        }
+    };
+}
+
+function buildParentDocument({
+    parentOf = [],
+    parentTeamIds = [],
+    parentPlayerKeys = []
+} = {}) {
+    return {
+        updateTime: '2026-07-29T18:00:00.000Z',
+        fields: {
+            parentOf: { arrayValue: { values: parentOf } },
+            parentTeamIds: stringArray(parentTeamIds),
+            parentPlayerKeys: stringArray(parentPlayerKeys)
+        }
+    };
+}
+
+function buildPlayerDocument({
+    active = true,
+    archived = false,
+    status = 'active'
+} = {}) {
+    return {
+        updateTime: '2026-07-29T18:00:00.000Z',
+        fields: {
+            active: { booleanValue: active },
+            archived: { booleanValue: archived },
+            status: { stringValue: status }
+        }
+    };
+}
+
+const teamId = 'allplays-smoke-team-v1';
+const playerId = 'allplays-smoke-player-v1';
+
+describe('production parent smoke fixture maintenance', () => {
+    it('requires the complete parent membership chain and an active player', () => {
+        const parentDocument = buildParentDocument({
+            parentOf: [
+                mapValue({
+                    teamId: { stringValue: teamId },
+                    playerId: { stringValue: playerId }
+                })
+            ],
+            parentTeamIds: [teamId],
+            parentPlayerKeys: [`${teamId}::${playerId}`]
+        });
+
+        expect(inspectParentFixture(parentDocument, buildPlayerDocument(), teamId, playerId)).toEqual({
+            ready: true,
+            hasParentOf: true,
+            hasParentTeamId: true,
+            hasParentPlayerKey: true,
+            playerExists: true,
+            playerActive: true
+        });
+        expect(inspectParentFixture(parentDocument, null, teamId, playerId)).toMatchObject({
+            ready: false,
+            playerExists: false,
+            playerActive: false
+        });
+    });
+
+    it('builds a deterministic membership repair while preserving unrelated links', () => {
+        const unrelatedLink = mapValue({
+            teamId: { stringValue: 'other-team' },
+            playerId: { stringValue: 'other-player' }
+        });
+        const staleSmokeLink = mapValue({
+            teamId: { stringValue: teamId },
+            playerId: { stringValue: playerId },
+            playerName: { stringValue: 'Stale name' }
+        });
+        const patch = buildParentMembershipPatch(
+            buildParentDocument({
+                parentOf: [unrelatedLink, staleSmokeLink],
+                parentTeamIds: ['other-team'],
+                parentPlayerKeys: ['other-team::other-player']
+            }),
+            {
+                teamId,
+                playerId,
+                teamName: 'Smoke Team',
+                playerName: 'Smoke Player'
+            }
+        );
+
+        expect(patch.fields.parentOf.arrayValue.values).toEqual([
+            unrelatedLink,
+            mapValue({
+                teamId: { stringValue: teamId },
+                teamName: { stringValue: 'Smoke Team' },
+                playerId: { stringValue: playerId },
+                playerName: { stringValue: 'Smoke Player' }
+            })
+        ]);
+        expect(patch.fields.parentTeamIds).toEqual(
+            stringArray(['other-team', teamId])
+        );
+        expect(patch.fields.parentPlayerKeys).toEqual(
+            stringArray(['other-team::other-player', `${teamId}::${playerId}`])
+        );
+    });
+
+    it('repairs only roster lifecycle fields when the player is inactive', () => {
+        expect(buildActivePlayerPatch()).toEqual({
+            fields: {
+                active: { booleanValue: true },
+                archived: { booleanValue: false },
+                status: { stringValue: 'active' }
+            }
+        });
+        expect(
+            inspectParentFixture(
+                buildParentDocument({
+                    parentOf: [
+                        mapValue({
+                            teamId: { stringValue: teamId },
+                            playerId: { stringValue: playerId }
+                        })
+                    ],
+                    parentTeamIds: [teamId],
+                    parentPlayerKeys: [`${teamId}::${playerId}`]
+                }),
+                buildPlayerDocument({ active: false }),
+                teamId,
+                playerId
+            )
+        ).toMatchObject({
+            ready: false,
+            playerActive: false
+        });
+    });
+
+    it('keeps parent repair credentials in the protected exact-SHA workflow', () => {
+        expect(workflowSource).toContain('Audit or repair parent smoke fixture');
+        expect(workflowSource).toContain('SMOKE_ADMIN_EMAIL: ${{ secrets.SMOKE_ADMIN_EMAIL }}');
+        expect(workflowSource).toContain('SMOKE_PARENT_EMAIL: ${{ secrets.SMOKE_PARENT_EMAIL }}');
+        expect(workflowSource).toContain('environment:\n      name: production-smoke');
+        expect(workflowSource).toContain('ref: ${{ github.sha }}');
+        expect(workflowSource).not.toContain('pull_request:');
+    });
+});

--- a/tests/unit/production-smoke-parent-fixture.test.js
+++ b/tests/unit/production-smoke-parent-fixture.test.js
@@ -150,6 +150,26 @@ describe('production parent smoke fixture maintenance', () => {
             ready: false,
             playerActive: false
         });
+        expect(
+            inspectParentFixture(
+                buildParentDocument({
+                    parentOf: [
+                        mapValue({
+                            teamId: { stringValue: teamId },
+                            playerId: { stringValue: playerId }
+                        })
+                    ],
+                    parentTeamIds: [teamId],
+                    parentPlayerKeys: [`${teamId}::${playerId}`]
+                }),
+                buildPlayerDocument({ status: 'Active' }),
+                teamId,
+                playerId
+            )
+        ).toMatchObject({
+            ready: false,
+            playerActive: false
+        });
     });
 
     it('keeps parent repair credentials in the protected exact-SHA workflow', () => {


### PR DESCRIPTION
## What changed
- Extend the protected production-smoke maintenance workflow to audit and repair the parent-to-player fixture chain.
- Verify the admin, staff, and parent identities independently before any mutation.
- Repair only smoke-owned membership arrays and roster lifecycle fields with field-scoped optimistic patches.
- Preserve unrelated parent links and keep all credentials in the protected GitHub environment.

## Why
Exact-SHA production validation passed the 25-route public baseline but the parent core workflow could not find its seeded player link on Home. The fixture readiness guard did not previously validate the parent membership chain.

## Validation
- Focused fixture tests: 12 passed.
- Full root suite: 5,259 passed; 121 skipped.
- Syntax and diff checks passed.
- Production repair and independent audit will run only after this exact head merges to master.