### PR TITLE
Compact chat message actions

### DIFF
--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -20,7 +20,6 @@ import {
   RefreshCw,
   Share2,
   ShieldCheck,
-  Smile,
   Trash2,
   Video,
   X
@@ -423,7 +422,6 @@ export function ChatWindow({
     closeEmailSheet: closeTeamEmailSheet
   } = useChatSheets();
   const [linkDraft, setLinkDraft] = useState('');
-  const [reactionMessageId, setReactionMessageId] = useState('');
   const [actionMessageId, setActionMessageId] = useState('');
   const [showJumpToLatest, setShowJumpToLatest] = useState(false);
   const [editingMessage, setEditingMessage] = useState<ChatMessage | null>(null);
@@ -531,6 +529,27 @@ export function ChatWindow({
   const staffConversationReady = !activeConversationIsStaff || (
     staffRepairState.key === activeStaffRepairKey && staffRepairState.status === 'ready'
   );
+
+  useEffect(() => {
+    if (!actionMessageId) return undefined;
+    const dismissMessageActions = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Element) || !target.closest('[data-chat-message-actions="true"]')) {
+        setActionMessageId('');
+      }
+    };
+    const dismissMessageActionsOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setActionMessageId('');
+      }
+    };
+    document.addEventListener('pointerdown', dismissMessageActions);
+    document.addEventListener('keydown', dismissMessageActionsOnEscape);
+    return () => {
+      document.removeEventListener('pointerdown', dismissMessageActions);
+      document.removeEventListener('keydown', dismissMessageActionsOnEscape);
+    };
+  }, [actionMessageId]);
 
   const repairStaffConversation = useCallback(async (requestedConversationId = CANONICAL_STAFF_CONVERSATION_ID) => {
     if (!auth.user || !team) return null;
@@ -1309,7 +1328,6 @@ export function ChatWindow({
     setSelectedRecipientTarget(nextDraft.selectedRecipientTarget);
     setSelectedRecipientIds([...nextDraft.selectedRecipientIds]);
     setComposerCursorPosition(undefined);
-    setReactionMessageId('');
     setActionMessageId('');
     closeConversationSheet();
   };
@@ -1791,7 +1809,7 @@ export function ChatWindow({
     if (!auth.user) return;
     try {
       await toggleTeamChatReaction(teamId, messageId, reactionKey, auth.user.uid, effectiveConversationId);
-      setReactionMessageId('');
+      setActionMessageId('');
     } catch (reactionError: any) {
       setStatus({ tone: 'error', message: reactionError?.message || 'Failed to update reaction.' });
     }
@@ -1995,10 +2013,8 @@ export function ChatWindow({
                 currentUserId={auth.user?.uid || ''}
                 canModerate={canModerate}
                 actionMessageId={actionMessageId}
-                reactionMessageId={reactionMessageId}
                 onMessageRowHeightChange={handleMessageRowHeightChange}
                 onActionMessage={setActionMessageId}
-                onReactionMessage={setReactionMessageId}
                 onToggleReaction={handleToggleReaction}
                 onEdit={handleEdit}
                 onDelete={handleDelete}
@@ -2378,10 +2394,8 @@ type MessageListProps = {
   currentUserId: string;
   canModerate: boolean;
   actionMessageId: string;
-  reactionMessageId: string;
   onMessageRowHeightChange: (messageId: string, height: number) => void;
   onActionMessage: (messageId: string) => void;
-  onReactionMessage: (messageId: string) => void;
   onToggleReaction: (messageId: string, reactionKey: string) => void;
   onEdit: (message: ChatMessage) => void;
   onDelete: (message: ChatMessage) => void;
@@ -2395,10 +2409,8 @@ const MessageList = memo(function MessageList({
   currentUserId,
   canModerate,
   actionMessageId,
-  reactionMessageId,
   onMessageRowHeightChange,
   onActionMessage,
-  onReactionMessage,
   onToggleReaction,
   onEdit,
   onDelete,
@@ -2411,7 +2423,7 @@ const MessageList = memo(function MessageList({
       {messages.map((message, index) => {
         const day = formatChatDay(message.createdAt);
         const showDay = day && day !== lastDay;
-        const preferReactionPickerAbove = index >= Math.max(0, messages.length - 2);
+        const preferActionsAbove = messages.length > 2 && index >= messages.length - 2;
         lastDay = day || lastDay;
         return (
           <div
@@ -2432,10 +2444,8 @@ const MessageList = memo(function MessageList({
               currentUserId={currentUserId}
               canModerate={canModerate}
               actionsOpen={actionMessageId === message.id}
-              reactionsOpen={reactionMessageId === message.id}
-              preferReactionPickerAbove={preferReactionPickerAbove}
+              preferActionsAbove={preferActionsAbove}
               onActionMessage={onActionMessage}
-              onReactionMessage={onReactionMessage}
               onToggleReaction={onToggleReaction}
               onEdit={onEdit}
               onDelete={onDelete}
@@ -2457,10 +2467,8 @@ type MessageBubbleProps = {
   currentUserId: string;
   canModerate: boolean;
   actionsOpen: boolean;
-  reactionsOpen: boolean;
-  preferReactionPickerAbove: boolean;
+  preferActionsAbove: boolean;
   onActionMessage: (messageId: string) => void;
-  onReactionMessage: (messageId: string) => void;
   onToggleReaction: (messageId: string, reactionKey: string) => void;
   onEdit: (message: ChatMessage) => void;
   onDelete: (message: ChatMessage) => void;
@@ -2473,10 +2481,8 @@ const MessageBubble = memo(function MessageBubble({
   currentUserId,
   canModerate,
   actionsOpen,
-  reactionsOpen,
-  preferReactionPickerAbove,
+  preferActionsAbove,
   onActionMessage,
-  onReactionMessage,
   onToggleReaction,
   onEdit,
   onDelete,
@@ -2489,6 +2495,7 @@ const MessageBubble = memo(function MessageBubble({
   const senderLabel = useMemo(() => getMessageSenderLabel(message, currentUserId), [currentUserId, message]);
   const attachments = useMemo(() => getSafeMessageAttachments(message), [message]);
   const reactions = useMemo(() => normalizeChatReactions(message), [message]);
+  const hasReactions = useMemo(() => Object.values(reactions).some((users) => users && users.length), [reactions]);
   const messageHtml = useMemo(() => formatChatMessageHtml(message.text || ''), [message.text]);
   const createdAtLabel = useMemo(() => formatChatTime(message.createdAt), [message.createdAt]);
   const canEdit = isOwn && !isLocalSend && !isDeleted && Boolean(message.text);
@@ -2507,7 +2514,7 @@ const MessageBubble = memo(function MessageBubble({
   return (
     <div className={`message-bubble group flex items-end gap-2 ${isOwn ? 'justify-end' : 'justify-start'}`}>
       {!isOwn ? <MessageAvatar message={message} label={senderLabel} /> : null}
-      <div className={`relative max-w-[82%] sm:max-w-[74%] ${isOwn ? 'items-end' : 'items-start'}`}>
+      <div className={`relative max-w-[74%] ${isOwn ? 'items-end' : 'items-start'}`}>
         <div className={`mb-1 flex items-center gap-2 text-[11px] font-bold text-gray-500 ${isOwn ? 'justify-end' : 'justify-start'}`}>
           {!isOwn ? <span className="truncate">{senderLabel}</span> : null}
           {message.editedAt ? <span className="italic">(edited)</span> : null}
@@ -2533,32 +2540,68 @@ const MessageBubble = memo(function MessageBubble({
             </div>
           ) : null}
         </div>
-        <div className={`chat-reactions-anchor ${isOwn ? 'justify-end' : 'justify-start'}`}>
-          {!isLocalSend ? (
+        {!isLocalSend ? (
+          <div className={`chat-message-actions ${isOwn ? 'chat-message-actions-own' : 'chat-message-actions-other'}`} data-chat-message-actions="true">
+            <button
+              type="button"
+              className="chat-message-actions-trigger"
+              onClick={() => onActionMessage(actionsOpen ? '' : message.id)}
+              aria-label={`Open message actions for ${senderLabel}`}
+              aria-expanded={actionsOpen}
+              aria-controls={`message-actions-${message.id}`}
+            >
+              <MoreVertical className="h-4 w-4" aria-hidden="true" />
+            </button>
+            {actionsOpen ? (
+              <div
+                id={`message-actions-${message.id}`}
+                role="group"
+                aria-label={`Message actions for ${senderLabel}`}
+                className={`chat-message-actions-popover ${preferActionsAbove ? 'chat-message-actions-popover-above' : 'chat-message-actions-popover-below'} ${isOwn ? 'left-0' : 'right-0'}`}
+              >
+                <div className="chat-message-reaction-options" aria-label="Reactions">
+                  {chatReactions.map((reaction) => (
+                    <button
+                      key={reaction.key}
+                      type="button"
+                      className="chat-message-reaction-option"
+                      onClick={() => onToggleReaction(message.id, reaction.key)}
+                      aria-label={reaction.label}
+                    >
+                      {reaction.emoji}
+                    </button>
+                  ))}
+                </div>
+                {(canEdit || canDelete) ? (
+                  <div className="chat-message-management-actions">
+                    {canEdit ? (
+                      <button type="button" className="chat-message-management-button" onClick={() => onEdit(message)}>
+                        <Edit3 className="h-4 w-4" aria-hidden="true" />
+                        Edit
+                      </button>
+                    ) : null}
+                    {canDelete ? (
+                      <button type="button" className="chat-message-management-button chat-message-management-button-danger" onClick={() => onDelete(message)}>
+                        <Trash2 className="h-4 w-4" aria-hidden="true" />
+                        Delete
+                      </button>
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+        {hasReactions ? (
+          <div className={`chat-message-reactions ${isOwn ? 'justify-end' : 'justify-start'}`}>
             <ReactionPills
               message={message}
               currentUserId={currentUserId}
               reactions={reactions}
               onToggleReaction={onToggleReaction}
-              onOpenPicker={() => onReactionMessage(reactionsOpen ? '' : message.id)}
             />
-          ) : null}
-          {reactionsOpen ? (
-            <div className={`chat-reaction-picker ${preferReactionPickerAbove ? 'chat-reaction-picker-above' : 'chat-reaction-picker-below'} ${isOwn ? 'right-0' : 'left-0'}`}>
-              {chatReactions.map((reaction) => (
-                <button
-                  key={reaction.key}
-                  type="button"
-                  className="flex h-9 w-9 items-center justify-center rounded-full text-lg hover:bg-gray-50"
-                  onClick={() => onToggleReaction(message.id, reaction.key)}
-                  aria-label={reaction.label}
-                >
-                  {reaction.emoji}
-                </button>
-              ))}
-            </div>
-          ) : null}
-        </div>
+          </div>
+        ) : null}
         {isLocalSend ? (
           <div className={`mt-1 flex ${isOwn ? 'justify-end' : 'justify-start'}`}>
             {message.sendStatus === 'failed' ? (
@@ -2577,34 +2620,6 @@ const MessageBubble = memo(function MessageBubble({
             )}
           </div>
         ) : null}
-        {(canEdit || canDelete) ? (
-          <div className={`mt-1 flex ${isOwn ? 'justify-end' : 'justify-start'}`}>
-            <button
-              type="button"
-              className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-500 shadow-sm"
-              onClick={() => onActionMessage(actionsOpen ? '' : message.id)}
-              aria-label={`Open actions for ${senderLabel}`}
-            >
-              <MoreVertical className="h-4 w-4" aria-hidden="true" />
-            </button>
-          </div>
-        ) : null}
-        {actionsOpen ? (
-          <div className={`absolute z-10 mt-1 min-w-36 rounded-xl border border-gray-200 bg-white p-1 shadow-app-lg ${isOwn ? 'right-0' : 'left-0'}`}>
-            {canEdit ? (
-              <button type="button" className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm font-bold text-gray-700 hover:bg-gray-50" onClick={() => onEdit(message)}>
-                <Edit3 className="h-4 w-4" aria-hidden="true" />
-                Edit
-              </button>
-            ) : null}
-            {canDelete ? (
-              <button type="button" className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm font-bold text-rose-700 hover:bg-rose-50" onClick={() => onDelete(message)}>
-                <Trash2 className="h-4 w-4" aria-hidden="true" />
-                Delete
-              </button>
-            ) : null}
-          </div>
-        ) : null}
       </div>
       {isOwn ? <MessageAvatar message={message} label={senderLabel} /> : null}
     </div>
@@ -2617,11 +2632,9 @@ function areMessageBubblePropsEqual(previous: MessageBubbleProps, next: MessageB
   return previous.currentUserId === next.currentUserId
     && previous.canModerate === next.canModerate
     && previous.actionsOpen === next.actionsOpen
-    && previous.reactionsOpen === next.reactionsOpen
-    && previous.preferReactionPickerAbove === next.preferReactionPickerAbove
+    && previous.preferActionsAbove === next.preferActionsAbove
     && previous.messageRevisionSignature === next.messageRevisionSignature
     && previous.onActionMessage === next.onActionMessage
-    && previous.onReactionMessage === next.onReactionMessage
     && previous.onToggleReaction === next.onToggleReaction
     && previous.onEdit === next.onEdit
     && previous.onDelete === next.onDelete
@@ -2773,16 +2786,15 @@ function ReactionPills({
   message,
   currentUserId,
   reactions,
-  onToggleReaction,
-  onOpenPicker
+  onToggleReaction
 }: {
   message: ChatMessage;
   currentUserId: string;
   reactions: Partial<Record<string, string[]>>;
   onToggleReaction: (messageId: string, reactionKey: string) => void;
-  onOpenPicker: () => void;
 }) {
   const hasReactions = Object.values(reactions).some((users) => users && users.length);
+  if (!hasReactions) return null;
   return (
     <div className="flex flex-wrap gap-1.5">
       {chatReactions.map((reaction) => {
@@ -2804,14 +2816,6 @@ function ReactionPills({
           </button>
         );
       })}
-      <button
-        type="button"
-        className={`inline-flex h-7 w-7 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-500 shadow-sm ${hasReactions ? '' : 'opacity-100 sm:opacity-0 sm:group-hover:opacity-100'}`}
-        onClick={onOpenPicker}
-        aria-label="Add reaction"
-      >
-        <Smile className="h-4 w-4" aria-hidden="true" />
-      </button>
     </div>
   );
 }

--- a/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
@@ -681,6 +681,28 @@ describe('ChatWindow virtualization', () => {
     expect(bubbleCount).toBeLessThan(liveMessages.length);
   });
 
+  it('keeps reactions and message management behind one compact action trigger', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <ChatWindow auth={auth} teamId="team-1" />
+      </MemoryRouter>
+    );
+
+    const firstBubble = container.querySelector('.message-bubble') as HTMLElement;
+    expect(firstBubble).toBeTruthy();
+    expect(within(firstBubble).queryByRole('button', { name: 'Add reaction' })).not.toBeInTheDocument();
+    expect(within(firstBubble).getAllByRole('button')).toHaveLength(1);
+
+    fireEvent.click(within(firstBubble).getByRole('button', { name: /Open message actions for/i }));
+
+    expect(within(firstBubble).getByRole('group', { name: /Message actions for/i })).toBeVisible();
+    expect(within(firstBubble).getByRole('button', { name: 'Like' })).toBeVisible();
+    expect(within(firstBubble).getByRole('button', { name: 'Delete' })).toBeVisible();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(within(firstBubble).queryByRole('group', { name: /Message actions for/i })).not.toBeInTheDocument();
+  });
+
   it('clears pending older-history layout state when switching teams on the default conversation', async () => {
     let releaseOlderLoad = () => {};
     olderLoadGate = {

--- a/apps/app/src/styles/index.css
+++ b/apps/app/src/styles/index.css
@@ -1737,30 +1737,143 @@
   color: #ffffff;
 }
 
-.chat-reactions-anchor {
-  position: relative;
+.chat-message-actions {
+  position: absolute;
+  bottom: 0;
+  z-index: 2;
+  display: inline-flex;
+}
+
+.chat-message-actions-own {
+  right: calc(100% + 6px);
+}
+
+.chat-message-actions-other {
+  left: calc(100% + 6px);
+}
+
+.chat-message-reactions {
   display: flex;
   margin-top: 4px;
 }
 
-.chat-reaction-picker {
-  position: absolute;
-  z-index: 20;
-  display: flex;
-  gap: 3px;
+.chat-message-actions-trigger {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
   border: 1px solid #e5e7eb;
   border-radius: 999px;
   background: #ffffff;
-  padding: 4px;
+  color: #667085;
+  box-shadow: 0 2px 6px rgba(16, 24, 40, 0.08);
+  transition: border-color 0.16s ease, color 0.16s ease, opacity 0.16s ease, transform 0.16s ease;
+}
+
+.chat-message-actions-trigger:hover,
+.chat-message-actions-trigger:focus-visible,
+.chat-message-actions-trigger[aria-expanded="true"] {
+  border-color: #c7d2fe;
+  color: #4f46e5;
+}
+
+.chat-message-actions-trigger:focus-visible {
+  outline: 2px solid #818cf8;
+  outline-offset: 2px;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .chat-message-actions-trigger:not([aria-expanded="true"]) {
+    opacity: 0;
+    transform: translateY(-1px);
+  }
+
+  .message-bubble:hover .chat-message-actions-trigger,
+  .message-bubble:focus-within .chat-message-actions-trigger {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.chat-message-actions-popover {
+  position: absolute;
+  z-index: 20;
+  width: max-content;
+  max-width: calc(100vw - 48px);
+  border: 1px solid #e5e7eb;
+  border-radius: 14px;
+  background: #ffffff;
+  padding: 5px;
   box-shadow: 0 12px 28px rgba(16, 24, 40, 0.18);
 }
 
-.chat-reaction-picker-below {
+.chat-message-actions-popover-below {
   top: calc(100% + 4px);
 }
 
-.chat-reaction-picker-above {
+.chat-message-actions-popover-above {
   bottom: calc(100% + 4px);
+}
+
+.chat-message-reaction-options {
+  display: flex;
+  gap: 2px;
+}
+
+.chat-message-reaction-option {
+  display: inline-flex;
+  width: 36px;
+  height: 36px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  font-size: 1.125rem;
+}
+
+.chat-message-reaction-option:hover,
+.chat-message-reaction-option:focus-visible {
+  background: #f9fafb;
+}
+
+.chat-message-reaction-option:focus-visible,
+.chat-message-management-button:focus-visible {
+  outline: 2px solid #818cf8;
+  outline-offset: -2px;
+}
+
+.chat-message-management-actions {
+  display: flex;
+  gap: 3px;
+  margin-top: 4px;
+  padding-top: 4px;
+  border-top: 1px solid #f2f4f7;
+}
+
+.chat-message-management-button {
+  display: inline-flex;
+  min-height: 36px;
+  flex: 1 1 0;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border-radius: 9px;
+  padding: 6px 10px;
+  color: #344054;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.chat-message-management-button:hover {
+  background: #f9fafb;
+}
+
+.chat-message-management-button-danger {
+  color: #be123c;
+}
+
+.chat-message-management-button-danger:hover {
+  background: #fff1f2;
 }
 
 .message-row {

--- a/team-chat.html
+++ b/team-chat.html
@@ -493,12 +493,12 @@
         const AI_EVENTS_GAMES_LIMIT = 3;
         const AI_EVENTS_PER_GAME_LIMIT = 25;
         const CHAT_REACTIONS = [
-            { key: 'thumbs_up', emoji: '👍' },
-            { key: 'heart', emoji: '❤️' },
-            { key: 'joy', emoji: '😂' },
-            { key: 'wow', emoji: '😮' },
-            { key: 'sad', emoji: '😢' },
-            { key: 'clap', emoji: '👏' }
+            { key: 'thumbs_up', emoji: '👍', label: 'Like' },
+            { key: 'heart', emoji: '❤️', label: 'Love' },
+            { key: 'joy', emoji: '😂', label: 'Funny' },
+            { key: 'wow', emoji: '😮', label: 'Wow' },
+            { key: 'sad', emoji: '😢', label: 'Sad' },
+            { key: 'clap', emoji: '👏', label: 'Clap' }
         ];
         const CHAT_REACTION_BY_KEY = new Map(CHAT_REACTIONS.map(r => [r.key, r.emoji]));
         let aiModelCache = null;
@@ -510,7 +510,7 @@
         let isLoadingMediaGalleryHistory = false;
         const chatMediaShareFileCache = new Map();
         const chatMediaShareFilePending = new Map();
-        let activeReactionPickerMessageId = null;
+        let activeMessageMenuId = null;
         let activeReactionInfo = null;
         const pendingReactionOps = new Set();
         const reactionUserNameCache = new Map();
@@ -793,7 +793,9 @@
                 return;
             }
 
-            let html = messages.map(msg => renderMessage(msg)).join('');
+            let html = messages.map((msg, index) => renderMessage(msg, {
+                preferActionsAbove: messages.length > 2 && index >= messages.length - 2
+            })).join('');
             if (aiUiPending) {
                 html += `
                     <div id="ai-thinking-placeholder" class="flex justify-start gap-2">
@@ -893,7 +895,7 @@
             return normalized;
         }
 
-        function renderReactionControls(msg, { isOwn }) {
+        function renderReactionControls(msg, { isOwn, canEdit, canDelete, displayName, preferActionsAbove }) {
             const reactions = normalizeMessageReactions(msg);
             const pills = CHAT_REACTIONS
                 .map(({ key, emoji }) => {
@@ -929,35 +931,61 @@
                 .filter(Boolean)
                 .join('');
 
-            const pickerOpen = activeReactionPickerMessageId === msg.id;
-            const picker = pickerOpen ? `
-                <div class="absolute bottom-full ${isOwn ? 'right-0' : 'left-0'} mb-2 inline-flex items-center gap-1.5 px-2 py-1.5 rounded-full border border-gray-200 bg-white shadow-lg z-20" data-reaction-ui="true">
-                    ${CHAT_REACTIONS.map(({ key, emoji }) => `
+            const menuOpen = activeMessageMenuId === msg.id;
+            const managementActions = [
+                canEdit ? `
+                    <button type="button" onclick="window.editMessage('${msg.id}')"
+                        class="min-h-9 flex-1 inline-flex items-center justify-center rounded-lg px-3 py-2 text-xs font-semibold text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-400" data-reaction-ui="true">
+                        Edit
+                    </button>
+                ` : '',
+                canDelete ? `
+                    <button type="button" onclick="window.deleteMessage('${msg.id}')"
+                        class="min-h-9 flex-1 inline-flex items-center justify-center rounded-lg px-3 py-2 text-xs font-semibold text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-primary-400" data-reaction-ui="true">
+                        Delete
+                    </button>
+                ` : ''
+            ].filter(Boolean).join('');
+            const menu = menuOpen ? `
+                <div id="message-actions-${escapeHtml(msg.id)}" role="group" aria-label="Message actions for ${escapeHtml(displayName)}"
+                    class="absolute ${preferActionsAbove ? 'bottom-full mb-2' : 'top-full mt-2'} ${isOwn ? 'left-0' : 'right-0 sm:left-0 sm:right-auto'} z-20 w-max max-w-[calc(100vw-3rem)] rounded-xl border border-gray-200 bg-white p-1 shadow-lg" data-reaction-ui="true">
+                    <div class="flex items-center gap-0.5" aria-label="Reactions" data-reaction-ui="true">
+                    ${CHAT_REACTIONS.map(({ key, emoji, label }) => `
                         <button type="button" onclick="window.reactToMessage('${msg.id}', '${key}')"
-                            class="w-8 h-8 rounded-full border border-gray-200 bg-white hover:bg-gray-50 text-sm" data-reaction-ui="true">
+                            class="w-9 h-9 rounded-full bg-white hover:bg-gray-50 text-lg focus:outline-none focus:ring-2 focus:ring-primary-400" aria-label="${label}" data-reaction-ui="true">
                             ${emoji}
                         </button>
                     `).join('')}
+                    </div>
+                    ${managementActions ? `
+                        <div class="mt-1 flex gap-1 border-t border-gray-100 pt-1" data-reaction-ui="true">
+                            ${managementActions}
+                        </div>
+                    ` : ''}
                 </div>
             ` : '';
 
             const alignClass = isOwn ? 'justify-end' : 'justify-start';
-            const addBtnState = pickerOpen ? 'opacity-100' : 'opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:focus:opacity-100';
-            return `
-                <div class="mt-1 flex ${alignClass} gap-1.5 flex-wrap" data-reaction-ui="true">
-                    <div class="relative inline-flex items-center gap-1.5" data-reaction-ui="true">
-                        ${pills}
-                        <button type="button" onclick="window.toggleReactionPicker('${msg.id}')" data-reaction-ui="true"
-                            class="inline-flex items-center justify-center w-7 h-7 rounded-full border border-gray-200 bg-white text-gray-500 hover:text-primary-600 hover:border-primary-200 transition ${addBtnState}">
-                            <span class="text-sm">😊</span>
-                        </button>
-                        ${picker}
-                    </div>
+            const menuButtonState = menuOpen ? 'opacity-100' : 'opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:focus:opacity-100';
+            const reactionControls = pills ? `
+                <div class="mt-1 flex ${alignClass} gap-1.5 flex-wrap" data-message-actions-footer="true" data-reaction-ui="true">
+                    ${pills}
+                </div>
+            ` : '';
+            const actionControl = `
+                <div class="absolute bottom-0 ${isOwn ? 'right-full mr-1.5' : 'left-full ml-1.5'} z-10 inline-flex" data-reaction-ui="true">
+                    <button type="button" onclick="window.toggleMessageMenu('${msg.id}')" data-reaction-ui="true"
+                            class="inline-flex items-center justify-center w-7 h-7 rounded-full border border-gray-200 bg-white text-gray-500 shadow-sm hover:text-primary-600 hover:border-primary-200 focus:outline-none focus:ring-2 focus:ring-primary-400 transition ${menuButtonState}"
+                            aria-label="Open message actions for ${escapeHtml(displayName)}" aria-expanded="${menuOpen}" aria-controls="message-actions-${escapeHtml(msg.id)}">
+                        <span class="text-lg leading-none" aria-hidden="true">⋮</span>
+                    </button>
+                    ${menu}
                 </div>
             `;
+            return { reactionControls, actionControl };
         }
 
-        function renderMessage(msg) {
+        function renderMessage(msg, { preferActionsAbove = false } = {}) {
             const isAi = msg.ai === true;
             const isOwn = !isAi && msg.senderId === currentUser.uid;
             const isDeleted = msg.deleted === true;
@@ -994,15 +1022,7 @@
                 </div>
             ` : '';
             const messageText = msg.text ? `<p class="text-sm whitespace-pre-wrap break-words">${formatMessageText(msg.text)}</p>` : '';
-            const reactionControls = renderReactionControls(msg, { isOwn });
-
-            const actions = [];
-            if (canEdit) {
-                actions.push(`<button onclick="window.editMessage('${msg.id}')" class="text-gray-400 hover:text-primary-600 text-xs">Edit</button>`);
-            }
-            if (canDelete) {
-                actions.push(`<button onclick="window.deleteMessage('${msg.id}')" class="text-gray-400 hover:text-red-600 text-xs">Delete</button>`);
-            }
+            const { reactionControls, actionControl } = renderReactionControls(msg, { isOwn, canEdit, canDelete, displayName, preferActionsAbove });
 
             const bubbleClass = isAi
                 ? 'bg-indigo-50 text-gray-900 border border-indigo-100'
@@ -1012,8 +1032,8 @@
 
             if (isOwn) {
                 return `
-                    <div class="group flex justify-end gap-2">
-                        <div class="max-w-[75%]">
+                    <div class="group flex justify-end gap-2" data-message-id="${escapeHtml(msg.id)}">
+                        <div class="relative max-w-[75%]">
                             <div class="text-xs text-gray-500 text-right mb-1">
                                 ${msg.editedAt ? '<span class="italic">(edited)</span> ' : ''}${timestamp}
                             </div>
@@ -1021,20 +1041,16 @@
                                 ${messageMedia}${messageText}
                             </div>
                             ${reactionControls}
-                            ${actions.length > 0 ? `
-                                <div class="flex justify-end gap-2 mt-1">
-                                    ${actions.join(' ')}
-                                </div>
-                            ` : ''}
+                            ${actionControl}
                         </div>
                         ${avatar}
                     </div>
                 `;
             } else {
                 return `
-                    <div class="group flex justify-start gap-2">
+                    <div class="group flex justify-start gap-2" data-message-id="${escapeHtml(msg.id)}">
                         ${avatar}
-                        <div class="max-w-[75%]">
+                        <div class="relative max-w-[75%]">
                             <div class="text-xs text-gray-500 mb-1">
                                 <span class="font-medium">${escapeHtml(displayName)}</span>
                                 ${msg.editedAt ? '<span class="italic">(edited)</span>' : ''}
@@ -1044,11 +1060,7 @@
                                 ${messageMedia}${messageText}
                             </div>
                             ${reactionControls}
-                            ${actions.length > 0 ? `
-                                <div class="flex gap-2 mt-1">
-                                    ${actions.join(' ')}
-                                </div>
-                            ` : ''}
+                            ${actionControl}
                         </div>
                     </div>
                 `;
@@ -1622,7 +1634,7 @@
             liveMessages = [];
             liveOldestDoc = null;
             hasMoreMessages = true;
-            activeReactionPickerMessageId = null;
+            activeMessageMenuId = null;
             activeReactionInfo = null;
             document.getElementById('messages-container').innerHTML = `
                 <div class="text-center py-8">
@@ -2655,8 +2667,8 @@
             return postChatMessage(teamId, message);
         }
 
-        window.toggleReactionPicker = function(messageId) {
-            activeReactionPickerMessageId = activeReactionPickerMessageId === messageId ? null : messageId;
+        window.toggleMessageMenu = function(messageId) {
+            activeMessageMenuId = activeMessageMenuId === messageId ? null : messageId;
             activeReactionInfo = null;
             renderMessages();
         };
@@ -2708,7 +2720,7 @@
 
             try {
                 await toggleChatReaction(teamId, messageId, reactionKey, currentUser.uid, { conversationId: selectedConversationId });
-                activeReactionPickerMessageId = null;
+                activeMessageMenuId = null;
                 activeReactionInfo = null;
             } catch (error) {
                 console.error('Error toggling reaction:', error);
@@ -2834,7 +2846,7 @@
                 liveMessages = [];
                 liveOldestDoc = null;
                 hasMoreMessages = true;
-                activeReactionPickerMessageId = null;
+                activeMessageMenuId = null;
                 activeReactionInfo = null;
                 startRealtimeUpdates();
                 btn.disabled = false;
@@ -2907,11 +2919,11 @@
                     hideMentionMenu();
                 }
                 if (!e.target.closest('[data-reaction-ui="true"]')) {
-                    const hadPicker = activeReactionPickerMessageId !== null;
+                    const hadMenu = activeMessageMenuId !== null;
                     const hadInfo = activeReactionInfo !== null;
-                    activeReactionPickerMessageId = null;
+                    activeMessageMenuId = null;
                     activeReactionInfo = null;
-                    if (hadPicker || hadInfo) {
+                    if (hadMenu || hadInfo) {
                         renderMessages();
                     }
                 }
@@ -3101,6 +3113,8 @@
             const msg = messages.find(m => m.id === messageId);
             if (!msg || msg.deleted || !msg.text) return;
 
+            activeMessageMenuId = null;
+            renderMessages();
             editingMessageId = messageId;
             document.getElementById('edit-textarea').value = msg.text;
             document.getElementById('edit-modal').classList.remove('hidden');
@@ -3140,6 +3154,8 @@
 
         // Delete functionality
         window.deleteMessage = async function(messageId) {
+            activeMessageMenuId = null;
+            renderMessages();
             if (!confirm('Delete this message?')) return;
 
             try {

--- a/tests/smoke/app-authenticated-extended.spec.js
+++ b/tests/smoke/app-authenticated-extended.spec.js
@@ -236,14 +236,14 @@ test('staff smoke writes are deterministic and removed after validation', async 
             });
 
             const messageRow = page.locator('.message-row-measure').filter({ hasText: chatText });
-            await messageRow.getByRole('button', { name: /^Open actions for / }).click();
+            await messageRow.getByRole('button', { name: /^Open message actions for / }).click();
             await messageRow.getByRole('button', { name: 'Edit' }).click();
             const editDialog = page.getByRole('dialog', { name: 'Edit message' });
             await editDialog.locator('textarea').fill(editedChatText);
             await editDialog.getByRole('button', { name: 'Save' }).click();
             await expect(page.getByText(editedChatText, { exact: true })).toBeVisible({ timeout: 20_000 });
             const editedRow = page.locator('.message-row-measure').filter({ hasText: editedChatText });
-            await editedRow.getByRole('button', { name: /^Open actions for / }).click();
+            await editedRow.getByRole('button', { name: /^Open message actions for / }).click();
             page.once('dialog', (dialog) => dialog.accept());
             await editedRow.getByRole('button', { name: 'Delete' }).click();
             await expect(editedRow.getByText('Message removed')).toBeVisible({ timeout: 20_000 });

--- a/tests/smoke/app-messages.spec.js
+++ b/tests/smoke/app-messages.spec.js
@@ -123,6 +123,16 @@ function buildDeferredMediaThreadMessagesScript() {
 
 async function mockMessagesModules(page, options = {}) {
     await page.addInitScript(({ speech }) => {
+        window.__ALLPLAYS_CONFIG__ = {
+            firebase: {
+                apiKey: 'demo-api-key',
+                authDomain: 'demo-allplays.firebaseapp.com',
+                projectId: 'demo-allplays',
+                messagingSenderId: '1234567890',
+                appId: '1:1234567890:web:allplayssmoke'
+            },
+            appCheck: { enabled: false }
+        };
         window.__chatCalls = {
             sends: [],
             reactions: [],
@@ -513,6 +523,10 @@ test('@visual messages inbox and team chat exercise real migrated chat UX', asyn
     await expect(thread).toContainText('Bring both jerseys.');
     await expect(thread).toContainText('We can bring snacks.');
     await expect(page.getByText('Latest ride update.')).toBeVisible();
+    const latestMessageRow = page.locator('.message-row-measure').filter({ hasText: 'Latest ride update.' });
+    await expect(latestMessageRow.getByRole('button', { name: /Open message actions for/i })).toBeVisible();
+    await expect(latestMessageRow.getByRole('button')).toHaveCount(1);
+    await expect.poll(() => latestMessageRow.locator('.chat-message-actions').evaluate((element) => element.getBoundingClientRect().height)).toBeLessThanOrEqual(28);
     await expect(bottomNav.getByRole('link', { name: 'Home' })).toBeVisible();
     await expect(bottomNav.getByRole('link', { name: 'Schedule' })).toBeVisible();
     await expect(bottomNav.getByRole('link', { name: 'Messages' })).toBeVisible();
@@ -640,8 +654,12 @@ test('@visual messages inbox and team chat exercise real migrated chat UX', asyn
         selectedRecipientIds: []
     }]);
 
-    await page.getByRole('button', { name: 'Add reaction' }).last().click();
-    await expect(page.locator('.chat-reaction-picker')).toBeVisible();
+    await page.getByRole('button', { name: /Open message actions for/i }).last().click();
+    await expect(page.locator('.chat-message-actions-popover')).toBeVisible();
+    await expect.poll(() => page.locator('.chat-message-actions-popover').evaluate((element) => {
+        const bounds = element.getBoundingClientRect();
+        return bounds.left >= 0 && bounds.right <= window.innerWidth;
+    })).toBe(true);
     await page.getByRole('button', { name: 'Like' }).click();
     await expect.poll(() => page.evaluate(() => window.__chatCalls.reactions[0])).toMatchObject({
         teamId: 'team-1',

--- a/tests/smoke/team-fallback-regressions.spec.js
+++ b/tests/smoke/team-fallback-regressions.spec.js
@@ -1072,7 +1072,17 @@ test('team chat scopes subscription, last-read, send, and reaction operations to
         text: 'Staff follow-up'
     });
 
-    await page.locator('#messages-container button').filter({ hasText: '👍' }).click();
+    const staffMessage = page.locator('[data-message-id="staff-message"]');
+    await expect(staffMessage.getByRole('button')).toHaveCount(2);
+    await expect.poll(() => staffMessage.locator('[data-message-actions-footer="true"]').evaluate((element) => element.getBoundingClientRect().height)).toBeLessThanOrEqual(28);
+    await staffMessage.getByRole('button', { name: /Open message actions for/i }).click();
+    await expect(staffMessage.getByRole('group', { name: /Message actions for/i })).toBeVisible();
+    await expect.poll(() => staffMessage.getByRole('group', { name: /Message actions for/i }).evaluate((element) => {
+        const bounds = element.getBoundingClientRect();
+        const containerBounds = document.getElementById('messages-container').getBoundingClientRect();
+        return bounds.left >= containerBounds.left && bounds.right <= containerBounds.right;
+    })).toBe(true);
+    await staffMessage.getByRole('button', { name: 'Like' }).click();
     await expect.poll(() => page.evaluate(() => window.__CHAT_CALLS__.reactions.at(-1))).toEqual({
         teamId: 'team-1',
         messageId: 'staff-message',

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -1476,15 +1476,11 @@ describe('React app messages integration', () => {
         expect(container.textContent).toContain('Bring both jerseys.');
         expect(container.textContent).toContain('We can bring snacks.');
 
-        const reactionButtons = Array.from(container.querySelectorAll('button[aria-label="Add reaction"]'));
-        await act(async () => {
-            reactionButtons[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
-        });
-        await flush();
+        await click(container, 'Open message actions for Coach Jamie');
         await click(container, 'Like');
         expect(chatMocks.toggleTeamChatReaction).toHaveBeenCalledWith('team-1', 'msg-1', 'thumbs_up', 'user-1', 'team');
 
-        await click(container, 'Open actions for You');
+        await click(container, 'Open message actions for You');
         await click(container, 'Edit');
         const dialog = container.querySelector('[role="dialog"][aria-label="Edit message"]');
         const editTextarea = dialog.querySelector('textarea');
@@ -1492,7 +1488,7 @@ describe('React app messages integration', () => {
         await click(container, 'Save');
         expect(chatMocks.editTeamChatMessage).toHaveBeenCalledWith('team-1', 'msg-2', 'We can bring snacks and waters.', 'team');
 
-        await click(container, 'Open actions for You');
+        await click(container, 'Open message actions for You');
         await click(container, 'Delete');
         expect(chatMocks.deleteTeamChatMessage).toHaveBeenCalledWith('team-1', 'msg-2', 'team');
     });


### PR DESCRIPTION
## Summary

- Replace the stacked reaction and message-management controls with one compact overflow trigger beside each chat bubble.
- Combine reactions, Edit, and Delete in one responsive popover without adding message-row height.
- Apply the same interaction to the shared React chat used by web/iOS/Android and the legacy team chat.
- Keep existing reaction counts visible and add viewport-aware placement, outside-click/Escape dismissal, focus states, and accessible labels.

## Why

The previous smile and overflow controls stacked beneath messages, making short chat messages consume substantially more vertical space than their content.

## Safety

- Existing ownership and moderator permission gates are unchanged.
- Delete confirmation remains required.
- Reaction, edit, and delete operations still use the existing conversation-scoped services and error handling.
- No authentication, persistence, privacy, or provider boundaries changed.

## Validation

Exact head `ef6a766320d1f373f54985a6d7d6424a0461388d`:

- `cd apps/app && npm test -- --run src/pages/messages/components/ChatWindow.virtualization.test.tsx src/pages/messages/components/ChatWindow.test.tsx` — 45 passed
- `npx vitest run tests/unit/app-chat-messages-integration.test.jsx --reporter=dot --silent` — 79 passed
- `npm run app:build` — passed, including bundle visualizer and cold-start budget
- React messages Playwright smoke — passed
- Legacy team chat Playwright smoke — passed

The full repository unit suite also passed before the final non-overlapping rebase: 5,389 passed, 140 skipped.