### PR TITLE
Deduplicate production authentication smoke

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -195,11 +195,13 @@ jobs:
           npx playwright test
           tests/smoke/app-admin-core.spec.js
           tests/smoke/app-authenticated-core.spec.js
+          tests/smoke/legacy-authenticated-core.spec.js
           --config=playwright.smoke.config.js
           --project=smoke
           --workers=1
           --reporter=line
         env:
+          SMOKE_BASE_URL: https://allplays.ai
           SMOKE_APP_BOOT_URL: https://allplays.ai/app/
           SMOKE_APP_BASE_URL: https://allplays.ai/app/
           SMOKE_SUITE: production

--- a/.github/workflows/scheduled-prod-smoke.yml
+++ b/.github/workflows/scheduled-prod-smoke.yml
@@ -48,6 +48,7 @@ jobs:
           tests/smoke/legacy-auth-redirects.spec.js
           tests/smoke/app-admin-core.spec.js
           tests/smoke/app-authenticated-core.spec.js
+          tests/smoke/legacy-authenticated-core.spec.js
           tests/smoke/app-authenticated-extended.spec.js
           --config=playwright.smoke.config.js
           --project=smoke

--- a/tests/smoke/legacy-authenticated-core.spec.js
+++ b/tests/smoke/legacy-authenticated-core.spec.js
@@ -1,0 +1,59 @@
+import { expect, test } from '@playwright/test';
+import {
+    AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS,
+    closeAuthenticatedAppSession,
+    createAuthenticatedAppSession,
+    getAppSmokeConfig,
+    redactSmokeDiagnostic
+} from './helpers/app-auth.js';
+import { assertPageBootsWithoutFatalErrors } from './helpers/boot-path.js';
+import {
+    getLegacyAuthenticatedSmokePages,
+    getSmokeContext
+} from './page-registry.js';
+
+const appConfig = getAppSmokeConfig();
+const smokeContext = getSmokeContext();
+const legacyBaseUrl = process.env.SMOKE_BASE_URL || '';
+const enabled = Boolean(appConfig.appBaseUrl) &&
+    Boolean(legacyBaseUrl) &&
+    ['production', 'extended-production'].includes(process.env.SMOKE_SUITE || '');
+const secrets = [appConfig.staffEmail, appConfig.staffPassword];
+
+test.skip(!enabled, 'Legacy authenticated workflows run only in production smoke');
+test.describe.configure({ mode: 'serial' });
+
+let staffSession;
+
+test.beforeAll(async ({ browser }) => {
+    test.setTimeout(AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS);
+    expect(appConfig.staffEmail, 'SMOKE_STAFF_EMAIL is required').toBeTruthy();
+    expect(appConfig.staffPassword, 'SMOKE_STAFF_PASSWORD is required').toBeTruthy();
+    expect(smokeContext.teamId, 'SMOKE_TEAM_ID is required').toBeTruthy();
+    staffSession = await createAuthenticatedAppSession(browser, {
+        appBaseUrl: appConfig.appBaseUrl,
+        email: appConfig.staffEmail,
+        password: appConfig.staffPassword,
+        roleLabel: 'legacy staff'
+    });
+});
+
+test.afterAll(async () => {
+    await closeAuthenticatedAppSession(staffSession);
+});
+
+test('staff account boots supported legacy authenticated workflows', async () => {
+    test.setTimeout(120_000);
+    const { page, issues } = staffSession;
+
+    for (const definition of getLegacyAuthenticatedSmokePages(smokeContext)) {
+        await test.step(definition.name, async () => {
+            await assertPageBootsWithoutFatalErrors(page, {
+                baseURL: legacyBaseUrl,
+                ...definition
+            });
+        });
+    }
+
+    expect(issues.map((issue) => redactSmokeDiagnostic(issue, secrets))).toEqual([]);
+});

