### PR TITLE
Make PR preview deployments opt-in

### DIFF
--- a/.github/workflows/deploy-preview-trusted.yml
+++ b/.github/workflows/deploy-preview-trusted.yml
@@ -9,10 +9,6 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: trusted-preview-${{ github.event.workflow_run.display_title || github.event.workflow_run.id }}
-  cancel-in-progress: true
-
 jobs:
   classify-trigger:
     if: >-
@@ -62,12 +58,25 @@ jobs:
             -f status=success \
             -f head_sha="$expected_head_sha" \
             -F per_page=100 > "$integration_runs_json"
-          if ! jq -e \
+          mapfile -t integration_run_ids < <(jq -r \
             --arg repo "$GITHUB_REPOSITORY" \
             --arg sha "$expected_head_sha" \
-            'any(.workflow_runs[]?; .event == "pull_request" and .status == "completed" and .conclusion == "success" and .head_sha == $sha and .head_repository.full_name == $repo)' \
-            "$integration_runs_json" >/dev/null; then
-            echo "No successful exact-head pr-integration run exists for this preview request." >&2
+            '.workflow_runs[]? | select(.event == "pull_request" and .status == "completed" and .conclusion == "success" and .head_sha == $sha and .head_repository.full_name == $repo) | .id' \
+            "$integration_runs_json")
+          integration_jobs_succeeded=false
+          for integration_run_id in "${integration_run_ids[@]}"; do
+            integration_jobs_json="$RUNNER_TEMP/firebase-preview-integration-jobs-$integration_run_id.json"
+            gh api "repos/$GITHUB_REPOSITORY/actions/runs/$integration_run_id/jobs?filter=latest&per_page=100" > "$integration_jobs_json"
+            if jq -e '
+              ([.jobs[]? | select(.name == "mobile-build" and .status == "completed" and .conclusion == "success")] | length) == 1 and
+              ([.jobs[]? | select(.name == "preview-smoke" and .status == "completed" and .conclusion == "success")] | length) == 1
+            ' "$integration_jobs_json" >/dev/null; then
+              integration_jobs_succeeded=true
+              break
+            fi
+          done
+          if [ "$integration_jobs_succeeded" != "true" ]; then
+            echo "No exact-head pr-integration run has successful mobile-build and preview-smoke jobs." >&2
             exit 1
           fi
 
@@ -216,6 +225,9 @@ jobs:
 
   deploy-preview:
     needs: prepare-preview
+    concurrency:
+      group: trusted-preview-pr-${{ needs.prepare-preview.outputs.pr_number }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     timeout-minutes: 8
     environment:

--- a/.github/workflows/deploy-preview-trusted.yml
+++ b/.github/workflows/deploy-preview-trusted.yml
@@ -10,14 +10,14 @@ on:
 permissions: {}
 
 concurrency:
-  group: trusted-preview-pr-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.id }}
+  group: trusted-preview-${{ github.event.workflow_run.display_title || github.event.workflow_run.id }}
   cancel-in-progress: true
 
 jobs:
   classify-trigger:
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.event == 'workflow_dispatch' &&
       github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -25,6 +25,8 @@ jobs:
       actions: read
       pull-requests: read
     outputs:
+      head_sha: ${{ steps.classify.outputs.head_sha }}
+      pr_number: ${{ steps.classify.outputs.pr_number }}
       preview_ready: ${{ steps.classify.outputs.preview_ready }}
 
     steps:
@@ -32,44 +34,45 @@ jobs:
         id: classify
         env:
           GH_TOKEN: ${{ github.token }}
-          WORKFLOW_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          WORKFLOW_DISPLAY_TITLE: ${{ github.event.workflow_run.display_title }}
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
           set -euo pipefail
