### PR TITLE
Fix Firestore indexes-only production deploy

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -539,7 +539,7 @@ jobs:
           set -euo pipefail
           firebase_cli="$FIREBASE_PRODUCTION_BUNDLE/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js"
           firebase_config="$FIREBASE_PRODUCTION_BUNDLE/firebase-prod.generated.json"
-          firestore_indexes_config="$RUNNER_TEMP/firebase-indexes.generated.json"
+          firestore_indexes_config="$FIREBASE_PRODUCTION_BUNDLE/firebase-indexes.generated.json"
           transient_pattern='(^|[^[:alnum:]])(429|500|502|503|504)([^[:alnum:]]|$)|HTTP Error:[[:space:]]*409,[[:space:]]*Requested entity already exists|service[[:space:]_-]+unavailable|econnreset|connection[[:space:]_-]+reset|network[[:space:]_-]+reset|etimedout|timed[[:space:]_-]+out|timeout'
           retry_enabled_function_targets="functions:processAccountDeletionRequest,functions:queueParentInviteEmail,functions:syncPublicUserProfileOnUserWrite,functions:syncPublicUserProfilesOnTeamWrite,functions:syncTeamOwnerAccessOnCreate"
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -539,8 +539,25 @@ jobs:
           set -euo pipefail
           firebase_cli="$FIREBASE_PRODUCTION_BUNDLE/firebase-cli/node_modules/firebase-tools/lib/bin/firebase.js"
           firebase_config="$FIREBASE_PRODUCTION_BUNDLE/firebase-prod.generated.json"
+          firestore_indexes_config="$RUNNER_TEMP/firebase-indexes.generated.json"
           transient_pattern='(^|[^[:alnum:]])(429|500|502|503|504)([^[:alnum:]]|$)|HTTP Error:[[:space:]]*409,[[:space:]]*Requested entity already exists|service[[:space:]_-]+unavailable|econnreset|connection[[:space:]_-]+reset|network[[:space:]_-]+reset|etimedout|timed[[:space:]_-]+out|timeout'
           retry_enabled_function_targets="functions:processAccountDeletionRequest,functions:queueParentInviteEmail,functions:syncPublicUserProfileOnUserWrite,functions:syncPublicUserProfilesOnTeamWrite,functions:syncTeamOwnerAccessOnCreate"
