### PR TITLE
Retry transient production smoke failures

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -166,6 +166,7 @@ jobs:
           tests/smoke/legacy-auth-redirects.spec.js
           --config=playwright.smoke.config.js
           --project=smoke
+          --retries=1
           --reporter=line
         env:
           SMOKE_BASE_URL: https://allplays.ai

--- a/tests/unit/production-smoke-config-gate.test.js
+++ b/tests/unit/production-smoke-config-gate.test.js
@@ -26,4 +26,14 @@ describe('production role-smoke gate', () => {
         );
         expect(postDeployWorkflow).not.toContain('not-configured ($CORE_MISSING)');
     });
+
+    it('retries the canonical production baseline once for transient deploy propagation failures', () => {
+        const baselineStart = postDeployWorkflow.indexOf('Run production smoke baseline');
+        const coreStart = postDeployWorkflow.indexOf('Run fixture-backed core production smoke');
+        const baselineBlock = postDeployWorkflow.slice(baselineStart, coreStart);
+
+        expect(baselineStart).toBeGreaterThan(-1);
+        expect(coreStart).toBeGreaterThan(baselineStart);
+        expect(baselineBlock).toContain('--retries=1');
+    });
 });


### PR DESCRIPTION
## Summary
- retry the canonical production Playwright baseline once so transient CDN propagation failures can recover
- keep persistent production failures blocking
- add a workflow contract test for the bounded retry

## Evidence
- post-deploy run 30721184892 saw a single transient 503 for the homepage JS asset immediately after deployment
- the other 23 baseline tests and all authenticated/fixture-backed probes passed

## Validation
- 52 focused workflow/unit tests passed
- post-deploy workflow YAML parsed successfully
- git diff --check passed

No UI behavior changed.