### PR TITLE
Fix web profile photo saves

### DIFF
--- a/apps/app/src/pages/Profile.test.tsx
+++ b/apps/app/src/pages/Profile.test.tsx
@@ -40,6 +40,12 @@ const profileServiceMocks = vi.hoisted(() => ({
   saveProfileDocument: vi.fn(async () => undefined)
 }));
 
+const profilePhotoServiceMocks = vi.hoisted(() => ({
+  acquireProfilePhoto: vi.fn(),
+  normalizeProfilePhoto: vi.fn(async (file: File) => file),
+  uploadProfilePhoto: vi.fn(async () => 'https://example.test/profile-photo.jpg')
+}));
+
 const pushServiceMocks = vi.hoisted(() => ({
   enablePushNotificationsForUser: vi.fn(async () => undefined),
   getPushNotificationPermissionStatus: vi.fn(async () => ({
@@ -64,6 +70,7 @@ const initialLoadTelemetryMocks = vi.hoisted(() => ({
 
 vi.mock('../lib/authService', () => authServiceMocks);
 vi.mock('../lib/profileService', () => profileServiceMocks);
+vi.mock('../lib/profilePhotoService', () => profilePhotoServiceMocks);
 vi.mock('../lib/pushService', () => pushServiceMocks);
 vi.mock('../lib/inviteUrls', () => ({
   buildAppAcceptInviteUrl: vi.fn((code: string) => `https://example.test/app/#/accept-invite?code=${code}`)
@@ -123,8 +130,8 @@ const auth: AuthState = {
   isCoach: false,
   isAdmin: false,
   isPlatformAdmin: false,
-  refresh: vi.fn(),
-  signOut: vi.fn()
+  refresh: vi.fn(async () => null),
+  signOut: vi.fn(async () => undefined)
 };
 
 function TestRouteControls() {
@@ -209,6 +216,14 @@ describe('Profile', () => {
         callback(0);
         return 0;
       },
+      writable: true
+    });
+    Object.defineProperty(URL, 'createObjectURL', {
+      value: vi.fn(() => 'blob:profile-photo-preview'),
+      writable: true
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      value: vi.fn(),
       writable: true
     });
   });
@@ -362,6 +377,58 @@ describe('Profile', () => {
     const familyLink = screen.getByRole('link', { name: 'Open Family workflows' });
     expect(familyLink.getAttribute('href')).toBe('/parent-tools');
     expect(familyLink.textContent).toContain('Player access, household, fees, calendars, sharing, registration, and awards.');
+  });
+
+  it('saves profile presentation fields without rewriting the auth-managed email', async () => {
+    renderProfile('/profile', false, false, {
+      ...auth,
+      profile: { fullName: 'Pat Parent', phone: '555-0100', photoUrl: '' },
+      profileHydration: 'success'
+    });
+
+    const fullNameInput = await screen.findByDisplayValue('Pat Parent');
+    fireEvent.change(fullNameInput, { target: { value: 'Pat Parent Updated' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save profile' }));
+
+    await waitFor(() => {
+      expect(profileServiceMocks.saveProfileDocument).toHaveBeenCalledWith('user-1', {
+        fullName: 'Pat Parent Updated',
+        phone: '555-0100',
+        photoUrl: null
+      });
+    });
+    expect(await screen.findByText('Profile saved.')).toBeTruthy();
+  });
+
+  it('reuses an uploaded profile photo when the document save is retried', async () => {
+    profileServiceMocks.saveProfileDocument
+      .mockRejectedValueOnce(new Error('permission-denied'))
+      .mockResolvedValueOnce(undefined);
+    renderProfile('/profile', false, false, {
+      ...auth,
+      profile: { fullName: 'Pat Parent', phone: '555-0100', photoUrl: '' },
+      profileHydration: 'success'
+    });
+
+    await screen.findByDisplayValue('Pat Parent');
+    fireEvent.change(screen.getByLabelText('Choose photo'), {
+      target: {
+        files: [new File(['avatar'], 'avatar.png', { type: 'image/png' })]
+      }
+    });
+    await waitFor(() => {
+      expect(profilePhotoServiceMocks.normalizeProfilePhoto).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save profile' }));
+    expect(await screen.findByText('Upload reached Firebase, but this account does not have permission to save the image.')).toBeTruthy();
+    expect(profilePhotoServiceMocks.uploadProfilePhoto).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save profile' }));
+
+    expect(await screen.findByText('Profile saved.')).toBeTruthy();
+    expect(profilePhotoServiceMocks.uploadProfilePhoto).toHaveBeenCalledTimes(1);
+    expect(profileServiceMocks.saveProfileDocument).toHaveBeenCalledTimes(2);
   });
 
   it('disables account merge while parent team eligibility is loading', async () => {

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -791,12 +791,16 @@ export function Profile({ auth }: { auth: AuthState }) {
         setProfileStatus({ message: 'Uploading photo...', tone: 'neutral' });
         const { uploadProfilePhoto } = await import('../lib/profilePhotoService');
         nextPhotoUrl = await uploadProfilePhoto(selectedPhotoFile, user.uid);
+        // Keep the completed upload available if the profile document save fails.
+        // A retry should attach this object instead of uploading a duplicate.
+        photoUrlRef.current = nextPhotoUrl;
+        photoFileRef.current = null;
+        setPhotoFile(null);
       }
 
       await saveProfileDocument(user.uid, {
         fullName: trimmedFullName,
         phone: trimmedPhone,
-        email: user.email,
         photoUrl: nextPhotoUrl || null
       });
 

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -779,6 +779,14 @@ test('profile exposes account, notification, invite, verification, password, upl
     expect(profileCalls.profileLoads).toBeGreaterThan(0);
     expect(profileCalls).toMatchObject({
         uploads: [{ name: 'avatar.png', type: 'image/png' }],
+        saves: [{
+            userId: 'user-1',
+            profile: {
+                fullName: 'Pat Parent Updated',
+                phone: '555-0100',
+                photoUrl: mockAvatarUrl
+            }
+        }],
         push: 1,
         notificationLoads: [
             { userId: 'user-1', teamId: 'team-1' }

--- a/tests/unit/app-profile-invites.test.tsx
+++ b/tests/unit/app-profile-invites.test.tsx
@@ -384,7 +384,6 @@ describe('Profile invites', () => {
     await waitFor(() => expect(profileServiceMocks.saveProfileDocument).toHaveBeenCalledWith('user-1', {
       fullName: 'Pat Parent Updated',
       phone: '555-0111',
-      email: 'parent@example.com',
       photoUrl: null
     }));
     await screen.findByText('Profile saved.');


### PR DESCRIPTION
## What changed

- stop the profile form from rewriting the authentication-managed email field when saving name, phone, or photo
- retain a completed photo upload across a failed profile-document save so retrying does not upload a duplicate object
- add focused component regressions and strengthen the existing profile browser and repository-level save contract assertions

## Root cause

The photo upload completed successfully, then the profile form included the app-visible email in an unrelated Firestore profile update. Firestore correctly requires email changes to match the Firebase authentication token. Migrated or linked accounts can have a different app-visible email, so the entire profile update was denied after Storage had already accepted the image.

The fix preserves the Firestore email authorization rule and removes email from this presentation-only mutation.

## User impact

Web users with migrated or linked identities can save their own profile photos again. If the document write fails for another reason after upload, retrying attaches the already-uploaded image instead of creating another copy.

## Validation

Current head: `e919a17e3234d56e6e298daf567621b6bdf3a34f`

- `npm --prefix apps/app test -- --run src/pages/Profile.test.tsx` — 21 passed
- `npx vitest run tests/unit/app-profile-invites.test.tsx --reporter=verbose` — 25 passed
- `npm run test:unit:ci` — 717 files / 5,352 tests plus 157 Firestore/Storage rule tests passed
- focused ESLint on `Profile.tsx` and `Profile.test.tsx` — 0 errors
- focused Playwright profile flow — 1 passed
- `npm run app:build` — TypeScript, Vite production build, visualizer verification, and bundle budget passed
- `git diff --check` — passed