### PR TITLE
Isolate production image upload smoke

### DIFF
--- a/.github/workflows/scheduled-prod-smoke.yml
+++ b/.github/workflows/scheduled-prod-smoke.yml
@@ -49,6 +49,7 @@ jobs:
           tests/smoke/app-admin-core.spec.js
           tests/smoke/app-authenticated-core.spec.js
           tests/smoke/legacy-authenticated-core.spec.js
+          tests/smoke/app-authenticated-image-writes.spec.js
           tests/smoke/app-authenticated-extended.spec.js
           --config=playwright.smoke.config.js
           --project=smoke

--- a/tests/smoke/app-authenticated-extended.spec.js
+++ b/tests/smoke/app-authenticated-extended.spec.js
@@ -13,7 +13,6 @@ import {
     deleteFirestoreDocument,
     deleteFirestoreDocumentsByStringField,
     deleteFirestoreDocumentsByStringFields,
-    deleteSmokeMediaByTitle,
     findFirestoreDocumentsByStringField,
     getFirestoreDocument,
     getFirestoreDocumentPath,
@@ -139,7 +138,6 @@ test('staff smoke writes are deterministic and removed after validation', async 
     const opponentName = `${smokePrefix}-opponent`;
     const chatText = `${smokePrefix}-chat`;
     const editedChatText = `${chatText}-edited`;
-    const mediaName = `${smokePrefix}-media.png`;
     const cleanupTasks = [
         {
             recordType: 'roster-player',
@@ -157,14 +155,6 @@ test('staff smoke writes are deterministic and removed after validation', async 
                 `teams/${config.teamId}/games`,
                 'opponent',
                 opponentName
-            )
-        },
-        {
-            recordType: 'team-media',
-            cleanup: () => deleteSmokeMediaByTitle(
-                staffRestSession,
-                `teams/${config.teamId}/mediaItems`,
-                mediaName
             )
         },
         {
@@ -192,8 +182,9 @@ test('staff smoke writes are deterministic and removed after validation', async 
 
             await openRoute(
                 page,
-                `/schedule?scope=staff&staffTools=1&staffSection=add&teamId=${encodeURIComponent(config.teamId)}`
+                `/schedule?scope=staff&teamId=${encodeURIComponent(config.teamId)}`
             );
+            await page.getByRole('button', { name: /manage schedule/i }).click();
             const createGame = page.locator('section[aria-label="Create game"]');
             await expect(createGame).toBeVisible({ timeout: 25_000 });
             await createGame.getByLabel('Opponent').fill(opponentName);
@@ -261,24 +252,6 @@ test('staff smoke writes are deterministic and removed after validation', async 
             await page.getByRole('button', { name: 'Undo last' }).click();
             await expect(page.getByText(/^Undid /).first()).toBeVisible({ timeout: 20_000 });
 
-            await openRoute(page, `/teams/${encodeURIComponent(config.teamId)}/media`);
-            const photoButton = page.getByRole('button', { name: 'Photo' });
-            await expect(photoButton, 'The smoke team must have an existing writable media album').toBeVisible({ timeout: 25_000 });
-            const photoInput = page.locator('input[type="file"][accept="image/*"]');
-            await photoInput.setInputFiles({
-                name: mediaName,
-                mimeType: 'image/png',
-                buffer: Buffer.from(
-                    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
-                    'base64'
-                )
-            });
-            await expect(page.getByText('Uploaded', { exact: true })).toBeVisible({ timeout: 35_000 });
-            const deleteMedia = page.getByRole('button', { name: `Delete ${mediaName}` });
-            await expect(deleteMedia).toBeVisible({ timeout: 25_000 });
-            page.once('dialog', (dialog) => dialog.accept());
-            await deleteMedia.click();
-            await expect(page.getByText('Media item deleted.')).toBeVisible({ timeout: 25_000 });
         });
 
         await withAuthenticatedPage(parentNotificationSession, async (page) => {

--- a/tests/smoke/app-authenticated-image-writes.spec.js
+++ b/tests/smoke/app-authenticated-image-writes.spec.js
@@ -25,12 +25,13 @@ const extendedEnabled = process.env.SMOKE_EXTENDED_WRITES === '1';
 const runId = String(config.runId || '').replace(/[^A-Za-z0-9_-]/g, '').slice(0, 48);
 const attemptNonce = randomUUID().replace(/-/g, '');
 const smokePrefix = `allplays-smoke-${runId}-${attemptNonce}`;
-const secretValues = [config.staffEmail, config.staffPassword];
+const secretValues = [config.staffEmail, config.staffPassword, config.parentEmail, config.parentPassword];
 
 test.skip(!extendedEnabled, 'SMOKE_EXTENDED_WRITES=1 is required');
 
 let staffSession;
 let staffRestSession;
+let parentRestSession;
 
 test.beforeAll(async ({ browser }) => {
     test.setTimeout(AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS);
@@ -40,12 +41,14 @@ test.beforeAll(async ({ browser }) => {
         SMOKE_TEAM_ID: config.teamId,
         SMOKE_PLAYER_ID: config.playerId,
         SMOKE_STAFF_EMAIL: config.staffEmail,
-        SMOKE_STAFF_PASSWORD: config.staffPassword
+        SMOKE_STAFF_PASSWORD: config.staffPassword,
+        SMOKE_PARENT_EMAIL: config.parentEmail,
+        SMOKE_PARENT_PASSWORD: config.parentPassword
     })) {
         expect(value, `${name} is required for the reversible image suite`).toBeTruthy();
     }
 
-    [staffSession, staffRestSession] = await Promise.all([
+    [staffSession, staffRestSession, parentRestSession] = await Promise.all([
         createAuthenticatedAppSession(browser, {
             appBaseUrl: config.appBaseUrl,
             email: config.staffEmail,
@@ -56,6 +59,11 @@ test.beforeAll(async ({ browser }) => {
             appBaseUrl: config.appBaseUrl,
             email: config.staffEmail,
             password: config.staffPassword
+        }),
+        createFirebaseRestSession({
+            appBaseUrl: config.appBaseUrl,
+            email: config.parentEmail,
+            password: config.parentPassword
         })
     ]);
 });
@@ -77,7 +85,7 @@ async function openRoute(page, route) {
 }
 
 async function restoreImageFieldsIfUnchanged(documentState, fieldNames = Object.keys(documentState.expectedFields)) {
-    const currentDocument = await getFirestoreDocument(staffRestSession, documentState.documentPath);
+    const currentDocument = await getFirestoreDocument(documentState.restSession, documentState.documentPath);
     if (!currentDocument) return;
     const expectedEntries = Object.entries(documentState.expectedFields)
         .filter(([fieldName]) => fieldNames.includes(fieldName));
@@ -88,13 +96,13 @@ async function restoreImageFieldsIfUnchanged(documentState, fieldNames = Object.
     if (!stillOwnsTestValues) return;
 
     await restoreFirestoreDocumentFields(
-        staffRestSession,
+        documentState.restSession,
         documentState.documentPath,
         documentState.originalDocument,
         expectedEntries.map(([fieldName]) => fieldName),
         { updateTime: currentDocument.updateTime }
     );
-    const restoredDocument = await getFirestoreDocument(staffRestSession, documentState.documentPath);
+    const restoredDocument = await getFirestoreDocument(documentState.restSession, documentState.documentPath);
     for (const [fieldName] of expectedEntries) {
         expect(restoredDocument?.fields?.[fieldName]).toEqual(
             documentState.originalDocument?.fields?.[fieldName]
@@ -107,11 +115,11 @@ function isAbandonedSmokeImageValue(value) {
         || String(value || '').startsWith('https://allplays.ai/img/logo_small.png?smoke=');
 }
 
-async function clearAbandonedField(documentPath, fieldName, expectedValue) {
-    const currentDocument = await getFirestoreDocument(staffRestSession, documentPath);
+async function clearAbandonedField(restSession, documentPath, fieldName, expectedValue) {
+    const currentDocument = await getFirestoreDocument(restSession, documentPath);
     if (getFirestoreStringField(currentDocument, fieldName) !== expectedValue) return false;
     await restoreFirestoreDocumentFields(
-        staffRestSession,
+        restSession,
         documentPath,
         { fields: {} },
         [fieldName],
@@ -124,7 +132,7 @@ async function reconcileDedicatedImageFixture(target) {
     const abandonedPaths = [];
 
     for (const documentTarget of target.documents) {
-        const document = await getFirestoreDocument(staffRestSession, documentTarget.documentPath);
+        const document = await getFirestoreDocument(target.restSession, documentTarget.documentPath);
         expect(document, `${target.recordType} fixture document must exist`).toBeTruthy();
         for (const fieldName of Object.keys(documentTarget.expectedFields)) {
             const fieldValue = getFirestoreStringField(document, fieldName);
@@ -139,26 +147,26 @@ async function reconcileDedicatedImageFixture(target) {
 
     for (const documentTarget of target.documents) {
         if (!Object.hasOwn(documentTarget.expectedFields, 'photoUrl')) continue;
-        const document = await getFirestoreDocument(staffRestSession, documentTarget.documentPath);
+        const document = await getFirestoreDocument(target.restSession, documentTarget.documentPath);
         const abandonedUrl = getFirestoreStringField(document, 'photoUrl');
         if (isAbandonedSmokeImageValue(abandonedUrl)) {
-            await clearAbandonedField(documentTarget.documentPath, 'photoUrl', abandonedUrl);
+            await clearAbandonedField(target.restSession, documentTarget.documentPath, 'photoUrl', abandonedUrl);
         }
     }
     for (const abandonedPath of [...new Set(abandonedPaths)]) {
-        await deleteFirebaseStorageObject(staffRestSession, abandonedPath);
+        await deleteFirebaseStorageObject(target.restSession, abandonedPath);
     }
     for (const documentTarget of target.documents) {
         if (!Object.hasOwn(documentTarget.expectedFields, 'photoPath')) continue;
-        const document = await getFirestoreDocument(staffRestSession, documentTarget.documentPath);
+        const document = await getFirestoreDocument(target.restSession, documentTarget.documentPath);
         const abandonedPath = getFirestoreStringField(document, 'photoPath');
         if (isAbandonedSmokeImageValue(abandonedPath)) {
-            await clearAbandonedField(documentTarget.documentPath, 'photoPath', abandonedPath);
+            await clearAbandonedField(target.restSession, documentTarget.documentPath, 'photoPath', abandonedPath);
         }
     }
 
     for (const documentTarget of target.documents) {
-        const document = await getFirestoreDocument(staffRestSession, documentTarget.documentPath);
+        const document = await getFirestoreDocument(target.restSession, documentTarget.documentPath);
         for (const fieldName of Object.keys(documentTarget.expectedFields)) {
             expect(getFirestoreStringField(document, fieldName)).toBe('');
         }
@@ -217,6 +225,7 @@ test('profile image paths accept authenticated storage and document writes', asy
     const targets = [
         {
             recordType: 'own-profile-image',
+            restSession: staffRestSession,
             storagePath: ownProfilePath,
             documents: [{
                 documentPath: `users/${staffRestSession.localId}`,
@@ -228,6 +237,7 @@ test('profile image paths accept authenticated storage and document writes', asy
         },
         {
             recordType: 'linked-player-image',
+            restSession: parentRestSession,
             storagePath: linkedPlayerPath,
             documents: [
                 {
@@ -248,9 +258,9 @@ test('profile image paths accept authenticated storage and document writes', asy
             await reconcileDedicatedImageFixture(target);
             const documentStates = [];
             for (const documentTarget of target.documents) {
-                const originalDocument = await getFirestoreDocument(staffRestSession, documentTarget.documentPath);
+                const originalDocument = await getFirestoreDocument(target.restSession, documentTarget.documentPath);
                 expect(originalDocument, `${target.recordType} fixture document must exist`).toBeTruthy();
-                documentStates.push({ ...documentTarget, originalDocument });
+                documentStates.push({ ...documentTarget, originalDocument, restSession: target.restSession });
             }
             cleanupTasks.push({
                 recordType: target.recordType,
@@ -258,7 +268,7 @@ test('profile image paths accept authenticated storage and document writes', asy
                     for (const documentState of [...documentStates].reverse()) {
                         await restoreImageFieldsIfUnchanged(documentState, ['photoUrl']);
                     }
-                    await deleteFirebaseStorageObject(staffRestSession, target.storagePath);
+                    await deleteFirebaseStorageObject(target.restSession, target.storagePath);
                     for (const documentState of [...documentStates].reverse()) {
                         await restoreImageFieldsIfUnchanged(documentState, ['photoPath']);
                     }
@@ -267,18 +277,18 @@ test('profile image paths accept authenticated storage and document writes', asy
 
             for (const documentState of documentStates) {
                 await patchFirestoreDocumentFields(
-                    staffRestSession,
+                    target.restSession,
                     documentState.documentPath,
                     documentState.expectedFields,
                     { updateTime: documentState.originalDocument.updateTime }
                 );
-                const savedDocument = await getFirestoreDocument(staffRestSession, documentState.documentPath);
+                const savedDocument = await getFirestoreDocument(target.restSession, documentState.documentPath);
                 for (const [fieldName, fieldValue] of Object.entries(documentState.expectedFields)) {
                     expect(getFirestoreStringField(savedDocument, fieldName)).toBe(fieldValue.stringValue);
                 }
             }
             const uploaded = await uploadFirebaseStorageObject(
-                staffRestSession,
+                target.restSession,
                 target.storagePath,
                 png,
                 'image/png'

--- a/tests/smoke/app-authenticated-image-writes.spec.js
+++ b/tests/smoke/app-authenticated-image-writes.spec.js
@@ -176,6 +176,17 @@ async function reconcileDedicatedImageFixture(target) {
         for (const fieldName of Object.keys(documentTarget.expectedFields)) {
             expect(getFirestoreStringField(document, fieldName)).toBe('');
         }
+        if (documentTarget.removeIfCreated) {
+            // This dedicated fixture's canonical private-profile baseline is missing.
+            // Remove only an authoritatively empty document left by an interrupted run.
+            const cleanupSession = documentTarget.cleanupRestSession || target.restSession;
+            const cleanupDocument = await getFirestoreDocument(cleanupSession, documentTarget.documentPath);
+            expect(Object.keys(cleanupDocument?.fields || {})).toEqual([]);
+            await deleteFirestoreDocument(cleanupSession, documentTarget.documentPath, {
+                updateTime: cleanupDocument.updateTime
+            });
+            expect(await getFirestoreDocument(cleanupSession, documentTarget.documentPath)).toBeNull();
+        }
     }
     // Path-only abandoned uploads are retained because their historical Storage
     // generation was not persisted and cannot be proven from current metadata.

--- a/tests/smoke/app-authenticated-image-writes.spec.js
+++ b/tests/smoke/app-authenticated-image-writes.spec.js
@@ -12,6 +12,7 @@ import {
     createFirestoreDocument,
     createFirebaseRestSession,
     deleteFirebaseStorageObject,
+    deleteFirestoreDocument,
     deleteSmokeMediaByTitle,
     getFirestoreDocument,
     getFirestoreStringField,
@@ -105,6 +106,16 @@ async function restoreImageFieldsIfUnchanged(documentState, fieldNames = Object.
         const restoredDocument = await getFirestoreDocument(documentState.restSession, documentState.documentPath);
         expect(getFirestoreStringField(restoredDocument, fieldName)).not.toBe(fieldValue.stringValue);
     }
+    if (!documentState.originalDocument && documentState.removeIfCreated) {
+        const cleanupSession = documentState.cleanupRestSession || documentState.restSession;
+        const createdDocument = await getFirestoreDocument(cleanupSession, documentState.documentPath);
+        if (!createdDocument) return;
+        expect(Object.keys(createdDocument.fields || {})).toEqual([]);
+        await deleteFirestoreDocument(cleanupSession, documentState.documentPath, {
+            updateTime: createdDocument.updateTime
+        });
+        expect(await getFirestoreDocument(cleanupSession, documentState.documentPath)).toBeNull();
+    }
 }
 
 function isAbandonedSmokeImageValue(value) {
@@ -128,8 +139,6 @@ async function clearAbandonedField(restSession, documentPath, fieldName, expecte
 }
 
 async function reconcileDedicatedImageFixture(target) {
-    const abandonedPaths = [];
-
     for (const documentTarget of target.documents) {
         const document = await getFirestoreDocument(target.restSession, documentTarget.documentPath);
         if (!document && documentTarget.allowMissing) continue;
@@ -141,7 +150,6 @@ async function reconcileDedicatedImageFixture(target) {
                 isAbandonedSmokeImageValue(fieldValue),
                 `${target.recordType} is a dedicated smoke fixture and must have an empty ${fieldName} baseline`
             ).toBe(true);
-            if (fieldName === 'photoPath') abandonedPaths.push(fieldValue);
         }
     }
 
@@ -169,9 +177,8 @@ async function reconcileDedicatedImageFixture(target) {
             expect(getFirestoreStringField(document, fieldName)).toBe('');
         }
     }
-    for (const abandonedPath of [...new Set(abandonedPaths)]) {
-        await deleteFirebaseStorageObject(target.restSession, abandonedPath);
-    }
+    // Path-only abandoned uploads are retained because their historical Storage
+    // generation was not persisted and cannot be proven from current metadata.
 }
 
 test('staff image upload is persisted and removed after validation', async () => {
@@ -244,6 +251,8 @@ test('profile image paths accept authenticated storage and document writes', asy
                 {
                     documentPath: `teams/${config.teamId}/players/${config.playerId}/private/profile`,
                     allowMissing: true,
+                    removeIfCreated: true,
+                    cleanupRestSession: staffRestSession,
                     expectedFields: { photoPath: { stringValue: linkedPlayerPath } }
                 },
                 {

--- a/tests/smoke/app-authenticated-image-writes.spec.js
+++ b/tests/smoke/app-authenticated-image-writes.spec.js
@@ -9,6 +9,7 @@ import {
     redactSmokeDiagnostic
 } from './helpers/app-auth.js';
 import {
+    createFirestoreDocument,
     createFirebaseRestSession,
     deleteFirebaseStorageObject,
     deleteSmokeMediaByTitle,
@@ -131,6 +132,7 @@ async function reconcileDedicatedImageFixture(target) {
 
     for (const documentTarget of target.documents) {
         const document = await getFirestoreDocument(target.restSession, documentTarget.documentPath);
+        if (!document && documentTarget.allowMissing) continue;
         expect(document, `${target.recordType} fixture document must exist`).toBeTruthy();
         for (const fieldName of Object.keys(documentTarget.expectedFields)) {
             const fieldValue = getFirestoreStringField(document, fieldName);
@@ -162,6 +164,7 @@ async function reconcileDedicatedImageFixture(target) {
 
     for (const documentTarget of target.documents) {
         const document = await getFirestoreDocument(target.restSession, documentTarget.documentPath);
+        if (!document && documentTarget.allowMissing) continue;
         for (const fieldName of Object.keys(documentTarget.expectedFields)) {
             expect(getFirestoreStringField(document, fieldName)).toBe('');
         }
@@ -240,6 +243,7 @@ test('profile image paths accept authenticated storage and document writes', asy
             documents: [
                 {
                     documentPath: `teams/${config.teamId}/players/${config.playerId}/private/profile`,
+                    allowMissing: true,
                     expectedFields: { photoPath: { stringValue: linkedPlayerPath } }
                 },
                 {
@@ -257,7 +261,9 @@ test('profile image paths accept authenticated storage and document writes', asy
             const documentStates = [];
             for (const documentTarget of target.documents) {
                 const originalDocument = await getFirestoreDocument(target.restSession, documentTarget.documentPath);
-                expect(originalDocument, `${target.recordType} fixture document must exist`).toBeTruthy();
+                if (!documentTarget.allowMissing) {
+                    expect(originalDocument, `${target.recordType} fixture document must exist`).toBeTruthy();
+                }
                 documentStates.push({ ...documentTarget, originalDocument, restSession: target.restSession });
             }
             cleanupTasks.push({
@@ -271,12 +277,20 @@ test('profile image paths accept authenticated storage and document writes', asy
             });
 
             for (const documentState of documentStates) {
-                await patchFirestoreDocumentFields(
-                    target.restSession,
-                    documentState.documentPath,
-                    documentState.expectedFields,
-                    { updateTime: documentState.originalDocument.updateTime }
-                );
+                if (documentState.originalDocument) {
+                    await patchFirestoreDocumentFields(
+                        target.restSession,
+                        documentState.documentPath,
+                        documentState.expectedFields,
+                        { updateTime: documentState.originalDocument.updateTime }
+                    );
+                } else {
+                    await createFirestoreDocument(
+                        target.restSession,
+                        documentState.documentPath,
+                        documentState.expectedFields
+                    );
+                }
                 const savedDocument = await getFirestoreDocument(target.restSession, documentState.documentPath);
                 for (const [fieldName, fieldValue] of Object.entries(documentState.expectedFields)) {
                     expect(getFirestoreStringField(savedDocument, fieldName)).toBe(fieldValue.stringValue);

--- a/tests/smoke/app-authenticated-image-writes.spec.js
+++ b/tests/smoke/app-authenticated-image-writes.spec.js
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';
 import {
     AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS,
@@ -22,7 +23,8 @@ import {
 const config = getAppSmokeConfig();
 const extendedEnabled = process.env.SMOKE_EXTENDED_WRITES === '1';
 const runId = String(config.runId || '').replace(/[^A-Za-z0-9_-]/g, '').slice(0, 48);
-const smokePrefix = `allplays-smoke-${runId}`;
+const attemptNonce = randomUUID().replace(/-/g, '');
+const smokePrefix = `allplays-smoke-${runId}-${attemptNonce}`;
 const secretValues = [config.staffEmail, config.staffPassword];
 
 test.skip(!extendedEnabled, 'SMOKE_EXTENDED_WRITES=1 is required');
@@ -144,8 +146,9 @@ test('profile image paths accept authenticated storage and document writes', asy
     );
     const ownProfilePath = `profile-photos/users/${staffRestSession.localId}/${smokePrefix}-profile.png`;
     const linkedPlayerPath = `profile-photos/teams/${config.teamId}/players/${config.playerId}/${smokePrefix}-player.png`;
-    const ownProfileUrl = `https://firebasestorage.googleapis.com/v0/b/${encodeURIComponent(staffRestSession.storageBucket)}/o/${encodeURIComponent(ownProfilePath)}?alt=media`;
-    const linkedPlayerUrl = `https://firebasestorage.googleapis.com/v0/b/${encodeURIComponent(staffRestSession.storageBucket)}/o/${encodeURIComponent(linkedPlayerPath)}?alt=media`;
+    // Exercise the same photoUrl field authorization without temporarily exposing
+    // the disposable object URL to consumers that persist profile snapshots.
+    const safeDocumentPhotoUrl = `https://allplays.ai/img/logo_small.png?smoke=${attemptNonce}`;
     const targets = [
         {
             recordType: 'own-profile-image',
@@ -154,7 +157,7 @@ test('profile image paths accept authenticated storage and document writes', asy
                 documentPath: `users/${staffRestSession.localId}`,
                 expectedFields: {
                     photoPath: { stringValue: ownProfilePath },
-                    photoUrl: { stringValue: ownProfileUrl }
+                    photoUrl: { stringValue: safeDocumentPhotoUrl }
                 }
             }]
         },
@@ -164,7 +167,7 @@ test('profile image paths accept authenticated storage and document writes', asy
             documents: [
                 {
                     documentPath: `teams/${config.teamId}/players/${config.playerId}`,
-                    expectedFields: { photoUrl: { stringValue: linkedPlayerUrl } }
+                    expectedFields: { photoUrl: { stringValue: safeDocumentPhotoUrl } }
                 },
                 {
                     documentPath: `teams/${config.teamId}/players/${config.playerId}/private/profile`,

--- a/tests/smoke/app-authenticated-image-writes.spec.js
+++ b/tests/smoke/app-authenticated-image-writes.spec.js
@@ -85,28 +85,24 @@ async function openRoute(page, route) {
 }
 
 async function restoreImageFieldsIfUnchanged(documentState, fieldNames = Object.keys(documentState.expectedFields)) {
-    const currentDocument = await getFirestoreDocument(documentState.restSession, documentState.documentPath);
-    if (!currentDocument) return;
     const expectedEntries = Object.entries(documentState.expectedFields)
         .filter(([fieldName]) => fieldNames.includes(fieldName));
     if (!expectedEntries.length) return;
-    const stillOwnsTestValues = expectedEntries.every(
-        ([fieldName, fieldValue]) => getFirestoreStringField(currentDocument, fieldName) === fieldValue.stringValue
-    );
-    if (!stillOwnsTestValues) return;
 
-    await restoreFirestoreDocumentFields(
-        documentState.restSession,
-        documentState.documentPath,
-        documentState.originalDocument,
-        expectedEntries.map(([fieldName]) => fieldName),
-        { updateTime: currentDocument.updateTime }
-    );
-    const restoredDocument = await getFirestoreDocument(documentState.restSession, documentState.documentPath);
-    for (const [fieldName] of expectedEntries) {
-        expect(restoredDocument?.fields?.[fieldName]).toEqual(
-            documentState.originalDocument?.fields?.[fieldName]
-        );
+    for (const [fieldName, fieldValue] of expectedEntries) {
+        const currentDocument = await getFirestoreDocument(documentState.restSession, documentState.documentPath);
+        if (!currentDocument) continue;
+        if (getFirestoreStringField(currentDocument, fieldName) === fieldValue.stringValue) {
+            await restoreFirestoreDocumentFields(
+                documentState.restSession,
+                documentState.documentPath,
+                documentState.originalDocument,
+                [fieldName],
+                { updateTime: currentDocument.updateTime }
+            );
+        }
+        const restoredDocument = await getFirestoreDocument(documentState.restSession, documentState.documentPath);
+        expect(getFirestoreStringField(restoredDocument, fieldName)).not.toBe(fieldValue.stringValue);
     }
 }
 
@@ -125,6 +121,8 @@ async function clearAbandonedField(restSession, documentPath, fieldName, expecte
         [fieldName],
         { updateTime: currentDocument.updateTime }
     );
+    const restoredDocument = await getFirestoreDocument(restSession, documentPath);
+    expect(getFirestoreStringField(restoredDocument, fieldName)).not.toBe(expectedValue);
     return true;
 }
 
@@ -153,9 +151,6 @@ async function reconcileDedicatedImageFixture(target) {
             await clearAbandonedField(target.restSession, documentTarget.documentPath, 'photoUrl', abandonedUrl);
         }
     }
-    for (const abandonedPath of [...new Set(abandonedPaths)]) {
-        await deleteFirebaseStorageObject(target.restSession, abandonedPath);
-    }
     for (const documentTarget of target.documents) {
         if (!Object.hasOwn(documentTarget.expectedFields, 'photoPath')) continue;
         const document = await getFirestoreDocument(target.restSession, documentTarget.documentPath);
@@ -170,6 +165,9 @@ async function reconcileDedicatedImageFixture(target) {
         for (const fieldName of Object.keys(documentTarget.expectedFields)) {
             expect(getFirestoreStringField(document, fieldName)).toBe('');
         }
+    }
+    for (const abandonedPath of [...new Set(abandonedPaths)]) {
+        await deleteFirebaseStorageObject(target.restSession, abandonedPath);
     }
 }
 
@@ -266,12 +264,9 @@ test('profile image paths accept authenticated storage and document writes', asy
                 recordType: target.recordType,
                 cleanup: async () => {
                     for (const documentState of [...documentStates].reverse()) {
-                        await restoreImageFieldsIfUnchanged(documentState, ['photoUrl']);
+                        await restoreImageFieldsIfUnchanged(documentState);
                     }
                     await deleteFirebaseStorageObject(target.restSession, target.storagePath);
-                    for (const documentState of [...documentStates].reverse()) {
-                        await restoreImageFieldsIfUnchanged(documentState, ['photoPath']);
-                    }
                 }
             });
 

--- a/tests/smoke/app-authenticated-image-writes.spec.js
+++ b/tests/smoke/app-authenticated-image-writes.spec.js
@@ -76,10 +76,12 @@ async function openRoute(page, route) {
     await expect.poll(() => new URL(page.url()).hash, { timeout: 20_000 }).toContain(`#${route.split('?')[0]}`);
 }
 
-async function restoreImageFieldsIfUnchanged(documentState) {
+async function restoreImageFieldsIfUnchanged(documentState, fieldNames = Object.keys(documentState.expectedFields)) {
     const currentDocument = await getFirestoreDocument(staffRestSession, documentState.documentPath);
     if (!currentDocument) return;
-    const expectedEntries = Object.entries(documentState.expectedFields);
+    const expectedEntries = Object.entries(documentState.expectedFields)
+        .filter(([fieldName]) => fieldNames.includes(fieldName));
+    if (!expectedEntries.length) return;
     const stillOwnsTestValues = expectedEntries.every(
         ([fieldName, fieldValue]) => getFirestoreStringField(currentDocument, fieldName) === fieldValue.stringValue
     );
@@ -97,6 +99,69 @@ async function restoreImageFieldsIfUnchanged(documentState) {
         expect(restoredDocument?.fields?.[fieldName]).toEqual(
             documentState.originalDocument?.fields?.[fieldName]
         );
+    }
+}
+
+function isAbandonedSmokeImageValue(value) {
+    return String(value || '').includes('allplays-smoke-')
+        || String(value || '').startsWith('https://allplays.ai/img/logo_small.png?smoke=');
+}
+
+async function clearAbandonedField(documentPath, fieldName, expectedValue) {
+    const currentDocument = await getFirestoreDocument(staffRestSession, documentPath);
+    if (getFirestoreStringField(currentDocument, fieldName) !== expectedValue) return false;
+    await restoreFirestoreDocumentFields(
+        staffRestSession,
+        documentPath,
+        { fields: {} },
+        [fieldName],
+        { updateTime: currentDocument.updateTime }
+    );
+    return true;
+}
+
+async function reconcileDedicatedImageFixture(target) {
+    const abandonedPaths = [];
+
+    for (const documentTarget of target.documents) {
+        const document = await getFirestoreDocument(staffRestSession, documentTarget.documentPath);
+        expect(document, `${target.recordType} fixture document must exist`).toBeTruthy();
+        for (const fieldName of Object.keys(documentTarget.expectedFields)) {
+            const fieldValue = getFirestoreStringField(document, fieldName);
+            if (!fieldValue) continue;
+            expect(
+                isAbandonedSmokeImageValue(fieldValue),
+                `${target.recordType} is a dedicated smoke fixture and must have an empty ${fieldName} baseline`
+            ).toBe(true);
+            if (fieldName === 'photoPath') abandonedPaths.push(fieldValue);
+        }
+    }
+
+    for (const documentTarget of target.documents) {
+        if (!Object.hasOwn(documentTarget.expectedFields, 'photoUrl')) continue;
+        const document = await getFirestoreDocument(staffRestSession, documentTarget.documentPath);
+        const abandonedUrl = getFirestoreStringField(document, 'photoUrl');
+        if (isAbandonedSmokeImageValue(abandonedUrl)) {
+            await clearAbandonedField(documentTarget.documentPath, 'photoUrl', abandonedUrl);
+        }
+    }
+    for (const abandonedPath of [...new Set(abandonedPaths)]) {
+        await deleteFirebaseStorageObject(staffRestSession, abandonedPath);
+    }
+    for (const documentTarget of target.documents) {
+        if (!Object.hasOwn(documentTarget.expectedFields, 'photoPath')) continue;
+        const document = await getFirestoreDocument(staffRestSession, documentTarget.documentPath);
+        const abandonedPath = getFirestoreStringField(document, 'photoPath');
+        if (isAbandonedSmokeImageValue(abandonedPath)) {
+            await clearAbandonedField(documentTarget.documentPath, 'photoPath', abandonedPath);
+        }
+    }
+
+    for (const documentTarget of target.documents) {
+        const document = await getFirestoreDocument(staffRestSession, documentTarget.documentPath);
+        for (const fieldName of Object.keys(documentTarget.expectedFields)) {
+            expect(getFirestoreStringField(document, fieldName)).toBe('');
+        }
     }
 }
 
@@ -166,12 +231,12 @@ test('profile image paths accept authenticated storage and document writes', asy
             storagePath: linkedPlayerPath,
             documents: [
                 {
-                    documentPath: `teams/${config.teamId}/players/${config.playerId}`,
-                    expectedFields: { photoUrl: { stringValue: safeDocumentPhotoUrl } }
-                },
-                {
                     documentPath: `teams/${config.teamId}/players/${config.playerId}/private/profile`,
                     expectedFields: { photoPath: { stringValue: linkedPlayerPath } }
+                },
+                {
+                    documentPath: `teams/${config.teamId}/players/${config.playerId}`,
+                    expectedFields: { photoUrl: { stringValue: safeDocumentPhotoUrl } }
                 }
             ]
         }
@@ -180,6 +245,7 @@ test('profile image paths accept authenticated storage and document writes', asy
 
     try {
         for (const target of targets) {
+            await reconcileDedicatedImageFixture(target);
             const documentStates = [];
             for (const documentTarget of target.documents) {
                 const originalDocument = await getFirestoreDocument(staffRestSession, documentTarget.documentPath);
@@ -190,25 +256,15 @@ test('profile image paths accept authenticated storage and document writes', asy
                 recordType: target.recordType,
                 cleanup: async () => {
                     for (const documentState of [...documentStates].reverse()) {
-                        await restoreImageFieldsIfUnchanged(documentState);
-                    }
-                    for (const documentState of documentStates) {
-                        const currentDocument = await getFirestoreDocument(staffRestSession, documentState.documentPath);
-                        for (const [fieldName, fieldValue] of Object.entries(documentState.expectedFields)) {
-                            expect(getFirestoreStringField(currentDocument, fieldName)).not.toBe(fieldValue.stringValue);
-                        }
+                        await restoreImageFieldsIfUnchanged(documentState, ['photoUrl']);
                     }
                     await deleteFirebaseStorageObject(staffRestSession, target.storagePath);
+                    for (const documentState of [...documentStates].reverse()) {
+                        await restoreImageFieldsIfUnchanged(documentState, ['photoPath']);
+                    }
                 }
             });
 
-            const uploaded = await uploadFirebaseStorageObject(
-                staffRestSession,
-                target.storagePath,
-                png,
-                'image/png'
-            );
-            expect(uploaded.name).toBe(target.storagePath);
             for (const documentState of documentStates) {
                 await patchFirestoreDocumentFields(
                     staffRestSession,
@@ -221,6 +277,13 @@ test('profile image paths accept authenticated storage and document writes', asy
                     expect(getFirestoreStringField(savedDocument, fieldName)).toBe(fieldValue.stringValue);
                 }
             }
+            const uploaded = await uploadFirebaseStorageObject(
+                staffRestSession,
+                target.storagePath,
+                png,
+                'image/png'
+            );
+            expect(uploaded.name).toBe(target.storagePath);
         }
     } finally {
         await runSmokeCleanup(runId, cleanupTasks);

--- a/tests/smoke/app-authenticated-image-writes.spec.js
+++ b/tests/smoke/app-authenticated-image-writes.spec.js
@@ -1,0 +1,225 @@
+import { expect, test } from '@playwright/test';
+import {
+    AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS,
+    buildAppSmokeUrl,
+    closeAuthenticatedAppSession,
+    createAuthenticatedAppSession,
+    getAppSmokeConfig,
+    redactSmokeDiagnostic
+} from './helpers/app-auth.js';
+import {
+    createFirebaseRestSession,
+    deleteFirebaseStorageObject,
+    deleteSmokeMediaByTitle,
+    getFirestoreDocument,
+    getFirestoreStringField,
+    patchFirestoreDocumentFields,
+    restoreFirestoreDocumentFields,
+    runSmokeCleanup,
+    uploadFirebaseStorageObject
+} from './helpers/firebase-rest.js';
+
+const config = getAppSmokeConfig();
+const extendedEnabled = process.env.SMOKE_EXTENDED_WRITES === '1';
+const runId = String(config.runId || '').replace(/[^A-Za-z0-9_-]/g, '').slice(0, 48);
+const smokePrefix = `allplays-smoke-${runId}`;
+const secretValues = [config.staffEmail, config.staffPassword];
+
+test.skip(!extendedEnabled, 'SMOKE_EXTENDED_WRITES=1 is required');
+
+let staffSession;
+let staffRestSession;
+
+test.beforeAll(async ({ browser }) => {
+    test.setTimeout(AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS);
+    for (const [name, value] of Object.entries({
+        SMOKE_RUN_ID: runId,
+        SMOKE_APP_BASE_URL: config.appBaseUrl,
+        SMOKE_TEAM_ID: config.teamId,
+        SMOKE_PLAYER_ID: config.playerId,
+        SMOKE_STAFF_EMAIL: config.staffEmail,
+        SMOKE_STAFF_PASSWORD: config.staffPassword
+    })) {
+        expect(value, `${name} is required for the reversible image suite`).toBeTruthy();
+    }
+
+    [staffSession, staffRestSession] = await Promise.all([
+        createAuthenticatedAppSession(browser, {
+            appBaseUrl: config.appBaseUrl,
+            email: config.staffEmail,
+            password: config.staffPassword,
+            roleLabel: 'staff image writes'
+        }),
+        createFirebaseRestSession({
+            appBaseUrl: config.appBaseUrl,
+            email: config.staffEmail,
+            password: config.staffPassword
+        })
+    ]);
+});
+
+test.afterAll(async () => {
+    await closeAuthenticatedAppSession(staffSession);
+});
+
+async function withAuthenticatedPage(callback) {
+    const { page, issues } = staffSession;
+    await callback(page);
+    expect(issues.map((issue) => redactSmokeDiagnostic(issue, secretValues))).toEqual([]);
+}
+
+async function openRoute(page, route) {
+    await page.goto(buildAppSmokeUrl(config.appBaseUrl, route), { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('main')).toBeVisible({ timeout: 25_000 });
+    await expect.poll(() => new URL(page.url()).hash, { timeout: 20_000 }).toContain(`#${route.split('?')[0]}`);
+}
+
+async function restoreImageFieldsIfUnchanged(documentState) {
+    const currentDocument = await getFirestoreDocument(staffRestSession, documentState.documentPath);
+    if (!currentDocument) return;
+    const expectedEntries = Object.entries(documentState.expectedFields);
+    const stillOwnsTestValues = expectedEntries.every(
+        ([fieldName, fieldValue]) => getFirestoreStringField(currentDocument, fieldName) === fieldValue.stringValue
+    );
+    if (!stillOwnsTestValues) return;
+
+    await restoreFirestoreDocumentFields(
+        staffRestSession,
+        documentState.documentPath,
+        documentState.originalDocument,
+        expectedEntries.map(([fieldName]) => fieldName),
+        { updateTime: currentDocument.updateTime }
+    );
+    const restoredDocument = await getFirestoreDocument(staffRestSession, documentState.documentPath);
+    for (const [fieldName] of expectedEntries) {
+        expect(restoredDocument?.fields?.[fieldName]).toEqual(
+            documentState.originalDocument?.fields?.[fieldName]
+        );
+    }
+}
+
+test('staff image upload is persisted and removed after validation', async () => {
+    test.setTimeout(240_000);
+    const mediaName = `${smokePrefix}-media.png`;
+    const cleanupTasks = [{
+        recordType: 'team-media',
+        cleanup: () => deleteSmokeMediaByTitle(
+            staffRestSession,
+            `teams/${config.teamId}/mediaItems`,
+            mediaName
+        )
+    }];
+
+    try {
+        await withAuthenticatedPage(async (page) => {
+            await openRoute(page, `/teams/${encodeURIComponent(config.teamId)}/media`);
+            const photoButton = page.getByRole('button', { name: 'Photo', exact: true });
+            await expect(photoButton, 'The smoke team must have an existing writable media album').toBeVisible({ timeout: 25_000 });
+            const photoInput = page.locator('input[type="file"][accept="image/*"]');
+            await photoInput.setInputFiles({
+                name: mediaName,
+                mimeType: 'image/png',
+                buffer: Buffer.from(
+                    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+                    'base64'
+                )
+            });
+            await expect(page.getByText('Uploaded', { exact: true })).toBeVisible({ timeout: 35_000 });
+            const deleteMedia = page.getByRole('button', { name: `Delete ${mediaName}` });
+            await expect(deleteMedia).toBeVisible({ timeout: 25_000 });
+            page.once('dialog', (dialog) => dialog.accept());
+            await deleteMedia.click();
+            await expect(page.getByText('Media item deleted.')).toBeVisible({ timeout: 25_000 });
+        });
+    } finally {
+        await runSmokeCleanup(runId, cleanupTasks);
+    }
+});
+
+test('profile image paths accept authenticated storage and document writes', async () => {
+    test.setTimeout(120_000);
+    const png = Buffer.from(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+        'base64'
+    );
+    const ownProfilePath = `profile-photos/users/${staffRestSession.localId}/${smokePrefix}-profile.png`;
+    const linkedPlayerPath = `profile-photos/teams/${config.teamId}/players/${config.playerId}/${smokePrefix}-player.png`;
+    const ownProfileUrl = `https://firebasestorage.googleapis.com/v0/b/${encodeURIComponent(staffRestSession.storageBucket)}/o/${encodeURIComponent(ownProfilePath)}?alt=media`;
+    const linkedPlayerUrl = `https://firebasestorage.googleapis.com/v0/b/${encodeURIComponent(staffRestSession.storageBucket)}/o/${encodeURIComponent(linkedPlayerPath)}?alt=media`;
+    const targets = [
+        {
+            recordType: 'own-profile-image',
+            storagePath: ownProfilePath,
+            documents: [{
+                documentPath: `users/${staffRestSession.localId}`,
+                expectedFields: {
+                    photoPath: { stringValue: ownProfilePath },
+                    photoUrl: { stringValue: ownProfileUrl }
+                }
+            }]
+        },
+        {
+            recordType: 'linked-player-image',
+            storagePath: linkedPlayerPath,
+            documents: [
+                {
+                    documentPath: `teams/${config.teamId}/players/${config.playerId}`,
+                    expectedFields: { photoUrl: { stringValue: linkedPlayerUrl } }
+                },
+                {
+                    documentPath: `teams/${config.teamId}/players/${config.playerId}/private/profile`,
+                    expectedFields: { photoPath: { stringValue: linkedPlayerPath } }
+                }
+            ]
+        }
+    ];
+    const cleanupTasks = [];
+
+    try {
+        for (const target of targets) {
+            const documentStates = [];
+            for (const documentTarget of target.documents) {
+                const originalDocument = await getFirestoreDocument(staffRestSession, documentTarget.documentPath);
+                expect(originalDocument, `${target.recordType} fixture document must exist`).toBeTruthy();
+                documentStates.push({ ...documentTarget, originalDocument });
+            }
+            cleanupTasks.push({
+                recordType: target.recordType,
+                cleanup: async () => {
+                    for (const documentState of [...documentStates].reverse()) {
+                        await restoreImageFieldsIfUnchanged(documentState);
+                    }
+                    for (const documentState of documentStates) {
+                        const currentDocument = await getFirestoreDocument(staffRestSession, documentState.documentPath);
+                        for (const [fieldName, fieldValue] of Object.entries(documentState.expectedFields)) {
+                            expect(getFirestoreStringField(currentDocument, fieldName)).not.toBe(fieldValue.stringValue);
+                        }
+                    }
+                    await deleteFirebaseStorageObject(staffRestSession, target.storagePath);
+                }
+            });
+
+            const uploaded = await uploadFirebaseStorageObject(
+                staffRestSession,
+                target.storagePath,
+                png,
+                'image/png'
+            );
+            expect(uploaded.name).toBe(target.storagePath);
+            for (const documentState of documentStates) {
+                await patchFirestoreDocumentFields(
+                    staffRestSession,
+                    documentState.documentPath,
+                    documentState.expectedFields,
+                    { updateTime: documentState.originalDocument.updateTime }
+                );
+                const savedDocument = await getFirestoreDocument(staffRestSession, documentState.documentPath);
+                for (const [fieldName, fieldValue] of Object.entries(documentState.expectedFields)) {
+                    expect(getFirestoreStringField(savedDocument, fieldName)).toBe(fieldValue.stringValue);
+                }
+            }
+        }
+    } finally {
+        await runSmokeCleanup(runId, cleanupTasks);
+    }
+});

--- a/tests/smoke/helpers/firebase-rest.js
+++ b/tests/smoke/helpers/firebase-rest.js
@@ -157,8 +157,13 @@ export function getFirestoreDocumentPath(document) {
     return name.slice(index + marker.length);
 }
 
-export async function deleteFirestoreDocument(session, documentPath) {
-    const url = `${firestoreApiOrigin}/v1/projects/${encodeURIComponent(session.projectId)}/databases/(default)/documents/${encodeDocumentPath(documentPath)}`;
+export async function deleteFirestoreDocument(session, documentPath, { updateTime = '' } = {}) {
+    const url = new URL(
+        `${firestoreApiOrigin}/v1/projects/${encodeURIComponent(session.projectId)}/databases/(default)/documents/${encodeDocumentPath(documentPath)}`
+    );
+    if (updateTime) {
+        url.searchParams.set('currentDocument.updateTime', updateTime);
+    }
     const response = await fetch(url, {
         method: 'DELETE',
         headers: { authorization: `Bearer ${session.idToken}` }

--- a/tests/smoke/helpers/firebase-rest.js
+++ b/tests/smoke/helpers/firebase-rest.js
@@ -210,6 +210,44 @@ export async function patchFirestoreDocumentFields(
     return readJson(response, 'Firestore smoke document patch');
 }
 
+export async function restoreFirestoreDocumentFields(
+    session,
+    documentPath,
+    originalDocument,
+    fieldNames,
+    { updateTime = '' } = {}
+) {
+    const normalizedFieldNames = [...new Set(
+        (fieldNames || []).map((fieldName) => String(fieldName || '').trim()).filter(Boolean)
+    )].sort();
+    if (!normalizedFieldNames.length) {
+        throw new Error('Firestore smoke field restore requires at least one field');
+    }
+    const url = new URL(
+        `${firestoreApiOrigin}/v1/projects/${encodeURIComponent(session.projectId)}/databases/(default)/documents/${encodeDocumentPath(documentPath)}`
+    );
+    normalizedFieldNames.forEach((fieldPath) => url.searchParams.append('updateMask.fieldPaths', fieldPath));
+    if (updateTime) {
+        url.searchParams.set('currentDocument.updateTime', updateTime);
+    }
+    const originalFields = originalDocument?.fields || {};
+    const response = await fetch(url, {
+        method: 'PATCH',
+        headers: {
+            authorization: `Bearer ${session.idToken}`,
+            'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+            fields: Object.fromEntries(
+                normalizedFieldNames
+                    .filter((fieldName) => Object.hasOwn(originalFields, fieldName))
+                    .map((fieldName) => [fieldName, originalFields[fieldName]])
+            )
+        })
+    });
+    return readJson(response, 'Firestore smoke field restore');
+}
+
 export async function createFirestoreDocument(session, documentPath, fields) {
     const url = new URL(
         `${firestoreApiOrigin}/v1/projects/${encodeURIComponent(session.projectId)}/databases/(default)/documents/${encodeDocumentPath(documentPath)}`
@@ -257,7 +295,26 @@ export async function deleteFirestoreDocumentsByStringFields(session, collection
     return documents.length;
 }
 
-async function deleteFirebaseStorageObject(session, storagePath) {
+export async function uploadFirebaseStorageObject(session, storagePath, body, contentType = 'image/png') {
+    if (!storagePath) throw new Error('Firebase smoke storage upload requires a path');
+    if (!session.storageBucket) throw new Error('Firebase smoke storage bucket is unavailable');
+    const url = new URL(
+        `${firebaseStorageOrigin}/v0/b/${encodeURIComponent(session.storageBucket)}/o`
+    );
+    url.searchParams.set('uploadType', 'media');
+    url.searchParams.set('name', storagePath);
+    const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+            authorization: `Bearer ${session.idToken}`,
+            'content-type': contentType
+        },
+        body
+    });
+    return readJson(response, 'Firebase smoke storage upload');
+}
+
+export async function deleteFirebaseStorageObject(session, storagePath) {
     if (!storagePath) return;
     if (!session.storageBucket) throw new Error('Firebase smoke storage bucket is unavailable');
     const url = `${firebaseStorageOrigin}/v0/b/${encodeURIComponent(session.storageBucket)}/o/${encodeURIComponent(storagePath)}`;

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -488,6 +488,9 @@ describe('preview deployment workflow trust boundary', () => {
         expect(profileImageWorkflow).toContain('createFirestoreDocument(');
         expect(imageWriteProductionSmoke).toContain('deleteFirestoreDocument(');
         expect(imageWriteProductionSmoke).toContain('Object.keys(createdDocument.fields || {})');
+        expect(reconciliationWorkflow).toContain("canonical private-profile baseline is missing");
+        expect(reconciliationWorkflow).toContain('Object.keys(cleanupDocument?.fields || {})');
+        expect(reconciliationWorkflow).toContain('updateTime: cleanupDocument.updateTime');
         expect(reconciliationWorkflow).not.toContain('deleteFirebaseStorageObject(');
         expect(profileImageWorkflow).toContain('restoreImageFieldsIfUnchanged(');
         expect(profileImageWorkflow).toContain('await reconcileDedicatedImageFixture(target)');

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -37,6 +37,10 @@ const extendedProductionSmoke = fs.readFileSync(
     path.join(repoRoot, 'tests', 'smoke', 'app-authenticated-extended.spec.js'),
     'utf8'
 );
+const imageWriteProductionSmoke = fs.readFileSync(
+    path.join(repoRoot, 'tests', 'smoke', 'app-authenticated-image-writes.spec.js'),
+    'utf8'
+);
 const trustBoundaryRunbook = fs.readFileSync(
     path.join(repoRoot, 'docs', 'preview-deploy-trust-boundary.md'),
     'utf8'
@@ -433,6 +437,51 @@ describe('preview deployment workflow trust boundary', () => {
         const cleanupCall = staffWorkflow.indexOf('await runSmokeCleanup(runId, cleanupTasks)');
         expect(notificationAssertion).toBeGreaterThanOrEqual(0);
         expect(cleanupCall).toBeGreaterThan(notificationAssertion);
+    });
+
+    it('keeps production image writes isolated and always schedules cleanup', () => {
+        const staffWorkflowStart = extendedProductionSmoke.indexOf(
+            "test('staff smoke writes are deterministic and removed after validation'"
+        );
+        const imageWorkflowStart = imageWriteProductionSmoke.indexOf(
+            "test('staff image upload is persisted and removed after validation'"
+        );
+        const profileImageWorkflowStart = imageWriteProductionSmoke.indexOf(
+            "test('profile image paths accept authenticated storage and document writes'"
+        );
+        const parentWorkflowStart = extendedProductionSmoke.indexOf(
+            "test('parent smoke writes restore or remove every touched record'"
+        );
+        const staffWorkflow = extendedProductionSmoke.slice(staffWorkflowStart, parentWorkflowStart);
+        const imageWorkflow = imageWriteProductionSmoke.slice(imageWorkflowStart, profileImageWorkflowStart);
+        const profileImageWorkflow = imageWriteProductionSmoke.slice(profileImageWorkflowStart);
+
+        expect(staffWorkflowStart).toBeGreaterThanOrEqual(0);
+        expect(parentWorkflowStart).toBeGreaterThan(staffWorkflowStart);
+        expect(imageWorkflowStart).toBeGreaterThanOrEqual(0);
+        expect(profileImageWorkflowStart).toBeGreaterThan(imageWorkflowStart);
+        expect(staffWorkflow).toContain("getByRole('button', { name: /manage schedule/i }).click()");
+        expect(staffWorkflow).not.toContain('input[type="file"][accept="image/*"]');
+        expect(imageWriteProductionSmoke).not.toContain("test.describe.configure({ mode: 'serial' })");
+        expect(scheduledProdSmokeWorkflow).toContain('tests/smoke/app-authenticated-image-writes.spec.js');
+        expect(imageWorkflow).toContain("recordType: 'team-media'");
+        expect(imageWorkflow).toContain('input[type="file"][accept="image/*"]');
+        expect(imageWorkflow).toContain("getByText('Uploaded', { exact: true })");
+        expect(imageWorkflow).toContain("getByText('Media item deleted.')");
+        expect(imageWorkflow).toContain('await runSmokeCleanup(runId, cleanupTasks)');
+        expect(profileImageWorkflow).toContain('profile-photos/users/${staffRestSession.localId}/');
+        expect(profileImageWorkflow).toContain('profile-photos/teams/${config.teamId}/players/${config.playerId}/');
+        expect(profileImageWorkflow).toContain('players/${config.playerId}/private/profile');
+        expect(profileImageWorkflow).toContain('uploadFirebaseStorageObject(');
+        expect(profileImageWorkflow).toContain('patchFirestoreDocumentFields(');
+        expect(profileImageWorkflow).toContain('restoreImageFieldsIfUnchanged(');
+        expect(imageWriteProductionSmoke).toContain('restoreFirestoreDocumentFields(');
+        expect(imageWriteProductionSmoke).toContain('{ updateTime: currentDocument.updateTime }');
+        expect(profileImageWorkflow).toContain('deleteFirebaseStorageObject(');
+        expect(profileImageWorkflow.indexOf('restoreImageFieldsIfUnchanged(')).toBeLessThan(
+            profileImageWorkflow.indexOf('deleteFirebaseStorageObject(')
+        );
+        expect(profileImageWorkflow).toContain('await runSmokeCleanup(runId, cleanupTasks)');
     });
 
     it('documents the keyless credential and exact-head operational contract', () => {

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -474,10 +474,12 @@ describe('preview deployment workflow trust boundary', () => {
         expect(imageWriteProductionSmoke).toContain("import { randomUUID } from 'node:crypto';");
         expect(imageWriteProductionSmoke).toContain("const attemptNonce = randomUUID().replace(/-/g, '');");
         expect(profileImageWorkflow).toContain('players/${config.playerId}/private/profile');
+        expect(profileImageWorkflow).toContain('allowMissing: true');
         expect(profileImageWorkflow).toContain('restSession: parentRestSession');
         expect(imageWriteProductionSmoke).toContain('SMOKE_PARENT_EMAIL: config.parentEmail');
         expect(profileImageWorkflow).toContain('uploadFirebaseStorageObject(');
         expect(profileImageWorkflow).toContain('patchFirestoreDocumentFields(');
+        expect(profileImageWorkflow).toContain('createFirestoreDocument(');
         expect(profileImageWorkflow).toContain('restoreImageFieldsIfUnchanged(');
         expect(profileImageWorkflow).toContain('await reconcileDedicatedImageFixture(target)');
         expect(imageWriteProductionSmoke).toContain('isAbandonedSmokeImageValue');

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -471,6 +471,8 @@ describe('preview deployment workflow trust boundary', () => {
         expect(imageWorkflow).toContain('await runSmokeCleanup(runId, cleanupTasks)');
         expect(profileImageWorkflow).toContain('profile-photos/users/${staffRestSession.localId}/');
         expect(profileImageWorkflow).toContain('profile-photos/teams/${config.teamId}/players/${config.playerId}/');
+        expect(imageWriteProductionSmoke).toContain("import { randomUUID } from 'node:crypto';");
+        expect(imageWriteProductionSmoke).toContain("const attemptNonce = randomUUID().replace(/-/g, '');");
         expect(profileImageWorkflow).toContain('players/${config.playerId}/private/profile');
         expect(profileImageWorkflow).toContain('uploadFirebaseStorageObject(');
         expect(profileImageWorkflow).toContain('patchFirestoreDocumentFields(');
@@ -481,6 +483,11 @@ describe('preview deployment workflow trust boundary', () => {
         expect(profileImageWorkflow.indexOf('restoreImageFieldsIfUnchanged(')).toBeLessThan(
             profileImageWorkflow.indexOf('deleteFirebaseStorageObject(')
         );
+        expect(profileImageWorkflow).toContain(
+            'const safeDocumentPhotoUrl = `https://allplays.ai/img/logo_small.png?smoke=${attemptNonce}`;'
+        );
+        expect(profileImageWorkflow).not.toContain('firebasestorage.googleapis.com');
+        expect(profileImageWorkflow).toContain('photoUrl: { stringValue: safeDocumentPhotoUrl }');
         expect(profileImageWorkflow).toContain('await runSmokeCleanup(runId, cleanupTasks)');
     });
 

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -474,6 +474,8 @@ describe('preview deployment workflow trust boundary', () => {
         expect(imageWriteProductionSmoke).toContain("import { randomUUID } from 'node:crypto';");
         expect(imageWriteProductionSmoke).toContain("const attemptNonce = randomUUID().replace(/-/g, '');");
         expect(profileImageWorkflow).toContain('players/${config.playerId}/private/profile');
+        expect(profileImageWorkflow).toContain('restSession: parentRestSession');
+        expect(imageWriteProductionSmoke).toContain('SMOKE_PARENT_EMAIL: config.parentEmail');
         expect(profileImageWorkflow).toContain('uploadFirebaseStorageObject(');
         expect(profileImageWorkflow).toContain('patchFirestoreDocumentFields(');
         expect(profileImageWorkflow).toContain('restoreImageFieldsIfUnchanged(');

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -477,11 +477,17 @@ describe('preview deployment workflow trust boundary', () => {
         expect(profileImageWorkflow).toContain('uploadFirebaseStorageObject(');
         expect(profileImageWorkflow).toContain('patchFirestoreDocumentFields(');
         expect(profileImageWorkflow).toContain('restoreImageFieldsIfUnchanged(');
+        expect(profileImageWorkflow).toContain('await reconcileDedicatedImageFixture(target)');
+        expect(imageWriteProductionSmoke).toContain('isAbandonedSmokeImageValue');
+        expect(imageWriteProductionSmoke).toContain('must have an empty ${fieldName} baseline');
         expect(imageWriteProductionSmoke).toContain('restoreFirestoreDocumentFields(');
         expect(imageWriteProductionSmoke).toContain('{ updateTime: currentDocument.updateTime }');
         expect(profileImageWorkflow).toContain('deleteFirebaseStorageObject(');
-        expect(profileImageWorkflow.indexOf('restoreImageFieldsIfUnchanged(')).toBeLessThan(
-            profileImageWorkflow.indexOf('deleteFirebaseStorageObject(')
+        expect(profileImageWorkflow.indexOf('patchFirestoreDocumentFields(')).toBeLessThan(
+            profileImageWorkflow.indexOf('uploadFirebaseStorageObject(')
+        );
+        expect(profileImageWorkflow).toMatch(
+            /restoreImageFieldsIfUnchanged\(documentState, \['photoUrl'\]\)[\s\S]*deleteFirebaseStorageObject\([\s\S]*restoreImageFieldsIfUnchanged\(documentState, \['photoPath'\]\)/
         );
         expect(profileImageWorkflow).toContain(
             'const safeDocumentPhotoUrl = `https://allplays.ai/img/logo_small.png?smoke=${attemptNonce}`;'

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -488,9 +488,12 @@ describe('preview deployment workflow trust boundary', () => {
         expect(profileImageWorkflow.indexOf('patchFirestoreDocumentFields(')).toBeLessThan(
             profileImageWorkflow.indexOf('uploadFirebaseStorageObject(')
         );
-        expect(profileImageWorkflow).toMatch(
-            /restoreImageFieldsIfUnchanged\(documentState, \['photoUrl'\]\)[\s\S]*deleteFirebaseStorageObject\([\s\S]*restoreImageFieldsIfUnchanged\(documentState, \['photoPath'\]\)/
+        expect(profileImageWorkflow.indexOf('restoreImageFieldsIfUnchanged(documentState)')).toBeLessThan(
+            profileImageWorkflow.indexOf('deleteFirebaseStorageObject(')
         );
+        expect(profileImageWorkflow.slice(
+            profileImageWorkflow.indexOf('deleteFirebaseStorageObject(')
+        )).not.toContain('restoreImageFieldsIfUnchanged(documentState)');
         expect(profileImageWorkflow).toContain(
             'const safeDocumentPhotoUrl = `https://allplays.ai/img/logo_small.png?smoke=${attemptNonce}`;'
         );

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -455,6 +455,10 @@ describe('preview deployment workflow trust boundary', () => {
         const staffWorkflow = extendedProductionSmoke.slice(staffWorkflowStart, parentWorkflowStart);
         const imageWorkflow = imageWriteProductionSmoke.slice(imageWorkflowStart, profileImageWorkflowStart);
         const profileImageWorkflow = imageWriteProductionSmoke.slice(profileImageWorkflowStart);
+        const reconciliationWorkflow = imageWriteProductionSmoke.slice(
+            imageWriteProductionSmoke.indexOf('async function reconcileDedicatedImageFixture'),
+            imageWorkflowStart
+        );
 
         expect(staffWorkflowStart).toBeGreaterThanOrEqual(0);
         expect(parentWorkflowStart).toBeGreaterThan(staffWorkflowStart);
@@ -475,11 +479,16 @@ describe('preview deployment workflow trust boundary', () => {
         expect(imageWriteProductionSmoke).toContain("const attemptNonce = randomUUID().replace(/-/g, '');");
         expect(profileImageWorkflow).toContain('players/${config.playerId}/private/profile');
         expect(profileImageWorkflow).toContain('allowMissing: true');
+        expect(profileImageWorkflow).toContain('removeIfCreated: true');
+        expect(profileImageWorkflow).toContain('cleanupRestSession: staffRestSession');
         expect(profileImageWorkflow).toContain('restSession: parentRestSession');
         expect(imageWriteProductionSmoke).toContain('SMOKE_PARENT_EMAIL: config.parentEmail');
         expect(profileImageWorkflow).toContain('uploadFirebaseStorageObject(');
         expect(profileImageWorkflow).toContain('patchFirestoreDocumentFields(');
         expect(profileImageWorkflow).toContain('createFirestoreDocument(');
+        expect(imageWriteProductionSmoke).toContain('deleteFirestoreDocument(');
+        expect(imageWriteProductionSmoke).toContain('Object.keys(createdDocument.fields || {})');
+        expect(reconciliationWorkflow).not.toContain('deleteFirebaseStorageObject(');
         expect(profileImageWorkflow).toContain('restoreImageFieldsIfUnchanged(');
         expect(profileImageWorkflow).toContain('await reconcileDedicatedImageFixture(target)');
         expect(imageWriteProductionSmoke).toContain('isAbandonedSmokeImageValue');

--- a/tests/unit/production-smoke-auth-setup-timeout.test.js
+++ b/tests/unit/production-smoke-auth-setup-timeout.test.js
@@ -5,13 +5,14 @@ const helper = readFileSync('tests/smoke/helpers/app-auth.js', 'utf8');
 const authenticatedCore = readFileSync('tests/smoke/app-authenticated-core.spec.js', 'utf8');
 const adminCore = readFileSync('tests/smoke/app-admin-core.spec.js', 'utf8');
 const authenticatedExtended = readFileSync('tests/smoke/app-authenticated-extended.spec.js', 'utf8');
+const authenticatedImageWrites = readFileSync('tests/smoke/app-authenticated-image-writes.spec.js', 'utf8');
 const legacyAuthenticatedCore = readFileSync('tests/smoke/legacy-authenticated-core.spec.js', 'utf8');
 
 describe('production smoke authenticated setup timeout', () => {
     it('uses an explicit bounded setup budget for every credentialed role suite', () => {
         expect(helper).toContain('export const AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS = 240_000;');
 
-        for (const source of [authenticatedCore, adminCore, authenticatedExtended, legacyAuthenticatedCore]) {
+        for (const source of [authenticatedCore, adminCore, authenticatedExtended, authenticatedImageWrites, legacyAuthenticatedCore]) {
             expect(source).toContain('AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS');
             expect(source).toMatch(
                 /test\.beforeAll\(async \(\{ browser \}\) => \{\s+test\.setTimeout\(AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS\);/

--- a/tests/unit/production-smoke-official-fixture.test.js
+++ b/tests/unit/production-smoke-official-fixture.test.js
@@ -9,6 +9,7 @@ import {
 } from '../../scripts/maintain-production-smoke-official-fixture.mjs';
 import {
     createFirebaseRestSession,
+    deleteFirestoreDocument,
     patchFirestoreDocumentFields,
     restoreFirestoreDocumentFields
 } from '../smoke/helpers/firebase-rest.js';
@@ -225,6 +226,31 @@ describe('production officials smoke fixture maintenance', () => {
             fields: {
                 photoUrl: { stringValue: 'https://example.test/original.png' }
             }
+        });
+    });
+
+    it('deletes a smoke-created document only at the verified update time', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+            ok: true,
+            status: 200
+        });
+
+        await deleteFirestoreDocument(
+            {
+                projectId: 'smoke-project',
+                idToken: 'redacted-token'
+            },
+            'teams/allplays-smoke-team-v1/players/allplays-smoke-player-v1/private/profile',
+            { updateTime: '2026-08-02T22:00:00.000Z' }
+        );
+
+        const [requestUrl, request] = fetchMock.mock.calls[0];
+        expect(new URL(requestUrl).searchParams.get('currentDocument.updateTime')).toBe(
+            '2026-08-02T22:00:00.000Z'
+        );
+        expect(request).toMatchObject({
+            method: 'DELETE',
+            headers: { authorization: 'Bearer redacted-token' }
         });
     });
 

--- a/tests/unit/production-smoke-official-fixture.test.js
+++ b/tests/unit/production-smoke-official-fixture.test.js
@@ -9,7 +9,8 @@ import {
 } from '../../scripts/maintain-production-smoke-official-fixture.mjs';
 import {
     createFirebaseRestSession,
-    patchFirestoreDocumentFields
+    patchFirestoreDocumentFields,
+    restoreFirestoreDocumentFields
 } from '../smoke/helpers/firebase-rest.js';
 
 const workflowSource = readFileSync('.github/workflows/production-smoke-fixture.yml', 'utf8');
@@ -190,6 +191,39 @@ describe('production officials smoke fixture maintenance', () => {
             fields: {
                 officiatingSlots: { arrayValue: { values: [] } },
                 officiatingSelfAssignmentEnabled: { booleanValue: true }
+            }
+        });
+    });
+
+    it('restores only named image fields and deletes fields absent from the original snapshot', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+            ok: true,
+            json: vi.fn().mockResolvedValue({ fields: {} })
+        });
+
+        await restoreFirestoreDocumentFields(
+            {
+                projectId: 'smoke-project',
+                idToken: 'redacted-token'
+            },
+            'users/smoke-user',
+            {
+                fields: {
+                    photoUrl: { stringValue: 'https://example.test/original.png' },
+                    fullName: { stringValue: 'Concurrent edits must survive' }
+                }
+            },
+            ['photoUrl', 'photoPath'],
+            { updateTime: '2026-08-02T20:00:00.000Z' }
+        );
+
+        const [requestUrl, request] = fetchMock.mock.calls[0];
+        const url = new URL(requestUrl);
+        expect(url.searchParams.getAll('updateMask.fieldPaths')).toEqual(['photoPath', 'photoUrl']);
+        expect(url.searchParams.get('currentDocument.updateTime')).toBe('2026-08-02T20:00:00.000Z');
+        expect(JSON.parse(request.body)).toEqual({
+            fields: {
+                photoUrl: { stringValue: 'https://example.test/original.png' }
             }
         });
     });


### PR DESCRIPTION
## What changed
- Open the schedule manager through its current explicit UI control instead of retired query parameters.
- Run production image writes in a dedicated non-serial spec so unrelated staff-write failures cannot skip them.
- Add reversible live production checks for team media plus authenticated own-profile and linked-player Storage/document paths.
- Restore only the image fields the smoke changed, with optimistic concurrency, and delete test objects only after no document references them.

## Root cause
The extended production smoke embedded media validation after schedule, chat, and tracker writes. Its stale schedule deep link no longer opened the management panel, so the test failed before reaching image upload. It also had no live check for the profile-document save stage that produced the reported permission error.

## Validation
- `npx vitest run tests/unit/preview-deploy-trust-boundary.test.js tests/unit/production-smoke-auth-setup-timeout.test.js tests/unit/production-smoke-official-fixture.test.js --reporter=verbose` — 44 passed.
- `npx playwright test tests/smoke/app-authenticated-image-writes.spec.js tests/smoke/app-authenticated-extended.spec.js --list` — five tests across two independent specs.
- Node syntax checks for both production specs and the Firebase REST helper.
- `git diff --check`

After merge, temporarily enable `SMOKE_EXTENDED_WRITES_ENABLED=1`, dispatch the scheduled production smoke, verify the media and profile-image tests pass, then restore the variable to `0`.