### PR TITLE
Audit active production smoke team fixture

### DIFF
--- a/scripts/maintain-production-smoke-parent-fixture.mjs
+++ b/scripts/maintain-production-smoke-parent-fixture.mjs
@@ -40,21 +40,37 @@ function isActiveRosterPlayer(document) {
         (!status || status === 'active');
 }
 
-export function inspectParentFixture(userDocument, playerDocument, teamId, playerId) {
+function isActiveTeam(document) {
+    const fields = document?.fields || {};
+    const status = getStringField(fields, 'status').trim().toLowerCase();
+    return getBooleanField(fields, 'active') !== false &&
+        getBooleanField(fields, 'archived') !== true &&
+        !['archived', 'inactive', 'disabled'].includes(status);
+}
+
+export function inspectParentFixture(
+    userDocument,
+    teamDocument,
+    playerDocument,
+    teamId,
+    playerId
+) {
     const fields = userDocument?.fields || {};
     const playerKey = `${teamId}::${playerId}`;
     const hasParentOf = getArrayValues(fields.parentOf)
         .some((value) => isParentLink(value, teamId, playerId));
     const hasParentTeamId = hasStringValue(fields.parentTeamIds, teamId);
     const hasParentPlayerKey = hasStringValue(fields.parentPlayerKeys, playerKey);
+    const teamActive = Boolean(teamDocument) && isActiveTeam(teamDocument);
     const playerExists = Boolean(playerDocument);
     const playerActive = playerExists && isActiveRosterPlayer(playerDocument);
 
     return {
-        ready: hasParentOf && hasParentTeamId && hasParentPlayerKey && playerActive,
+        ready: hasParentOf && hasParentTeamId && hasParentPlayerKey && teamActive && playerActive,
         hasParentOf,
         hasParentTeamId,
         hasParentPlayerKey,
+        teamActive,
         playerExists,
         playerActive
     };
@@ -113,6 +129,16 @@ export function buildParentMembershipPatch(
 }
 
 export function buildActivePlayerPatch() {
+    return {
+        fields: {
+            active: { booleanValue: true },
+            archived: { booleanValue: false },
+            status: { stringValue: 'active' }
+        }
+    };
+}
+
+export function buildActiveTeamPatch() {
     return {
         fields: {
             active: { booleanValue: true },
@@ -186,7 +212,7 @@ async function main() {
         })
     ]);
 
-    const [adminDocument, teamDocument] = await Promise.all([
+    let [adminDocument, teamDocument] = await Promise.all([
         getFirestoreDocument(adminSession, `users/${adminSession.localId}`),
         getFirestoreDocument(staffSession, `teams/${teamId}`)
     ]);
@@ -210,8 +236,22 @@ async function main() {
         throw new Error('The parent smoke user profile does not exist');
     }
 
-    let inspection = inspectParentFixture(parentDocument, playerDocument, teamId, playerId);
+    let inspection = inspectParentFixture(
+        parentDocument,
+        teamDocument,
+        playerDocument,
+        teamId,
+        playerId
+    );
     if (mode === 'repair' && !inspection.ready) {
+        if (!inspection.teamActive) {
+            await patchFirestoreDocumentFields(
+                staffSession,
+                `teams/${teamId}`,
+                buildActiveTeamPatch().fields,
+                { updateTime: String(teamDocument.updateTime || '') }
+            );
+        }
         if (!inspection.playerActive) {
             await patchFirestoreDocumentFields(
                 staffSession,
@@ -239,18 +279,26 @@ async function main() {
             );
         }
 
-        [playerDocument, parentDocument] = await Promise.all([
+        [teamDocument, playerDocument, parentDocument] = await Promise.all([
+            getFirestoreDocument(staffSession, `teams/${teamId}`),
             getFirestoreDocument(staffSession, playerPath),
             getFirestoreDocument(parentSession, parentPath)
         ]);
-        inspection = inspectParentFixture(parentDocument, playerDocument, teamId, playerId);
+        inspection = inspectParentFixture(
+            parentDocument,
+            teamDocument,
+            playerDocument,
+            teamId,
+            playerId
+        );
     }
 
     if (!inspection.ready) {
         throw new Error(
             `Parent fixture is not ready (parent-link=${inspection.hasParentOf}, ` +
             `team-link=${inspection.hasParentTeamId}, player-key=${inspection.hasParentPlayerKey}, ` +
-            `player-exists=${inspection.playerExists}, player-active=${inspection.playerActive})`
+            `team-active=${inspection.teamActive}, player-exists=${inspection.playerExists}, ` +
+            `player-active=${inspection.playerActive})`
         );
     }
 

--- a/tests/unit/production-smoke-parent-fixture.test.js
+++ b/tests/unit/production-smoke-parent-fixture.test.js
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import {
     buildActivePlayerPatch,
+    buildActiveTeamPatch,
     buildParentMembershipPatch,
     inspectParentFixture
 } from '../../scripts/maintain-production-smoke-parent-fixture.mjs';
@@ -50,6 +51,21 @@ function buildPlayerDocument({
     };
 }
 
+function buildTeamDocument({
+    active = true,
+    archived = false,
+    status = 'active'
+} = {}) {
+    return {
+        updateTime: '2026-07-29T18:00:00.000Z',
+        fields: {
+            active: { booleanValue: active },
+            archived: { booleanValue: archived },
+            status: { stringValue: status }
+        }
+    };
+}
+
 const teamId = 'allplays-smoke-team-v1';
 const playerId = 'allplays-smoke-player-v1';
 
@@ -66,15 +82,32 @@ describe('production parent smoke fixture maintenance', () => {
             parentPlayerKeys: [`${teamId}::${playerId}`]
         });
 
-        expect(inspectParentFixture(parentDocument, buildPlayerDocument(), teamId, playerId)).toEqual({
+        expect(
+            inspectParentFixture(
+                parentDocument,
+                buildTeamDocument(),
+                buildPlayerDocument(),
+                teamId,
+                playerId
+            )
+        ).toEqual({
             ready: true,
             hasParentOf: true,
             hasParentTeamId: true,
             hasParentPlayerKey: true,
+            teamActive: true,
             playerExists: true,
             playerActive: true
         });
-        expect(inspectParentFixture(parentDocument, null, teamId, playerId)).toMatchObject({
+        expect(
+            inspectParentFixture(
+                parentDocument,
+                buildTeamDocument(),
+                null,
+                teamId,
+                playerId
+            )
+        ).toMatchObject({
             ready: false,
             playerExists: false,
             playerActive: false
@@ -142,6 +175,7 @@ describe('production parent smoke fixture maintenance', () => {
                     parentTeamIds: [teamId],
                     parentPlayerKeys: [`${teamId}::${playerId}`]
                 }),
+                buildTeamDocument(),
                 buildPlayerDocument({ active: false }),
                 teamId,
                 playerId
@@ -162,6 +196,7 @@ describe('production parent smoke fixture maintenance', () => {
                     parentTeamIds: [teamId],
                     parentPlayerKeys: [`${teamId}::${playerId}`]
                 }),
+                buildTeamDocument(),
                 buildPlayerDocument({ status: 'Active' }),
                 teamId,
                 playerId
@@ -169,6 +204,38 @@ describe('production parent smoke fixture maintenance', () => {
         ).toMatchObject({
             ready: false,
             playerActive: false
+        });
+    });
+
+    it('matches the app team lifecycle predicate and repairs only those fields', () => {
+        const parentDocument = buildParentDocument({
+            parentOf: [
+                mapValue({
+                    teamId: { stringValue: teamId },
+                    playerId: { stringValue: playerId }
+                })
+            ],
+            parentTeamIds: [teamId],
+            parentPlayerKeys: [`${teamId}::${playerId}`]
+        });
+        expect(
+            inspectParentFixture(
+                parentDocument,
+                buildTeamDocument({ status: ' Disabled ' }),
+                buildPlayerDocument(),
+                teamId,
+                playerId
+            )
+        ).toMatchObject({
+            ready: false,
+            teamActive: false
+        });
+        expect(buildActiveTeamPatch()).toEqual({
+            fields: {
+                active: { booleanValue: true },
+                archived: { booleanValue: false },
+                status: { stringValue: 'active' }
+            }
         });
     });
 


### PR DESCRIPTION
## What changed
- Make the protected parent-fixture audit enforce the same team lifecycle predicate as the app.
- Repair only the synthetic team lifecycle fields when the dedicated fixture is inactive.
- Re-read the team, player, and parent documents before declaring repair success.

## Why
The parent player card is suppressed when its team is inactive. The first parent-fixture audit covered membership and player state but not this final app predicate.

## Validation
- Focused fixture tests: 13 passed.
- Full root suite: 5,260 passed; 121 skipped.
- Syntax and diff checks passed.