### PR TITLE
Stabilize post-deploy production smoke

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -199,6 +199,7 @@ jobs:
           --config=playwright.smoke.config.js
           --project=smoke
           --workers=1
+          --retries=1
           --reporter=line
         env:
           SMOKE_BASE_URL: https://allplays.ai

--- a/tests/smoke/candidate-host-auth.spec.js
+++ b/tests/smoke/candidate-host-auth.spec.js
@@ -1,6 +1,8 @@
 import { expect, test } from '@playwright/test';
-import { mkdir, writeFile } from 'node:fs/promises';
-import path from 'node:path';
+import {
+    redactDiagnosticText as redactText,
+    writeRedactedDiagnostic as writeDiagnostic
+} from './helpers/candidate-auth-diagnostic.js';
 
 const candidateHostUrl = process.env.CANDIDATE_HOST_URL || '';
 const authEmail = process.env.SMOKE_STAFF_EMAIL || process.env.SMOKE_AUTH_EMAIL || '';
@@ -13,45 +15,11 @@ function candidateUrl(path) {
 }
 
 function redactDiagnosticText(value) {
-    let redacted = String(value || '');
-    if (authPassword) {
-        redacted = redacted.replaceAll(authPassword, '[REDACTED]');
-    }
-    if (authEmail) {
-        redacted = redacted.replaceAll(authEmail, '[REDACTED_EMAIL]');
-    }
-    return redacted
-        .replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi, '[REDACTED_EMAIL]')
-        .slice(0, 500);
+    return redactText(value, authEmail, authPassword);
 }
 
 async function writeRedactedDiagnostic(page, testInfo, failure) {
-    const errorMessage = page.locator('[role="alert"]').first();
-    const submitButton = page.getByRole('button', { name: 'Sign in' }).last();
-    const loginHeading = page.getByRole('heading', { name: 'Sign in' });
-    const hasErrorMessage = (await errorMessage.count()) > 0;
-    const hasSubmitButton = (await submitButton.count()) > 0;
-    const hasLoginHeading = (await loginHeading.count()) > 0;
-    const errorText = hasErrorMessage
-        ? await errorMessage.textContent({ timeout: 1_000 }).catch(() => '')
-        : '';
-    const submitDisabled = hasSubmitButton
-        ? await submitButton.isDisabled({ timeout: 1_000 }).catch(() => null)
-        : null;
-    const loginFormVisible = hasLoginHeading
-        ? await loginHeading.isVisible({ timeout: 1_000 }).catch(() => false)
-        : false;
-    const diagnosticPath = testInfo.outputPath('candidate-auth-diagnostic.json');
-    await mkdir(path.dirname(diagnosticPath), { recursive: true });
-    await writeFile(diagnosticPath, `${JSON.stringify({
-        observedAt: new Date().toISOString(),
-        origin: new URL(candidateHostUrl).origin,
-        path: new URL(page.url()).pathname,
-        loginFormVisible,
-        submitDisabled,
-        visibleError: redactDiagnosticText(errorText),
-        failure: redactDiagnosticText(failure?.message)
-    }, null, 2)}\n`);
+    await writeDiagnostic(page, testInfo, failure, { candidateHostUrl, authEmail, authPassword });
 }
 
 test('candidate host accepts authentication and loads a protected landing page', async ({ page }, testInfo) => {
@@ -114,10 +82,10 @@ test('candidate host accepts authentication and loads a protected landing page',
     } catch (error) {
         const passwordInput = page.getByLabel('Password', { exact: true });
         const emailInput = page.getByLabel('Email');
-        if (await passwordInput.count()) {
+        if (await passwordInput.count().catch(() => 0)) {
             await passwordInput.fill('', { timeout: 1_000 }).catch(() => {});
         }
-        if (await emailInput.count()) {
+        if (await emailInput.count().catch(() => 0)) {
             await emailInput.fill('', { timeout: 1_000 }).catch(() => {});
         }
         await writeRedactedDiagnostic(page, testInfo, error);

--- a/tests/smoke/candidate-host-auth.spec.js
+++ b/tests/smoke/candidate-host-auth.spec.js
@@ -26,9 +26,21 @@ function redactDiagnosticText(value) {
 }
 
 async function writeRedactedDiagnostic(page, testInfo, failure) {
-    const errorText = await page.locator('[role="alert"]').first().textContent().catch(() => '');
-    const submitDisabled = await page.getByRole('button', { name: 'Sign in' }).last().isDisabled().catch(() => null);
-    const loginFormVisible = await page.getByRole('heading', { name: 'Sign in' }).isVisible().catch(() => false);
+    const errorMessage = page.locator('[role="alert"]').first();
+    const submitButton = page.getByRole('button', { name: 'Sign in' }).last();
+    const loginHeading = page.getByRole('heading', { name: 'Sign in' });
+    const hasErrorMessage = (await errorMessage.count()) > 0;
+    const hasSubmitButton = (await submitButton.count()) > 0;
+    const hasLoginHeading = (await loginHeading.count()) > 0;
+    const errorText = hasErrorMessage
+        ? await errorMessage.textContent({ timeout: 1_000 }).catch(() => '')
+        : '';
+    const submitDisabled = hasSubmitButton
+        ? await submitButton.isDisabled({ timeout: 1_000 }).catch(() => null)
+        : null;
+    const loginFormVisible = hasLoginHeading
+        ? await loginHeading.isVisible({ timeout: 1_000 }).catch(() => false)
+        : false;
     const diagnosticPath = testInfo.outputPath('candidate-auth-diagnostic.json');
     await mkdir(path.dirname(diagnosticPath), { recursive: true });
     await writeFile(diagnosticPath, `${JSON.stringify({
@@ -97,11 +109,17 @@ test('candidate host accepts authentication and loads a protected landing page',
             await expect(
                 page.locator('h1').first(),
                 `Candidate post-login assertion failed at ${candidateHostUrl}: authenticated heading was not visible`
-            ).toContainText(/Your day|Your teams|Team/, { timeout: 10_000 });
+            ).toContainText(/Your day|Your teams|Team/, { timeout: 25_000 });
         });
     } catch (error) {
-        await page.getByLabel('Password', { exact: true }).fill('').catch(() => {});
-        await page.getByLabel('Email').fill('').catch(() => {});
+        const passwordInput = page.getByLabel('Password', { exact: true });
+        const emailInput = page.getByLabel('Email');
+        if (await passwordInput.count()) {
+            await passwordInput.fill('', { timeout: 1_000 }).catch(() => {});
+        }
+        if (await emailInput.count()) {
+            await emailInput.fill('', { timeout: 1_000 }).catch(() => {});
+        }
         await writeRedactedDiagnostic(page, testInfo, error);
         throw new Error(
             `Candidate authentication failed at ${new URL(candidateHostUrl).origin}: ${redactDiagnosticText(error?.message)}`

--- a/tests/smoke/helpers/candidate-auth-diagnostic.js
+++ b/tests/smoke/helpers/candidate-auth-diagnostic.js
@@ -1,0 +1,48 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export function redactDiagnosticText(value, authEmail, authPassword) {
+    let redacted = String(value || '');
+    if (authPassword) {
+        redacted = redacted.replaceAll(authPassword, '[REDACTED]');
+    }
+    if (authEmail) {
+        redacted = redacted.replaceAll(authEmail, '[REDACTED_EMAIL]');
+    }
+    return redacted
+        .replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi, '[REDACTED_EMAIL]')
+        .slice(0, 500);
+}
+
+export async function writeRedactedDiagnostic(page, testInfo, failure, {
+    candidateHostUrl,
+    authEmail,
+    authPassword
+}) {
+    const errorMessage = page.locator('[role="alert"]').first();
+    const submitButton = page.getByRole('button', { name: 'Sign in' }).last();
+    const loginHeading = page.getByRole('heading', { name: 'Sign in' });
+    const hasErrorMessage = (await errorMessage.count().catch(() => 0)) > 0;
+    const hasSubmitButton = (await submitButton.count().catch(() => 0)) > 0;
+    const hasLoginHeading = (await loginHeading.count().catch(() => 0)) > 0;
+    const errorText = hasErrorMessage
+        ? await errorMessage.textContent({ timeout: 1_000 }).catch(() => '')
+        : '';
+    const submitDisabled = hasSubmitButton
+        ? await submitButton.isDisabled({ timeout: 1_000 }).catch(() => null)
+        : null;
+    const loginFormVisible = hasLoginHeading
+        ? await loginHeading.isVisible({ timeout: 1_000 }).catch(() => false)
+        : false;
+    const diagnosticPath = testInfo.outputPath('candidate-auth-diagnostic.json');
+    await mkdir(path.dirname(diagnosticPath), { recursive: true });
+    await writeFile(diagnosticPath, `${JSON.stringify({
+        observedAt: new Date().toISOString(),
+        origin: new URL(candidateHostUrl).origin,
+        path: new URL(page.url()).pathname,
+        loginFormVisible,
+        submitDisabled,
+        visibleError: redactDiagnosticText(errorText, authEmail, authPassword),
+        failure: redactDiagnosticText(failure?.message, authEmail, authPassword)
+    }, null, 2)}\n`);
+}

--- a/tests/unit/candidate-host-auth-smoke.test.js
+++ b/tests/unit/candidate-host-auth-smoke.test.js
@@ -33,6 +33,9 @@ describe('candidate-host authenticated smoke coverage', () => {
         expect(spec).toContain('redactDiagnosticText');
         expect(spec).toContain('test.setTimeout(90_000)');
         expect(spec).toContain("toBeVisible({ timeout: 30_000 })");
+        expect(spec).toContain("toContainText(/Your day|Your teams|Team/, { timeout: 25_000 })");
+        expect(spec).toContain('if (await passwordInput.count())');
+        expect(spec).toContain('if (await emailInput.count())');
         expect(spec).not.toContain('page.screenshot');
 
         const diagnosticUpload = workflow.indexOf('Upload redacted candidate authentication diagnostic');

--- a/tests/unit/candidate-host-auth-smoke.test.js
+++ b/tests/unit/candidate-host-auth-smoke.test.js
@@ -1,6 +1,9 @@
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { writeRedactedDiagnostic } from '../smoke/helpers/candidate-auth-diagnostic.js';
 
 const repoRoot = path.resolve(import.meta.dirname, '../..');
 const readRepoFile = (file) => readFileSync(path.join(repoRoot, file), 'utf8');
@@ -9,6 +12,7 @@ describe('candidate-host authenticated smoke coverage', () => {
     it('targets the candidate origin with protected CI credentials', () => {
         const workflow = readRepoFile('.github/workflows/post-deploy-smoke.yml');
         const spec = readRepoFile('tests/smoke/candidate-host-auth.spec.js');
+        const diagnosticHelper = readRepoFile('tests/smoke/helpers/candidate-auth-diagnostic.js');
 
         expect(workflow).toContain('npx playwright test tests/smoke/candidate-host-auth.spec.js');
         expect(workflow).toContain('CANDIDATE_HOST_URL: https://game-flow-c6311.web.app');
@@ -29,19 +33,63 @@ describe('candidate-host authenticated smoke coverage', () => {
         expect(spec).toContain('Candidate post-login assertion failed at ${candidateHostUrl}: unexpected route');
         expect(spec).toContain("toBe('/app/')");
         expect(spec).toContain("expect(landingUrl.hash).not.toMatch(/^#\\/auth");
-        expect(spec).toContain("testInfo.outputPath('candidate-auth-diagnostic.json')");
+        expect(diagnosticHelper).toContain("testInfo.outputPath('candidate-auth-diagnostic.json')");
         expect(spec).toContain('redactDiagnosticText');
         expect(spec).toContain('test.setTimeout(90_000)');
         expect(spec).toContain("toBeVisible({ timeout: 30_000 })");
         expect(spec).toContain("toContainText(/Your day|Your teams|Team/, { timeout: 25_000 })");
-        expect(spec).toContain('if (await passwordInput.count())');
-        expect(spec).toContain('if (await emailInput.count())');
+        expect(spec).toContain('if (await passwordInput.count().catch(() => 0))');
+        expect(spec).toContain('if (await emailInput.count().catch(() => 0))');
         expect(spec).not.toContain('page.screenshot');
 
         const diagnosticUpload = workflow.indexOf('Upload redacted candidate authentication diagnostic');
         const baseline = workflow.indexOf('Run production smoke baseline');
         expect(diagnosticUpload).toBeGreaterThan(-1);
         expect(diagnosticUpload).toBeLessThan(baseline);
+    });
+
+    it('writes a diagnostic when locator counts fail after the page closes', async () => {
+        const outputDir = await mkdtemp(path.join(os.tmpdir(), 'candidate-auth-diagnostic-'));
+        const diagnosticPath = path.join(outputDir, 'candidate-auth-diagnostic.json');
+        const closedLocator = {
+            count: () => Promise.reject(new Error('Target page, context or browser has been closed')),
+            first() {
+                return this;
+            },
+            last() {
+                return this;
+            }
+        };
+        const page = {
+            locator: () => closedLocator,
+            getByRole: () => closedLocator,
+            url: () => 'https://candidate.example/app/#/auth'
+        };
+
+        try {
+            await writeRedactedDiagnostic(
+                page,
+                { outputPath: () => diagnosticPath },
+                new Error('page closed for staff@example.com'),
+                {
+                    candidateHostUrl: 'https://candidate.example',
+                    authEmail: 'staff@example.com',
+                    authPassword: 'secret'
+                }
+            );
+
+            expect(existsSync(diagnosticPath)).toBe(true);
+            expect(JSON.parse(await readFile(diagnosticPath, 'utf8'))).toMatchObject({
+                origin: 'https://candidate.example',
+                path: '/app/',
+                loginFormVisible: false,
+                submitDisabled: null,
+                visibleError: '',
+                failure: 'page closed for [REDACTED_EMAIL]'
+            });
+        } finally {
+            rmSync(outputDir, { recursive: true, force: true });
+        }
     });
 
     it('does not enable App Check enforcement for candidate authentication', () => {

--- a/tests/unit/production-smoke-auth-setup-timeout.test.js
+++ b/tests/unit/production-smoke-auth-setup-timeout.test.js
@@ -79,6 +79,9 @@ describe('production smoke authenticated setup timeout', () => {
         expect(workflow).toMatch(
             /tests\/smoke\/app-admin-core\.spec\.js[\s\S]*?tests\/smoke\/app-authenticated-core\.spec\.js[\s\S]*?--workers=1/
         );
+        expect(workflow).toMatch(
+            /tests\/smoke\/app-admin-core\.spec\.js[\s\S]*?tests\/smoke\/app-authenticated-core\.spec\.js[\s\S]*?--retries=1/
+        );
         expect(scheduledWorkflow).toMatch(
             /tests\/smoke\/app-admin-core\.spec\.js[\s\S]*?tests\/smoke\/app-authenticated-core\.spec\.js[\s\S]*?--workers=1/
         );


### PR DESCRIPTION
## What changed
- allow the authenticated candidate app bootstrap to settle before failing
- collect redacted diagnostics without waiting on login controls that have already disappeared
- retry a failed fixture-backed production smoke test once inside the same workflow run

## Why
Two consecutive deployments exposed separate transient failures: a delayed authenticated heading and a one-off 503 for a hashed app asset that immediately recovered. Persistent failures still fail after the bounded wait or retry.

## Validation
- npx vitest run tests/unit/candidate-host-auth-smoke.test.js tests/unit/production-smoke-auth-setup-timeout.test.js --reporter=verbose (15 passed)
- npx playwright test tests/smoke/candidate-host-auth.spec.js --config=playwright.smoke.config.js --reporter=line (credential-gated test skipped locally)
- git diff --check