### PR TITLE
Fix migration workload identity authentication

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -492,6 +492,7 @@ jobs:
             fi
             if git diff --quiet "$last_success_sha" "$GITHUB_SHA" -- \
               _migration/backfill-team-fee-checkout-attempts.js \
+              _migration/firebase-admin-credential.mjs \
               functions/team-fees-core.cjs; then
               echo "team_fee_checkout_backfill_needed=false" >> "$GITHUB_OUTPUT"
             else
@@ -499,6 +500,7 @@ jobs:
             fi
             if git diff --quiet "$last_success_sha" "$GITHUB_SHA" -- \
               _migration/backfill-registration-checkout-attempts.js \
+              _migration/firebase-admin-credential.mjs \
               functions/registration-payment-webhook-core.cjs; then
               echo "registration_checkout_backfill_needed=false" >> "$GITHUB_OUTPUT"
             else
@@ -608,6 +610,8 @@ jobs:
             "$FIREBASE_PRODUCTION_BUNDLE/_migration/backfill-registration-checkout-attempts.mjs"
           cp _migration/backfill-certificate-legacy-signature-inventory.js \
             "$FIREBASE_PRODUCTION_BUNDLE/_migration/backfill-certificate-legacy-signature-inventory.mjs"
+          cp _migration/firebase-admin-credential.mjs \
+            "$FIREBASE_PRODUCTION_BUNDLE/_migration/firebase-admin-credential.mjs"
           cp scripts/extract-production-functions-handoff.py "$FIREBASE_PRODUCTION_BUNDLE/context/"
 
       - name: Install isolated Firebase deploy CLI without OIDC or lifecycle scripts
@@ -723,6 +727,8 @@ jobs:
           test ! -L "$bundle/_migration/backfill-registration-checkout-attempts.mjs"
           test -f "$bundle/_migration/backfill-certificate-legacy-signature-inventory.mjs"
           test ! -L "$bundle/_migration/backfill-certificate-legacy-signature-inventory.mjs"
