### PR TITLE
Fix production smoke reconciliation

### DIFF
--- a/tests/smoke/app-authenticated-extended.spec.js
+++ b/tests/smoke/app-authenticated-extended.spec.js
@@ -184,7 +184,12 @@ test('staff smoke writes are deterministic and removed after validation', async 
                 page,
                 `/schedule?scope=staff&teamId=${encodeURIComponent(config.teamId)}`
             );
-            await page.getByRole('button', { name: /manage schedule/i }).click();
+            const scheduleTools = page.locator('section[aria-label="Manage schedule tools"]');
+            await expect(scheduleTools).toBeVisible({ timeout: 25_000 });
+            const manageSchedule = scheduleTools.locator('button[aria-controls]').first();
+            await expect(manageSchedule).toBeVisible({ timeout: 25_000 });
+            await manageSchedule.click({ timeout: 25_000 });
+            await expect(manageSchedule).toHaveAttribute('aria-expanded', 'true', { timeout: 25_000 });
             const createGame = page.locator('section[aria-label="Create game"]');
             await expect(createGame).toBeVisible({ timeout: 25_000 });
             await createGame.getByLabel('Opponent').fill(opponentName);

--- a/tests/smoke/app-authenticated-image-writes.spec.js
+++ b/tests/smoke/app-authenticated-image-writes.spec.js
@@ -16,6 +16,7 @@ import {
     deleteSmokeMediaByTitle,
     getFirestoreDocument,
     getFirestoreStringField,
+    isEmptyFirestoreDocument,
     patchFirestoreDocumentFields,
     restoreFirestoreDocumentFields,
     runSmokeCleanup,
@@ -177,11 +178,12 @@ async function reconcileDedicatedImageFixture(target) {
             expect(getFirestoreStringField(document, fieldName)).toBe('');
         }
         if (documentTarget.removeIfCreated) {
-            // This dedicated fixture's canonical private-profile baseline is missing.
-            // Remove only an authoritatively empty document left by an interrupted run.
+            // An interrupted image smoke can leave an empty private-profile shell after
+            // its abandoned image field is cleared. Existing fixture metadata is a real
+            // baseline and must survive reconciliation.
             const cleanupSession = documentTarget.cleanupRestSession || target.restSession;
             const cleanupDocument = await getFirestoreDocument(cleanupSession, documentTarget.documentPath);
-            expect(Object.keys(cleanupDocument?.fields || {})).toEqual([]);
+            if (!isEmptyFirestoreDocument(cleanupDocument)) continue;
             await deleteFirestoreDocument(cleanupSession, documentTarget.documentPath, {
                 updateTime: cleanupDocument.updateTime
             });

--- a/tests/smoke/helpers/firebase-rest.js
+++ b/tests/smoke/helpers/firebase-rest.js
@@ -95,6 +95,10 @@ export function getFirestoreStringField(document, fieldName) {
     return String(document?.fields?.[fieldName]?.stringValue || '');
 }
 
+export function isEmptyFirestoreDocument(document) {
+    return Boolean(document) && Object.keys(document.fields || {}).length === 0;
+}
+
 function buildStructuredQuery(collectionPath, fields) {
     const segments = String(collectionPath || '').split('/').filter(Boolean);
     const collectionId = segments.pop();

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -464,7 +464,10 @@ describe('preview deployment workflow trust boundary', () => {
         expect(parentWorkflowStart).toBeGreaterThan(staffWorkflowStart);
         expect(imageWorkflowStart).toBeGreaterThanOrEqual(0);
         expect(profileImageWorkflowStart).toBeGreaterThan(imageWorkflowStart);
-        expect(staffWorkflow).toContain("getByRole('button', { name: /manage schedule/i }).click()");
+        expect(staffWorkflow).toContain('section[aria-label="Manage schedule tools"]');
+        expect(staffWorkflow).toContain("locator('button[aria-controls]').first()");
+        expect(staffWorkflow).toContain('manageSchedule.click({ timeout: 25_000 })');
+        expect(staffWorkflow).toContain("toHaveAttribute('aria-expanded', 'true'");
         expect(staffWorkflow).not.toContain('input[type="file"][accept="image/*"]');
         expect(imageWriteProductionSmoke).not.toContain("test.describe.configure({ mode: 'serial' })");
         expect(scheduledProdSmokeWorkflow).toContain('tests/smoke/app-authenticated-image-writes.spec.js');
@@ -488,8 +491,8 @@ describe('preview deployment workflow trust boundary', () => {
         expect(profileImageWorkflow).toContain('createFirestoreDocument(');
         expect(imageWriteProductionSmoke).toContain('deleteFirestoreDocument(');
         expect(imageWriteProductionSmoke).toContain('Object.keys(createdDocument.fields || {})');
-        expect(reconciliationWorkflow).toContain("canonical private-profile baseline is missing");
-        expect(reconciliationWorkflow).toContain('Object.keys(cleanupDocument?.fields || {})');
+        expect(reconciliationWorkflow).toContain('Existing fixture metadata is a real');
+        expect(reconciliationWorkflow).toContain('isEmptyFirestoreDocument(cleanupDocument)');
         expect(reconciliationWorkflow).toContain('updateTime: cleanupDocument.updateTime');
         expect(reconciliationWorkflow).not.toContain('deleteFirebaseStorageObject(');
         expect(profileImageWorkflow).toContain('restoreImageFieldsIfUnchanged(');

--- a/tests/unit/production-smoke-official-fixture.test.js
+++ b/tests/unit/production-smoke-official-fixture.test.js
@@ -10,6 +10,7 @@ import {
 import {
     createFirebaseRestSession,
     deleteFirestoreDocument,
+    isEmptyFirestoreDocument,
     patchFirestoreDocumentFields,
     restoreFirestoreDocumentFields
 } from '../smoke/helpers/firebase-rest.js';
@@ -252,6 +253,17 @@ describe('production officials smoke fixture maintenance', () => {
             method: 'DELETE',
             headers: { authorization: 'Bearer redacted-token' }
         });
+    });
+
+    it('distinguishes an empty interrupted image document from a metadata-bearing fixture', () => {
+        expect(isEmptyFirestoreDocument({ fields: {} })).toBe(true);
+        expect(isEmptyFirestoreDocument({
+            fields: {
+                smokeOwned: { booleanValue: true },
+                parentUserId: { stringValue: 'smoke-parent' }
+            }
+        })).toBe(false);
+        expect(isEmptyFirestoreDocument(null)).toBe(false);
     });
 
     it('loads canonical-host Firebase configuration from the AllPlays runtime fallback', async () => {


### PR DESCRIPTION
## What changed

- Preserve metadata-bearing private player profile fixtures during abandoned-image reconciliation.
- Delete only authoritatively empty private-profile shells left by interrupted image smoke runs.
- Scope the schedule-management toggle to the visible staff tools section and bound every interaction.
- Add regression coverage for empty versus metadata-bearing Firestore documents and the scoped schedule flow.

## Root cause

The production profile-image smoke assumed the dedicated player private-profile document had a missing baseline and tried to delete it after clearing image fields. The live fixture legitimately contained ownership/link metadata, so the preflight failed before exercising the linked-parent image write. Separately, the schedule smoke used a broad unbounded role locator, allowing a missing or wrong toggle target to consume the entire five-minute test budget.

## User impact

This makes production validation accurately exercise own-profile, linked-player, and team-media image uploads without deleting fixture metadata, and makes schedule failures fast and actionable.

## Validation

- `node --check` on the three changed smoke helpers/specs
- Focused Vitest: 46/46 passed
- Full unit suite: 739 files passed, 5,608 tests passed, 154 expected skips
- `git diff --check`

## Production evidence

- Deploy run `30771757573` succeeded for latest master containing the original image rules fix.
- Post-deploy smoke `30772339719` succeeded.
- Extended run `30772378036` proved the team-media upload path passed and exposed these two smoke-harness defects; the write switch was reset to `0`.