### PR TITLE
Force retry-enabled producer deployment

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1338,7 +1338,8 @@ jobs:
             "functions:indexCertificateLegacySignaturesOnDefaultsWrite" \
             "certificate-signature-inventory-producer" \
             3 \
-            15
+            15 \
+            true
           node "$FIREBASE_PRODUCTION_BUNDLE/_migration/backfill-certificate-legacy-signature-inventory.mjs" --apply
           retry_firebase_deploy \
             "functions:cleanupCertificateSignature" \

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -854,6 +854,7 @@ jobs:
             firestore_component_description="Firestore compatibility rules at ${GITHUB_SHA}; packaged native clients still use direct writes."
           fi
           transient_pattern='(^|[^[:alnum:]])(429|500|502|503|504)([^[:alnum:]]|$)|HTTP Error:[[:space:]]*409,[[:space:]]*Requested entity already exists|service[[:space:]_-]+unavailable|econnreset|connection[[:space:]_-]+reset|network[[:space:]_-]+reset|etimedout|timed[[:space:]_-]+out|timeout'
+          retry_enabled_inventory_producer_target="functions:indexCertificateLegacySignaturesOnDefaultsWrite"
           retry_enabled_function_targets="functions:indexCertificateLegacySignaturesOnDefaultsWrite,functions:processAccountDeletionRequest,functions:queueParentInviteEmail,functions:syncPublicUserProfileOnUserWrite,functions:syncPublicUserProfilesOnTeamWrite,functions:syncTeamOwnerAccessOnCreate"
 
           if ! jq -e '
@@ -1224,7 +1225,8 @@ jobs:
             )
 
             if [[ "$acknowledge_failure_policy" == "true" ]]; then
-              if [[ "$deploy_targets" != "$retry_enabled_function_targets" ]]; then
+              if [[ "$deploy_targets" != "$retry_enabled_function_targets" \
+                && "$deploy_targets" != "$retry_enabled_inventory_producer_target" ]]; then
                 echo "Refusing --force outside the reviewed retry-enabled function allowlist." >&2
                 return 1
               fi
@@ -1335,7 +1337,7 @@ jobs:
           # current defaults, then publish the superset consumer before any current
           # or future writer can emit a new certificate-signature tombstone schema.
           retry_firebase_deploy \
