### PR TITLE
Cache Chromium in regression CI

### DIFF
--- a/.github/workflows/regression-guards.yml
+++ b/.github/workflows/regression-guards.yml
@@ -47,8 +47,28 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Resolve Playwright version
+        id: pw-version
+        run: |
+          set -euo pipefail
+          version="$(node -e "console.log(require('@playwright/test/package.json').version)" 2>/dev/null \
+            || node -e "console.log(require('playwright/package.json').version)")"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.pw-version.outputs.version }}
+
       - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
+        run: |
+          if [ "${{ steps.pw-cache.outputs.cache-hit }}" = "true" ]; then
+            npx playwright install-deps chromium
+          else
+            npx playwright install --with-deps chromium
+          fi
 
       - name: Start local static server
         run: python3 -m http.server 4173 >/tmp/allplays-regression-guards.log 2>&1 &

--- a/tests/unit/pr-ci-consolidation.test.js
+++ b/tests/unit/pr-ci-consolidation.test.js
@@ -53,6 +53,27 @@ describe('pull request CI consolidation', () => {
         expect(integration).not.toContain('secrets: inherit');
     });
 
+    it('reuses version-bound Playwright browsers in the regression workflow', () => {
+        const regression = workflow('regression-guards.yml');
+        const parsed = parseYaml(regression);
+
+        expect(parsed.jobs['roster-chat-media-replay-smoke'].steps).toBeTruthy();
+        expect(regression).toContain('name: Resolve Playwright version');
+        expect(regression).toContain(
+            'uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4'
+        );
+        expect(regression).toContain('path: ~/.cache/ms-playwright');
+        expect(regression).toContain(
+            'key: ${{ runner.os }}-playwright-${{ steps.pw-version.outputs.version }}'
+        );
+        expect(regression).toContain(
+            'if [ "${{ steps.pw-cache.outputs.cache-hit }}" = "true" ]; then'
+        );
+        expect(regression).toContain('npx playwright install-deps chromium');
+        expect(regression).toContain('npx playwright install --with-deps chromium');
+        expect(regression).not.toContain('restore-keys:');
+    });
+
     it.each([
         ['mobile-build', { MOBILE_RESULT: 'cancelled' }],
         ['preview-smoke', {


### PR DESCRIPTION
## What changed
- restore Playwright Chromium by exact installed Playwright version in the regression workflow
- install only OS libraries when the browser cache hits
- add a parsed-workflow contract covering the pinned cache action and bounded key

## Why
PR #4300 spent more than 11 minutes in `npx playwright install --with-deps chromium` on its required rebased head. The parallel preview workflow already uses this cache safely, but `regression-guards` downloaded Chromium again on every head.

## Validation
- `npx vitest run tests/unit/pr-ci-consolidation.test.js --reporter=verbose` (9 passed)
- workflow YAML parsed by the regression contract
- `git diff --check`

## Security
- cache action is pinned to the existing repository-approved SHA
- cache key is exact OS + installed Playwright version; no broad restore key
- workflow permissions remain `contents: read` and no secrets are inherited.