### PR TITLE
Build TestFlight releases with Xcode 26

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -85,12 +85,19 @@ jobs:
   ios-release:
     runs-on: macos-15
     environment: mobile-release
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: npm
+      - name: Validate App Store Xcode toolchain
+        run: |
+          xcodebuild -version
+          SDK_VERSION="$(xcrun --sdk iphoneos --show-sdk-version)"
+          [[ "$SDK_VERSION" == 26.* ]]
       - name: Install dependencies
         run: |
           npm ci

--- a/tests/unit/mobile-release-workflow.test.js
+++ b/tests/unit/mobile-release-workflow.test.js
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { parse as parseYaml } from 'yaml';
+
+const workflowPath = '.github/workflows/mobile-release.yml';
+const workflowSource = readFileSync(resolve(process.cwd(), workflowPath), 'utf8');
+const workflow = parseYaml(workflowSource);
+
+describe('mobile release workflow', () => {
+    it('builds App Store archives with an iOS 26 SDK toolchain', () => {
+        const iosRelease = workflow.jobs['ios-release'];
+        const toolchainStep = iosRelease.steps.find(
+            (step) => step.name === 'Validate App Store Xcode toolchain'
+        );
+
+        expect(iosRelease['runs-on']).toBe('macos-15');
+        expect(iosRelease.env.DEVELOPER_DIR).toBe(
+            '/Applications/Xcode_26.3.app/Contents/Developer'
+        );
+        expect(toolchainStep.run).toContain('xcodebuild -version');
+        expect(toolchainStep.run).toContain('xcrun --sdk iphoneos --show-sdk-version');
+        expect(toolchainStep.run).toContain('[[ "$SDK_VERSION" == 26.* ]]');
+    });
+
+    it('keeps TestFlight upload manual and the workflow token read-only', () => {
+        expect(workflow.on).toHaveProperty('workflow_dispatch');
+        expect(workflow.permissions).toEqual({ contents: 'read' });
+        expect(workflow.jobs['ios-release'].steps).toContainEqual(
+            expect.objectContaining({
+                name: 'Upload to TestFlight',
+                if: 'inputs.upload_ios'
+            })
+        );
+        expect(workflowSource).not.toContain('pull_request_target:');
+        expect(workflowSource).not.toContain('permissions: write-all');
+    });
+});


### PR DESCRIPTION
## Summary
- select the installed Xcode 26.3 toolchain for iOS release jobs
- fail early unless the selected iPhoneOS SDK is version 26
- add a deterministic workflow contract test

## Root cause
App Store Connect rejected build 1.0.0 because the macos-15 runner defaulted to Xcode 16.4 and the iOS 18.5 SDK. Apple now requires iOS 26 SDK or later.

## Validation
- `npx vitest run tests/unit/mobile-release-workflow.test.js --reporter=verbose`
- `npx vitest run tests/unit/pr-ci-consolidation.test.js tests/unit/mobile-release-workflow.test.js --reporter=dot`
- `git diff --check`
- GitHub runner image inventory confirms `/Applications/Xcode_26.3.app` is installed

## Security
The workflow remains manual with `contents: read`; existing actions remain pinned to full commit SHAs. No new expression interpolation or secret exposure was introduced.