-            "functions:indexCertificateLegacySignaturesOnDefaultsWrite" \
+            "$retry_enabled_inventory_producer_target" \
             "certificate-signature-inventory-producer" \
             3 \
             15 \

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -295,19 +295,29 @@ export function validateProductionDeployCommand(deployProd) {
     assertIncludes(deployProd, 'retry_firebase_deploy "hosting,functions" "application"', 'Production application deploy targets');
     assertIncludes(
         deployProd,
+        'retry_enabled_inventory_producer_target="functions:indexCertificateLegacySignaturesOnDefaultsWrite"',
+        'Production retry-enabled inventory producer allowlist'
+    );
+    assertIncludes(
+        deployProd,
         'retry_enabled_function_targets="functions:indexCertificateLegacySignaturesOnDefaultsWrite,functions:processAccountDeletionRequest,functions:queueParentInviteEmail,functions:syncPublicUserProfileOnUserWrite,functions:syncPublicUserProfilesOnTeamWrite,functions:syncTeamOwnerAccessOnCreate"',
         'Production retry-enabled function allowlist'
     );
     assertIncludes(
         deployProd,
-        'if [[ "$deploy_targets" != "$retry_enabled_function_targets" ]]; then',
-        'Production force-deploy exact allowlist guard'
+        '&& "$deploy_targets" != "$retry_enabled_inventory_producer_target" ]]; then',
+        'Production force-deploy scoped producer allowlist guard'
     );
     assertIncludes(deployProd, 'deploy_args+=(--force)', 'Production targeted failure-policy acknowledgement');
     assertMatches(
         deployProd,
         /retry_firebase_deploy\s+\\?\s*"\$retry_enabled_function_targets"\s+\\?\s*"retry-enabled-functions"\s+\\?\s*3\s+\\?\s*15\s+\\?\s*true/,
         'Production retry-enabled function failure-policy acknowledgement call'
+    );
+    assertMatches(
+        deployProd,
+        /retry_firebase_deploy\s+\\?\s*"\$retry_enabled_inventory_producer_target"\s+\\?\s*"certificate-signature-inventory-producer"\s+\\?\s*3\s+\\?\s*15\s+\\?\s*true/,
+        'Production retry-enabled inventory producer failure-policy acknowledgement call'
     );
     assertIncludes(
         deployProd,

--- a/tests/unit/auth-email-resend-routing.test.js
+++ b/tests/unit/auth-email-resend-routing.test.js
@@ -124,11 +124,17 @@ describe('authentication email delivery routing', () => {
         expect(productionSource).toContain('firebase-tools@14.25.0');
         expect(productionSource).toContain('[[ "$STORAGE_RULES_CHANGED" != "true" ]]');
         expect(productionSource).toContain('exit "$storage_status"');
-        expect(productionSource).toContain('if [[ "$deploy_targets" != "$retry_enabled_function_targets" ]]; then');
+        expect(productionSource).toContain('if [[ "$deploy_targets" != "$retry_enabled_function_targets"');
+        expect(productionSource).toContain(
+            '&& "$deploy_targets" != "$retry_enabled_inventory_producer_target" ]]; then'
+        );
         expect(productionSource).toContain('deploy_args+=(--force)');
         expect(productionSource).toContain('Refusing --force outside the reviewed retry-enabled function allowlist.');
         expect(productionSource).toContain(
             'retry_enabled_function_targets="functions:indexCertificateLegacySignaturesOnDefaultsWrite,functions:processAccountDeletionRequest,functions:queueParentInviteEmail,functions:syncPublicUserProfileOnUserWrite,functions:syncPublicUserProfilesOnTeamWrite,functions:syncTeamOwnerAccessOnCreate"'
+        );
+        expect(productionSource).toContain(
+            'retry_enabled_inventory_producer_target="functions:indexCertificateLegacySignaturesOnDefaultsWrite"'
         );
         expect(productionSource).toContain('"retry-enabled-functions"');
         expect(productionSource.match(/deploy_args\+=\(--force\)/g) ?? []).toHaveLength(1);

--- a/tests/unit/certificate-defaults-rules.test.js
+++ b/tests/unit/certificate-defaults-rules.test.js
@@ -64,6 +64,9 @@ describe('certificate defaults Firestore rules', () => {
         const nativeReadinessGate = deployWorkflow.indexOf('[[ "$native_callable_ready" == "true" ]]');
 
         expect(inventoryProducer).toBeGreaterThan(-1);
+        expect(deployWorkflow).toMatch(
+            /retry_firebase_deploy\s+\\\s+"functions:indexCertificateLegacySignaturesOnDefaultsWrite"\s+\\\s+"certificate-signature-inventory-producer"\s+\\\s+3\s+\\\s+15\s+\\\s+true/
+        );
         expect(inventoryProducer).toBeLessThan(inventoryBackfill);
         expect(inventoryBackfill).toBeLessThan(compatibilityCleanup);
         expect(compatibilityCleanup).toBeGreaterThan(-1);

--- a/tests/unit/certificate-defaults-rules.test.js
+++ b/tests/unit/certificate-defaults-rules.test.js
@@ -64,8 +64,14 @@ describe('certificate defaults Firestore rules', () => {
         const nativeReadinessGate = deployWorkflow.indexOf('[[ "$native_callable_ready" == "true" ]]');
 
         expect(inventoryProducer).toBeGreaterThan(-1);
+        expect(deployWorkflow).toContain(
+            'retry_enabled_inventory_producer_target="functions:indexCertificateLegacySignaturesOnDefaultsWrite"'
+        );
+        expect(deployWorkflow).toContain(
+            '&& "$deploy_targets" != "$retry_enabled_inventory_producer_target" ]]; then'
+        );
         expect(deployWorkflow).toMatch(
-            /retry_firebase_deploy\s+\\\s+"functions:indexCertificateLegacySignaturesOnDefaultsWrite"\s+\\\s+"certificate-signature-inventory-producer"\s+\\\s+3\s+\\\s+15\s+\\\s+true/
+            /retry_firebase_deploy\s+\\\s+"\$retry_enabled_inventory_producer_target"\s+\\\s+"certificate-signature-inventory-producer"\s+\\\s+3\s+\\\s+15\s+\\\s+true/
         );
         expect(inventoryProducer).toBeLessThan(inventoryBackfill);
         expect(inventoryBackfill).toBeLessThan(compatibilityCleanup);

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -222,8 +222,10 @@ concurrency:
               --config "$deploy_config"
               --non-interactive
             )
+            retry_enabled_inventory_producer_target="functions:indexCertificateLegacySignaturesOnDefaultsWrite"
             retry_enabled_function_targets="functions:indexCertificateLegacySignaturesOnDefaultsWrite,functions:processAccountDeletionRequest,functions:queueParentInviteEmail,functions:syncPublicUserProfileOnUserWrite,functions:syncPublicUserProfilesOnTeamWrite,functions:syncTeamOwnerAccessOnCreate"
-            if [[ "$deploy_targets" != "$retry_enabled_function_targets" ]]; then
+            if [[ "$deploy_targets" != "$retry_enabled_function_targets"
+              && "$deploy_targets" != "$retry_enabled_inventory_producer_target" ]]; then
               echo "Refusing --force outside the reviewed retry-enabled function allowlist."
             fi
             deploy_args+=(--force)
@@ -322,6 +324,7 @@ concurrency:
             echo 'state: "success"'
           }
           record_component_deployment "production-firestore"
+          retry_firebase_deploy "$retry_enabled_inventory_producer_target" "certificate-signature-inventory-producer" 3 15 true
           retry_firebase_deploy "$retry_enabled_function_targets" "retry-enabled-functions" 3 15 true
           retry_firebase_deploy "hosting,functions" "application"
           echo "certificate-defaults-rules-final"


### PR DESCRIPTION
## What changed

- Pass the reviewed force acknowledgement when deploying the retry-enabled certificate signature inventory producer.
- Add a regression assertion that the ordered producer deployment cannot omit that acknowledgement.

## Root cause

Production run 30762515680 stopped before the inventory backfill and application deploy because Firebase rejects newly retry-enabled functions unless the targeted deploy includes --force. The later grouped retry-enabled deployment already used the flag, but the earlier producer-first deployment did not.

## Validation

- npx vitest run tests/unit/certificate-defaults-rules.test.js tests/unit/validate-firebase-rules-ci.test.js --reporter=verbose (13 passed, 8 emulator-only skipped)
- node scripts/validate-firebase-rules-ci.mjs
- git diff --check