+          test -f "$bundle/_migration/firebase-admin-credential.mjs"
+          test ! -L "$bundle/_migration/firebase-admin-credential.mjs"
           test -f "$bundle/firestore.rules"
           test -f "$bundle/firestore-certificate-defaults-compat.rules"
           test ! -L "$bundle/firestore-certificate-defaults-compat.rules"

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ serviceAccountKey*.json
 _migration/*
 !_migration/
 !_migration/backfill-certificate-legacy-signature-inventory.js
+!_migration/firebase-admin-credential.mjs
 !_migration/backfill-public-user-profiles.js
 !_migration/migrate-player-private-profile.js
 !_migration/fix-orphaned-invite-redemptions.js

--- a/_migration/backfill-certificate-legacy-signature-inventory.js
+++ b/_migration/backfill-certificate-legacy-signature-inventory.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 
 import { createRequire } from 'node:module';
-import { readFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
-import { applicationDefault, cert, getApps, initializeApp } from 'firebase-admin/app';
+import { getApps, initializeApp } from 'firebase-admin/app';
 import { getAuth } from 'firebase-admin/auth';
 import { FieldValue, getFirestore } from 'firebase-admin/firestore';
 import { getStorage } from 'firebase-admin/storage';
+import { getMigrationAdminAppOptions } from './firebase-admin-credential.mjs';
 
 const require = createRequire(import.meta.url);
 const {
@@ -21,21 +21,10 @@ const LEGACY_IMAGE_BUCKET = process.env.IMAGE_STORAGE_BUCKET || 'game-flow-img.f
 const MIGRATION_MARKER_PATH = 'systemMigrations/certificateLegacySignatureInventoryV1';
 
 function getAdminAppOptions() {
-    if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
-        return {
-            credential: applicationDefault(),
-            projectId: FIREBASE_PROJECT_ID,
-            storageBucket: LEGACY_IMAGE_BUCKET
-        };
-    }
-    const serviceAccount = JSON.parse(
-        readFileSync(new URL('./serviceAccountKey.json', import.meta.url), 'utf8')
-    );
-    return {
-        credential: cert(serviceAccount),
+    return getMigrationAdminAppOptions({
         projectId: FIREBASE_PROJECT_ID,
         storageBucket: LEGACY_IMAGE_BUCKET
-    };
+    });
 }
 
 async function getAuthorizedUploaderIds(auth, team = {}) {

--- a/_migration/backfill-certificate-legacy-signature-inventory.js
+++ b/_migration/backfill-certificate-legacy-signature-inventory.js
@@ -4,9 +4,12 @@ import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
 import { getApps, initializeApp } from 'firebase-admin/app';
 import { getAuth } from 'firebase-admin/auth';
-import { FieldValue, getFirestore } from 'firebase-admin/firestore';
+import { FieldValue } from 'firebase-admin/firestore';
 import { getStorage } from 'firebase-admin/storage';
-import { getMigrationAdminAppOptions } from './firebase-admin-credential.mjs';
+import {
+    getMigrationAdminAppOptions,
+    getMigrationFirestore
+} from './firebase-admin-credential.mjs';
 
 const require = createRequire(import.meta.url);
 const {
@@ -143,7 +146,7 @@ export async function backfillCertificateLegacySignatureInventory({
 async function main() {
     if (!getApps().length) initializeApp(getAdminAppOptions());
     await backfillCertificateLegacySignatureInventory({
-        db: getFirestore(),
+        db: getMigrationFirestore({ projectId: FIREBASE_PROJECT_ID }),
         auth: getAuth(),
         legacyBucket: getStorage().bucket(LEGACY_IMAGE_BUCKET)
     });

--- a/_migration/backfill-certificate-legacy-signature-inventory.js
+++ b/_migration/backfill-certificate-legacy-signature-inventory.js
@@ -5,10 +5,10 @@ import { pathToFileURL } from 'node:url';
 import { getApps, initializeApp } from 'firebase-admin/app';
 import { getAuth } from 'firebase-admin/auth';
 import { FieldValue } from 'firebase-admin/firestore';
-import { getStorage } from 'firebase-admin/storage';
 import {
     getMigrationAdminAppOptions,
-    getMigrationFirestore
+    getMigrationFirestore,
+    getMigrationStorageBucket
 } from './firebase-admin-credential.mjs';
 
 const require = createRequire(import.meta.url);
@@ -148,7 +148,10 @@ async function main() {
     await backfillCertificateLegacySignatureInventory({
         db: getMigrationFirestore({ projectId: FIREBASE_PROJECT_ID }),
         auth: getAuth(),
-        legacyBucket: getStorage().bucket(LEGACY_IMAGE_BUCKET)
+        legacyBucket: getMigrationStorageBucket({
+            projectId: FIREBASE_PROJECT_ID,
+            bucketName: LEGACY_IMAGE_BUCKET
+        })
     });
 }
 

--- a/_migration/backfill-registration-checkout-attempts.js
+++ b/_migration/backfill-registration-checkout-attempts.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
-import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
-import { applicationDefault, cert, getApps, initializeApp } from 'firebase-admin/app';
+import { getApps, initializeApp } from 'firebase-admin/app';
 import { FieldValue, getFirestore } from 'firebase-admin/firestore';
+import { getMigrationAdminAppOptions } from './firebase-admin-credential.mjs';
 
 const require = createRequire(import.meta.url);
 const {
@@ -17,20 +17,9 @@ const APPLY = process.argv.includes('--apply');
 const FIREBASE_PROJECT_ID = process.env.FIREBASE_PROJECT_ID || 'game-flow-c6311';
 
 function getAdminAppOptions() {
-    if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
-        return {
-            credential: applicationDefault(),
-            projectId: FIREBASE_PROJECT_ID
-        };
-    }
-
-    const serviceAccount = JSON.parse(
-        readFileSync(new URL('./serviceAccountKey.json', import.meta.url), 'utf8')
-    );
-    return {
-        credential: cert(serviceAccount),
+    return getMigrationAdminAppOptions({
         projectId: FIREBASE_PROJECT_ID
-    };
+    });
 }
 
 export async function backfillLegacyRegistrationCheckoutAttempts({

--- a/_migration/backfill-registration-checkout-attempts.js
+++ b/_migration/backfill-registration-checkout-attempts.js
@@ -3,8 +3,11 @@
 import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
 import { getApps, initializeApp } from 'firebase-admin/app';
-import { FieldValue, getFirestore } from 'firebase-admin/firestore';
-import { getMigrationAdminAppOptions } from './firebase-admin-credential.mjs';
+import { FieldValue } from 'firebase-admin/firestore';
+import {
+    getMigrationAdminAppOptions,
+    getMigrationFirestore
+} from './firebase-admin-credential.mjs';
 
 const require = createRequire(import.meta.url);
 const {
@@ -77,7 +80,9 @@ export async function backfillLegacyRegistrationCheckoutAttempts({
 
 async function main() {
     if (!getApps().length) initializeApp(getAdminAppOptions());
-    await backfillLegacyRegistrationCheckoutAttempts({ db: getFirestore() });
+    await backfillLegacyRegistrationCheckoutAttempts({
+        db: getMigrationFirestore({ projectId: FIREBASE_PROJECT_ID })
+    });
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/_migration/backfill-team-fee-checkout-attempts.js
+++ b/_migration/backfill-team-fee-checkout-attempts.js
@@ -3,8 +3,11 @@
 import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
 import { getApps, initializeApp } from 'firebase-admin/app';
-import { FieldValue, getFirestore } from 'firebase-admin/firestore';
-import { getMigrationAdminAppOptions } from './firebase-admin-credential.mjs';
+import { FieldValue } from 'firebase-admin/firestore';
+import {
+    getMigrationAdminAppOptions,
+    getMigrationFirestore
+} from './firebase-admin-credential.mjs';
 
 const require = createRequire(import.meta.url);
 const {
@@ -125,7 +128,9 @@ export async function backfillLegacyTeamFeeCheckoutAttempts({
 
 async function main() {
     if (!getApps().length) initializeApp(getAdminAppOptions());
-    await backfillLegacyTeamFeeCheckoutAttempts({ db: getFirestore() });
+    await backfillLegacyTeamFeeCheckoutAttempts({
+        db: getMigrationFirestore({ projectId: FIREBASE_PROJECT_ID })
+    });
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/_migration/backfill-team-fee-checkout-attempts.js
+++ b/_migration/backfill-team-fee-checkout-attempts.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
-import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
-import { applicationDefault, cert, getApps, initializeApp } from 'firebase-admin/app';
+import { getApps, initializeApp } from 'firebase-admin/app';
 import { FieldValue, getFirestore } from 'firebase-admin/firestore';
+import { getMigrationAdminAppOptions } from './firebase-admin-credential.mjs';
 
 const require = createRequire(import.meta.url);
 const {
@@ -56,20 +56,9 @@ function buildReadableRecipientScrub(recipient, fieldValue) {
 }
 
 function getAdminAppOptions() {
-    if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
-        return {
-            credential: applicationDefault(),
-            projectId: FIREBASE_PROJECT_ID
-        };
-    }
-
-    const serviceAccount = JSON.parse(
-        readFileSync(new URL('./serviceAccountKey.json', import.meta.url), 'utf8')
-    );
-    return {
-        credential: cert(serviceAccount),
+    return getMigrationAdminAppOptions({
         projectId: FIREBASE_PROJECT_ID
-    };
+    });
 }
 
 export async function backfillLegacyTeamFeeCheckoutAttempts({

--- a/_migration/firebase-admin-credential.mjs
+++ b/_migration/firebase-admin-credential.mjs
@@ -1,5 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { applicationDefault, cert } from 'firebase-admin/app';
+import { Firestore, getFirestore } from 'firebase-admin/firestore';
+import { GoogleAuth, OAuth2Client } from 'google-auth-library';
 
 const ACCESS_TOKEN_CACHE_SECONDS = 300;
 
@@ -16,6 +18,26 @@ export function createAccessTokenCredential(accessToken) {
             };
         }
     };
+}
+
+export function getMigrationFirestore({
+    projectId,
+    env = process.env,
+    FirestoreClass = Firestore,
+    GoogleAuthClass = GoogleAuth,
+    OAuth2ClientClass = OAuth2Client,
+    getFirestoreFn = getFirestore
+}) {
+    const accessToken = String(env.GOOGLE_OAUTH_ACCESS_TOKEN || '').trim();
+    if (!accessToken) return getFirestoreFn();
+
+    // Firebase Admin 12.7 rejects custom Credential implementations before
+    // constructing Firestore. Pass the short-lived OIDC token through the
+    // officially supported Google Auth hook on the underlying Firestore client.
+    const authClient = new OAuth2ClientClass();
+    authClient.setCredentials({ access_token: accessToken });
+    const auth = new GoogleAuthClass({ authClient, projectId });
+    return new FirestoreClass({ projectId, auth });
 }
 
 export function getMigrationAdminAppOptions({

--- a/_migration/firebase-admin-credential.mjs
+++ b/_migration/firebase-admin-credential.mjs
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs';
+import { applicationDefault, cert } from 'firebase-admin/app';
+
+const ACCESS_TOKEN_CACHE_SECONDS = 300;
+
+export function createAccessTokenCredential(accessToken) {
+    const normalizedAccessToken = String(accessToken || '').trim();
+    if (!normalizedAccessToken) {
+        throw new Error('GOOGLE_OAUTH_ACCESS_TOKEN must be non-empty.');
+    }
+    return {
+        async getAccessToken() {
+            return {
+                access_token: normalizedAccessToken,
+                expires_in: ACCESS_TOKEN_CACHE_SECONDS
+            };
+        }
+    };
+}
+
+export function getMigrationAdminAppOptions({
+    projectId,
+    storageBucket,
+    env = process.env,
+    serviceAccountUrl = new URL('./serviceAccountKey.json', import.meta.url)
+}) {
+    const options = {
+        projectId,
+        ...(storageBucket ? { storageBucket } : {})
+    };
+    if (env.GOOGLE_OAUTH_ACCESS_TOKEN) {
+        return {
+            ...options,
+            credential: createAccessTokenCredential(env.GOOGLE_OAUTH_ACCESS_TOKEN)
+        };
+    }
+    if (env.GOOGLE_APPLICATION_CREDENTIALS) {
+        return {
+            ...options,
+            credential: applicationDefault()
+        };
+    }
+    const serviceAccount = JSON.parse(readFileSync(serviceAccountUrl, 'utf8'));
+    return {
+        ...options,
+        credential: cert(serviceAccount)
+    };
+}

--- a/_migration/firebase-admin-credential.mjs
+++ b/_migration/firebase-admin-credential.mjs
@@ -1,6 +1,8 @@
 import { readFileSync } from 'node:fs';
+import { Storage as GoogleCloudStorage } from '@google-cloud/storage';
 import { applicationDefault, cert } from 'firebase-admin/app';
 import { Firestore, getFirestore } from 'firebase-admin/firestore';
+import { getStorage } from 'firebase-admin/storage';
 import { GoogleAuth, OAuth2Client } from 'google-auth-library';
 
 const ACCESS_TOKEN_CACHE_SECONDS = 300;
@@ -20,6 +22,15 @@ export function createAccessTokenCredential(accessToken) {
     };
 }
 
+function createMigrationGoogleAuth(accessToken, projectId, {
+    GoogleAuthClass = GoogleAuth,
+    OAuth2ClientClass = OAuth2Client
+} = {}) {
+    const authClient = new OAuth2ClientClass();
+    authClient.setCredentials({ access_token: accessToken });
+    return new GoogleAuthClass({ authClient, projectId });
+}
+
 export function getMigrationFirestore({
     projectId,
     env = process.env,
@@ -34,10 +45,30 @@ export function getMigrationFirestore({
     // Firebase Admin 12.7 rejects custom Credential implementations before
     // constructing Firestore. Pass the short-lived OIDC token through the
     // officially supported Google Auth hook on the underlying Firestore client.
-    const authClient = new OAuth2ClientClass();
-    authClient.setCredentials({ access_token: accessToken });
-    const auth = new GoogleAuthClass({ authClient, projectId });
+    const auth = createMigrationGoogleAuth(accessToken, projectId, {
+        GoogleAuthClass,
+        OAuth2ClientClass
+    });
     return new FirestoreClass({ projectId, auth });
+}
+
+export function getMigrationStorageBucket({
+    projectId,
+    bucketName,
+    env = process.env,
+    StorageClass = GoogleCloudStorage,
+    GoogleAuthClass = GoogleAuth,
+    OAuth2ClientClass = OAuth2Client,
+    getStorageFn = getStorage
+}) {
+    const accessToken = String(env.GOOGLE_OAUTH_ACCESS_TOKEN || '').trim();
+    if (!accessToken) return getStorageFn().bucket(bucketName);
+
+    const authClient = createMigrationGoogleAuth(accessToken, projectId, {
+        GoogleAuthClass,
+        OAuth2ClientClass
+    });
+    return new StorageClass({ projectId, authClient }).bucket(bucketName);
 }
 
 export function getMigrationAdminAppOptions({

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "firebase-admin": "12.7.0",
         "firebase-functions": "5.1.1",
+        "google-auth-library": "9.15.1",
         "resend": "^6.17.2",
         "stripe": "^16.12.0"
       },
@@ -1395,7 +1396,6 @@
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
       "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "allplays-functions",
       "dependencies": {
+        "@google-cloud/storage": "7.21.0",
         "firebase-admin": "12.7.0",
         "firebase-functions": "5.1.1",
         "google-auth-library": "9.15.1",
@@ -163,7 +164,6 @@
       "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.21.0.tgz",
       "integrity": "sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@google-cloud/paginator": "^5.0.0",
         "@google-cloud/projectify": "^4.0.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "firebase-admin": "12.7.0",
     "firebase-functions": "5.1.1",
+    "google-auth-library": "9.15.1",
     "resend": "^6.17.2",
     "stripe": "^16.12.0"
   }

--- a/functions/package.json
+++ b/functions/package.json
@@ -13,6 +13,7 @@
     "test:notifications": "node ../node_modules/vitest/vitest.mjs run test/send-category-notification.test.js test/send-category-notification-load.test.js test/notification-triggers.test.js --environment node"
   },
   "dependencies": {
+    "@google-cloud/storage": "7.21.0",
     "firebase-admin": "12.7.0",
     "firebase-functions": "5.1.1",
     "google-auth-library": "9.15.1",

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -809,6 +809,7 @@ export function validateFirebaseRulesCi() {
     const gameEventsRules = (firestoreRules.match(/match \/events\/\{eventId} \{[\s\S]*?\n\s*}/) || [''])[0];
     const aggregatedStatsRules = (firestoreRules.match(/match \/aggregatedStats\/\{statId} \{[\s\S]*?\n\s*}/) || [''])[0];
     const deployProd = readText('.github/workflows/deploy-prod.yml');
+    const migrationCredential = readText('_migration/firebase-admin-credential.mjs');
     const deployPreviewBuild = readText('.github/workflows/deploy-preview.yml');
     const deployPreviewTrusted = readText('.github/workflows/deploy-preview-trusted.yml');
     const prIntegration = readText('.github/workflows/pr-integration.yml');
@@ -888,6 +889,26 @@ export function validateFirebaseRulesCi() {
     assertIncludes(firestoreRules, 'isNestedChatMessageCreateValid(', 'Nested chat create rules');
 
     validateProductionDeployCommand(deployProd);
+    assertIncludes(
+        deployProd,
+        'cp _migration/firebase-admin-credential.mjs',
+        'Production migration access-token credential handoff'
+    );
+    assertIncludes(
+        deployProd,
+        'test -f "$bundle/_migration/firebase-admin-credential.mjs"',
+        'Production migration credential handoff validation'
+    );
+    assertIncludes(
+        migrationCredential,
+        'if (env.GOOGLE_OAUTH_ACCESS_TOKEN)',
+        'Production migration workload-identity access-token preference'
+    );
+    assertIncludes(
+        migrationCredential,
+        'credential: applicationDefault()',
+        'Production migration local application-default fallback'
+    );
     validateFirebaseDeployWorkloadIdentity(deployProd, 'Production deploy');
     assertMatches(deployProd, /needs:\s*\[\s*unit-tests\s*,\s*regression-guards\s*\]/, 'Production deploy gate');
 

--- a/tests/unit/certificate-defaults-rules.test.js
+++ b/tests/unit/certificate-defaults-rules.test.js
@@ -73,6 +73,10 @@ describe('certificate defaults Firestore rules', () => {
         expect(deployWorkflow).toMatch(
             /retry_firebase_deploy\s+\\\s+"\$retry_enabled_inventory_producer_target"\s+\\\s+"certificate-signature-inventory-producer"\s+\\\s+3\s+\\\s+15\s+\\\s+true/
         );
+        expect(deployWorkflow).toContain('cp _migration/firebase-admin-credential.mjs \\');
+        expect(deployWorkflow).toContain(
+            'test -f "$bundle/_migration/firebase-admin-credential.mjs"'
+        );
         expect(inventoryProducer).toBeLessThan(inventoryBackfill);
         expect(inventoryBackfill).toBeLessThan(compatibilityCleanup);
         expect(compatibilityCleanup).toBeGreaterThan(-1);

--- a/tests/unit/certificate-legacy-signature-inventory-backfill.test.js
+++ b/tests/unit/certificate-legacy-signature-inventory-backfill.test.js
@@ -2,10 +2,13 @@ import { describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { backfillCertificateLegacySignatureInventory } from '../../_migration/backfill-certificate-legacy-signature-inventory.js';
 import { deleteApp, initializeApp } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
 import { getFirestore } from 'firebase-admin/firestore';
+import { getStorage } from 'firebase-admin/storage';
 import {
     getMigrationAdminAppOptions,
-    getMigrationFirestore
+    getMigrationFirestore,
+    getMigrationStorageBucket
 } from '../../_migration/firebase-admin-credential.mjs';
 
 describe('certificate legacy signature inventory backfill', () => {
@@ -31,6 +34,7 @@ describe('certificate legacy signature inventory backfill', () => {
 
         const app = initializeApp(options, `migration-credential-${Date.now()}`);
         try {
+            expect(() => getAuth(app)).not.toThrow();
             expect(() => getFirestore(app)).toThrow(/Failed to initialize Google Cloud Firestore/i);
             const db = getMigrationFirestore({
                 projectId: 'game-flow-c6311',
@@ -38,6 +42,16 @@ describe('certificate legacy signature inventory backfill', () => {
             });
             expect(db).toBeInstanceOf((await import('firebase-admin/firestore')).Firestore);
             expect(db._settings.auth.cachedCredential.credentials.access_token)
+                .toBe('oidc-access-token');
+
+            expect(() => getStorage(app)).toThrow(/Failed to initialize Google Cloud Storage/i);
+            const bucket = getMigrationStorageBucket({
+                projectId: 'game-flow-c6311',
+                bucketName: 'game-flow-img.firebasestorage.app',
+                env: { GOOGLE_OAUTH_ACCESS_TOKEN: 'oidc-access-token' }
+            });
+            expect(bucket.name).toBe('game-flow-img.firebasestorage.app');
+            expect(bucket.storage.authClient.cachedCredential.credentials.access_token)
                 .toBe('oidc-access-token');
         } finally {
             await deleteApp(app);

--- a/tests/unit/certificate-legacy-signature-inventory-backfill.test.js
+++ b/tests/unit/certificate-legacy-signature-inventory-backfill.test.js
@@ -1,7 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { backfillCertificateLegacySignatureInventory } from '../../_migration/backfill-certificate-legacy-signature-inventory.js';
-import { getMigrationAdminAppOptions } from '../../_migration/firebase-admin-credential.mjs';
+import { deleteApp, initializeApp } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+import {
+    getMigrationAdminAppOptions,
+    getMigrationFirestore
+} from '../../_migration/firebase-admin-credential.mjs';
 
 describe('certificate legacy signature inventory backfill', () => {
     it('uses the workload-identity access token instead of parsing its external-account file', async () => {
@@ -23,6 +28,20 @@ describe('certificate legacy signature inventory backfill', () => {
             projectId: 'game-flow-c6311',
             storageBucket: 'game-flow-img.firebasestorage.app'
         });
+
+        const app = initializeApp(options, `migration-credential-${Date.now()}`);
+        try {
+            expect(() => getFirestore(app)).toThrow(/Failed to initialize Google Cloud Firestore/i);
+            const db = getMigrationFirestore({
+                projectId: 'game-flow-c6311',
+                env: { GOOGLE_OAUTH_ACCESS_TOKEN: 'oidc-access-token' }
+            });
+            expect(db).toBeInstanceOf((await import('firebase-admin/firestore')).Firestore);
+            expect(db._settings.auth.cachedCredential.credentials.access_token)
+                .toBe('oidc-access-token');
+        } finally {
+            await deleteApp(app);
+        }
     });
 
     it('routes every automatically deployed Admin SDK backfill through the workload-identity helper', () => {

--- a/tests/unit/certificate-legacy-signature-inventory-backfill.test.js
+++ b/tests/unit/certificate-legacy-signature-inventory-backfill.test.js
@@ -1,7 +1,46 @@
 import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
 import { backfillCertificateLegacySignatureInventory } from '../../_migration/backfill-certificate-legacy-signature-inventory.js';
+import { getMigrationAdminAppOptions } from '../../_migration/firebase-admin-credential.mjs';
 
 describe('certificate legacy signature inventory backfill', () => {
+    it('uses the workload-identity access token instead of parsing its external-account file', async () => {
+        const options = getMigrationAdminAppOptions({
+            projectId: 'game-flow-c6311',
+            storageBucket: 'game-flow-img.firebasestorage.app',
+            env: {
+                GOOGLE_OAUTH_ACCESS_TOKEN: 'oidc-access-token',
+                GOOGLE_APPLICATION_CREDENTIALS: '/tmp/external-account.json'
+            },
+            serviceAccountUrl: new URL('file:///does-not-exist.json')
+        });
+
+        await expect(options.credential.getAccessToken()).resolves.toEqual({
+            access_token: 'oidc-access-token',
+            expires_in: 300
+        });
+        expect(options).toMatchObject({
+            projectId: 'game-flow-c6311',
+            storageBucket: 'game-flow-img.firebasestorage.app'
+        });
+    });
+
+    it('routes every automatically deployed Admin SDK backfill through the workload-identity helper', () => {
+        for (const migrationName of [
+            'backfill-certificate-legacy-signature-inventory.js',
+            'backfill-team-fee-checkout-attempts.js',
+            'backfill-registration-checkout-attempts.js'
+        ]) {
+            const source = readFileSync(
+                new URL(`../../_migration/${migrationName}`, import.meta.url),
+                'utf8'
+            );
+            expect(source).toContain("from './firebase-admin-credential.mjs'");
+            expect(source).toContain('getMigrationAdminAppOptions({');
+            expect(source).not.toContain('credential: applicationDefault()');
+        }
+    });
+
     it('persists an exact team/signer/object binding before marking the migration complete', async () => {
         const legacyPath = 'user-photos/1700000000000_certificate-signature_owner_admin_signature.png';
         const legacyUrl = `https://firebasestorage.googleapis.com/v0/b/game-flow-img.firebasestorage.app/o/${encodeURIComponent(legacyPath)}?alt=media&token=legacy-token`;


### PR DESCRIPTION
## What changed
- Prefer the short-lived OAuth access token issued by GitHub workload identity for Firebase migration scripts.
- Route Firestore through its supported Google Auth hook while retaining the token-backed Admin credential for Auth and Storage.
- Route certificate inventory, team-fee checkout, and registration checkout backfills through one shared helper.
- Stage and validate that helper in the trusted production handoff, and make helper changes retrigger dependent backfills.

## Root cause
Firebase Admin 12.7 rejects both the GitHub Actions external-account credential JSON and arbitrary custom credentials when constructing Firestore. The producer deployment succeeded, then the certificate inventory backfill stopped safely before cleanup, Hosting, and the release marker.

## Verification
- Focused credential, backfill, deploy-sequencing, rules, and workload-identity regression suites passed locally.
- The regression executes the exact Firebase Admin 12.7 invalid-credential path, then proves the supported token-backed Firestore client initializes.
- Production workflow validator, migration syntax checks, lockfile dry-run, and git diff checks passed.