### PR TITLE
Add passive repository security guardrails

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,64 @@
+name: Bug report
+description: Report a reproducible product defect that is safe to discuss publicly.
+title: "[Bug] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for helping improve AllPlays.
+
+        **Stop here if this may involve a security or privacy vulnerability.**
+        Use the [private vulnerability reporting form](https://github.com/pauljsnider/allplays/security/advisories/new) instead.
+
+        Never include credentials, invite or access codes, signed links, real user contact information, information about minors, production records, private support conversations, or unredacted logs and screenshots.
+
+  - type: checkboxes
+    id: public-safety
+    attributes:
+      label: Public-report safety
+      options:
+        - label: This is not a suspected security or privacy vulnerability.
+          required: true
+        - label: I used synthetic or redacted data and removed credentials, codes, tokens, signed links, personal data, and production identifiers.
+          required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the defect without including sensitive or production data.
+      placeholder: A concise description using synthetic names and identifiers.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Safe reproduction steps
+      description: Use test accounts and synthetic data only.
+      placeholder: |
+        1. Open...
+        2. Select...
+        3. Observe...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser, device, and app version only. Do not paste account identifiers, tokens, URLs containing codes, or raw logs.
+      placeholder: Safari 18, iPhone, AllPlays app version...
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional redacted context
+      description: Optional. Remove personal data and protected identifiers before attaching screenshots or logs.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security or privacy vulnerability
+    url: https://github.com/pauljsnider/allplays/security/advisories/new
+    about: Use the private reporting form. Do not disclose vulnerabilities, credentials, access codes, or personal data in a public issue.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    open-pull-requests-limit: 2
     schedule:
       interval: "weekly"
     groups:
@@ -12,10 +13,44 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/apps/app"
+    open-pull-requests-limit: 2
     schedule:
       interval: "weekly"
     groups:
       app-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/functions"
+    open-pull-requests-limit: 2
+    schedule:
+      interval: "weekly"
+    groups:
+      functions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/services/chatgpt-mcp"
+    open-pull-requests-limit: 2
+    schedule:
+      interval: "weekly"
+    groups:
+      chatgpt-mcp-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 2
+    schedule:
+      interval: "weekly"
+    groups:
+      actions-minor-patch:
         update-types:
           - "minor"
           - "patch"

--- a/.github/workflows/codeql-passive.yml
+++ b/.github/workflows/codeql-passive.yml
@@ -1,0 +1,41 @@
+name: CodeQL passive analysis
+
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: "23 9 * * 1"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: codeql-passive-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: CodeQL passive analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Check out trusted default-branch source
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        with:
+          languages: javascript-typescript
+          queries: security-extended
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        with:
+          category: /language:javascript-typescript

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,61 @@
+# Security Policy
+
+## Report vulnerabilities privately
+
+Do not open a public issue, pull request, discussion, or support post for a
+suspected security or privacy vulnerability.
+
+Use GitHub's
+[private vulnerability reporting](https://github.com/pauljsnider/allplays/security/advisories/new)
+to report the problem. The private report allows the reporter and maintainers
+to investigate, develop a fix, and coordinate deployment without publishing an
+unpatched attack path.
+
+Normal product bugs and feature requests that do not involve security or
+privacy can continue to use the public issue tracker.
+
+## What to include
+
+Provide the smallest safe description that lets maintainers understand the
+affected workflow:
+
+- The affected page, API, or user role.
+- The expected and observed authorization or privacy boundary.
+- Impact and severity in plain language.
+- Reproduction steps using synthetic accounts and redacted identifiers.
+- Any suggested remediation or regression test.
+
+## Never include
+
+Do not include any of the following in a public or private report:
+
+- Passwords, session tokens, API secrets, service-account material, private
+  keys, cookies, or authorization headers.
+- Invite codes, access codes, password-reset links, payment links, or signed
+  URLs.
+- Real user email addresses, phone numbers, names, addresses, medical
+  information, or information about minors.
+- Raw production database records, support conversations, logs, screenshots,
+  or transcripts containing personal or protected data.
+
+Use synthetic examples and replace sensitive values with labels such as
+`[REDACTED_EMAIL]`, `[REDACTED_CODE]`, and `[REDACTED_TOKEN]`. Treat any
+identifier accidentally posted publicly as compromised and revoke or rotate it
+before continuing the investigation.
+
+## Scope and support
+
+The production service and the current `master` branch receive security fixes.
+Historical deployments and unsupported local modifications are out of scope.
+
+AllPlays does not currently promise a bug bounty or a fixed response time.
+Maintainers will triage private reports, prioritize issues according to
+customer and data impact, and publish details only after the production fix is
+verified.
+
+## Automation and disclosure
+
+Automated security scouts and maintainers must route suspected vulnerabilities
+to a private advisory or another access-controlled security queue. Public issue
+automation may record only non-sensitive coordination metadata and must not
+publish exploit instructions, production identifiers, or private user data.

--- a/tests/unit/repository-security-guardrails.test.js
+++ b/tests/unit/repository-security-guardrails.test.js
@@ -1,0 +1,105 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+const repoRoot = path.resolve(import.meta.dirname, '../..');
+
+function readRepoFile(relativePath) {
+    return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+const securityPolicy = readRepoFile('SECURITY.md');
+const issueConfig = parse(readRepoFile('.github/ISSUE_TEMPLATE/config.yml'));
+const bugReport = parse(readRepoFile('.github/ISSUE_TEMPLATE/bug-report.yml'));
+const dependabot = parse(readRepoFile('.github/dependabot.yml'));
+const codeqlSource = readRepoFile('.github/workflows/codeql-passive.yml');
+const codeql = parse(codeqlSource);
+
+describe('repository security guardrails', () => {
+    it('routes vulnerability reports privately and prohibits sensitive report content', () => {
+        expect(securityPolicy).toContain(
+            'https://github.com/pauljsnider/allplays/security/advisories/new'
+        );
+        expect(securityPolicy).toContain('Do not open a public issue');
+        expect(securityPolicy).toContain('Invite codes');
+        expect(securityPolicy).toContain('information about minors');
+        expect(securityPolicy).toContain('[REDACTED_TOKEN]');
+
+        expect(issueConfig.blank_issues_enabled).toBe(true);
+        expect(issueConfig.contact_links).toContainEqual(
+            expect.objectContaining({
+                url: 'https://github.com/pauljsnider/allplays/security/advisories/new'
+            })
+        );
+
+        const safetyCheckboxes = bugReport.body.find(
+            (section) => section.id === 'public-safety'
+        );
+        expect(safetyCheckboxes.attributes.options).toHaveLength(2);
+        expect(
+            safetyCheckboxes.attributes.options.every((option) => option.required === true)
+        ).toBe(true);
+        expect(JSON.stringify(bugReport)).toContain('synthetic or redacted data');
+        expect(JSON.stringify(bugReport)).toContain('private vulnerability reporting form');
+    });
+
+    it('covers every maintained dependency workspace without opening an unbounded PR queue', () => {
+        const configuredUpdates = new Map(
+            dependabot.updates.map((update) => [
+                `${update['package-ecosystem']}:${update.directory}`,
+                update
+            ])
+        );
+
+        expect([...configuredUpdates.keys()].sort()).toEqual([
+            'github-actions:/',
+            'npm:/',
+            'npm:/apps/app',
+            'npm:/functions',
+            'npm:/services/chatgpt-mcp'
+        ]);
+
+        for (const update of configuredUpdates.values()) {
+            expect(update.schedule.interval).toBe('weekly');
+            expect(update['open-pull-requests-limit']).toBeLessThanOrEqual(2);
+        }
+    });
+
+    it('keeps CodeQL advisory, trusted, least-privilege, and immutable', () => {
+        expect(codeql.name).toBe('CodeQL passive analysis');
+        expect(codeql.permissions).toEqual({});
+        expect(codeql.on.push.branches).toEqual(['master']);
+        expect(codeql.on).toHaveProperty('schedule');
+        expect(codeql.on).toHaveProperty('workflow_dispatch');
+        expect(codeql.on).not.toHaveProperty('pull_request');
+        expect(codeql.on).not.toHaveProperty('pull_request_target');
+        expect(codeql.on).not.toHaveProperty('workflow_run');
+        expect(codeql.on).not.toHaveProperty('issue_comment');
+
+        const analyze = codeql.jobs.analyze;
+        expect(analyze.permissions).toEqual({
+            contents: 'read',
+            'security-events': 'write'
+        });
+        expect(analyze).not.toHaveProperty('environment');
+
+        const checkout = analyze.steps.find((step) => step.uses?.startsWith('actions/checkout@'));
+        expect(checkout.uses).toMatch(/^actions\/checkout@[0-9a-f]{40}$/);
+        expect(checkout.with['persist-credentials']).toBe(false);
+
+        const codeqlSteps = analyze.steps.filter((step) =>
+            step.uses?.startsWith('github/codeql-action/')
+        );
+        expect(codeqlSteps).toHaveLength(2);
+        for (const step of codeqlSteps) {
+            expect(step.uses).toMatch(/^github\/codeql-action\/(init|analyze)@[0-9a-f]{40}$/);
+        }
+
+        expect(codeqlSource).not.toMatch(/^\s*pull_request:/m);
+        expect(codeqlSource).not.toContain('secrets.');
+        expect(codeqlSource).not.toContain('pull_request_target');
+        expect(codeqlSource).not.toContain('workflow_run');
+        expect(codeqlSource).not.toMatch(/uses:\s+[^@\s]+@(v\d+|main|master)\b/);
+    });
+});


### PR DESCRIPTION
## Summary

- add a private vulnerability-reporting path and safer public issue forms
- expand Dependabot coverage with bounded weekly update limits
- add advisory CodeQL analysis on trusted default-branch and scheduled runs
- add unit coverage for the repository guardrails

## Safety boundaries

- no application, Firebase rules, database, hosting, DNS, or runtime behavior changes
- CodeQL is not a required check and does not run privileged analysis on pull-request code
- Dependabot is capped at two open pull requests per ecosystem
- repository visibility and App Check enforcement remain unchanged

## Validation

- `npm test -- --reporter=dot` — 712 files passed, 3 skipped; 5,274 tests passed, 123 skipped
- focused guardrail tests — 3 passed
- YAML lint — passed
- actionlint v1.7.12 — passed
- `git diff --check` — passed
- staged gitleaks scan — no leaks found

Closes #4258