+
+          if ! jq -e '
+            .firestore.rules == "firestore.rules"
+            and .firestore.indexes == "firestore.indexes.json"
+          ' "$firebase_config" >/dev/null; then
+            echo "The trusted production config does not contain the exact Firestore rules and indexes paths." >&2
+            exit 1
+          fi
+          jq 'del(.firestore.rules)' "$firebase_config" > "$firestore_indexes_config"
+          if ! jq -e '
+            .firestore.indexes == "firestore.indexes.json"
+            and (.firestore | has("rules") | not)
+          ' "$firestore_indexes_config" >/dev/null; then
+            echo "The indexes-only Firebase config still contains a Firestore rules target." >&2
+            exit 1
+          fi
 
           verify_active_firestore_rules() {
             local release_json ruleset_json ruleset_name local_rules_b64 active_rules_b64
@@ -854,11 +871,20 @@ jobs:
             local max_attempts="${3:-3}"
             local base_delay_seconds="${4:-15}"
             local acknowledge_failure_policy="${5:-false}"
-            local attempt deploy_log deploy_status retry_delay_seconds retry_jitter_seconds
+            local attempt deploy_config deploy_log deploy_status retry_delay_seconds retry_jitter_seconds
+            deploy_config="$firebase_config"
+            if [[ "$deploy_targets" == "firestore:indexes" ]]; then
+              # firebase-tools 14.25 prepares every Firestore rules path present
+              # in the config even for --only firestore:indexes. Supplying the
+              # derived indexes-only config prevents an unrelated projects:test
+              # outage from blocking index deployment after exact rules were
+              # already compiled, source-verified, and activated above.
+              deploy_config="$firestore_indexes_config"
+            fi
             local -a deploy_args=(
               --only "$deploy_targets"
               --project game-flow-c6311
-              --config "$firebase_config"
+              --config "$deploy_config"
               --non-interactive
             )
 

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -343,8 +343,8 @@ export function validateProductionDeployCommand(deployProd) {
     );
     assertIncludes(
         deployProd,
-        'firestore_indexes_config="$RUNNER_TEMP/firebase-indexes.generated.json"',
-        'Production Firestore isolated indexes config path'
+        'firestore_indexes_config="$FIREBASE_PRODUCTION_BUNDLE/firebase-indexes.generated.json"',
+        'Production Firestore indexes config beside staged indexes'
     );
     assertIncludes(
         deployProd,

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -289,7 +289,8 @@ export function validateProductionDeployCommand(deployProd) {
     const deployArgs = deployProd.slice(deployArgsStart, deployArgsEnd);
     assertIncludes(deployArgs, '--only "$deploy_targets"', 'Production Firebase deploy target arguments');
     assertIncludes(deployArgs, '--project game-flow-c6311', 'Production Firebase deploy project');
-    assertIncludes(deployArgs, '--config "$firebase_config"', 'Production Firebase generated config');
+    assertIncludes(deployProd, 'deploy_config="$firebase_config"', 'Production Firebase generated config default');
+    assertIncludes(deployArgs, '--config "$deploy_config"', 'Production Firebase selected generated config');
 
     assertIncludes(deployProd, 'retry_firebase_deploy "hosting,functions" "application"', 'Production application deploy targets');
     assertIncludes(
@@ -339,6 +340,26 @@ export function validateProductionDeployCommand(deployProd) {
         deployProd,
         'retry_firebase_deploy "firestore:indexes" "firestore-indexes" 3 15',
         'Production Firestore exact-source indexes-only deploy'
+    );
+    assertIncludes(
+        deployProd,
+        'firestore_indexes_config="$RUNNER_TEMP/firebase-indexes.generated.json"',
+        'Production Firestore isolated indexes config path'
+    );
+    assertIncludes(
+        deployProd,
+        "jq 'del(.firestore.rules)' \"$firebase_config\" > \"$firestore_indexes_config\"",
+        'Production Firestore indexes config removes the rules target'
+    );
+    assertIncludes(
+        deployProd,
+        'and (.firestore | has("rules") | not)',
+        'Production Firestore indexes config rejects a retained rules target'
+    );
+    assertMatches(
+        deployProd,
+        /if \[\[ "\$deploy_targets" == "firestore:indexes" \]\]; then[\s\S]{0,1000}deploy_config="\$firestore_indexes_config"[\s\S]{0,1000}--config "\$deploy_config"/,
+        'Production Firestore indexes deploy uses the rules-free config'
     );
     assertIncludes(
         deployProd,

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -147,10 +147,17 @@ concurrency:
           if [[ "$STORAGE_RULES_CHANGED" != "true" ]]; then exit 0; fi
           exit "$storage_status"
             transient_pattern='HTTP Error:[[:space:]]*409,[[:space:]]*Requested entity already exists'
+            firestore_indexes_config="$RUNNER_TEMP/firebase-indexes.generated.json"
+            jq 'del(.firestore.rules)' "$firebase_config" > "$firestore_indexes_config"
+            jq -e 'and (.firestore | has("rules") | not)' "$firestore_indexes_config"
+            deploy_config="$firebase_config"
+            if [[ "$deploy_targets" == "firestore:indexes" ]]; then
+              deploy_config="$firestore_indexes_config"
+            fi
             local -a deploy_args=(
               --only "$deploy_targets"
               --project game-flow-c6311
-              --config "$firebase_config"
+              --config "$deploy_config"
               --non-interactive
             )
             retry_enabled_function_targets="functions:processAccountDeletionRequest,functions:queueParentInviteEmail,functions:syncPublicUserProfileOnUserWrite,functions:syncPublicUserProfilesOnTeamWrite,functions:syncTeamOwnerAccessOnCreate"
@@ -249,8 +256,17 @@ concurrency:
             validDeployCommand.replace('              --project game-flow-c6311\n', '')
         )).toThrow('Production Firebase deploy project');
         expect(() => validateProductionDeployCommand(
-            validDeployCommand.replace('              --config "$firebase_config"\n', '')
-        )).toThrow('Production Firebase generated config');
+            validDeployCommand.replace('            deploy_config="$firebase_config"\n', '')
+        )).toThrow('Production Firebase generated config default');
+        expect(() => validateProductionDeployCommand(
+            validDeployCommand.replace(
+                "            jq 'del(.firestore.rules)' \"$firebase_config\" > \"$firestore_indexes_config\"\n",
+                ''
+            )
+        )).toThrow('Production Firestore indexes config removes the rules target');
+        expect(() => validateProductionDeployCommand(
+            validDeployCommand.replace('              deploy_config="$firestore_indexes_config"', '              deploy_config="$firebase_config"')
+        )).toThrow('Production Firestore indexes deploy uses the rules-free config');
         expect(() => validateProductionDeployCommand(
             validDeployCommand.replace(
                 'git diff --quiet "$last_success_sha" "$GITHUB_SHA" -- storage.rules',

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -147,7 +147,7 @@ concurrency:
           if [[ "$STORAGE_RULES_CHANGED" != "true" ]]; then exit 0; fi
           exit "$storage_status"
             transient_pattern='HTTP Error:[[:space:]]*409,[[:space:]]*Requested entity already exists'
-            firestore_indexes_config="$RUNNER_TEMP/firebase-indexes.generated.json"
+            firestore_indexes_config="$FIREBASE_PRODUCTION_BUNDLE/firebase-indexes.generated.json"
             jq 'del(.firestore.rules)' "$firebase_config" > "$firestore_indexes_config"
             jq -e 'and (.firestore | has("rules") | not)' "$firestore_indexes_config"
             deploy_config="$firebase_config"
@@ -258,6 +258,12 @@ concurrency:
         expect(() => validateProductionDeployCommand(
             validDeployCommand.replace('            deploy_config="$firebase_config"\n', '')
         )).toThrow('Production Firebase generated config default');
+        expect(() => validateProductionDeployCommand(
+            validDeployCommand.replace(
+                'firestore_indexes_config="$FIREBASE_PRODUCTION_BUNDLE/firebase-indexes.generated.json"',
+                'firestore_indexes_config="$RUNNER_TEMP/firebase-indexes.generated.json"'
+            )
+        )).toThrow('Production Firestore indexes config beside staged indexes');
         expect(() => validateProductionDeployCommand(
             validDeployCommand.replace(
                 "            jq 'del(.firestore.rules)' \"$firebase_config\" > \"$firestore_indexes_config\"\n",


### PR DESCRIPTION
## What changed and why

- Derive a trusted Firebase config for `firestore:indexes` that omits the Firestore rules target.
- Keep the existing fail-closed exact-rules compilation, source verification, and release activation path unchanged.
- Add deploy-gate regression coverage proving the indexes deploy cannot fall back to the rules-bearing config.

Firebase CLI 14.25 prepares every Firestore rules path present in the config even with `--only firestore:indexes`. That caused production index deploys to call the unavailable Rules API `projects:test` endpoint after the workflow had already verified the exact active rules.

## Validation

- `npm run ci:firebase-rules`
- `npx vitest run tests/unit/validate-firebase-rules-ci.test.js --reporter=dot` (7 tests passed)
- `git diff --check`

Tested exact head: `90453a9018d5c9d629a810a84ed25aecd79369df`
