### PR TITLE
Fix parent Home production smoke route

### DIFF
--- a/tests/smoke/app-authenticated-core.spec.js
+++ b/tests/smoke/app-authenticated-core.spec.js
@@ -123,6 +123,9 @@ test('parent account reaches every critical family workflow with linked fixtures
     await withAuthenticatedPage(parentWorkflowSession, async (page) => {
         const playerPath = `/players/${encodeURIComponent(config.teamId)}/${encodeURIComponent(config.playerId)}`;
         await assertAuthenticatedAppRoute(page, '/home', {
+            heading: 'Your day'
+        });
+        await openAuthenticatedAppRoute(page, config.appBaseUrl, '/home?section=players', {
             heading: 'Your day',
             requiredHref: playerPath
         });

--- a/tests/unit/production-smoke-auth-setup-timeout.test.js
+++ b/tests/unit/production-smoke-auth-setup-timeout.test.js
@@ -136,6 +136,24 @@ describe('production smoke authenticated setup timeout', () => {
         );
     });
 
+    it('checks the linked parent fixture in the Home Players section', () => {
+        const parentWorkflow = authenticatedCore.slice(
+            authenticatedCore.indexOf("test('parent account reaches"),
+            authenticatedCore.indexOf("test('role boundaries")
+        );
+
+        expect(parentWorkflow).toContain("assertAuthenticatedAppRoute(page, '/home',");
+        expect(parentWorkflow).toContain(
+            "openAuthenticatedAppRoute(page, config.appBaseUrl, '/home?section=players'"
+        );
+        expect(parentWorkflow).toMatch(
+            /\/home\?section=players'[\s\S]*?requiredHref: playerPath/
+        );
+        expect(parentWorkflow).not.toContain(
+            "assertAuthenticatedAppRoute(page, '/home', {\n            heading: 'Your day',\n            requiredHref: playerPath"
+        );
+    });
+
     it('measures the initial admin Home transition from before the sign-in action', () => {
         expect(helper).toMatch(
             /const authenticatedHomeStartedAt = Date\.now\(\);[\s\S]*?await page\.getByRole\('button', \{ name: 'Sign in' \}\)/


### PR DESCRIPTION
## Summary
- keep the authenticated parent Home landing assertion on the default Today section
- open the Home Players section before requiring the seeded player-detail link
- add a regression contract that prevents the invalid Today-section fixture assertion from returning

## Validation
- `npx vitest run tests/unit/production-smoke-auth-setup-timeout.test.js --reporter=verbose` (10 passed)
- `npm test` (711 files passed, 3 skipped; 5,261 tests passed, 121 skipped)
- `npm run test:app -- src/pages/Home.test.tsx` (43 passed)
- `npm run test:app -- src/pages/Schedule.test.tsx` (78 passed)
- `git diff --check`

The full app suite had four pre-existing timing failures under aggregate load; all four passed when their exact Home and Schedule files were rerun in isolation.