### PR TITLE
Fix ambiguous production smoke locator

### DIFF
--- a/tests/smoke/app-authenticated-core.spec.js
+++ b/tests/smoke/app-authenticated-core.spec.js
@@ -144,7 +144,7 @@ test('parent account reaches every critical family workflow with linked fixtures
         await openAuthenticatedAppRoute(page, config.appBaseUrl, '/parent-tools/access', { heading: 'Family workflows' });
         await expect(page.getByText('Access requests', { exact: true })).toBeVisible();
         await openAuthenticatedAppRoute(page, config.appBaseUrl, '/parent-tools/household', { heading: 'Family workflows' });
-        await expect(page.getByText('Create invite', { exact: true })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Create invite' })).toBeVisible();
         await openAuthenticatedAppRoute(page, config.appBaseUrl, '/parent-tools/share', { heading: 'Family workflows' });
         await expect(page.getByText('Family share', { exact: true })).toBeVisible();
         await openAuthenticatedAppRoute(page, config.appBaseUrl, '/parent-tools/certificates', { heading: 'Family workflows' });

--- a/tests/unit/production-smoke-parent-fixture.test.js
+++ b/tests/unit/production-smoke-parent-fixture.test.js
@@ -8,6 +8,7 @@ import {
 } from '../../scripts/maintain-production-smoke-parent-fixture.mjs';
 
 const workflowSource = readFileSync('.github/workflows/production-smoke-fixture.yml', 'utf8');
+const authenticatedCoreSource = readFileSync('tests/smoke/app-authenticated-core.spec.js', 'utf8');
 
 function mapValue(fields) {
     return { mapValue: { fields } };
@@ -246,5 +247,14 @@ describe('production parent smoke fixture maintenance', () => {
         expect(workflowSource).toContain('environment:\n      name: production-smoke');
         expect(workflowSource).toContain('ref: ${{ github.sha }}');
         expect(workflowSource).not.toContain('pull_request:');
+    });
+
+    it('uses an unambiguous semantic locator for the household invite heading', () => {
+        expect(authenticatedCoreSource).toContain(
+            "page.getByRole('heading', { name: 'Create invite' })"
+        );
+        expect(authenticatedCoreSource).not.toContain(
+            "page.getByText('Create invite', { exact: true })"
+        );
     });
 });


### PR DESCRIPTION
## What changed
- target the household invite heading by semantic role instead of ambiguous visible text
- add a unit contract that prevents the ambiguous locator from returning

## Root cause
The production fixture smoke used `getByText("Create invite")`, but the household workflow now renders both a heading and submit button with that exact text. Playwright strict mode rejected the two matches on both attempts even though production was healthy.

## Validation
- `npx vitest run tests/unit/production-smoke-parent-fixture.test.js tests/unit/production-smoke-auth-setup-timeout.test.js tests/unit/candidate-host-auth-smoke.test.js --reporter=verbose` (22 passed)
- `git diff --check`

## Manual test
- Reviewed failed post-deploy run 30675111345: public origin, candidate authentication, and canonical production baseline passed; only the ambiguous parent fixture locator failed.