### PR TITLE
Skip native builds for React-only PRs

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -59,7 +59,7 @@ jobs:
           # by pr-fast/preview-smoke. Rebuilding both native shells for an
           # ordinary apps/app/src change adds minutes without exercising a new
           # native boundary. Reserve these jobs for shell/config/plugin inputs.
-          if echo "$CHANGED" | grep -Eq '^(\.github/workflows/mobile-build\.yml|android/|ios/|capacitor\.config\.(json|ts)|package\.json|package-lock\.json|apps/app/package\.json|apps/app/package-lock\.json)'; then
+          if echo "$CHANGED" | grep -Eq '^(\.github/workflows/mobile-build\.yml|android/|ios/|capacitor\.config\.(js|json|ts)|package\.json|package-lock\.json|apps/app/package\.json|apps/app/package-lock\.json)'; then
             echo "mobile=true" >> "$GITHUB_OUTPUT"
           else
             echo "mobile=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -55,7 +55,11 @@ jobs:
           echo "Changed files:" >&2
           echo "$CHANGED" >&2
 
-          if echo "$CHANGED" | grep -Eq '^(\.github/workflows/mobile-build\.yml|apps/app/|android/|ios/|capacitor\.config\.json|package\.json|package-lock\.json)'; then
+          # React source is already typechecked, tested, built, and smoke-tested
+          # by pr-fast/preview-smoke. Rebuilding both native shells for an
+          # ordinary apps/app/src change adds minutes without exercising a new
+          # native boundary. Reserve these jobs for shell/config/plugin inputs.
+          if echo "$CHANGED" | grep -Eq '^(\.github/workflows/mobile-build\.yml|android/|ios/|capacitor\.config\.(json|ts)|package\.json|package-lock\.json|apps/app/package\.json|apps/app/package-lock\.json)'; then
             echo "mobile=true" >> "$GITHUB_OUTPUT"
           else
             echo "mobile=false" >> "$GITHUB_OUTPUT"

--- a/tests/unit/mobile-build-workflow.test.js
+++ b/tests/unit/mobile-build-workflow.test.js
@@ -27,7 +27,7 @@ describe('mobile-build CI workflow', () => {
         expect(workflow).toContain('android-debug/');
         expect(changesSection).toContain('android/');
         expect(changesSection).toContain('ios/');
-        expect(changesSection).toContain('capacitor\\.config\\.(json|ts)');
+        expect(changesSection).toContain('capacitor\\.config\\.(js|json|ts)');
         expect(changesSection).toContain('apps/app/package\\.json');
         expect(changesSection).toContain('apps/app/package-lock\\.json');
         expect(changesSection).not.toContain('mobile-build\\.yml|apps/app/|android/');
@@ -38,6 +38,7 @@ describe('mobile-build CI workflow', () => {
             '.github/workflows/mobile-build.yml',
             'android/app/build.gradle',
             'ios/App/App.xcodeproj/project.pbxproj',
+            'capacitor.config.js',
             'capacitor.config.ts',
             'package-lock.json',
             'apps/app/package.json'

--- a/tests/unit/mobile-build-workflow.test.js
+++ b/tests/unit/mobile-build-workflow.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { readdirSync, readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 
 const workflow = readFileSync(new URL('../../.github/workflows/mobile-build.yml', import.meta.url), 'utf8');
 const integrationWorkflow = readFileSync(
@@ -17,16 +18,40 @@ describe('mobile-build CI workflow', () => {
         expect(triggerSection).not.toContain('push:');
     });
 
-    it('gates the expensive android/ios build jobs on a path-detection job instead of removing path awareness entirely', () => {
+    it('reserves expensive android/ios builds for native shell, config, and dependency changes', () => {
+        const changesSection = workflow.slice(workflow.indexOf('  changes:'), workflow.indexOf('  android-debug:'));
+        const nativePathRegex = changesSection.match(/grep -Eq '([^']+)'/)?.[1];
+
         expect(workflow).toContain('changes:');
         expect(workflow).toContain("outputs.mobile");
         expect(workflow).toContain('android-debug/');
-        // The mobile-relevant path list moved from the trigger filter into the
-        // changes-detection job body.
-        expect(workflow).toContain('apps/app/');
-        expect(workflow).toContain('android/');
-        expect(workflow).toContain('ios/');
-        expect(workflow).toContain('capacitor\\.config\\.json');
+        expect(changesSection).toContain('android/');
+        expect(changesSection).toContain('ios/');
+        expect(changesSection).toContain('capacitor\\.config\\.(json|ts)');
+        expect(changesSection).toContain('apps/app/package\\.json');
+        expect(changesSection).toContain('apps/app/package-lock\\.json');
+        expect(changesSection).not.toContain('mobile-build\\.yml|apps/app/|android/');
+        expect(changesSection).toContain('ordinary apps/app/src change');
+        expect(nativePathRegex).toBeTruthy();
+
+        for (const path of [
+            '.github/workflows/mobile-build.yml',
+            'android/app/build.gradle',
+            'ios/App/App.xcodeproj/project.pbxproj',
+            'capacitor.config.ts',
+            'package-lock.json',
+            'apps/app/package.json'
+        ]) {
+            expect(spawnSync('grep', ['-Eq', nativePathRegex], { input: `${path}\n` }).status, path).toBe(0);
+        }
+        for (const path of [
+            'apps/app/src/pages/TeamDetail.tsx',
+            'apps/app/src/lib/teamService.ts',
+            'apps/app/src/pages/TeamDetail.test.tsx',
+            'tests/unit/app-team-detail-integration.test.jsx'
+        ]) {
+            expect(spawnSync('grep', ['-Eq', nativePathRegex], { input: `${path}\n` }).status, path).toBe(1);
+        }
     });
 
     it('is called by the consolidated code-head workflow without label-churn runs', () => {


### PR DESCRIPTION
## What changed
- keep the required `mobile-build` aggregate context always present and fail-closed
- run Android/iOS jobs only when native shells, Capacitor config, or package manifests change
- cover the path classifier with executable positive and negative cases

## Why
React-only changes are already typechecked, unit-tested, built, and preview-smoke-tested. PR #4345 spent about 7 minutes on iOS and 4 minutes on Android on each head even though it changed only React source. This removes two redundant jobs from qualifying heads without weakening the required context.

## Validation
- `vitest run tests/unit/mobile-build-workflow.test.js` (9/9)
- workflow YAML parsed successfully
- `npm run ci:firebase-rules`
- `git diff --check`
- GitHub Actions trust review: no permission, secret, trigger, checkout, or third-party action changes