### PR TITLE
Allow cleanup retry policy deployment

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -861,6 +861,7 @@ jobs:
           fi
           transient_pattern='(^|[^[:alnum:]])(429|500|502|503|504)([^[:alnum:]]|$)|HTTP Error:[[:space:]]*409,[[:space:]]*Requested entity already exists|service[[:space:]_-]+unavailable|econnreset|connection[[:space:]_-]+reset|network[[:space:]_-]+reset|etimedout|timed[[:space:]_-]+out|timeout'
           retry_enabled_inventory_producer_target="functions:indexCertificateLegacySignaturesOnDefaultsWrite"
+          retry_enabled_cleanup_compatibility_target="functions:cleanupCertificateSignature"
           retry_enabled_function_targets="functions:indexCertificateLegacySignaturesOnDefaultsWrite,functions:processAccountDeletionRequest,functions:queueParentInviteEmail,functions:syncPublicUserProfileOnUserWrite,functions:syncPublicUserProfilesOnTeamWrite,functions:syncTeamOwnerAccessOnCreate"
 
           if ! jq -e '
@@ -1232,7 +1233,8 @@ jobs:
 
             if [[ "$acknowledge_failure_policy" == "true" ]]; then
               if [[ "$deploy_targets" != "$retry_enabled_function_targets" \
-                && "$deploy_targets" != "$retry_enabled_inventory_producer_target" ]]; then
+                && "$deploy_targets" != "$retry_enabled_inventory_producer_target" \
+                && "$deploy_targets" != "$retry_enabled_cleanup_compatibility_target" ]]; then
                 echo "Refusing --force outside the reviewed retry-enabled function allowlist." >&2
                 return 1
               fi
@@ -1350,10 +1352,11 @@ jobs:
             true
           node "$FIREBASE_PRODUCTION_BUNDLE/_migration/backfill-certificate-legacy-signature-inventory.mjs" --apply
           retry_firebase_deploy \
-            "functions:cleanupCertificateSignature" \
+            "$retry_enabled_cleanup_compatibility_target" \
             "certificate-signature-cleanup-compatibility" \
             3 \
-            15
+            15 \
+            true
           if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then
             # Most authorization changes publish before their callers. Certificate
             # defaults are a compatibility migration: deploy the server writer,

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -300,12 +300,17 @@ export function validateProductionDeployCommand(deployProd) {
     );
     assertIncludes(
         deployProd,
+        'retry_enabled_cleanup_compatibility_target="functions:cleanupCertificateSignature"',
+        'Production retry-enabled cleanup compatibility allowlist'
+    );
+    assertIncludes(
+        deployProd,
         'retry_enabled_function_targets="functions:indexCertificateLegacySignaturesOnDefaultsWrite,functions:processAccountDeletionRequest,functions:queueParentInviteEmail,functions:syncPublicUserProfileOnUserWrite,functions:syncPublicUserProfilesOnTeamWrite,functions:syncTeamOwnerAccessOnCreate"',
         'Production retry-enabled function allowlist'
     );
     assertIncludes(
         deployProd,
-        '&& "$deploy_targets" != "$retry_enabled_inventory_producer_target" ]]; then',
+        '&& "$deploy_targets" != "$retry_enabled_cleanup_compatibility_target" ]]; then',
         'Production force-deploy scoped producer allowlist guard'
     );
     assertIncludes(deployProd, 'deploy_args+=(--force)', 'Production targeted failure-policy acknowledgement');