-          if [[ ! "$WORKFLOW_PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
-            echo "Invalid triggering pull-request identity." >&2
+          if [[ "$WORKFLOW_DISPLAY_TITLE" =~ ^PR\ preview\ \#([1-9][0-9]*)\ @\ ([0-9a-f]{40})$ ]]; then
+            workflow_pr_number="${BASH_REMATCH[1]}"
+            expected_head_sha="${BASH_REMATCH[2]}"
+          else
+            echo "Invalid preview dispatch identity." >&2
             exit 1
           fi
-          head_repository="$(
-            gh api "repos/$GITHUB_REPOSITORY/pulls/$WORKFLOW_PR_NUMBER" \
-              --jq '.head.repo.full_name'
-          )"
-          if [ "$head_repository" != "$GITHUB_REPOSITORY" ]; then
-            echo "Fork pull request — no trusted preview deploy is required."
-            echo "preview_ready=false" >> "$GITHUB_OUTPUT"
-            exit 0
+          pr_json="$RUNNER_TEMP/firebase-preview-classify-pr.json"
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$workflow_pr_number" > "$pr_json"
+          if ! jq -e \
+            --arg repo "$GITHUB_REPOSITORY" \
+            --arg sha "$expected_head_sha" \
+            '.state == "open" and .draft == false and .head.repo.full_name == $repo and .head.sha == $sha' \
+            "$pr_json" >/dev/null; then
+            echo "Preview dispatch is not bound to the current ready same-repository PR head." >&2
+            exit 1
           fi
 
           artifacts_json="$RUNNER_TEMP/firebase-preview-source-artifacts.json"
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$WORKFLOW_RUN_ID/artifacts?per_page=100" > "$artifacts_json"
 
           bundle_count="$(jq '[.artifacts[]? | select(.name == "firebase-preview-hosting-bundle")] | length' "$artifacts_json")"
-          if [ "$bundle_count" -eq 0 ]; then
-            echo "No preview bundle was requested by this label event."
-            echo "preview_ready=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
           if [ "$bundle_count" -ne 1 ]; then
             echo "Expected exactly one preview bundle, found $bundle_count." >&2
             exit 1
           fi
+          echo "head_sha=$expected_head_sha" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$workflow_pr_number" >> "$GITHUB_OUTPUT"
           echo "preview_ready=true" >> "$GITHUB_OUTPUT"
 
   prepare-preview:
     needs: classify-trigger
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.event == 'workflow_dispatch' &&
       github.event.workflow_run.head_repository.full_name == github.repository &&
       needs.classify-trigger.outputs.preview_ready == 'true'
     runs-on: ubuntu-latest
@@ -97,7 +100,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
-          WORKFLOW_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          WORKFLOW_PR_NUMBER: ${{ needs.classify-trigger.outputs.pr_number }}
         run: |
           set -euo pipefail
           if [[ ! "$WORKFLOW_RUN_ID" =~ ^[1-9][0-9]*$ ]] || [[ ! "$WORKFLOW_PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
@@ -283,7 +286,7 @@ jobs:
             echo "Trusted preview verifier must not be a symbolic link." >&2
             exit 1
           }
-          expected_verifier_sha256='98074e19129c3402e7f6313234beb6734cd74c941f9a75fb44d02accb50f82ac'
+          expected_verifier_sha256='795c938b2b7d16c5468d905a183810fd6cb9005f4f765e1c4fcd472a0a42fb81'
           printf '%s  %s\n' "$expected_verifier_sha256" "$verifier" | sha256sum --check --strict
 
           recheck_current_head() {

--- a/.github/workflows/deploy-preview-trusted.yml
+++ b/.github/workflows/deploy-preview-trusted.yml
@@ -56,6 +56,21 @@ jobs:
             exit 1
           fi
 
+          integration_runs_json="$RUNNER_TEMP/firebase-preview-integration-runs.json"
+          gh api --method GET "repos/$GITHUB_REPOSITORY/actions/workflows/pr-integration.yml/runs" \
+            -f event=pull_request \
+            -f status=success \
+            -f head_sha="$expected_head_sha" \
+            -F per_page=100 > "$integration_runs_json"
+          if ! jq -e \
+            --arg repo "$GITHUB_REPOSITORY" \
+            --arg sha "$expected_head_sha" \
+            'any(.workflow_runs[]?; .event == "pull_request" and .status == "completed" and .conclusion == "success" and .head_sha == $sha and .head_repository.full_name == $repo)' \
+            "$integration_runs_json" >/dev/null; then
+            echo "No successful exact-head pr-integration run exists for this preview request." >&2
+            exit 1
+          fi
+
           artifacts_json="$RUNNER_TEMP/firebase-preview-source-artifacts.json"
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$WORKFLOW_RUN_ID/artifacts?per_page=100" > "$artifacts_json"
 

--- a/.github/workflows/deploy-preview-trusted.yml
+++ b/.github/workflows/deploy-preview-trusted.yml
@@ -3,7 +3,7 @@ name: deploy-preview-trusted
 on:
   workflow_run:
     workflows:
-      - pr-integration
+      - pr-preview
     types:
       - completed
 
@@ -54,6 +54,11 @@ jobs:
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$WORKFLOW_RUN_ID/artifacts?per_page=100" > "$artifacts_json"
 
           bundle_count="$(jq '[.artifacts[]? | select(.name == "firebase-preview-hosting-bundle")] | length' "$artifacts_json")"
+          if [ "$bundle_count" -eq 0 ]; then
+            echo "No preview bundle was requested by this label event."
+            echo "preview_ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if [ "$bundle_count" -ne 1 ]; then
             echo "Expected exactly one preview bundle, found $bundle_count." >&2
             exit 1
@@ -278,7 +283,7 @@ jobs:
             echo "Trusted preview verifier must not be a symbolic link." >&2
             exit 1
           }
-          expected_verifier_sha256='cf22c88b47b9e47026bbf3813998ce877e29891b66c668c7559085c6cb358927'
+          expected_verifier_sha256='98074e19129c3402e7f6313234beb6734cd74c941f9a75fb44d02accb50f82ac'
           printf '%s  %s\n' "$expected_verifier_sha256" "$verifier" | sha256sum --check --strict
 
           recheck_current_head() {

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -2,6 +2,13 @@ name: deploy-preview
 
 on:
   workflow_call:
+    inputs:
+      pr_number:
+        required: true
+        type: string
+      head_sha:
+        required: true
+        type: string
 
 # Pull-request-controlled code runs here, so this workflow has no repository
 # permissions and receives no privileged secrets. Its only deploy input is an
@@ -9,22 +16,33 @@ on:
 permissions: {}
 
 concurrency:
-  group: preview-${{ github.event.pull_request.number }}
+  group: preview-${{ inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
   build-preview-artifact:
-    if: >-
-      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout pull request merge
+      - name: Checkout exact pull request head
+        env:
+          EXPECTED_HEAD_SHA: ${{ inputs.head_sha }}
+          PR_NUMBER: ${{ inputs.pr_number }}
         run: |
+          set -euo pipefail
+          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]] || [[ ! "$EXPECTED_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid pull request number or exact head SHA." >&2
+            exit 1
+          fi
           git init .
           git remote add origin https://github.com/${{ github.repository }}.git
-          git fetch --no-tags --prune --depth=1 origin +refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge
-          git checkout --force refs/remotes/pull/${{ github.event.pull_request.number }}/merge
+          git fetch --no-tags --prune --depth=1 origin "+refs/pull/$PR_NUMBER/head:refs/remotes/pull/$PR_NUMBER/head"
+          actual_head_sha="$(git rev-parse "refs/remotes/pull/$PR_NUMBER/head")"
+          if [ "$actual_head_sha" != "$EXPECTED_HEAD_SHA" ]; then
+            echo "Pull request head changed before preview construction." >&2
+            exit 1
+          fi
+          git checkout --detach --force "$actual_head_sha"
 
       - name: Setup Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5

--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - synchronize
       - reopened
+      - ready_for_review
 
 permissions: {}
 
@@ -15,6 +16,7 @@ concurrency:
 
 jobs:
   cache-bust-guard:
+    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -38,6 +40,7 @@ jobs:
           GITHUB_BASE_REF: ${{ github.base_ref }}
 
   unit-tests:
+    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -102,6 +105,7 @@ jobs:
         run: npm run test:functions:team-email
 
   app-quality:
+    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - synchronize
       - reopened
+      - ready_for_review
 
 permissions:
   contents: read
@@ -16,18 +17,21 @@ concurrency:
 
 jobs:
   regression-integration:
+    if: ${{ github.event.pull_request.draft == false }}
     uses: ./.github/workflows/regression-guards.yml
 
   mobile-integration:
+    if: ${{ github.event.pull_request.draft == false }}
     uses: ./.github/workflows/mobile-build.yml
 
   preview-integration:
+    if: ${{ github.event.pull_request.draft == false }}
     uses: ./.github/workflows/preview-smoke.yml
 
   mobile-build:
     name: mobile-build
     needs: mobile-integration
-    if: ${{ always() }}
+    if: ${{ always() && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - name: Enforce reusable mobile workflow result
@@ -45,7 +49,7 @@ jobs:
     needs:
       - regression-integration
       - preview-integration
-    if: ${{ always() }}
+    if: ${{ always() && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - name: Enforce complete integration result

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -24,9 +24,6 @@ jobs:
   preview-integration:
     uses: ./.github/workflows/preview-smoke.yml
 
-  preview-artifact:
-    uses: ./.github/workflows/deploy-preview.yml
-
   mobile-build:
     name: mobile-build
     needs: mobile-integration
@@ -48,14 +45,11 @@ jobs:
     needs:
       - regression-integration
       - preview-integration
-      - preview-artifact
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
       - name: Enforce complete integration result
         env:
-          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
-          PREVIEW_ARTIFACT_RESULT: ${{ needs.preview-artifact.result }}
           PREVIEW_RESULT: ${{ needs.preview-integration.result }}
           REGRESSION_RESULT: ${{ needs.regression-integration.result }}
         run: |
@@ -66,16 +60,6 @@ jobs:
           fi
           if [ "$PREVIEW_RESULT" != "success" ]; then
             echo "Preview smoke integration did not succeed ($PREVIEW_RESULT)." >&2
-            exit 1
-          fi
-          if [ "$HEAD_REPOSITORY" = "$GITHUB_REPOSITORY" ] && [ "$PREVIEW_ARTIFACT_RESULT" != "success" ]; then
-            echo "Same-repository preview artifact did not succeed ($PREVIEW_ARTIFACT_RESULT)." >&2
-            exit 1
-          fi
-          if [ "$HEAD_REPOSITORY" != "$GITHUB_REPOSITORY" ] && \
-             [ "$PREVIEW_ARTIFACT_RESULT" != "success" ] && \
-             [ "$PREVIEW_ARTIFACT_RESULT" != "skipped" ]; then
-            echo "Fork preview artifact had an unexpected result ($PREVIEW_ARTIFACT_RESULT)." >&2
             exit 1
           fi
           echo "Integration checks succeeded with fail-closed stable contexts."

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,20 +1,27 @@
 name: pr-preview
+run-name: PR preview #${{ inputs.pr_number }} @ ${{ inputs.head_sha }}
 
 on:
-  pull_request:
-    types:
-      - labeled
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Ready same-repository pull request number
+        required: true
+        type: string
+      head_sha:
+        description: Exact current pull request head SHA
+        required: true
+        type: string
 
 permissions: {}
 
 concurrency:
-  group: pr-preview-${{ github.event.pull_request.number }}
+  group: pr-preview-${{ inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
   preview-artifact:
-    if: >-
-      github.event.label.name == 'preview-requested' &&
-      github.event.pull_request.draft == false &&
-      github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/deploy-preview.yml
+    with:
+      pr_number: ${{ inputs.pr_number }}
+      head_sha: ${{ inputs.head_sha }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,20 @@
+name: pr-preview
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+permissions: {}
+
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview-artifact:
+    if: >-
+      github.event.label.name == 'preview-requested' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    uses: ./.github/workflows/deploy-preview.yml

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,5 +1,5 @@
 name: pr-preview
-run-name: PR preview #${{ inputs.pr_number }} @ ${{ inputs.head_sha }}
+run-name: "PR preview #${{ inputs.pr_number }} @ ${{ inputs.head_sha }}"
 
 on:
   workflow_dispatch:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,5 +107,6 @@ HTML test pages in the repo root (`test-foul-tracking.html`, `test-pr-changes.ht
 - Keep the untrusted reusable `deploy-preview.yml` builder separate from the
   default-branch `deploy-preview-trusted.yml` OIDC workflow. The trusted
   verifier accepts only an explicit `pr-preview` dispatch containing a ready
-  same-repository PR number and its exact current head SHA. Normal PR pushes
-  and labels must not deploy Firebase preview channels.
+  same-repository PR number and its exact current head SHA after that head has
+  passed `pr-integration`. Normal PR pushes and labels must not deploy Firebase
+  preview channels.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,8 @@ HTML test pages in the repo root (`test-foul-tracking.html`, `test-pr-changes.ht
 - Public Firebase config in app/native bundles is expected; do not commit service account keys, private API keys, provisioning profiles, or signing certificates.
 - Pull-request CI has two code-head entrypoints: `pr-fast` for unit and app
   quality checks, and `pr-integration` for reusable regression, native, preview
-  smoke, and untrusted preview-artifact work. Preserve the stable
+  smoke work. Draft heads intentionally skip heavy jobs; `ready_for_review`
+  starts exact-head validation. Preserve the stable
   `unit-tests`, `cache-bust-guard`, `app-quality`, `mobile-build`, and
   `preview-smoke` contexts.
 - `external-claim` is ownership metadata and must not trigger or restart CI.
@@ -105,5 +106,6 @@ HTML test pages in the repo root (`test-foul-tracking.html`, `test-pr-changes.ht
   `.github/workflows/app-github-pages.yml` is manual validation only.
 - Keep the untrusted reusable `deploy-preview.yml` builder separate from the
   default-branch `deploy-preview-trusted.yml` OIDC workflow. The trusted
-  verifier is bound to the successful `pr-integration` run and exact current
-  head.
+  verifier accepts only an explicit `pr-preview` dispatch containing a ready
+  same-repository PR number and its exact current head SHA. Normal PR pushes
+  and labels must not deploy Firebase preview channels.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,6 @@ firebase deploy --only hosting
 
 GitHub Pages: `.github/workflows/app-github-pages.yml` stages the legacy root site plus the React app under `/app/` with `scripts/stage-pages-bundle.mjs`.
 
-Firebase previews: dispatch `.github/workflows/pr-preview.yml` with a ready same-repository PR number and its exact current head SHA. Its permissionless builder stages `/app/`; the separate default-branch trusted workflow verifies the live PR/head before deploying. Normal PR pushes and labels do not deploy a Firebase preview.
+Firebase previews: after `pr-integration` succeeds, dispatch `.github/workflows/pr-preview.yml` with a ready same-repository PR number and its exact current head SHA. Its permissionless builder stages `/app/`; the separate default-branch trusted workflow verifies the integration result and live PR/head before deploying. Normal PR pushes and labels do not deploy a Firebase preview.
 
 Production smoke: `post-deploy-smoke` and `scheduled-prod-smoke` check the legacy site plus the deployed `/app/` boot route.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,6 @@ firebase deploy --only hosting
 
 GitHub Pages: `.github/workflows/app-github-pages.yml` stages the legacy root site plus the React app under `/app/` with `scripts/stage-pages-bundle.mjs`.
 
-Firebase previews: `.github/workflows/deploy-preview.yml` deploys a staged preview bundle so PR preview URLs include `/app/`.
+Firebase previews: dispatch `.github/workflows/pr-preview.yml` with a ready same-repository PR number and its exact current head SHA. Its permissionless builder stages `/app/`; the separate default-branch trusted workflow verifies the live PR/head before deploying. Normal PR pushes and labels do not deploy a Firebase preview.
 
 Production smoke: `post-deploy-smoke` and `scheduled-prod-smoke` check the legacy site plus the deployed `/app/` boot route.

--- a/docs/preview-deploy-trust-boundary.md
+++ b/docs/preview-deploy-trust-boundary.md
@@ -2,13 +2,15 @@
 
 ## Required invariants
 
-The `pr-integration` pull-request workflow calls the reusable
-`deploy-preview` artifact builder, which executes untrusted PR code. Neither may
-receive a Firebase credential or a repository token with write permissions.
-The reusable builder may only build, stage public Hosting content, and upload
-the single `firebase-preview-hosting-bundle` artifact. The same consolidated
-run must also pass the reusable regression and preview-smoke workflows before
-its stable `preview-smoke` aggregate succeeds.
+The optional `pr-preview` pull-request workflow calls the reusable
+`deploy-preview` artifact builder only when an operator applies the
+`preview-requested` label to a ready same-repository PR. The builder executes
+untrusted PR code. Neither workflow may receive a Firebase credential or a
+repository token with write permissions. The reusable builder may only build,
+stage public Hosting content, and upload the single
+`firebase-preview-hosting-bundle` artifact. Required regression and local
+preview-smoke validation remain in `pr-integration`; a Firebase channel deploy
+is not a merge prerequisite and must not run on every pushed PR head.
 
 The `deploy-preview-trusted` workflow is the only preview deployer. GitHub runs
 its `workflow_run` definition from the default branch. It checks out only the
@@ -89,10 +91,10 @@ Before merging a change to either preview workflow:
 5. Review the exact PR head SHA after all requested automated reviews and CI
    complete. Any new commit invalidates prior review evidence.
 
-The first `workflow_run` preview cannot execute until `pr-integration` and its
+The first `workflow_run` preview cannot execute until `pr-preview` and its
 trusted verifier scripts are present on the default branch. The reusable
-artifact build remains testable before merge; the first post-merge PR run is
-the deployment canary.
+artifact build remains testable before merge; apply `preview-requested` to a
+ready same-repository canary PR after merge to exercise the deployment path.
 
 ## Workload Identity cutover and JSON-key retirement
 

--- a/docs/preview-deploy-trust-boundary.md
+++ b/docs/preview-deploy-trust-boundary.md
@@ -2,10 +2,11 @@
 
 ## Required invariants
 
-The optional `pr-preview` pull-request workflow calls the reusable
-`deploy-preview` artifact builder only when an operator applies the
-`preview-requested` label to a ready same-repository PR. The builder executes
-untrusted PR code. Neither workflow may receive a Firebase credential or a
+The optional `pr-preview` workflow calls the reusable `deploy-preview`
+artifact builder only after an operator dispatches it with a ready
+same-repository PR number and its exact current head SHA. The builder fetches
+that PR ref and fails if it no longer matches the requested SHA. It executes
+untrusted PR code, so neither workflow may receive a Firebase credential or a
 repository token with write permissions. The reusable builder may only build,
 stage public Hosting content, and upload the single
 `firebase-preview-hosting-bundle` artifact. Required regression and local
@@ -93,8 +94,9 @@ Before merging a change to either preview workflow:
 
 The first `workflow_run` preview cannot execute until `pr-preview` and its
 trusted verifier scripts are present on the default branch. The reusable
-artifact build remains testable before merge; apply `preview-requested` to a
-ready same-repository canary PR after merge to exercise the deployment path.
+artifact build remains testable before merge; dispatch `pr-preview` with a
+ready same-repository canary PR number and exact head SHA after merge to
+exercise the deployment path.
 
 ## Workload Identity cutover and JSON-key retirement
 

--- a/docs/preview-deploy-trust-boundary.md
+++ b/docs/preview-deploy-trust-boundary.md
@@ -11,7 +11,8 @@ repository token with write permissions. The reusable builder may only build,
 stage public Hosting content, and upload the single
 `firebase-preview-hosting-bundle` artifact. Required regression and local
 preview-smoke validation remain in `pr-integration`; a Firebase channel deploy
-is not a merge prerequisite and must not run on every pushed PR head.
+requires a successful `pr-integration` run for the exact requested head, but is
+not a merge prerequisite and must not run on every pushed PR head.
 
 The `deploy-preview-trusted` workflow is the only preview deployer. GitHub runs
 its `workflow_run` definition from the default branch. It checks out only the

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -666,7 +666,8 @@ export function validateFirebaseRulesCi() {
 
     assertIncludes(deployPreviewBuild, 'workflow_call:', 'Untrusted preview reusable workflow');
     assertIncludes(prIntegration, 'uses: ./.github/workflows/regression-guards.yml', 'PR integration regression gate');
-    assertIncludes(prPreview, "github.event.label.name == 'preview-requested'", 'Explicit PR preview request gate');
+    assertIncludes(prPreview, 'workflow_dispatch:', 'Explicit PR preview dispatch gate');
+    assertIncludes(prPreview, 'head_sha: ${{ inputs.head_sha }}', 'Exact-head PR preview dispatch input');
     assertIncludes(prPreview, 'uses: ./.github/workflows/deploy-preview.yml', 'PR preview artifact gate');
     assertIncludes(prIntegration, 'name: preview-smoke', 'PR integration stable preview context');
     assertIncludes(prIntegration, 'name: mobile-build', 'PR integration stable mobile context');

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -585,6 +585,7 @@ export function validateFirebaseRulesCi() {
     const deployPreviewBuild = readText('.github/workflows/deploy-preview.yml');
     const deployPreviewTrusted = readText('.github/workflows/deploy-preview-trusted.yml');
     const prIntegration = readText('.github/workflows/pr-integration.yml');
+    const prPreview = readText('.github/workflows/pr-preview.yml');
     const regressionGuards = readText('.github/workflows/regression-guards.yml');
 
     validateFirestoreRulesDeployBudget(compactFirestoreRules(firestoreRules));
@@ -665,7 +666,8 @@ export function validateFirebaseRulesCi() {
 
     assertIncludes(deployPreviewBuild, 'workflow_call:', 'Untrusted preview reusable workflow');
     assertIncludes(prIntegration, 'uses: ./.github/workflows/regression-guards.yml', 'PR integration regression gate');
-    assertIncludes(prIntegration, 'uses: ./.github/workflows/deploy-preview.yml', 'PR integration preview artifact gate');
+    assertIncludes(prPreview, "github.event.label.name == 'preview-requested'", 'Explicit PR preview request gate');
+    assertIncludes(prPreview, 'uses: ./.github/workflows/deploy-preview.yml', 'PR preview artifact gate');
     assertIncludes(prIntegration, 'name: preview-smoke', 'PR integration stable preview context');
     assertIncludes(prIntegration, 'name: mobile-build', 'PR integration stable mobile context');
     validatePreviewDeployCommand(deployPreviewTrusted);

--- a/scripts/verify-preview-deploy-trigger.mjs
+++ b/scripts/verify-preview-deploy-trigger.mjs
@@ -5,6 +5,7 @@ export const PREVIEW_WORKFLOW_NAME = 'pr-preview';
 export const PREVIEW_WORKFLOW_PATH = '.github/workflows/pr-preview.yml';
 export const PREVIEW_ARTIFACT_NAME = 'firebase-preview-hosting-bundle';
 export const MAX_PREVIEW_ARCHIVE_BYTES = 100 * 1024 * 1024;
+const PREVIEW_DISPLAY_TITLE_PATTERN = /^PR preview #([1-9][0-9]*) @ ([0-9a-f]{40})$/;
 
 function fail(message) {
     throw new Error(`Preview deploy trust check failed: ${message}`);
@@ -42,8 +43,8 @@ export function verifyPreviewDeployTrigger({ event, run, pullRequest, artifacts 
     if (!eventRun || eventRun.name !== PREVIEW_WORKFLOW_NAME) {
         fail(`event must come from ${PREVIEW_WORKFLOW_NAME}.`);
     }
-    if (eventRun.event !== 'pull_request' || eventRun.status !== 'completed' || eventRun.conclusion !== 'success') {
-        fail('triggering workflow must be a completed successful pull_request run.');
+    if (eventRun.event !== 'workflow_dispatch' || eventRun.status !== 'completed' || eventRun.conclusion !== 'success') {
+        fail('triggering workflow must be a completed successful workflow_dispatch run.');
     }
 
     const runId = requirePositiveInteger(eventRun.id, 'event workflow run ID');
@@ -53,7 +54,7 @@ export function verifyPreviewDeployTrigger({ event, run, pullRequest, artifacts 
     if (
         run.name !== PREVIEW_WORKFLOW_NAME
         || run.path !== PREVIEW_WORKFLOW_PATH
-        || run.event !== 'pull_request'
+        || run.event !== 'workflow_dispatch'
         || run.status !== 'completed'
         || run.conclusion !== 'success'
     ) {
@@ -68,26 +69,30 @@ export function verifyPreviewDeployTrigger({ event, run, pullRequest, artifacts 
         fail('triggering workflow and head repository must both match this repository.');
     }
 
-    const eventHeadSha = requireSha(eventRun.head_sha, 'event head SHA');
-    const runHeadSha = requireSha(run.head_sha, 'API workflow run head SHA');
-    if (eventHeadSha !== runHeadSha) {
+    const eventRunSha = requireSha(eventRun.head_sha, 'event workflow SHA');
+    const apiRunSha = requireSha(run.head_sha, 'API workflow run SHA');
+    if (eventRunSha !== apiRunSha) {
         fail('event and API workflow run head SHAs do not match.');
     }
 
-    const eventPullRequests = eventRun.pull_requests;
-    if (!Array.isArray(eventPullRequests) || eventPullRequests.length !== 1) {
-        fail('triggering workflow must identify exactly one pull request.');
+    if (eventRun.display_title !== run.display_title) {
+        fail('event and API workflow display titles do not match.');
     }
-    const prNumber = requirePositiveInteger(eventPullRequests[0]?.number, 'event pull-request number');
+    const displayIdentity = PREVIEW_DISPLAY_TITLE_PATTERN.exec(eventRun.display_title || '');
+    if (!displayIdentity) {
+        fail('workflow display title must bind one pull request and exact head SHA.');
+    }
+    const prNumber = requirePositiveInteger(Number(displayIdentity[1]), 'display-title pull-request number');
+    const previewHeadSha = requireSha(displayIdentity[2], 'display-title pull-request head SHA');
     if (requirePositiveInteger(pullRequest?.number, 'API pull-request number') !== prNumber) {
         fail('event and API pull-request numbers do not match.');
     }
     if (
         pullRequest.state !== 'open'
+        || pullRequest.draft !== false
         || pullRequest.base?.repo?.full_name !== repository
         || pullRequest.head?.repo?.full_name !== repository
-        || pullRequest.head?.sha !== runHeadSha
-        || pullRequest.head?.ref !== run.head_branch
+        || pullRequest.head?.sha !== previewHeadSha
     ) {
         fail('pull request must remain open with a same-repository head matching the triggering run.');
     }
@@ -119,7 +124,7 @@ export function verifyPreviewDeployTrigger({ event, run, pullRequest, artifacts 
 
     return {
         artifactId,
-        headSha: runHeadSha,
+        headSha: previewHeadSha,
         prNumber,
         repository,
         runId

--- a/scripts/verify-preview-deploy-trigger.mjs
+++ b/scripts/verify-preview-deploy-trigger.mjs
@@ -1,8 +1,8 @@
 import fs from 'node:fs';
 import { pathToFileURL } from 'node:url';
 
-export const PREVIEW_WORKFLOW_NAME = 'pr-integration';
-export const PREVIEW_WORKFLOW_PATH = '.github/workflows/pr-integration.yml';
+export const PREVIEW_WORKFLOW_NAME = 'pr-preview';
+export const PREVIEW_WORKFLOW_PATH = '.github/workflows/pr-preview.yml';
 export const PREVIEW_ARTIFACT_NAME = 'firebase-preview-hosting-bundle';
 export const MAX_PREVIEW_ARCHIVE_BYTES = 100 * 1024 * 1024;
 

--- a/tests/unit/pr-ci-consolidation.test.js
+++ b/tests/unit/pr-ci-consolidation.test.js
@@ -72,8 +72,8 @@ describe('pull request CI consolidation', () => {
         const preview = workflow('pr-preview.yml');
 
         expect(integration).not.toContain('uses: ./.github/workflows/deploy-preview.yml');
-        expect(preview).toContain("github.event.label.name == 'preview-requested'");
-        expect(preview).toContain('github.event.pull_request.draft == false');
+        expect(preview).toContain('workflow_dispatch:');
+        expect(preview).toContain('run-name: PR preview #${{ inputs.pr_number }} @ ${{ inputs.head_sha }}');
         expect(preview).toContain('uses: ./.github/workflows/deploy-preview.yml');
     });
 

--- a/tests/unit/pr-ci-consolidation.test.js
+++ b/tests/unit/pr-ci-consolidation.test.js
@@ -70,13 +70,14 @@ describe('pull request CI consolidation', () => {
     it('keeps credentialed preview work off the required PR path', () => {
         const integration = workflow('pr-integration.yml');
         const preview = workflow('pr-preview.yml');
+        const parsedPreview = parseYaml(preview);
         const agentGuidance = fs.readFileSync(path.join(repoRoot, 'AGENTS.md'), 'utf8');
 
         expect(integration).not.toContain('uses: ./.github/workflows/deploy-preview.yml');
         expect(preview).toContain('workflow_dispatch:');
-        expect(preview).toContain('run-name: PR preview #${{ inputs.pr_number }} @ ${{ inputs.head_sha }}');
+        expect(parsedPreview['run-name']).toBe('PR preview #${{ inputs.pr_number }} @ ${{ inputs.head_sha }}');
         expect(preview).toContain('uses: ./.github/workflows/deploy-preview.yml');
-        expect(agentGuidance).toContain('Normal PR pushes\n  and labels must not deploy Firebase preview channels.');
+        expect(agentGuidance).toContain('passed `pr-integration`. Normal PR pushes and labels must not deploy Firebase');
     });
 
     it('reuses version-bound Playwright browsers in the regression workflow', () => {
@@ -133,6 +134,10 @@ describe('pull request CI consolidation', () => {
         );
 
         expect(trusted).toContain('      - pr-preview');
+        expect(trusted).toContain('actions/workflows/pr-integration.yml/runs');
+        expect(trusted).toContain('-f status=success');
+        expect(trusted).toContain('-f head_sha="$expected_head_sha"');
+        expect(trusted).toContain('No successful exact-head pr-integration run exists for this preview request.');
         expect(verifier).toContain("PREVIEW_WORKFLOW_NAME = 'pr-preview'");
         expect(verifier).toContain("PREVIEW_WORKFLOW_PATH = '.github/workflows/pr-preview.yml'");
     });

--- a/tests/unit/pr-ci-consolidation.test.js
+++ b/tests/unit/pr-ci-consolidation.test.js
@@ -137,7 +137,7 @@ describe('pull request CI consolidation', () => {
         expect(trusted).toContain('actions/workflows/pr-integration.yml/runs');
         expect(trusted).toContain('-f status=success');
         expect(trusted).toContain('-f head_sha="$expected_head_sha"');
-        expect(trusted).toContain('No successful exact-head pr-integration run exists for this preview request.');
+        expect(trusted).toContain('No exact-head pr-integration run has successful mobile-build and preview-smoke jobs.');
         expect(verifier).toContain("PREVIEW_WORKFLOW_NAME = 'pr-preview'");
         expect(verifier).toContain("PREVIEW_WORKFLOW_PATH = '.github/workflows/pr-preview.yml'");
     });

--- a/tests/unit/pr-ci-consolidation.test.js
+++ b/tests/unit/pr-ci-consolidation.test.js
@@ -70,11 +70,13 @@ describe('pull request CI consolidation', () => {
     it('keeps credentialed preview work off the required PR path', () => {
         const integration = workflow('pr-integration.yml');
         const preview = workflow('pr-preview.yml');
+        const agentGuidance = fs.readFileSync(path.join(repoRoot, 'AGENTS.md'), 'utf8');
 
         expect(integration).not.toContain('uses: ./.github/workflows/deploy-preview.yml');
         expect(preview).toContain('workflow_dispatch:');
         expect(preview).toContain('run-name: PR preview #${{ inputs.pr_number }} @ ${{ inputs.head_sha }}');
         expect(preview).toContain('uses: ./.github/workflows/deploy-preview.yml');
+        expect(agentGuidance).toContain('Normal PR pushes\n  and labels must not deploy Firebase preview channels.');
     });
 
     it('reuses version-bound Playwright browsers in the regression workflow', () => {

--- a/tests/unit/pr-ci-consolidation.test.js
+++ b/tests/unit/pr-ci-consolidation.test.js
@@ -26,6 +26,20 @@ describe('pull request CI consolidation', () => {
         expect(integration).toContain('name: preview-smoke');
     });
 
+    it('does not spend runners on draft heads and starts validation at handoff', () => {
+        const fast = parseYaml(workflow('pr-fast.yml'));
+        const integration = parseYaml(workflow('pr-integration.yml'));
+
+        expect(fast.on.pull_request.types).toContain('ready_for_review');
+        expect(integration.on.pull_request.types).toContain('ready_for_review');
+        for (const jobName of ['cache-bust-guard', 'unit-tests', 'app-quality']) {
+            expect(fast.jobs[jobName].if).toBe('${{ github.event.pull_request.draft == false }}');
+        }
+        for (const jobName of ['regression-integration', 'mobile-integration', 'preview-integration']) {
+            expect(integration.jobs[jobName].if).toBe('${{ github.event.pull_request.draft == false }}');
+        }
+    });
+
     it('keeps legacy workflows callable or manual without duplicate PR triggers', () => {
         for (const name of [
             'ci.yml',
@@ -105,7 +119,7 @@ describe('pull request CI consolidation', () => {
             }
         });
 
-        expect(job.if).toBe('${{ always() }}');
+        expect(job.if).toBe('${{ always() && github.event.pull_request.draft == false }}');
         expect(result.status).toBe(1);
     });
 

--- a/tests/unit/pr-ci-consolidation.test.js
+++ b/tests/unit/pr-ci-consolidation.test.js
@@ -53,6 +53,16 @@ describe('pull request CI consolidation', () => {
         expect(integration).not.toContain('secrets: inherit');
     });
 
+    it('keeps credentialed preview work off the required PR path', () => {
+        const integration = workflow('pr-integration.yml');
+        const preview = workflow('pr-preview.yml');
+
+        expect(integration).not.toContain('uses: ./.github/workflows/deploy-preview.yml');
+        expect(preview).toContain("github.event.label.name == 'preview-requested'");
+        expect(preview).toContain('github.event.pull_request.draft == false');
+        expect(preview).toContain('uses: ./.github/workflows/deploy-preview.yml');
+    });
+
     it('reuses version-bound Playwright browsers in the regression workflow', () => {
         const regression = workflow('regression-guards.yml');
         const parsed = parseYaml(regression);
@@ -77,21 +87,11 @@ describe('pull request CI consolidation', () => {
     it.each([
         ['mobile-build', { MOBILE_RESULT: 'cancelled' }],
         ['preview-smoke', {
-            HEAD_REPOSITORY: 'allplays/allplays',
-            PREVIEW_ARTIFACT_RESULT: 'success',
             PREVIEW_RESULT: 'success',
             REGRESSION_RESULT: 'cancelled'
         }],
         ['preview-smoke', {
-            HEAD_REPOSITORY: 'allplays/allplays',
-            PREVIEW_ARTIFACT_RESULT: 'success',
             PREVIEW_RESULT: 'cancelled',
-            REGRESSION_RESULT: 'success'
-        }],
-        ['preview-smoke', {
-            HEAD_REPOSITORY: 'allplays/allplays',
-            PREVIEW_ARTIFACT_RESULT: 'cancelled',
-            PREVIEW_RESULT: 'success',
             REGRESSION_RESULT: 'success'
         }]
     ])('runs %s after cancellation and rejects cancelled upstream results', (jobName, env) => {
@@ -116,8 +116,8 @@ describe('pull request CI consolidation', () => {
             'utf8'
         );
 
-        expect(trusted).toContain('      - pr-integration');
-        expect(verifier).toContain("PREVIEW_WORKFLOW_NAME = 'pr-integration'");
-        expect(verifier).toContain("PREVIEW_WORKFLOW_PATH = '.github/workflows/pr-integration.yml'");
+        expect(trusted).toContain('      - pr-preview');
+        expect(verifier).toContain("PREVIEW_WORKFLOW_NAME = 'pr-preview'");
+        expect(verifier).toContain("PREVIEW_WORKFLOW_PATH = '.github/workflows/pr-preview.yml'");
     });
 });

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -54,30 +54,33 @@ function validTriggerFixture() {
             workflow_run: {
                 id: runId,
                 name: 'pr-preview',
-                event: 'pull_request',
+                display_title: `PR preview #${prNumber} @ ${headSha}`,
+                event: 'workflow_dispatch',
                 status: 'completed',
                 conclusion: 'success',
-                head_sha: headSha,
+                head_sha: 'ed4cc306a66cdf31c5672b965ebffc452bcbad2d',
                 repository: { full_name: repository },
                 head_repository: { full_name: repository },
-                pull_requests: [{ number: prNumber }]
+                pull_requests: []
             }
         },
         run: {
             id: runId,
             name: 'pr-preview',
+            display_title: `PR preview #${prNumber} @ ${headSha}`,
             path: '.github/workflows/pr-preview.yml',
-            event: 'pull_request',
+            event: 'workflow_dispatch',
             status: 'completed',
             conclusion: 'success',
-            head_sha: headSha,
-            head_branch: 'security/payment-authority-followup',
+            head_sha: 'ed4cc306a66cdf31c5672b965ebffc452bcbad2d',
+            head_branch: 'master',
             repository: { full_name: repository },
             head_repository: { full_name: repository }
         },
         pullRequest: {
             number: prNumber,
             state: 'open',
+            draft: false,
             base: { repo: { full_name: repository } },
             head: {
                 repo: { full_name: repository },
@@ -193,12 +196,12 @@ describe('preview deployment workflow trust boundary', () => {
         expect(pullRequestWorkflow).not.toContain('external-claim');
     });
 
-    it('builds the untrusted preview artifact only after an explicit label request', () => {
+    it('builds the untrusted preview artifact only after an exact-head manual dispatch', () => {
         expect(previewRequestWorkflow).toContain('name: pr-preview');
-        expect(previewRequestWorkflow).toContain('group: pr-preview-${{ github.event.pull_request.number }}');
+        expect(previewRequestWorkflow).toContain('workflow_dispatch:');
+        expect(previewRequestWorkflow).toContain('run-name: PR preview #${{ inputs.pr_number }} @ ${{ inputs.head_sha }}');
+        expect(previewRequestWorkflow).toContain('group: pr-preview-${{ inputs.pr_number }}');
         expect(previewRequestWorkflow).toContain('cancel-in-progress: true');
-        expect(previewRequestWorkflow).toContain("github.event.label.name == 'preview-requested'");
-        expect(previewRequestWorkflow).toContain('github.event.pull_request.draft == false');
         expect(previewRequestWorkflow).toContain('uses: ./.github/workflows/deploy-preview.yml');
     });
 
@@ -208,13 +211,12 @@ describe('preview deployment workflow trust boundary', () => {
         expect(trustedWorkflow).toContain('classify-trigger:');
         expect(trustedWorkflow).toContain('preview_ready: ${{ steps.classify.outputs.preview_ready }}');
         expect(trustedWorkflow).toContain('pull-requests: read');
-        expect(trustedWorkflow).toContain('Fork pull request — no trusted preview deploy is required.');
-        expect(trustedWorkflow).toContain('echo "preview_ready=false" >> "$GITHUB_OUTPUT"');
-        expect(trustedWorkflow).toContain('No preview bundle was requested by this label event.');
+        expect(trustedWorkflow).toContain('Preview dispatch is not bound to the current ready same-repository PR head.');
+        expect(trustedWorkflow).toContain('WORKFLOW_DISPLAY_TITLE: ${{ github.event.workflow_run.display_title }}');
         expect(trustedWorkflow).toContain('Expected exactly one preview bundle');
         expect(trustedWorkflow).toContain("needs.classify-trigger.outputs.preview_ready == 'true'");
         expect(trustedWorkflow).toContain(
-            'group: trusted-preview-pr-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.id }}'
+            'group: trusted-preview-${{ github.event.workflow_run.display_title || github.event.workflow_run.id }}'
         );
         expect(trustedWorkflow).toContain('cancel-in-progress: true');
         expect(trustedWorkflow).toContain('name: firebase-preview-trusted');

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -16,8 +16,8 @@ const pullRequestWorkflow = fs.readFileSync(
     path.join(repoRoot, '.github', 'workflows', 'deploy-preview.yml'),
     'utf8'
 );
-const integrationWorkflow = fs.readFileSync(
-    path.join(repoRoot, '.github', 'workflows', 'pr-integration.yml'),
+const previewRequestWorkflow = fs.readFileSync(
+    path.join(repoRoot, '.github', 'workflows', 'pr-preview.yml'),
     'utf8'
 );
 const trustedWorkflow = fs.readFileSync(
@@ -53,7 +53,7 @@ function validTriggerFixture() {
             repository: { full_name: repository },
             workflow_run: {
                 id: runId,
-                name: 'pr-integration',
+                name: 'pr-preview',
                 event: 'pull_request',
                 status: 'completed',
                 conclusion: 'success',
@@ -65,8 +65,8 @@ function validTriggerFixture() {
         },
         run: {
             id: runId,
-            name: 'pr-integration',
-            path: '.github/workflows/pr-integration.yml',
+            name: 'pr-preview',
+            path: '.github/workflows/pr-preview.yml',
             event: 'pull_request',
             status: 'completed',
             conclusion: 'success',
@@ -193,24 +193,24 @@ describe('preview deployment workflow trust boundary', () => {
         expect(pullRequestWorkflow).not.toContain('external-claim');
     });
 
-    it('serializes the untrusted preview artifact inside the consolidated PR run', () => {
-        expect(integrationWorkflow).toContain('name: pr-integration');
-        expect(integrationWorkflow).toContain('group: pr-integration-${{ github.event.pull_request.number }}');
-        expect(integrationWorkflow).toContain('cancel-in-progress: true');
-        expect(integrationWorkflow).toContain('uses: ./.github/workflows/deploy-preview.yml');
-        expect(integrationWorkflow).toContain('name: preview-smoke');
-        expect(integrationWorkflow).not.toContain('      - unlabeled');
-        expect(integrationWorkflow).not.toContain('      - labeled');
+    it('builds the untrusted preview artifact only after an explicit label request', () => {
+        expect(previewRequestWorkflow).toContain('name: pr-preview');
+        expect(previewRequestWorkflow).toContain('group: pr-preview-${{ github.event.pull_request.number }}');
+        expect(previewRequestWorkflow).toContain('cancel-in-progress: true');
+        expect(previewRequestWorkflow).toContain("github.event.label.name == 'preview-requested'");
+        expect(previewRequestWorkflow).toContain('github.event.pull_request.draft == false');
+        expect(previewRequestWorkflow).toContain('uses: ./.github/workflows/deploy-preview.yml');
     });
 
     it('runs the credentialed deploy only from trusted default-branch code', () => {
         expect(trustedWorkflow).toContain('workflow_run:');
-        expect(trustedWorkflow).toContain('      - pr-integration');
+        expect(trustedWorkflow).toContain('      - pr-preview');
         expect(trustedWorkflow).toContain('classify-trigger:');
         expect(trustedWorkflow).toContain('preview_ready: ${{ steps.classify.outputs.preview_ready }}');
         expect(trustedWorkflow).toContain('pull-requests: read');
         expect(trustedWorkflow).toContain('Fork pull request — no trusted preview deploy is required.');
         expect(trustedWorkflow).toContain('echo "preview_ready=false" >> "$GITHUB_OUTPUT"');
+        expect(trustedWorkflow).toContain('No preview bundle was requested by this label event.');
         expect(trustedWorkflow).toContain('Expected exactly one preview bundle');
         expect(trustedWorkflow).toContain("needs.classify-trigger.outputs.preview_ready == 'true'");
         expect(trustedWorkflow).toContain(

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -211,6 +211,9 @@ describe('preview deployment workflow trust boundary', () => {
     });
 
     it('runs the credentialed deploy only from trusted default-branch code', () => {
+        const parsedTrustedWorkflow = parseYaml(trustedWorkflow);
+        const classifyScript = parsedTrustedWorkflow.jobs['classify-trigger'].steps[0].run;
+
         expect(trustedWorkflow).toContain('workflow_run:');
         expect(trustedWorkflow).toContain('      - pr-preview');
         expect(trustedWorkflow).toContain('classify-trigger:');
@@ -221,14 +224,14 @@ describe('preview deployment workflow trust boundary', () => {
         expect(trustedWorkflow).toContain('-f event=pull_request');
         expect(trustedWorkflow).toContain('-f status=success');
         expect(trustedWorkflow).toContain('-f head_sha="$expected_head_sha"');
-        expect(trustedWorkflow).toContain('No successful exact-head pr-integration run exists for this preview request.');
+        expect(classifyScript).toContain('actions/runs/$integration_run_id/jobs?filter=latest&per_page=100');
+        expect(classifyScript).toContain('.name == "mobile-build"');
+        expect(classifyScript).toContain('.name == "preview-smoke"');
+        expect(classifyScript).toContain('.conclusion == "success"');
+        expect(classifyScript).toContain('No exact-head pr-integration run has successful mobile-build and preview-smoke jobs.');
         expect(trustedWorkflow).toContain('WORKFLOW_DISPLAY_TITLE: ${{ github.event.workflow_run.display_title }}');
         expect(trustedWorkflow).toContain('Expected exactly one preview bundle');
         expect(trustedWorkflow).toContain("needs.classify-trigger.outputs.preview_ready == 'true'");
-        expect(trustedWorkflow).toContain(
-            'group: trusted-preview-${{ github.event.workflow_run.display_title || github.event.workflow_run.id }}'
-        );
-        expect(trustedWorkflow).toContain('cancel-in-progress: true');
         expect(trustedWorkflow).toContain('name: firebase-preview-trusted');
         expect(trustedWorkflow).toContain('ref: ${{ github.event.repository.default_branch }}');
         expect(trustedWorkflow).toContain('persist-credentials: false');
@@ -248,6 +251,54 @@ describe('preview deployment workflow trust boundary', () => {
         expect(trustedWorkflow).toContain('refusing to report a partially functional preview');
         expect(trustedWorkflow).toContain('find "$bundle/site" -type l');
         expect(trustedWorkflow).not.toContain('find "$bundle" -type l');
+    });
+
+    it('rejects a successful integration workflow whose stable jobs were only skipped', () => {
+        const parsedTrustedWorkflow = parseYaml(trustedWorkflow);
+        const classifyScript = parsedTrustedWorkflow.jobs['classify-trigger'].steps[0].run;
+        const skippedDraftJobs = {
+            jobs: [
+                { name: 'mobile-build', status: 'completed', conclusion: 'skipped' },
+                { name: 'preview-smoke', status: 'completed', conclusion: 'skipped' }
+            ]
+        };
+        const successfulReadyJobs = {
+            jobs: [
+                { name: 'mobile-build', status: 'completed', conclusion: 'success' },
+                { name: 'preview-smoke', status: 'completed', conclusion: 'success' }
+            ]
+        };
+        const stableJobsSucceeded = ({ jobs }) => ['mobile-build', 'preview-smoke'].every(
+            (name) => jobs.filter((job) => (
+                job.name === name && job.status === 'completed' && job.conclusion === 'success'
+            )).length === 1
+        );
+
+        expect(classifyScript).toContain('integration_jobs_succeeded=false');
+        expect(classifyScript).toContain('if [ "$integration_jobs_succeeded" != "true" ]');
+        expect(stableJobsSucceeded(skippedDraftJobs)).toBe(false);
+        expect(stableJobsSucceeded(successfulReadyJobs)).toBe(true);
+    });
+
+    it('serializes trusted deployments by PR across different requested heads', () => {
+        const parsedTrustedWorkflow = parseYaml(trustedWorkflow);
+        const deployConcurrency = parsedTrustedWorkflow.jobs['deploy-preview'].concurrency;
+        const firstRequest = validTriggerFixture();
+        const secondRequest = validTriggerFixture();
+        secondRequest.event.workflow_run.display_title =
+            'PR preview #4032 @ 1111111111111111111111111111111111111111';
+        const prNumberFromTitle = (title) => /^PR preview #(\d+) @ [0-9a-f]{40}$/.exec(title)?.[1];
+        const resolveGroup = (request) => deployConcurrency.group.replace(
+            '${{ needs.prepare-preview.outputs.pr_number }}',
+            prNumberFromTitle(request.event.workflow_run.display_title)
+        );
+
+        expect(deployConcurrency).toEqual({
+            group: 'trusted-preview-pr-${{ needs.prepare-preview.outputs.pr_number }}',
+            'cancel-in-progress': true
+        });
+        expect(resolveGroup(firstRequest)).toBe('trusted-preview-pr-4032');
+        expect(resolveGroup(secondRequest)).toBe(resolveGroup(firstRequest));
     });
 
     it('rechecks the exact pull-request head immediately before deploy and comment writes', () => {

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
+import { parse as parseYaml } from 'yaml';
 
 import {
     MAX_PREVIEW_ARCHIVE_BYTES,
@@ -197,9 +198,13 @@ describe('preview deployment workflow trust boundary', () => {
     });
 
     it('builds the untrusted preview artifact only after an exact-head manual dispatch', () => {
+        const parsedPreviewRequestWorkflow = parseYaml(previewRequestWorkflow);
+
         expect(previewRequestWorkflow).toContain('name: pr-preview');
         expect(previewRequestWorkflow).toContain('workflow_dispatch:');
-        expect(previewRequestWorkflow).toContain('run-name: PR preview #${{ inputs.pr_number }} @ ${{ inputs.head_sha }}');
+        expect(parsedPreviewRequestWorkflow['run-name']).toBe(
+            'PR preview #${{ inputs.pr_number }} @ ${{ inputs.head_sha }}'
+        );
         expect(previewRequestWorkflow).toContain('group: pr-preview-${{ inputs.pr_number }}');
         expect(previewRequestWorkflow).toContain('cancel-in-progress: true');
         expect(previewRequestWorkflow).toContain('uses: ./.github/workflows/deploy-preview.yml');
@@ -212,6 +217,11 @@ describe('preview deployment workflow trust boundary', () => {
         expect(trustedWorkflow).toContain('preview_ready: ${{ steps.classify.outputs.preview_ready }}');
         expect(trustedWorkflow).toContain('pull-requests: read');
         expect(trustedWorkflow).toContain('Preview dispatch is not bound to the current ready same-repository PR head.');
+        expect(trustedWorkflow).toContain('actions/workflows/pr-integration.yml/runs');
+        expect(trustedWorkflow).toContain('-f event=pull_request');
+        expect(trustedWorkflow).toContain('-f status=success');
+        expect(trustedWorkflow).toContain('-f head_sha="$expected_head_sha"');
+        expect(trustedWorkflow).toContain('No successful exact-head pr-integration run exists for this preview request.');
         expect(trustedWorkflow).toContain('WORKFLOW_DISPLAY_TITLE: ${{ github.event.workflow_run.display_title }}');
         expect(trustedWorkflow).toContain('Expected exactly one preview bundle');
         expect(trustedWorkflow).toContain("needs.classify-trigger.outputs.preview_ready == 'true'");


### PR DESCRIPTION
## What changed

- remove Firebase preview artifact construction from the required `pr-integration` path
- add an explicitly dispatched `pr-preview` workflow bound to a ready PR number and exact head SHA
- bind the trusted OIDC deploy verifier to that dedicated source workflow and exact live PR head
- skip all heavy `pr-fast` and `pr-integration` jobs while a PR is draft, then run them on `ready_for_review`
- update Codex/Claude repository guidance for the new handoff and preview flow
- preserve the stable `cache-bust-guard`, `unit-tests`, `app-quality`, `preview-smoke`, and `mobile-build` contexts

## Why

The previous pipeline built a preview bundle and launched a separate trusted Firebase workflow for every PR head even though the preview channel was not a merge requirement. In the observed 12-hour baseline, that produced about 46 of 174 workflow runs. Explicit dispatch removes those automatic preview runs, an expected reduction of about 26%. Draft gating additionally removes runner work for pre-handoff heads while retaining exact-head validation once the producer marks the PR ready.

## Security

The untrusted builder remains permissionless and fails if the fetched PR ref differs from the requested SHA. The credentialed workflow still executes default-branch code, validates the dispatch identity, current ready same-repository PR, exact head, source run, and artifact, and keeps raw PR content outside the OIDC job.

## Validation

- 98 focused workflow, trust-boundary, manifest, mobile, preview, and Firebase policy tests passed
- `node scripts/validate-firebase-rules-ci.mjs`
- clean exact head `9be71a86a`