--- a/tests/smoke/page-registry.js
+++ b/tests/smoke/page-registry.js
@@ -160,3 +160,28 @@ export function getPreviewBootPages(context) {
         ...buildOptionalCorePages(context)
     ];
 }
+
+export function getLegacyAuthenticatedSmokePages(context) {
+    const { teamId } = context;
+
+    return [
+        {
+            name: 'legacy edit schedule',
+            path: `/edit-schedule.html#teamId=${teamId}`,
+            titlePatterns: [/Edit Schedule - ALL PLAYS/i],
+            readySelectors: ['#add-game-form', '#schedule-list']
+        },
+        {
+            name: 'legacy team chat',
+            path: `/team-chat.html#teamId=${teamId}`,
+            titlePatterns: [/Team Chat - ALL PLAYS/i],
+            readySelectors: ['#messages-container', '#message-input']
+        },
+        {
+            name: 'legacy certificates',
+            path: `/certificates.html#teamId=${teamId}`,
+            titlePatterns: [/Certificates - ALL PLAYS/i],
+            readySelectors: ['#cert-setup', '#cert-parent-view']
+        }
+    ];
+}

--- a/tests/smoke/page-registry.js
+++ b/tests/smoke/page-registry.js
@@ -5,9 +5,7 @@ export function getSmokeContext() {
         suite: process.env.SMOKE_SUITE || 'preview',
         teamId: process.env.SMOKE_TEAM_ID || DEFAULT_TEAM_ID,
         gameId: process.env.SMOKE_GAME_ID || '',
-        playerId: process.env.SMOKE_PLAYER_ID || '',
-        authEmail: process.env.SMOKE_STAFF_EMAIL || process.env.SMOKE_AUTH_EMAIL || '',
-        authPassword: process.env.SMOKE_STAFF_PASSWORD || process.env.SMOKE_AUTH_PASSWORD || ''
+        playerId: process.env.SMOKE_PLAYER_ID || ''
     };
 }
 
@@ -158,44 +156,6 @@ export function getPreviewBootPages(context) {
             path: '/certificates.html?demo=1#teamId=demo-junior-current',
             titlePatterns: [/Certificates - ALL PLAYS/i],
             readySelectors: ['#cert-setup', '#cert-preview']
-        },
-        ...buildOptionalCorePages(context)
-    ];
-}
-
-export function getAuthenticatedSmokePages(context) {
-    const { teamId } = context;
-
-    return [
-        {
-            name: 'dashboard',
-            path: '/app/#/teams',
-            titlePatterns: [/ALL PLAYS APP/i],
-            readySelectors: ['#root']
-        },
-        {
-            name: 'parent dashboard',
-            path: '/app/#/home',
-            titlePatterns: [/ALL PLAYS APP/i],
-            readySelectors: ['#root']
-        },
-        {
-            name: 'edit schedule',
-            path: `/edit-schedule.html#teamId=${teamId}`,
-            titlePatterns: [/Edit Schedule - ALL PLAYS/i],
-            readySelectors: ['#add-game-form', '#schedule-list']
-        },
-        {
-            name: 'team chat',
-            path: `/team-chat.html#teamId=${teamId}`,
-            titlePatterns: [/Team Chat - ALL PLAYS/i],
-            readySelectors: ['#messages-container', '#message-input']
-        },
-        {
-            name: 'certificates',
-            path: `/certificates.html#teamId=${teamId}`,
-            titlePatterns: [/Certificates - ALL PLAYS/i],
-            readySelectors: ['#cert-setup', '#cert-parent-view']
         },
         ...buildOptionalCorePages(context)
     ];

--- a/tests/smoke/static-hosting-bootstrap.spec.js
+++ b/tests/smoke/static-hosting-bootstrap.spec.js
@@ -2,20 +2,10 @@ import { test } from '@playwright/test';
 import { PUBLIC_HOMEPAGE_GAMES_URL } from '../../js/public-homepage-games.js';
 import { assertPageBootsWithoutFatalErrors } from './helpers/boot-path.js';
 import {
-    getAuthenticatedSmokePages,
     getPreviewBootPages,
     getPublicSmokePages,
     getSmokeContext
 } from './page-registry.js';
-
-async function loginWithPassword(page, baseURL, email, password) {
-    await page.goto(`${baseURL}/app/#/auth`, { waitUntil: 'domcontentloaded' });
-    await page.getByLabel('Email').fill(email);
-    await page.getByLabel('Password', { exact: true }).fill(password);
-    await page.getByRole('button', { name: 'Sign in' }).last().click();
-    await page.waitForURL((url) => url.pathname === '/app/' && !url.hash.startsWith('#/auth'), { timeout: 20000 });
-    await page.waitForTimeout(1000);
-}
 
 const smokeContext = getSmokeContext();
 const previewSmokeRuntime = process.env.SMOKE_EXPECTED_FIREBASE_RUNTIME_TARGET === 'preview-smoke';
@@ -75,25 +65,4 @@ test.describe('preview boot smoke pages', () => {
             });
         });
     }