@@ -318,6 +323,11 @@ export function validateProductionDeployCommand(deployProd) {
         deployProd,
         /retry_firebase_deploy\s+\\?\s*"\$retry_enabled_inventory_producer_target"\s+\\?\s*"certificate-signature-inventory-producer"\s+\\?\s*3\s+\\?\s*15\s+\\?\s*true/,
         'Production retry-enabled inventory producer failure-policy acknowledgement call'
+    );
+    assertMatches(
+        deployProd,
+        /retry_firebase_deploy\s+\\?\s*"\$retry_enabled_cleanup_compatibility_target"\s+\\?\s*"certificate-signature-cleanup-compatibility"\s+\\?\s*3\s+\\?\s*15\s+\\?\s*true/,
+        'Production retry-enabled cleanup compatibility failure-policy acknowledgement call'
     );
     assertIncludes(
         deployProd,

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -310,8 +310,18 @@ export function validateProductionDeployCommand(deployProd) {
     );
     assertIncludes(
         deployProd,
+        'if [[ "$deploy_targets" != "$retry_enabled_function_targets"',
+        'Production force-deploy scoped function-group allowlist guard'
+    );
+    assertIncludes(
+        deployProd,
+        '&& "$deploy_targets" != "$retry_enabled_inventory_producer_target"',
+        'Production force-deploy scoped inventory-producer allowlist guard'
+    );
+    assertIncludes(
+        deployProd,
         '&& "$deploy_targets" != "$retry_enabled_cleanup_compatibility_target" ]]; then',
-        'Production force-deploy scoped producer allowlist guard'
+        'Production force-deploy scoped cleanup allowlist guard'
     );
     assertIncludes(deployProd, 'deploy_args+=(--force)', 'Production targeted failure-policy acknowledgement');
     assertMatches(

--- a/tests/unit/auth-email-resend-routing.test.js
+++ b/tests/unit/auth-email-resend-routing.test.js
@@ -126,7 +126,7 @@ describe('authentication email delivery routing', () => {
         expect(productionSource).toContain('exit "$storage_status"');
         expect(productionSource).toContain('if [[ "$deploy_targets" != "$retry_enabled_function_targets"');
         expect(productionSource).toContain(
-            '&& "$deploy_targets" != "$retry_enabled_inventory_producer_target" ]]; then'
+            '&& "$deploy_targets" != "$retry_enabled_cleanup_compatibility_target" ]]; then'
         );
         expect(productionSource).toContain('deploy_args+=(--force)');
         expect(productionSource).toContain('Refusing --force outside the reviewed retry-enabled function allowlist.');
@@ -135,6 +135,9 @@ describe('authentication email delivery routing', () => {
         );
         expect(productionSource).toContain(
             'retry_enabled_inventory_producer_target="functions:indexCertificateLegacySignaturesOnDefaultsWrite"'
+        );
+        expect(productionSource).toContain(
+            'retry_enabled_cleanup_compatibility_target="functions:cleanupCertificateSignature"'
         );
         expect(productionSource).toContain('"retry-enabled-functions"');
         expect(productionSource.match(/deploy_args\+=\(--force\)/g) ?? []).toHaveLength(1);

--- a/tests/unit/auth-email-resend-routing.test.js
+++ b/tests/unit/auth-email-resend-routing.test.js
@@ -126,6 +126,9 @@ describe('authentication email delivery routing', () => {
         expect(productionSource).toContain('exit "$storage_status"');
         expect(productionSource).toContain('if [[ "$deploy_targets" != "$retry_enabled_function_targets"');
         expect(productionSource).toContain(
+            '&& "$deploy_targets" != "$retry_enabled_inventory_producer_target" \\'
+        );
+        expect(productionSource).toContain(
             '&& "$deploy_targets" != "$retry_enabled_cleanup_compatibility_target" ]]; then'
         );
         expect(productionSource).toContain('deploy_args+=(--force)');

--- a/tests/unit/certificate-defaults-rules.test.js
+++ b/tests/unit/certificate-defaults-rules.test.js
@@ -68,10 +68,16 @@ describe('certificate defaults Firestore rules', () => {
             'retry_enabled_inventory_producer_target="functions:indexCertificateLegacySignaturesOnDefaultsWrite"'
         );
         expect(deployWorkflow).toContain(
-            '&& "$deploy_targets" != "$retry_enabled_inventory_producer_target" ]]; then'
+            'retry_enabled_cleanup_compatibility_target="functions:cleanupCertificateSignature"'
+        );
+        expect(deployWorkflow).toContain(
+            '&& "$deploy_targets" != "$retry_enabled_cleanup_compatibility_target" ]]; then'
         );
         expect(deployWorkflow).toMatch(
             /retry_firebase_deploy\s+\\\s+"\$retry_enabled_inventory_producer_target"\s+\\\s+"certificate-signature-inventory-producer"\s+\\\s+3\s+\\\s+15\s+\\\s+true/
+        );
+        expect(deployWorkflow).toMatch(
+            /retry_firebase_deploy\s+\\\s+"\$retry_enabled_cleanup_compatibility_target"\s+\\\s+"certificate-signature-cleanup-compatibility"\s+\\\s+3\s+\\\s+15\s+\\\s+true/
         );
         expect(deployWorkflow).toContain('cp _migration/firebase-admin-credential.mjs \\');
         expect(deployWorkflow).toContain(

--- a/tests/unit/certificate-defaults-rules.test.js
+++ b/tests/unit/certificate-defaults-rules.test.js
@@ -71,6 +71,9 @@ describe('certificate defaults Firestore rules', () => {
             'retry_enabled_cleanup_compatibility_target="functions:cleanupCertificateSignature"'
         );
         expect(deployWorkflow).toContain(
+            '&& "$deploy_targets" != "$retry_enabled_inventory_producer_target" \\'
+        );
+        expect(deployWorkflow).toContain(
             '&& "$deploy_targets" != "$retry_enabled_cleanup_compatibility_target" ]]; then'
         );
         expect(deployWorkflow).toMatch(

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -223,9 +223,11 @@ concurrency:
               --non-interactive
             )
             retry_enabled_inventory_producer_target="functions:indexCertificateLegacySignaturesOnDefaultsWrite"
+            retry_enabled_cleanup_compatibility_target="functions:cleanupCertificateSignature"
             retry_enabled_function_targets="functions:indexCertificateLegacySignaturesOnDefaultsWrite,functions:processAccountDeletionRequest,functions:queueParentInviteEmail,functions:syncPublicUserProfileOnUserWrite,functions:syncPublicUserProfilesOnTeamWrite,functions:syncTeamOwnerAccessOnCreate"
             if [[ "$deploy_targets" != "$retry_enabled_function_targets"
-              && "$deploy_targets" != "$retry_enabled_inventory_producer_target" ]]; then
+              && "$deploy_targets" != "$retry_enabled_inventory_producer_target"
+              && "$deploy_targets" != "$retry_enabled_cleanup_compatibility_target" ]]; then
               echo "Refusing --force outside the reviewed retry-enabled function allowlist."
             fi
             deploy_args+=(--force)
@@ -284,7 +286,7 @@ concurrency:
           }
           retry_firebase_deploy "functions:indexCertificateLegacySignaturesOnDefaultsWrite" "certificate-signature-inventory-producer" 3 15
           node "$FIREBASE_PRODUCTION_BUNDLE/_migration/backfill-certificate-legacy-signature-inventory.mjs" --apply
-          retry_firebase_deploy "functions:cleanupCertificateSignature" "certificate-signature-cleanup-compatibility" 3 15
+          retry_firebase_deploy "$retry_enabled_cleanup_compatibility_target" "certificate-signature-cleanup-compatibility" 3 15 true
           if [[ "$FIRESTORE_CONFIG_CHANGED" == "true" ]]; then
             if [[ "$native_callable_ready" == "true" && "$CERTIFICATE_DEFAULTS_LOCKDOWN_NEEDED" == "true" ]]; then
               FIRESTORE_CONFIG_CHANGED="true"
@@ -349,6 +351,9 @@ concurrency:
         expect(() => validateProductionDeployCommand(
             validDeployCommand.replace('"retry-enabled-functions" 3 15 true', '"retry-enabled-functions" 3 15')
         )).toThrow('Production retry-enabled function failure-policy acknowledgement call');
+        expect(() => validateProductionDeployCommand(
+            validDeployCommand.replace('"certificate-signature-cleanup-compatibility" 3 15 true', '"certificate-signature-cleanup-compatibility" 3 15')
+        )).toThrow('Production retry-enabled cleanup compatibility failure-policy acknowledgement call');
         expect(() => validateProductionDeployCommand(
             validDeployCommand.replace('              --project game-flow-c6311\n', '')
         )).toThrow('Production Firebase deploy project');

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -352,6 +352,15 @@ concurrency:
             validDeployCommand.replace('"retry-enabled-functions" 3 15 true', '"retry-enabled-functions" 3 15')
         )).toThrow('Production retry-enabled function failure-policy acknowledgement call');
         expect(() => validateProductionDeployCommand(
+            validDeployCommand.replace('if [[ "$deploy_targets" != "$retry_enabled_function_targets"', 'if [[ "disabled" == "true"')
+        )).toThrow('Production force-deploy scoped function-group allowlist guard');
+        expect(() => validateProductionDeployCommand(
+            validDeployCommand.replace('&& "$deploy_targets" != "$retry_enabled_inventory_producer_target"', '&& "disabled" == "true"')
+        )).toThrow('Production force-deploy scoped inventory-producer allowlist guard');
+        expect(() => validateProductionDeployCommand(
+            validDeployCommand.replace('&& "$deploy_targets" != "$retry_enabled_cleanup_compatibility_target" ]]; then', '&& "disabled" == "true" ]]; then')
+        )).toThrow('Production force-deploy scoped cleanup allowlist guard');
+        expect(() => validateProductionDeployCommand(
             validDeployCommand.replace('"certificate-signature-cleanup-compatibility" 3 15 true', '"certificate-signature-cleanup-compatibility" 3 15')
         )).toThrow('Production retry-enabled cleanup compatibility failure-policy acknowledgement call');
         expect(() => validateProductionDeployCommand(


### PR DESCRIPTION
## What changed
- Add only functions:cleanupCertificateSignature to the reviewed production --force allowlist.
- Require the ordered compatibility cleanup deploy to explicitly acknowledge its retry failure policy.
- Extend the deploy validator and focused regression tests so every retry-enabled targeted deploy must opt in and non-allowlisted targets still fail closed.

## Root cause
Production run 30765239373 proved the OIDC migration fix worked: the inventory producer deployed and the certificate inventory backfill processed 2 defaults documents with 0 conflicts. The next ordered cleanup function is retry-enabled, but the prior scoped allowlist covered the inventory producer and the later retry-enabled group only, so Firebase required --force and the workflow stopped before cleanup, Hosting, and the release marker.

## Verification
- 20 focused tests passed; 8 emulator-only cases skipped.
- node scripts/validate-firebase-rules-ci.mjs
- git diff --check