-});
-
-test.describe('authenticated smoke pages', () => {
-    test.skip(
-        previewSmokeRuntime || !smokeContext.authEmail || !smokeContext.authPassword,
-        'Authenticated smoke requires a configured non-isolated Firebase runtime.'
-    );
-    test.setTimeout(300_000);
-
-    test('authenticated coach and parent pages render', async ({ page, baseURL }) => {
-        await loginWithPassword(page, baseURL, smokeContext.authEmail, smokeContext.authPassword);
-
-        for (const definition of getAuthenticatedSmokePages(smokeContext)) {
-            await test.step(definition.name, async () => {
-                await assertPageBootsWithoutFatalErrors(page, {
-                    baseURL,
-                    ...definition
-                });
-            });
-        }
-    });
 });

--- a/tests/unit/candidate-host-auth-smoke.test.js
+++ b/tests/unit/candidate-host-auth-smoke.test.js
@@ -74,12 +74,27 @@ describe('candidate-host authenticated smoke coverage', () => {
         for (const file of [
             'tests/smoke/candidate-host-auth.spec.js',
             'tests/smoke/helpers/app-auth.js',
-            'tests/smoke/static-hosting-bootstrap.spec.js',
             'tests/smoke/app-parent-live.spec.js'
         ]) {
             const source = readRepoFile(file);
             expect(source).not.toMatch(/getByLabel\(['"]Password['"]\)(?!\s*,)/);
             expect(source).toContain("getByLabel('Password', { exact: true })");
         }
+    });
+
+    it('keeps the public baseline credential-free while dedicated probes own authentication', () => {
+        const workflow = readRepoFile('.github/workflows/post-deploy-smoke.yml');
+        const baseline = readRepoFile('tests/smoke/static-hosting-bootstrap.spec.js');
+        const registry = readRepoFile('tests/smoke/page-registry.js');
+
+        expect(baseline).not.toContain('loginWithPassword');
+        expect(baseline).not.toContain('getAuthenticatedSmokePages');
+        expect(baseline).not.toContain("getByLabel('Email')");
+        expect(registry).not.toContain('getAuthenticatedSmokePages');
+        expect(registry).not.toContain('authEmail');
+        expect(registry).not.toContain('authPassword');
+        expect(workflow).toContain('npx playwright test tests/smoke/candidate-host-auth.spec.js');
+        expect(workflow).toContain('tests/smoke/app-admin-core.spec.js');
+        expect(workflow).toContain('tests/smoke/app-authenticated-core.spec.js');
     });
 });

--- a/tests/unit/candidate-host-auth-smoke.test.js
+++ b/tests/unit/candidate-host-auth-smoke.test.js
@@ -85,6 +85,7 @@ describe('candidate-host authenticated smoke coverage', () => {
     it('keeps the public baseline credential-free while dedicated probes own authentication', () => {
         const workflow = readRepoFile('.github/workflows/post-deploy-smoke.yml');
         const baseline = readRepoFile('tests/smoke/static-hosting-bootstrap.spec.js');
+        const legacyAuthenticatedCore = readRepoFile('tests/smoke/legacy-authenticated-core.spec.js');
         const registry = readRepoFile('tests/smoke/page-registry.js');
 
         expect(baseline).not.toContain('loginWithPassword');
@@ -96,5 +97,13 @@ describe('candidate-host authenticated smoke coverage', () => {
         expect(workflow).toContain('npx playwright test tests/smoke/candidate-host-auth.spec.js');
         expect(workflow).toContain('tests/smoke/app-admin-core.spec.js');
         expect(workflow).toContain('tests/smoke/app-authenticated-core.spec.js');
+        expect(workflow).toContain('tests/smoke/legacy-authenticated-core.spec.js');
+        expect(workflow).toMatch(
+            /tests\/smoke\/legacy-authenticated-core\.spec\.js[\s\S]*?env:\s+SMOKE_BASE_URL: https:\/\/allplays\.ai/
+        );
+        expect(legacyAuthenticatedCore).toContain('getLegacyAuthenticatedSmokePages');
+        for (const route of ['edit-schedule.html', 'team-chat.html', 'certificates.html']) {
+            expect(registry).toContain(route);
+        }
     });
 });

--- a/tests/unit/production-smoke-auth-setup-timeout.test.js
+++ b/tests/unit/production-smoke-auth-setup-timeout.test.js
@@ -5,12 +5,13 @@ const helper = readFileSync('tests/smoke/helpers/app-auth.js', 'utf8');
 const authenticatedCore = readFileSync('tests/smoke/app-authenticated-core.spec.js', 'utf8');
 const adminCore = readFileSync('tests/smoke/app-admin-core.spec.js', 'utf8');
 const authenticatedExtended = readFileSync('tests/smoke/app-authenticated-extended.spec.js', 'utf8');
+const legacyAuthenticatedCore = readFileSync('tests/smoke/legacy-authenticated-core.spec.js', 'utf8');
 
 describe('production smoke authenticated setup timeout', () => {
     it('uses an explicit bounded setup budget for every credentialed role suite', () => {
         expect(helper).toContain('export const AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS = 240_000;');
 
-        for (const source of [authenticatedCore, adminCore, authenticatedExtended]) {
+        for (const source of [authenticatedCore, adminCore, authenticatedExtended, legacyAuthenticatedCore]) {
             expect(source).toContain('AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS');
             expect(source).toMatch(
                 /test\.beforeAll\(async \(\{ browser \}\) => \{\s+test\.setTimeout\(AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS\);/


### PR DESCRIPTION
## Summary
- keep the static-hosting baseline credential-free and focused on public/boot routes
- remove the stale duplicate password-login block that timed out after the dedicated auth and role suites had already passed
- preserve candidate-host and app role coverage, and move supported legacy edit-schedule, team-chat, and certificates checks into a bounded authenticated suite
- run the dedicated legacy suite in both post-deploy and scheduled production workflows with the protected staff account
- add contracts preventing credentials from returning to the public registry or the legacy suite from silently losing its production base URL

## Evidence
- exact production run 30490885797: candidate-host authentication passed and authenticated core workflows passed 4/4; only the stale duplicate baseline login timed out
- focused contracts: 15/15 passed
- credential-free production baseline against https://allplays.ai: 14/14 passed with locally available fixture context
- npm test: 711 files passed, 3 skipped; 5,262 tests passed, 121 skipped
- exact head 24b97afa245c27ea239dd82ed4bd8d39fa0e1a4f: all 13 applicable PR checks passed; 2 irrelevant native platform builds skipped
- Playwright discovery, syntax checks, and git diff --check passed

No user-facing behavior or production data changes.