### PR TITLE
Improve app loading, profile navigation, and imported RSVPs

### DIFF
--- a/apps/app/src/components/PublicTeamSearch.tsx
+++ b/apps/app/src/components/PublicTeamSearch.tsx
@@ -13,7 +13,17 @@ function publicTeamRequestKey(searchText?: string | null) {
   return trimmedSearchText ? `search:${trimmedSearchText}` : 'browse';
 }
 
-export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = false }: { autoBrowseOnMount?: boolean; showBackLink?: boolean }) {
+export function PublicTeamSearch({
+  autoBrowseOnMount = false,
+  showBackLink = false,
+  showRosterCounts = true,
+  pageSize = 24
+}: {
+  autoBrowseOnMount?: boolean;
+  showBackLink?: boolean;
+  showRosterCounts?: boolean;
+  pageSize?: number;
+}) {
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [publicTeams, setPublicTeams] = useState<ParentHomeTeam[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
@@ -56,18 +66,25 @@ export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = fal
     }
     setHasSearched(true);
     try {
-      const result = await getPublicTeamsPage({ searchText: submittedSearchText, cursor, includeRosterCounts: false });
+      const result = await getPublicTeamsPage({
+        searchText: submittedSearchText,
+        cursor,
+        includeRosterCounts: false,
+        ...(pageSize === 24 ? {} : { pageSize })
+      });
       if (requestId !== latestRequestIdRef.current) {
         return;
       }
       const discoveredTeamIds = new Set(result.teams.map((team) => team.teamId));
-      setRosterCountsLoading((current) => append
-        ? new Set([...current, ...discoveredTeamIds])
-        : discoveredTeamIds);
+      if (showRosterCounts) {
+        setRosterCountsLoading((current) => append
+          ? new Set([...current, ...discoveredTeamIds])
+          : discoveredTeamIds);
+      }
       setPublicTeams((current) => append ? [...current, ...result.teams] : result.teams);
       setNextCursor(result.nextCursor);
       setActiveSearchQuery(submittedSearchText || null);
-      void hydratePublicTeamRosterCounts(result.teams)
+      if (showRosterCounts) void hydratePublicTeamRosterCounts(result.teams)
         .then((hydratedTeams) => {
           if (rosterHydrationGeneration !== rosterHydrationGenerationRef.current) {
             return;
@@ -109,7 +126,7 @@ export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = fal
         setPendingRequestKey(null);
       }
     }
-  }, []);
+  }, [pageSize, showRosterCounts]);
 
   const handleSearch = () => {
     const trimmedQuery = searchQuery.trim();
@@ -261,7 +278,7 @@ export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = fal
               <h3 className="text-lg font-black text-gray-950">{location}</h3>
               <div className="grid gap-2 sm:grid-cols-2">
                 {teams.map(team => (
-                  <PublicTeamCard key={team.teamId} team={team} rosterCountLoading={rosterCountsLoading.has(team.teamId)} />
+                  <PublicTeamCard key={team.teamId} team={team} rosterCountLoading={rosterCountsLoading.has(team.teamId)} showRosterCount={showRosterCounts} />
                 ))}
               </div>
             </div>
@@ -310,7 +327,7 @@ export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = fal
   );
 }
 
-function PublicTeamCard({ team, rosterCountLoading }: { team: ParentHomeTeam; rosterCountLoading: boolean }) {
+function PublicTeamCard({ team, rosterCountLoading, showRosterCount }: { team: ParentHomeTeam; rosterCountLoading: boolean; showRosterCount: boolean }) {
   const hasRosterCount = typeof team.publicRosterCount === 'number';
   const rosterCountLabel = rosterCountLoading
     ? 'Loading roster count'
@@ -325,9 +342,9 @@ function PublicTeamCard({ team, rosterCountLoading }: { team: ParentHomeTeam; ro
         <span className="min-w-0 flex-1">
           <span className="truncate text-sm font-black text-gray-950">{team.teamName}</span>
           <span className="mt-0.5 block truncate text-xs font-semibold text-gray-500">{team.location || 'Location Unknown'}</span>
-          <span className="mt-1 flex min-w-0 flex-wrap gap-1.5">
+          {showRosterCount ? <span className="mt-1 flex min-w-0 flex-wrap gap-1.5">
             <TeamLauncherChip label={rosterCountLabel} />
-          </span>
+          </span> : null}
         </span>
       </div>
 

--- a/apps/app/src/components/schedule/AvailabilityPanels.tsx
+++ b/apps/app/src/components/schedule/AvailabilityPanels.tsx
@@ -31,7 +31,9 @@ function getReadOnlyAvailabilityMessage(event: ParentScheduleEvent) {
     return 'This event was cancelled, so availability can no longer be changed.';
   }
   if (!event.isDbGame) {
-    return 'This event is not tracked in the team schedule, so availability is unavailable.';
+    return event.isImported && event.sourceType === 'calendar'
+      ? 'RSVP is not enabled for this imported event.'
+      : 'This event is not tracked in the team schedule, so availability is unavailable.';
   }
   if (event.availabilityLocked) {
     const cutoffLabel = String(event.availabilityCutoffLabel || '').trim().toLowerCase();
@@ -48,13 +50,14 @@ export function ReadOnlyAvailabilityPanel({ event, rsvp }: {
 }) {
   const savedNote = String(event.myRsvpNote || '').trim();
   const responseLabel = rsvp === 'not_responded' ? 'No response recorded' : rsvpLabels[rsvp];
+  const isCalendarOnly = !event.isDbGame && event.isImported && event.sourceType === 'calendar';
 
   return (
     <div className="border-b border-gray-200 bg-gray-50 px-3 py-3 sm:px-4">
       <div className="flex items-start gap-2.5 sm:gap-3">
         <PlayerInitials name={event.childName} />
         <div className="min-w-0 flex-1">
-          <div className="text-[11px] font-black uppercase tracking-[0.06em] text-gray-500">Availability unavailable</div>
+          <div className="text-[11px] font-black uppercase tracking-[0.06em] text-gray-500">{isCalendarOnly ? 'Calendar-only event' : 'Availability unavailable'}</div>
           <div className="mt-1 text-sm font-semibold leading-5 text-gray-700">{getReadOnlyAvailabilityMessage(event)}</div>
           <div className="mt-3 flex flex-wrap items-center justify-between gap-2 rounded-xl border border-gray-200 bg-white px-3 py-2">
             <span className="text-xs font-bold text-gray-600">Current response for {event.childName}</span>

--- a/apps/app/src/lib/calendarOccurrence.test.ts
+++ b/apps/app/src/lib/calendarOccurrence.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { getCalendarOccurrenceTrackingId, isCalendarOccurrenceTracked } from './calendarOccurrence';
+
+describe('calendar occurrence provenance', () => {
+  it('combines a reused source ID with the normalized occurrence start', () => {
+    expect(getCalendarOccurrenceTrackingId('calendar-uid-1', new Date('2026-06-04T18:00:00Z')))
+      .toBe('calendar-uid-1__2026-06-04T18:00:00.000Z');
+  });
+
+  it('does not append the start twice when the parser already supplied an occurrence ID', () => {
+    const occurrenceId = 'calendar-uid-1__2026-06-04T18:00:00.000Z';
+    expect(getCalendarOccurrenceTrackingId(occurrenceId, '2026-06-04T18:00:00Z')).toBe(occurrenceId);
+  });
+
+  it('matches only the materialized occurrence when later occurrences reuse the source ID', () => {
+    const tracked = ['calendar-uid-1__2026-06-04T18:00:00.000Z'];
+
+    expect(isCalendarOccurrenceTracked('calendar-uid-1', '2026-06-04T18:00:00Z', tracked)).toBe(true);
+    expect(isCalendarOccurrenceTracked('calendar-uid-1', '2026-06-11T18:00:00Z', tracked)).toBe(false);
+  });
+});

--- a/apps/app/src/lib/calendarOccurrence.ts
+++ b/apps/app/src/lib/calendarOccurrence.ts
@@ -1,0 +1,29 @@
+function normalizeOccurrenceDate(value: unknown) {
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+  if (typeof (value as any)?.toDate === 'function') {
+    const date = (value as any).toDate();
+    return date instanceof Date && !Number.isNaN(date.getTime()) ? date : null;
+  }
+  if (!value) return null;
+  const date = new Date(value as any);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function getCalendarOccurrenceTrackingId(sourceId: unknown, startsAt: unknown) {
+  const normalizedSourceId = String(sourceId || '').trim();
+  const normalizedStartsAt = normalizeOccurrenceDate(startsAt);
+  if (!normalizedSourceId || !normalizedStartsAt) return '';
+  const occurrenceSuffix = `__${normalizedStartsAt.toISOString()}`;
+  return normalizedSourceId.endsWith(occurrenceSuffix)
+    ? normalizedSourceId
+    : `${normalizedSourceId}${occurrenceSuffix}`;
+}
+
+export function isCalendarOccurrenceTracked(sourceId: unknown, startsAt: unknown, trackedIds: unknown[] | Set<unknown>) {
+  const occurrenceId = getCalendarOccurrenceTrackingId(sourceId, startsAt);
+  if (!occurrenceId) return false;
+  const normalizedTrackedIds = trackedIds instanceof Set
+    ? trackedIds
+    : new Set(Array.isArray(trackedIds) ? trackedIds : []);
+  return normalizedTrackedIds.has(occurrenceId);
+}

--- a/apps/app/src/lib/familyShareViewerService.ts
+++ b/apps/app/src/lib/familyShareViewerService.ts
@@ -8,6 +8,7 @@ import {
   isPracticeEvent,
   isTrackedCalendarEvent
 } from './adapters/legacyScheduleHelpers';
+import { isCalendarOccurrenceTracked } from './calendarOccurrence';
 import { getCalendarLocationDetail } from './scheduleLogic';
 
 export type FamilyShareTokenErrorReason = 'missing' | 'invalid' | 'revoked' | 'expired' | 'load-failed';
@@ -362,7 +363,10 @@ async function buildTeamFamilyEvents(
   if (calendarUrls.length) {
     const calendarResults = await Promise.all(calendarUrls.map((calendarUrl) => loadCalendar(calendarUrl, teamName, calendarWarnings)));
     calendarResults.flat().forEach((calendarEvent) => {
-      if (isTrackedCalendarEvent(calendarEvent, trackedUids)) return;
+      if (
+        isCalendarOccurrenceTracked(getCalendarEventTrackingId(calendarEvent), calendarEvent.dtstart, trackedUids)
+        || isTrackedCalendarEvent(calendarEvent, trackedUids)
+      ) return;
       const eventDate = toDate(calendarEvent.dtstart);
       if (!eventDate) return;
       if (dbTimestamps.some((timestamp) => Math.abs(timestamp - eventDate.getTime()) < 60000)) return;

--- a/apps/app/src/lib/scheduleLogic.test.ts
+++ b/apps/app/src/lib/scheduleLogic.test.ts
@@ -1,13 +1,35 @@
 import { describe, expect, it } from 'vitest';
 import {
+  canSubmitScheduleEventRsvp,
   countOpenScheduleAssignments,
   getCalendarScheduleEntries,
   getManageableScheduleTeamOptions,
+  getScheduleEventRsvpCapability,
   getWindowedCalendarScheduleEntries,
   getWindowedPracticePacketRows,
+  isScheduleEventAvailabilityNeeded,
   type ParentScheduleEvent,
   type ParentScheduleTeamOption
 } from './scheduleLogic';
+
+describe('schedule RSVP capability', () => {
+  it.each([
+    ['tracked game', buildParentScheduleEvent(), 'editable', true],
+    ['tracked practice', buildParentScheduleEvent({ type: 'practice' }), 'editable', true],
+    ['calendar-only import', buildParentScheduleEvent({ isDbGame: false, isImported: true, sourceType: 'calendar' }), 'calendar_only', false],
+    ['non-calendar import', buildParentScheduleEvent({ isDbGame: false, isImported: true, sourceType: 'registration' }), 'untracked', false],
+    ['locked event', buildParentScheduleEvent({ availabilityLocked: true }), 'locked', false],
+    ['cancelled event', buildParentScheduleEvent({ isCancelled: true }), 'cancelled', false]
+  ])('derives %s consistently', (_label, event, capability, canSubmit) => {
+    expect(getScheduleEventRsvpCapability(event)).toBe(capability);
+    expect(canSubmitScheduleEventRsvp(event)).toBe(canSubmit);
+    expect(isScheduleEventAvailabilityNeeded(event)).toBe(canSubmit);
+  });
+
+  it('does not mark a saved tracked response as needed', () => {
+    expect(isScheduleEventAvailabilityNeeded(buildParentScheduleEvent({ myRsvp: 'going' }))).toBe(false);
+  });
+});
 
 function buildParentScheduleEvent(overrides: Partial<ParentScheduleEvent> = {}): ParentScheduleEvent {
   const assignments = Array.isArray(overrides.assignments) ? overrides.assignments : [];

--- a/apps/app/src/lib/scheduleLogic.ts
+++ b/apps/app/src/lib/scheduleLogic.ts
@@ -453,8 +453,23 @@ export function normalizeRsvpResponse(response: unknown): RsvpResponse {
   return 'not_responded';
 }
 
-export function canSubmitScheduleEventRsvp(event: Pick<ParentScheduleEvent, 'isDbGame' | 'isCancelled' | 'availabilityLocked'>) {
-  return Boolean(event.isDbGame && !event.isCancelled && !event.availabilityLocked);
+export type ScheduleEventRsvpCapability = 'editable' | 'calendar_only' | 'locked' | 'cancelled' | 'untracked';
+
+export function getScheduleEventRsvpCapability(event: Pick<ParentScheduleEvent, 'isDbGame' | 'isCancelled' | 'availabilityLocked' | 'isImported' | 'sourceType'>): ScheduleEventRsvpCapability {
+  if (event.isCancelled) return 'cancelled';
+  if (!event.isDbGame) {
+    return event.isImported && event.sourceType === 'calendar' ? 'calendar_only' : 'untracked';
+  }
+  if (event.availabilityLocked) return 'locked';
+  return 'editable';
+}
+
+export function canSubmitScheduleEventRsvp(event: Pick<ParentScheduleEvent, 'isDbGame' | 'isCancelled' | 'availabilityLocked' | 'isImported' | 'sourceType'>) {
+  return getScheduleEventRsvpCapability(event) === 'editable';
+}
+
+export function isScheduleEventAvailabilityNeeded(event: Pick<ParentScheduleEvent, 'isDbGame' | 'isCancelled' | 'availabilityLocked' | 'isImported' | 'sourceType' | 'myRsvp'>) {
+  return canSubmitScheduleEventRsvp(event) && normalizeRsvpResponse(event.myRsvp) === 'not_responded';
 }
 
 function compactString(value: unknown) {

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -226,7 +226,7 @@ import { getCachedAppData, invalidateCachedAppData, loadCachedAppData } from './
 import { mapScheduleEventRecord } from './firestore/mappers';
 import { loadProfileDocument } from './profileService';
 import { getScheduleTournamentInfo } from './scheduleLogic';
-import { adjustGameScore, buildPlayerScoringLiveEvent, buildSingleGameTournamentLegacySchedulePayload, cancelScheduledGameForApp, claimOfficialAssignmentItem, createScheduledGameForApp, createScheduledPracticeForApp, createScheduledTournamentBlockForApp, createStaffRsvpAvailabilityLoader, flushPendingLivePublishOperations, hydrateParentScheduleDetails, hydrateParentScheduleEventOptionalDetails, hydrateParentScheduleRsvps, loadHomeScoringPlayers, loadOfficialAssignments, loadParentSchedule, loadParentScheduleAssignments, loadParentScheduleChildren, loadParentScheduleEventDetail, loadParentScheduleRideOffers, loadParentScheduleScope, loadScheduledPracticeSeriesForEdit, loadStaffPracticeAttendance, loadStaffScheduleRsvpBreakdown, publishLiveScoreUpdateEvent, recordPlayerGameStat, recordPlayerScoringStat, releaseParentScheduleAssignmentClaim, resolveCachedParentScheduleEvents, resolveLiveGameClockSnapshot, resolveParentGameRoute, respondToOfficialAssignmentItem, revertScheduledPracticeOccurrenceForApp, saveScheduledGameLineupDraftForApp, saveStaffPracticeAttendance, submitParentScheduleRsvp, submitParentScheduleRsvpForChildren, submitStaffScheduleRsvpOverride, TournamentBlockPartialSaveError, undoRecordedPlayerGameStat, updateLiveGameClockState, updateScheduledPracticeForApp } from './scheduleService';
+import { adjustGameScore, buildPlayerScoringLiveEvent, buildSingleGameTournamentLegacySchedulePayload, cancelScheduledGameForApp, claimOfficialAssignmentItem, createScheduledGameForApp, createScheduledPracticeForApp, createScheduledTournamentBlockForApp, createStaffRsvpAvailabilityLoader, enableRsvpForImportedCalendarEvent, flushPendingLivePublishOperations, hydrateParentScheduleDetails, hydrateParentScheduleEventOptionalDetails, hydrateParentScheduleRsvps, loadHomeScoringPlayers, loadOfficialAssignments, loadParentSchedule, loadParentScheduleAssignments, loadParentScheduleChildren, loadParentScheduleEventDetail, loadParentScheduleRideOffers, loadParentScheduleScope, loadScheduledPracticeSeriesForEdit, loadStaffPracticeAttendance, loadStaffScheduleRsvpBreakdown, publishLiveScoreUpdateEvent, recordPlayerGameStat, recordPlayerScoringStat, releaseParentScheduleAssignmentClaim, resolveCachedParentScheduleEvents, resolveLiveGameClockSnapshot, resolveParentGameRoute, respondToOfficialAssignmentItem, revertScheduledPracticeOccurrenceForApp, saveScheduledGameLineupDraftForApp, saveStaffPracticeAttendance, submitParentScheduleRsvp, submitParentScheduleRsvpForChildren, submitStaffScheduleRsvpOverride, TournamentBlockPartialSaveError, undoRecordedPlayerGameStat, updateLiveGameClockState, updateScheduledPracticeForApp } from './scheduleService';
 
 function playerSnapshot(id: string, data: Record<string, unknown> | null) {
   return {
@@ -4550,6 +4550,93 @@ describe('resolveCachedParentScheduleEvents (#2649)', () => {
   it('returns empty on a cache miss', () => {
     vi.mocked(getCachedAppData).mockReturnValue(null);
     expect(resolveCachedParentScheduleEvents('u1', 't1', 'e1')).toEqual([]);
+  });
+});
+
+describe('enableRsvpForImportedCalendarEvent', () => {
+  const user = { uid: 'coach-1', displayName: 'Coach', email: 'coach@example.com', roles: ['coach'] } as any;
+  const calendarEvent = {
+    eventKey: 'team-1::calendar-uid-1::player-1::2026-06-04T18:00:00.000Z::game',
+    id: 'calendar-uid-1',
+    teamId: 'team-1',
+    teamName: 'Bears',
+    type: 'game',
+    date: new Date('2026-06-04T18:00:00.000Z'),
+    endDate: new Date('2026-06-04T20:00:00.000Z'),
+    location: 'Main Gym',
+    opponent: 'Wolves',
+    title: null,
+    childId: 'player-1',
+    childName: 'Avery',
+    isDbGame: false,
+    isCancelled: false,
+    isImported: true,
+    sourceType: 'calendar',
+    sourceLabel: 'Imported calendar',
+    assignments: []
+  } as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getTeam).mockResolvedValue({ id: 'team-1', name: 'Bears', ownerId: 'coach-1', active: true } as any);
+    mocks.transactionGet.mockReset();
+    mocks.transactionSet.mockReset();
+  });
+
+  it.each([
+    ['game', calendarEvent, { type: 'game', opponent: 'Wolves', title: null }],
+    ['practice', { ...calendarEvent, type: 'practice', opponent: null, title: 'Skills practice' }, { type: 'practice', opponent: null, title: 'Skills practice' }]
+  ])('materializes an imported calendar %s with stable provenance and idempotency', async (_label, event, expectedPayload) => {
+    mocks.transactionGet.mockResolvedValueOnce({ exists: () => false });
+
+    const firstId = await enableRsvpForImportedCalendarEvent(event as any, user);
+    const firstWrite = mocks.transactionSet.mock.calls[0]?.[1] as any;
+
+    expect(firstId).toMatch(/^calendar_[a-f0-9]{64}$/);
+    expect(mocks.transactionSet).toHaveBeenCalledWith(
+      expect.objectContaining({ path: `teams/team-1/games/${firstId}` }),
+      expect.objectContaining({
+        ...expectedPayload,
+        calendarEventUid: 'calendar-uid-1',
+        source: 'calendar',
+        sourceMetadata: {
+          sourceType: 'calendar',
+          sourceLabel: 'Imported calendar'
+        },
+        importBatch: expect.objectContaining({
+          rowNumber: 1,
+          totalCount: 1,
+          actionId: expect.stringMatching(/^calendar-materialize:/)
+        }),
+        createdBy: 'coach-1'
+      })
+    );
+
+    mocks.transactionGet.mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ importBatch: firstWrite.importBatch })
+    });
+    const retryId = await enableRsvpForImportedCalendarEvent(event as any, user);
+
+    expect(retryId).toBe(firstId);
+    expect(mocks.transactionSet).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed before writing when the caller cannot manage the team', async () => {
+    vi.mocked(getTeam).mockResolvedValue({ id: 'team-1', name: 'Bears', ownerId: 'another-user', active: true } as any);
+
+    await expect(enableRsvpForImportedCalendarEvent(calendarEvent, user)).rejects.toThrow('permission');
+    expect(mocks.runTransactionMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['already tracked', { isDbGame: true }],
+    ['cancelled', { isCancelled: true }],
+    ['not a calendar import', { isImported: false, sourceType: 'db' }]
+  ])('rejects an invalid %s event before authorization or persistence', async (_label, overrides) => {
+    await expect(enableRsvpForImportedCalendarEvent({ ...calendarEvent, ...overrides } as any, user)).rejects.toThrow();
+    expect(getTeam).not.toHaveBeenCalled();
+    expect(mocks.runTransactionMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -4629,6 +4629,34 @@ describe('enableRsvpForImportedCalendarEvent', () => {
     expect(mocks.runTransactionMock).not.toHaveBeenCalled();
   });
 
+  it('rejects coach-only staff because game creation requires owner/admin access', async () => {
+    const coachOnlyUser = { ...user, coachOf: ['team-1'] } as any;
+    vi.mocked(getTeam).mockResolvedValue({ id: 'team-1', name: 'Bears', ownerId: 'another-user', active: true } as any);
+
+    await expect(enableRsvpForImportedCalendarEvent(calendarEvent, coachOnlyUser)).rejects.toThrow('permission');
+    expect(mocks.runTransactionMock).not.toHaveBeenCalled();
+  });
+
+  it('materializes separate occurrences that reuse the same calendar event ID', async () => {
+    mocks.transactionGet.mockResolvedValue({ exists: () => false });
+    const laterOccurrence = {
+      ...calendarEvent,
+      eventKey: 'team-1::calendar-uid-1::player-1::2026-06-11T18:00:00.000Z::game',
+      date: new Date('2026-06-11T18:00:00.000Z'),
+      endDate: new Date('2026-06-11T20:00:00.000Z')
+    };
+
+    const firstId = await enableRsvpForImportedCalendarEvent(calendarEvent, user);
+    const laterId = await enableRsvpForImportedCalendarEvent(laterOccurrence, user);
+
+    expect(laterId).not.toBe(firstId);
+    expect(mocks.transactionSet).toHaveBeenCalledTimes(2);
+    expect(mocks.transactionSet.mock.calls.map((call) => call[0]?.path)).toEqual([
+      `teams/team-1/games/${firstId}`,
+      `teams/team-1/games/${laterId}`
+    ]);
+  });
+
   it.each([
     ['already tracked', { isDbGame: true }],
     ['cancelled', { isCancelled: true }],

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -221,7 +221,7 @@ vi.mock('./appDataCache', () => ({
 
 import { addGame, addPractice, broadcastLiveEvent, buildSingleLegacyTournamentGameDocument, buildLegacyTournamentGameDocument, buildLegacyTournamentGameDocuments, claimOpenOfficiatingSlot, clearOccurrenceOverride, releaseAssignmentClaim, respondToOfficiatingAssignment, updateEvent, updateGame, updateOccurrence, getAssignmentClaims, getGame, getGames, getMyRsvps, getPlayers, getPracticeSession, getPracticeSessions, getPublicTeamCalendarEvents, getRsvpBreakdownByPlayer, getRsvpSummaries, getRsvps, getStaffTeams, getTeam, getTeams, listRideOffersForEvent, postChatMessage, postSharedGameCancellationNotification, submitRsvp, submitRsvpForPlayer, updatePracticeAttendance, getDoc, getDocs } from './adapters/legacyScheduleDb';
 import { getNativeAuthIdToken } from './authService';
-import { expandRecurrence, fetchAndParseCalendar, isTeamActive, mergeAssignmentsWithClaims } from './adapters/legacyScheduleHelpers';
+import { expandRecurrence, fetchAndParseCalendar, getCalendarEventTrackingId, isTeamActive, isTrackedCalendarEvent, mergeAssignmentsWithClaims } from './adapters/legacyScheduleHelpers';
 import { getCachedAppData, invalidateCachedAppData, loadCachedAppData } from './appDataCache';
 import { mapScheduleEventRecord } from './firestore/mappers';
 import { loadProfileDocument } from './profileService';
@@ -4597,7 +4597,7 @@ describe('enableRsvpForImportedCalendarEvent', () => {
       expect.objectContaining({ path: `teams/team-1/games/${firstId}` }),
       expect.objectContaining({
         ...expectedPayload,
-        calendarEventUid: 'calendar-uid-1',
+        calendarEventUid: 'calendar-uid-1__2026-06-04T18:00:00.000Z',
         source: 'calendar',
         sourceMetadata: {
           sourceType: 'calendar',
@@ -4655,6 +4655,83 @@ describe('enableRsvpForImportedCalendarEvent', () => {
       `teams/team-1/games/${firstId}`,
       `teams/team-1/games/${laterId}`
     ]);
+    expect(mocks.transactionSet.mock.calls.map((call) => call[1]?.calendarEventUid)).toEqual([
+      'calendar-uid-1__2026-06-04T18:00:00.000Z',
+      'calendar-uid-1__2026-06-11T18:00:00.000Z'
+    ]);
+  });
+
+  it('keeps a later shared-UID occurrence visible after reloading the materialized occurrence', async () => {
+    const parent = {
+      uid: 'parent-1',
+      email: 'parent@example.com',
+      parentOf: [{ teamId: 'team-1', playerId: 'player-1', playerName: 'Avery', teamName: 'Bears' }]
+    } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: parent.parentOf } as any);
+    vi.mocked(getTeams).mockResolvedValue([] as any);
+    vi.mocked(getTeam).mockResolvedValue({
+      id: 'team-1',
+      name: 'Bears',
+      ownerId: 'coach-1',
+      active: true,
+      calendarUrls: ['https://calendar.example.com/bears.ics']
+    } as any);
+    vi.mocked(getDoc).mockResolvedValue(playerSnapshot('player-1', { id: 'player-1', name: 'Avery', active: true }) as any);
+    vi.mocked(getGames).mockResolvedValue([{
+      id: 'tracked-first-occurrence',
+      type: 'game',
+      date: new Date('2026-06-04T18:00:00.000Z'),
+      opponent: 'Wolves',
+      calendarEventUid: 'calendar-uid-1__2026-06-04T18:00:00.000Z'
+    }] as any);
+    vi.mocked(getPracticeSessions).mockResolvedValue([] as any);
+    vi.mocked(getCalendarEventTrackingId).mockImplementation((event: any) => event.id || event.uid || '');
+    vi.mocked(isTrackedCalendarEvent).mockImplementation((event: any, trackedIds: string[]) => (
+      trackedIds.includes(event.id || event.uid || '')
+    ));
+    vi.mocked(fetchAndParseCalendar).mockResolvedValue([
+      {
+        id: 'calendar-uid-1',
+        uid: 'calendar-uid-1',
+        summary: 'Bears vs Wolves',
+        dtstart: new Date('2026-06-04T18:00:00.000Z'),
+        dtend: new Date('2026-06-04T20:00:00.000Z')
+      },
+      {
+        id: 'calendar-uid-1',
+        uid: 'calendar-uid-1',
+        summary: 'Bears vs Tigers',
+        dtstart: new Date('2026-06-11T18:00:00.000Z'),
+        dtend: new Date('2026-06-11T20:00:00.000Z')
+      }
+    ] as any);
+
+    const reloaded = await loadParentSchedule(parent, {
+      hydrateDetails: false,
+      expandStaffPlayers: false,
+      includePastGames: true
+    });
+
+    expect(reloaded.events).toHaveLength(2);
+    expect(reloaded.events).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'tracked-first-occurrence', isDbGame: true }),
+      expect.objectContaining({
+        id: 'calendar-uid-1',
+        date: new Date('2026-06-11T18:00:00.000Z'),
+        isDbGame: false,
+        isImported: true
+      })
+    ]));
+
+    mocks.transactionGet.mockResolvedValueOnce({ exists: () => false });
+    const laterOccurrence = reloaded.events.find((event) => event.date.toISOString() === '2026-06-11T18:00:00.000Z');
+    const laterId = await enableRsvpForImportedCalendarEvent({ ...laterOccurrence, opponent: 'Tigers' } as any, user);
+
+    expect(laterId).not.toBe('tracked-first-occurrence');
+    expect(mocks.transactionSet).toHaveBeenCalledWith(
+      expect.objectContaining({ path: `teams/team-1/games/${laterId}` }),
+      expect.objectContaining({ calendarEventUid: 'calendar-uid-1__2026-06-11T18:00:00.000Z' })
+    );
   });
 
   it.each([

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -2562,6 +2562,76 @@ async function createIdempotentScheduleImportEvent(
   return eventId;
 }
 
+async function getCalendarMaterializationDigest(teamId: string, calendarEventId: string) {
+  if (!globalThis.crypto?.subtle) {
+    throw new Error('This device cannot safely create a stable tracked event ID.');
+  }
+  const input = new TextEncoder().encode(`${teamId}:${calendarEventId}`);
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', input);
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+export async function enableRsvpForImportedCalendarEvent(event: ParentScheduleEvent, user: AuthUser | null) {
+  const teamId = compactString(event.teamId);
+  const calendarEventId = compactString(event.id);
+  if (!teamId || !calendarEventId) throw new Error('The imported calendar event is missing its team or event ID.');
+  if (event.isDbGame) throw new Error('RSVP is already enabled for this event.');
+  if (event.isCancelled) throw new Error('RSVP cannot be enabled for a cancelled event.');
+  if (!event.isImported || event.sourceType !== 'calendar') {
+    throw new Error('Only imported calendar events can be converted to tracked events.');
+  }
+  if (!(event.date instanceof Date) || Number.isNaN(event.date.getTime())) {
+    throw new Error('The imported calendar event has an invalid start time.');
+  }
+  const opponent = compactString(event.opponent);
+  const title = compactString(event.title) || 'Practice';
+  if (event.type === 'game' && !opponent) throw new Error('The imported game needs an opponent before RSVP can be enabled.');
+
+  await requireScheduleImportStaff(teamId, user);
+  const digest = await getCalendarMaterializationDigest(teamId, calendarEventId);
+  const actionId = `calendar-materialize:${digest}`;
+  const trackedEventId = `calendar_${digest}`;
+  const importedAt = new Date().toISOString();
+  const importBatch = {
+    batchId: actionId,
+    totalCount: 1,
+    rowNumber: 1,
+    importedAt,
+    importedBy: user?.uid || null,
+    actionId
+  };
+  const payload = {
+    type: event.type,
+    date: event.date,
+    end: event.endDate || null,
+    opponent: event.type === 'game' ? opponent : null,
+    title: event.type === 'practice' ? title : null,
+    location: compactString(event.location),
+    isHome: event.type === 'game' ? (event.isHome ?? null) : null,
+    arrivalTime: event.arrivalTime || null,
+    notes: compactString(event.notes),
+    assignments: [],
+    status: 'scheduled',
+    homeScore: 0,
+    awayScore: 0,
+    competitionType: event.type === 'game' ? (compactString(event.competitionType) || 'league') : null,
+    countsTowardSeasonRecord: event.type === 'game' ? (event.countsTowardSeasonRecord ?? true) : null,
+    statTrackerConfigId: null,
+    calendarEventUid: calendarEventId,
+    source: 'calendar',
+    sourceMetadata: {
+      sourceType: 'calendar',
+      sourceLabel: compactString(event.sourceLabel) || 'Imported calendar'
+    },
+    importBatch,
+    createdBy: user?.uid || null
+  };
+
+  await createIdempotentScheduleImportEvent(teamId, trackedEventId, payload, actionId);
+  invalidateParentScheduleCaches(user);
+  return trackedEventId;
+}
+
 export async function addTeamCalendarUrl(teamId: string, url: string, user: AuthUser | null) {
   const normalizedTeamId = compactString(teamId);
   if (!normalizedTeamId) {
@@ -3420,7 +3490,7 @@ function toNullableScore(value: unknown) {
 
 function getScheduleSourceLabel(game: any) {
   const metadata = game?.sourceMetadata || game?.registrationSource || {};
-  const provider = compactString(metadata.providerName || metadata.provider || metadata.sourceName || metadata.sourceType || game?.source);
+  const provider = compactString(metadata.sourceLabel || metadata.providerName || metadata.provider || metadata.sourceName || metadata.sourceType || game?.source);
   if (provider) return provider;
   if (game?.source === 'calendar') return 'Imported calendar';
   if (game?.source === 'registration') return 'Registration import';

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -1860,6 +1860,19 @@ function requireScheduleImportStaff(teamId: string, user: AuthUser | null) {
   });
 }
 
+function requireScheduleMaterializationManager(teamId: string, user: AuthUser | null) {
+  if (!user?.uid) {
+    throw new Error('You need to sign in before enabling RSVP for an imported event.');
+  }
+  return loadTeam(teamId).then((team) => {
+    const teamWithId = team ? { ...team, id: team.id || teamId } : null;
+    if (!teamWithId || !isPublicRsvpReminderManager(teamWithId, user)) {
+      throw new Error('You do not have permission to enable RSVP for this team schedule.');
+    }
+    return teamWithId;
+  });
+}
+
 function parseScheduleImportDate(value: string | null | undefined, label: string) {
   const date = new Date(String(value || ''));
   if (Number.isNaN(date.getTime())) {
@@ -2562,11 +2575,11 @@ async function createIdempotentScheduleImportEvent(
   return eventId;
 }
 
-async function getCalendarMaterializationDigest(teamId: string, calendarEventId: string) {
+async function getCalendarMaterializationDigest(teamId: string, calendarEventId: string, startsAt: Date) {
   if (!globalThis.crypto?.subtle) {
     throw new Error('This device cannot safely create a stable tracked event ID.');
   }
-  const input = new TextEncoder().encode(`${teamId}:${calendarEventId}`);
+  const input = new TextEncoder().encode(`${teamId}:${calendarEventId}:${startsAt.toISOString()}`);
   const digest = await globalThis.crypto.subtle.digest('SHA-256', input);
   return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
 }
@@ -2587,8 +2600,8 @@ export async function enableRsvpForImportedCalendarEvent(event: ParentScheduleEv
   const title = compactString(event.title) || 'Practice';
   if (event.type === 'game' && !opponent) throw new Error('The imported game needs an opponent before RSVP can be enabled.');
 
-  await requireScheduleImportStaff(teamId, user);
-  const digest = await getCalendarMaterializationDigest(teamId, calendarEventId);
+  await requireScheduleMaterializationManager(teamId, user);
+  const digest = await getCalendarMaterializationDigest(teamId, calendarEventId, event.date);
   const actionId = `calendar-materialize:${digest}`;
   const trackedEventId = `calendar_${digest}`;
   const importedAt = new Date().toISOString();

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -60,6 +60,7 @@ import {
   Timestamp
 } from './adapters/legacyScheduleDb';
 import { getPrimaryAppCheckHeaders } from './adapters/legacyFirebaseAppCheck';
+import { getCalendarOccurrenceTrackingId, isCalendarOccurrenceTracked } from './calendarOccurrence';
 import {
   sendPublicRsvpReminderEmails,
   normalizeOfficialLinkEmail,
@@ -2601,6 +2602,7 @@ export async function enableRsvpForImportedCalendarEvent(event: ParentScheduleEv
   if (event.type === 'game' && !opponent) throw new Error('The imported game needs an opponent before RSVP can be enabled.');
 
   await requireScheduleMaterializationManager(teamId, user);
+  const calendarOccurrenceId = getCalendarOccurrenceTrackingId(calendarEventId, event.date);
   const digest = await getCalendarMaterializationDigest(teamId, calendarEventId, event.date);
   const actionId = `calendar-materialize:${digest}`;
   const trackedEventId = `calendar_${digest}`;
@@ -2630,7 +2632,7 @@ export async function enableRsvpForImportedCalendarEvent(event: ParentScheduleEv
     competitionType: event.type === 'game' ? (compactString(event.competitionType) || 'league') : null,
     countsTowardSeasonRecord: event.type === 'game' ? (event.countsTowardSeasonRecord ?? true) : null,
     statTrackerConfigId: null,
-    calendarEventUid: calendarEventId,
+    calendarEventUid: calendarOccurrenceId,
     source: 'calendar',
     sourceMetadata: {
       sourceType: 'calendar',
@@ -3861,7 +3863,11 @@ async function buildTeamSchedule(teamId: string, teamChildren: ParentScheduleChi
       : [projectedCalendarEvents];
 
     calendarResults.flat().forEach((calendarEvent: any) => {
-      if (isTrackedCalendarEvent(calendarEvent, trackedUids)) return;
+      const calendarEventTrackingId = getCalendarEventTrackingId(calendarEvent);
+      if (
+        isCalendarOccurrenceTracked(calendarEventTrackingId, calendarEvent.dtstart, trackedUids)
+        || isTrackedCalendarEvent(calendarEvent, trackedUids)
+      ) return;
       const date = normalizeScheduleDate(calendarEvent.dtstart);
       if (!date) return;
       const hasConflict = scheduleGames.some((dbGame: any) => Math.abs(toEventDate(dbGame.date).getTime() - date.getTime()) < 60000);
@@ -3871,7 +3877,7 @@ async function buildTeamSchedule(teamId: string, teamChildren: ParentScheduleChi
         : isPracticeEvent(calendarEvent.summary);
       const type = isPractice ? 'practice' : 'game';
       const cleanSummary = calendarEvent.summary?.replace(/\[CANCELED\]\s*/gi, '') || '';
-      const id = getCalendarEventTrackingId(calendarEvent) || `ics-${date.getTime()}`;
+      const id = calendarEventTrackingId || `ics-${date.getTime()}`;
       const session = isPractice ? resolvePracticeSessionForEvent(calendarEvent, date, sessionsByEventId, sessions, matchedSessionIds) : null;
       teamChildren.forEach((child) => {
         events.push(createScheduleEvent({

--- a/apps/app/src/pages/Discover.tsx
+++ b/apps/app/src/pages/Discover.tsx
@@ -93,7 +93,7 @@ export function Discover({ auth, initialTab }: { auth: AuthState; initialTab?: '
         </div> : null}
       </section>
 
-      {tab === 'teams' ? <section id={initialTab ? undefined : 'discover-teams-panel'} role={initialTab ? undefined : 'tabpanel'} aria-labelledby={initialTab ? undefined : 'discover-teams-tab'}><PublicTeamSearch autoBrowseOnMount /></section> : (
+      {tab === 'teams' ? <section id={initialTab ? undefined : 'discover-teams-panel'} role={initialTab ? undefined : 'tabpanel'} aria-labelledby={initialTab ? undefined : 'discover-teams-tab'}><PublicTeamSearch pageSize={12} showRosterCounts={false} /></section> : (
         <section id={initialTab ? undefined : 'discover-opportunities-panel'} role={initialTab ? undefined : 'tabpanel'} aria-labelledby={initialTab ? undefined : 'discover-opportunities-tab'} className="space-y-4">
           <form className="app-card grid gap-3 p-4 sm:grid-cols-2 lg:grid-cols-6" onSubmit={submitFilters}>
             <FilterSelect label="Category" value={filters.kind || ''} onChange={(value) => setFilters((current) => ({ ...current, kind: value as OpportunityKind | '' }))} options={[{ id: '', label: 'All categories' }, ...opportunityKinds]} />

--- a/apps/app/src/pages/FriendProfile.test.tsx
+++ b/apps/app/src/pages/FriendProfile.test.tsx
@@ -62,11 +62,31 @@ describe('FriendProfile', () => {
     expect(await screen.findByRole('heading', { name: 'Pat Parent' })).toBeVisible();
     expect(screen.getByRole('link', { name: /Bears/ })).toHaveAttribute('href', '/teams/team-1/public');
     expect(screen.getByRole('link', { name: /Pat Star/ })).toHaveAttribute('href', profile.publicChildren[0].shareUrl);
-    expect(screen.getAllByRole('link', { name: /settings/i }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('link', { name: 'Edit profile' })).toHaveLength(1);
+    expect(screen.getByRole('navigation', { name: 'Profile sections' })).toBeVisible();
+    expect(screen.getByRole('link', { name: 'Overview' })).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByRole('link', { name: 'Posts' })).toHaveAttribute('href', '/profile?section=posts');
+    expect(screen.getByRole('link', { name: 'Teams' })).toHaveAttribute('href', '/profile?section=teams');
+    expect(screen.getByRole('link', { name: 'Players' })).toHaveAttribute('href', '/profile?section=players');
     expect(document.querySelector('main')).toBeNull();
 
     fireEvent.click(screen.getByRole('button', { name: 'Copy profile link' }));
     await waitFor(() => expect(publicActionMocks.copyPublicText).toHaveBeenCalledWith(`${window.location.origin}/app/#/people/user-1`));
+  });
+
+  it('supports route-addressable profile sections without rendering unrelated collections', async () => {
+    render(
+      <MemoryRouter initialEntries={['/profile?section=teams']}>
+        <Routes>
+          <Route path="/profile" element={<FriendProfile auth={auth} profileUserId="user-1" />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Public teams' })).toBeVisible();
+    expect(screen.getByRole('link', { name: 'Teams' })).toHaveAttribute('aria-current', 'page');
+    expect(screen.queryByRole('heading', { name: 'Public players' })).toBeNull();
+    expect(screen.queryByRole('heading', { name: 'Recent posts' })).toBeNull();
   });
 
   it('shows a direct message action for an accepted friend profile', async () => {

--- a/apps/app/src/pages/FriendProfile.tsx
+++ b/apps/app/src/pages/FriendProfile.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type ReactNode } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useLocation, useParams, useSearchParams } from 'react-router-dom';
 import type { LucideIcon } from 'lucide-react';
 import { AlertCircle, ArrowLeft, Copy, Heart, Loader2, MessageCircle, Settings, Trophy, UserRound, UsersRound } from 'lucide-react';
 import { AvatarImage } from '../components/AvatarImage';
@@ -15,6 +15,8 @@ import type { AuthState } from '../lib/types';
 
 export function FriendProfile({ auth, profileUserId }: { auth: AuthState; profileUserId?: string }) {
   const { userId: routeUserId = '' } = useParams();
+  const location = useLocation();
+  const [searchParams] = useSearchParams();
   const userId = profileUserId || routeUserId;
   const [profile, setProfile] = useState<FriendProfileModel | null>(null);
   const [loading, setLoading] = useState(true);
@@ -126,21 +128,26 @@ export function FriendProfile({ auth, profileUserId }: { auth: AuthState; profil
   const initials = getInitials(profile.name);
   const publicTeams = profile.publicTeams || [];
   const publicChildren = profile.publicChildren || [];
+  const requestedSection = searchParams.get('section');
+  const activeSection = requestedSection === 'posts' || requestedSection === 'teams' || requestedSection === 'players'
+    ? requestedSection
+    : 'overview';
+  const profileSections = [
+    { id: 'overview', label: 'Overview', to: location.pathname },
+    { id: 'posts', label: 'Posts', to: `${location.pathname}?section=posts` },
+    { id: 'teams', label: 'Teams', to: `${location.pathname}?section=teams` },
+    { id: 'players', label: 'Players', to: `${location.pathname}?section=players` }
+  ] as const;
   return (
     <div className="mx-auto max-w-3xl px-4 py-5 sm:py-7">
-      {profile.isSelf ? (
-        <Link to="/profile/settings" className="ghost-button !inline-flex !min-h-11 !px-3 text-sm">
-          <Settings className="h-4 w-4" aria-hidden="true" />
-          Profile settings
-        </Link>
-      ) : (
+      {!profile.isSelf ? (
         <Link to="/home?section=friends" className="ghost-button !inline-flex !min-h-11 !px-3 text-sm">
           <ArrowLeft className="h-4 w-4" aria-hidden="true" />
           Back to friends
         </Link>
-      )}
+      ) : null}
 
-      <header className="app-card mt-4 overflow-hidden">
+      <header className={`app-card overflow-hidden ${profile.isSelf ? '' : 'mt-4'}`}>
         <div className="h-24 bg-gradient-to-br from-primary-700 via-primary-600 to-sky-500 sm:h-32" />
         <div className="px-5 pb-5 sm:px-7">
           <div className="-mt-10 flex items-end justify-between gap-4">
@@ -179,7 +186,7 @@ export function FriendProfile({ auth, profileUserId }: { auth: AuthState; profil
             {profile.isSelf ? (
               <Link to="/profile/settings" className="secondary-button !min-h-11 text-sm">
                 <Settings className="h-4 w-4" aria-hidden="true" />
-                Settings
+                Edit profile
               </Link>
             ) : null}
           </div>
@@ -193,26 +200,43 @@ export function FriendProfile({ auth, profileUserId }: { auth: AuthState; profil
 
       {status ? <div className="mt-3 rounded-xl bg-gray-950 px-3 py-2 text-sm font-bold text-white" role="status">{status}</div> : null}
 
-      <div className="mt-6 grid gap-4 sm:grid-cols-2">
-        <ProfileCollection title="Public teams" icon={Trophy} empty="No public teams shared.">
+      <nav className="sticky top-24 z-20 mt-3 overflow-x-auto rounded-2xl border border-gray-200 bg-white/95 p-1 shadow-sm backdrop-blur" aria-label="Profile sections">
+        <div className="grid min-w-max grid-cols-4 gap-1">
+          {profileSections.map((section) => (
+            <Link
+              key={section.id}
+              to={section.to}
+              aria-current={activeSection === section.id ? 'page' : undefined}
+              className={`inline-flex min-h-11 items-center justify-center rounded-xl px-4 text-sm font-black transition ${activeSection === section.id ? 'bg-primary-600 text-white shadow-sm' : 'text-gray-600 hover:bg-gray-50 hover:text-gray-950'}`}
+            >
+              {section.label}
+            </Link>
+          ))}
+        </div>
+      </nav>
+
+      {activeSection === 'overview' || activeSection === 'teams' || activeSection === 'players' ? (
+      <div className={`mt-6 grid gap-4 ${activeSection === 'overview' ? 'sm:grid-cols-2' : ''}`}>
+        {activeSection === 'overview' || activeSection === 'teams' ? <ProfileCollection title="Public teams" icon={Trophy} empty="No public teams shared.">
           {publicTeams.map((team) => (
             <Link key={team.id} to={`/teams/${encodeURIComponent(team.id)}/public`} className="flex items-center gap-3 rounded-xl border border-gray-200 bg-gray-50 p-3 hover:border-primary-200">
               {team.photoUrl ? <img src={team.photoUrl} alt="" className="h-10 w-10 rounded-xl object-cover" /> : <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary-50 text-primary-700"><Trophy className="h-5 w-5" /></span>}
               <span className="min-w-0"><span className="block truncate text-sm font-black text-gray-950">{team.name}</span><span className="block truncate text-xs font-semibold text-gray-500">{team.sport || 'Public team'}</span></span>
             </Link>
           ))}
-        </ProfileCollection>
-        <ProfileCollection title="Public players" icon={UserRound} empty="No public player profiles shared.">
+        </ProfileCollection> : null}
+        {activeSection === 'overview' || activeSection === 'players' ? <ProfileCollection title="Public players" icon={UserRound} empty="No public player profiles shared.">
           {publicChildren.map((child) => (
             <a key={child.id} href={child.shareUrl} target="_blank" rel="noreferrer" className="flex items-center gap-3 rounded-xl border border-gray-200 bg-gray-50 p-3 hover:border-primary-200">
               {child.photoUrl ? <img src={child.photoUrl} alt="" className="h-10 w-10 rounded-xl object-cover" /> : <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-gray-950 text-white"><UserRound className="h-5 w-5" /></span>}
               <span className="min-w-0"><span className="block truncate text-sm font-black text-gray-950">{child.name}</span><span className="block truncate text-xs font-semibold text-gray-500">{child.headline || 'View public profile'}</span></span>
             </a>
           ))}
-        </ProfileCollection>
+        </ProfileCollection> : null}
       </div>
+      ) : null}
 
-      <section className="mt-6" aria-labelledby="profile-posts-heading">
+      {activeSection === 'overview' || activeSection === 'posts' ? <section className="mt-6" aria-labelledby="profile-posts-heading">
         <div className="flex items-end justify-between gap-3">
           <div>
             <p className="text-xs font-black uppercase tracking-[0.12em] text-primary-700">Timeline</p>
@@ -261,7 +285,7 @@ export function FriendProfile({ auth, profileUserId }: { auth: AuthState; profil
             </div>
           )}
         </div>
-      </section>
+      </section> : null}
     </div>
   );
 }

--- a/apps/app/src/pages/Home.test.tsx
+++ b/apps/app/src/pages/Home.test.tsx
@@ -676,6 +676,23 @@ describe('Home', () => {
     expect(screen.queryByRole('heading', { name: 'Checking today’s actions…' })).toBeNull();
   });
 
+  it('keeps the Needs refresh badge when a secondary retry also fails', async () => {
+    homeServiceMocks.loadParentHomeWithSecondaryData
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockRejectedValueOnce(new Error('Permission denied for Home refresh'));
+
+    renderHome(signedInAuth);
+
+    expect(await screen.findByText('Home details could not refresh while offline.')).toBeTruthy();
+    expect(screen.getByText('Needs refresh')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh Home' }));
+
+    expect(await screen.findByText('Home details could not refresh because access was denied.')).toBeTruthy();
+    expect(screen.getByText('Needs refresh')).toBeTruthy();
+    expect(homeServiceMocks.loadParentHomeWithSecondaryData).toHaveBeenCalledTimes(2);
+  });
+
   it('shows first-run access actions instead of an empty Today dashboard when no players or teams are linked', async () => {
     homeServiceMocks.loadParentHomeSummaryBootstrap.mockResolvedValueOnce({ home: emptyHome, schedule: [] });
     homeServiceMocks.loadParentHomeWithSecondaryData.mockResolvedValueOnce(emptyHome);

--- a/apps/app/src/pages/Home.test.tsx
+++ b/apps/app/src/pages/Home.test.tsx
@@ -670,6 +670,10 @@ describe('Home', () => {
     expect(screen.getByRole('heading', { name: 'Your day' })).toBeTruthy();
     expect(screen.queryByText('Home could not connect')).toBeNull();
     expect(screen.queryByRole('button', { name: 'Retry loading Home' })).toBeNull();
+    expect(screen.getByText('Needs refresh')).toBeTruthy();
+    expect(screen.queryByText('Loading')).toBeNull();
+    expect(screen.queryByText('Checking actions')).toBeNull();
+    expect(screen.queryByRole('heading', { name: 'Checking today’s actions…' })).toBeNull();
   });
 
   it('shows first-run access actions instead of an empty Today dashboard when no players or teams are linked', async () => {

--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -187,6 +187,7 @@ export function Home({ auth }: { auth: AuthState }) {
   const navigate = useNavigate();
   const [previewHomeUserId, setPreviewHomeUserId] = useState<string | null>(null);
   const [loadedHomeDetailsUserId, setLoadedHomeDetailsUserId] = useState<string | null>(null);
+  const [failedHomeDetailsUserId, setFailedHomeDetailsUserId] = useState<string | null>(null);
   const [homeLoadError, setHomeLoadError] = useState<AppServiceError | null>(null);
   const { loading, error, clearError, run: runPrimaryLoad } = useAsyncOperation();
   const { loading: socialLoading, run: runSecondaryLoad } = useAsyncOperation();
@@ -204,6 +205,7 @@ export function Home({ auth }: { auth: AuthState }) {
     const hasExistingHome = loadedHomeDetailsUserId === user.uid;
     clearError();
     setHomeLoadError(null);
+    setFailedHomeDetailsUserId(null);
     setSocialStatus(null);
     const timer = startScreenMountTimer('home', {
       force,
@@ -236,6 +238,7 @@ export function Home({ auth }: { auth: AuthState }) {
             });
             setHome(secondaryHome);
             setLoadedHomeDetailsUserId(user.uid);
+            setFailedHomeDetailsUserId(null);
             setHomeLoadError(null);
             const socialHome = await loadSocialHome(user, secondaryHome);
             setSocial(socialHome);
@@ -266,7 +269,11 @@ export function Home({ auth }: { auth: AuthState }) {
               });
               if (!hasExistingHome) {
                 setHomeLoadError(appError);
-                setLoadedHomeDetailsUserId(null);
+                // The summary bootstrap is still useful even when a secondary
+                // permission or network request fails. Mark the attempt settled
+                // so Home does not present an infinite loading state.
+                setLoadedHomeDetailsUserId(user.uid);
+                setFailedHomeDetailsUserId(user.uid);
                 setSocial(emptySocialHome());
                 setSocialStatus({ tone: 'error', message: getHomeSecondaryErrorMessage(appError) });
                 return;
@@ -376,6 +383,7 @@ export function Home({ auth }: { auth: AuthState }) {
   const homeSectionReady = isHomeSectionReady(activeSection, { loading, socialLoading, hasLoadedHomeDetails, showBlockingErrorState });
   const canRenderFirstRunHome = !authUserId || hasLoadedHomeDetails;
   const homeDetailsPending = Boolean(authUserId) && !hasLoadedHomeDetails;
+  const homeDetailsRefreshFailed = Boolean(authUserId) && authUserId === failedHomeDetailsUserId;
   const resolvedOfficialsAccess = authUserId ? officialsAccess : { hasAccess: false, teamCount: 0 };
 
   useViewLoadTimer({
@@ -490,8 +498,8 @@ export function Home({ auth }: { auth: AuthState }) {
           <div className="min-w-0 flex-1">
             <div className="flex min-w-0 items-center gap-2">
               <span className="app-label">Home</span>
-              <span className={`rounded-full px-2 py-0.5 text-[10px] font-black uppercase tracking-[0.04em] ${homeDetailsPending ? 'bg-gray-100 text-gray-600' : openCount ? 'bg-amber-100 text-amber-800' : 'bg-emerald-100 text-emerald-800'}`}>
-                {homeDetailsPending ? 'Loading' : openCount ? `${openCount} open` : 'Caught up'}
+              <span className={`rounded-full px-2 py-0.5 text-[10px] font-black uppercase tracking-[0.04em] ${homeDetailsRefreshFailed ? 'bg-rose-50 text-rose-700' : homeDetailsPending ? 'bg-gray-100 text-gray-600' : openCount ? 'bg-amber-100 text-amber-800' : 'bg-emerald-100 text-emerald-800'}`}>
+                {homeDetailsRefreshFailed ? 'Needs refresh' : homeDetailsPending ? 'Loading' : openCount ? `${openCount} open` : 'Caught up'}
               </span>
             </div>
             <h1 className="mt-0.5 text-xl font-black leading-tight text-gray-950">Your day</h1>

--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -205,7 +205,6 @@ export function Home({ auth }: { auth: AuthState }) {
     const hasExistingHome = loadedHomeDetailsUserId === user.uid;
     clearError();
     setHomeLoadError(null);
-    setFailedHomeDetailsUserId(null);
     setSocialStatus(null);
     const timer = startScreenMountTimer('home', {
       force,
@@ -267,13 +266,13 @@ export function Home({ auth }: { auth: AuthState }) {
                 feeCount: summary.home.fees.length,
                 error: appError.message
               });
+              setFailedHomeDetailsUserId(user.uid);
               if (!hasExistingHome) {
                 setHomeLoadError(appError);
                 // The summary bootstrap is still useful even when a secondary
                 // permission or network request fails. Mark the attempt settled
                 // so Home does not present an infinite loading state.
                 setLoadedHomeDetailsUserId(user.uid);
-                setFailedHomeDetailsUserId(user.uid);
                 setSocial(emptySocialHome());
                 setSocialStatus({ tone: 'error', message: getHomeSecondaryErrorMessage(appError) });
                 return;

--- a/apps/app/src/pages/Profile.test.tsx
+++ b/apps/app/src/pages/Profile.test.tsx
@@ -365,7 +365,7 @@ describe('Profile', () => {
     expect(await screen.findByRole('heading', { name: 'Your Account' })).toBeTruthy();
     expect(pushServiceMocks.getPushNotificationPermissionStatus).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole('button', { name: /^Alerts$/ }));
+    fireEvent.click(screen.getByRole('link', { name: /^Notifications$/ }));
 
     expect(await screen.findByText('Notification preferences')).toBeTruthy();
     await waitFor(() => {
@@ -388,7 +388,7 @@ describe('Profile', () => {
       .mockRejectedValueOnce(new Error('save failed'));
 
     renderProfile();
-    fireEvent.click(await screen.findByRole('button', { name: /^Alerts$/ }));
+    fireEvent.click(await screen.findByRole('link', { name: /^Notifications$/ }));
 
     const teamSelect = await screen.findByLabelText('Team') as HTMLSelectElement;
     await waitFor(() => expect((screen.getByLabelText('Live Chat') as HTMLInputElement).checked).toBe(true));
@@ -422,16 +422,17 @@ describe('Profile', () => {
     expect((screen.getByRole('button', { name: 'Save preferences' }) as HTMLButtonElement).disabled).toBe(false);
   });
 
-  it('keeps mobile profile section buttons in a two-column grid so Alerts stays reachable', async () => {
+  it('keeps semantic mobile profile navigation in a two-column grid', async () => {
     renderProfile();
 
     expect(await screen.findByRole('heading', { name: 'Your Account' })).toBeTruthy();
-    const alertsButton = screen.getByRole('button', { name: /^Alerts$/ });
-    expect(alertsButton).toBeTruthy();
-    expect(screen.getByRole('button', { name: /^Invites$/ })).toBeTruthy();
-    expect(screen.getByRole('button', { name: /^Security$/ })).toBeTruthy();
+    const notificationsLink = screen.getByRole('link', { name: /^Notifications$/ });
+    expect(notificationsLink).toHaveAttribute('href', '/profile/settings?section=alerts');
+    expect(screen.getByRole('link', { name: /^Invites$/ })).toHaveAttribute('href', '/profile/settings?section=invites');
+    expect(screen.getByRole('link', { name: /^Sign-in & security$/ })).toHaveAttribute('href', '/profile/settings?section=security');
+    expect(screen.getByRole('link', { name: /^Profile$/ })).toHaveAttribute('aria-current', 'page');
 
-    const sectionGrid = alertsButton.parentElement;
+    const sectionGrid = notificationsLink.parentElement;
     expect(sectionGrid).not.toBeNull();
     expect(sectionGrid?.className).toContain('grid-cols-2');
     expect(sectionGrid?.className).toContain('sm:grid-cols-4');

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -76,10 +76,10 @@ const notificationPreferenceGroups = NOTIFICATION_PREFERENCE_GROUPS as readonly 
 const collapsedInviteCount = 3;
 const logger = createLogger('profile');
 const profileSections: Array<{ id: ProfileSectionId; label: string }> = [
-  { id: 'account', label: 'Account' },
-  { id: 'alerts', label: 'Alerts' },
+  { id: 'account', label: 'Profile' },
+  { id: 'alerts', label: 'Notifications' },
   { id: 'invites', label: 'Invites' },
-  { id: 'security', label: 'Security' }
+  { id: 'security', label: 'Sign-in & security' }
 ];
 type PushServiceModule = typeof import('../lib/pushService');
 let pushServiceRequest: Promise<PushServiceModule> | null = null;
@@ -292,14 +292,8 @@ export function Profile({ auth }: { auth: AuthState }) {
     }
   }, [activeProfileSection, isNative]);
 
-  const selectProfileSection = (sectionId: ProfileSectionId) => {
+  const focusProfileSection = (sectionId: ProfileSectionId) => {
     setActiveProfileSection(sectionId);
-    setSearchParams((current) => {
-      const next = new URLSearchParams(current);
-      next.set('section', sectionId);
-      next.delete('teamId');
-      return next;
-    }, { replace: true });
     window.requestAnimationFrame(() => {
       window.scrollTo({ top: 0, behavior: 'smooth' });
     });
@@ -1407,9 +1401,6 @@ export function Profile({ auth }: { auth: AuthState }) {
             <p className="truncate text-sm font-semibold text-gray-600">{user.email || 'No email loaded'}</p>
             <p className="mt-1 text-xs font-bold text-gray-400">Last updated: {updatedAt}</p>
           </div>
-          <button type="button" className="ghost-button flex-none !min-h-11 !px-3" onClick={handleSignOut} disabled={busy === 'logout'} aria-label="Sign out">
-            {busy === 'logout' ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <LogOut className="h-4 w-4" aria-hidden="true" />}
-          </button>
         </div>
         <Link to="/profile" className="secondary-button mt-3 !min-h-11 text-xs">
           <UserCircle className="h-4 w-4" aria-hidden="true" />
@@ -1422,15 +1413,15 @@ export function Profile({ auth }: { auth: AuthState }) {
           {profileSections.map((section) => {
             const active = activeProfileSection === section.id;
             return (
-              <button
+              <Link
                 key={section.id}
-                type="button"
+                to={getProfileSectionRoute(section.id)}
                 className={`min-h-11 rounded-xl px-3 text-sm font-black transition ${active ? 'bg-primary-600 text-white shadow-sm' : 'text-gray-600 hover:bg-gray-50 hover:text-gray-950'}`}
-                onClick={() => selectProfileSection(section.id)}
-                aria-pressed={active}
+                onClick={() => focusProfileSection(section.id)}
+                aria-current={active ? 'page' : undefined}
               >
                 {section.label}
-              </button>
+              </Link>
             );
           })}
         </div>

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -2011,6 +2011,29 @@ describe('Schedule', () => {
     expect(screen.getByRole('link', { name: 'Packets' }).getAttribute('aria-current')).toBe('page');
   });
 
+  it('labels calendar-only imports without contradicting the RSVP-needed metric', async () => {
+    shellLayoutMocks.isDesktopWeb = true;
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
+      children: [
+        { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+      ],
+      events: [buildScheduleEvent(1, {
+        isDbGame: false,
+        isImported: true,
+        sourceType: 'calendar',
+        sourceLabel: 'Imported calendar',
+        myRsvp: 'not_responded'
+      })]
+    });
+
+    renderSchedule();
+
+    expect((await screen.findAllByText('Calendar only')).length).toBeGreaterThan(0);
+    expect(screen.getByText('Imported')).toBeTruthy();
+    expect(screen.queryByText('RSVP needed')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Show rsvp needed' }).textContent).toContain('0');
+  });
+
   it('renders web-created tournament game metadata and the create tournament flow', async () => {
     scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
       children: [

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -30,7 +30,7 @@ import { useShellLayout } from '../lib/useShellLayout';
 import {
   buildScheduleIcs,
   buildScheduleAgendaText,
-  canSubmitScheduleEventRsvp,
+  getScheduleEventRsvpCapability,
   filterParentScheduleEvents,
   formatEventDateLabel,
   formatEventTimeLabel,
@@ -43,6 +43,7 @@ import {
   getScheduleLocationLabel,
   getWindowedCalendarScheduleEntries,
   getWindowedPracticePacketRows,
+  isScheduleEventAvailabilityNeeded,
   getScheduleTitle,
   getScheduleTournamentInfo,
   getScheduleMapHref,
@@ -1740,6 +1741,7 @@ function ScheduleNextUpCard({ event, preferGameHubForStaff }: { event: ParentSch
   }
 
   const rsvp = normalizeRsvpResponse(event.myRsvp);
+  const rsvpBadge = getScheduleRsvpBadge(event, rsvp);
   const actionText = getEventPrimaryActionText(event);
   const tournamentInfo = getScheduleTournamentInfo(event);
 
@@ -1755,9 +1757,9 @@ function ScheduleNextUpCard({ event, preferGameHubForStaff }: { event: ParentSch
           <div className="mt-1 text-sm font-bold text-gray-700">{formatEventDateLabel(event.date)} · {formatEventTimeLabel(event.date)}</div>
           <div className="mt-0.5 truncate text-xs font-semibold text-gray-600">{event.childName} · {getScheduleLocationLabel(event, 'Location TBD')}</div>
         </div>
-        <span className={`inline-flex min-h-6 flex-none items-center rounded-full border px-2 text-[11px] font-extrabold uppercase tracking-[0.04em] ${rsvpBadgeClasses[rsvp]}`}>
-          {rsvpLabels[rsvp]}
-        </span>
+        {rsvpBadge ? <span className={`inline-flex min-h-6 flex-none items-center rounded-full border px-2 text-[11px] font-extrabold uppercase tracking-[0.04em] ${rsvpBadge.className}`}>
+          {rsvpBadge.label}
+        </span> : null}
       </div>
       <div className="mt-3 inline-flex min-h-8 items-center gap-2 rounded-full bg-white px-3 text-xs font-black text-primary-700 shadow-sm">
         {actionText}
@@ -2089,6 +2091,7 @@ function CompactScheduleList({ events, totalCount, visibleCount, pageSize, canSh
         <div className="divide-y divide-gray-100">
           {renderedEvents.map((event) => {
             const rsvp = normalizeRsvpResponse(event.myRsvp);
+            const rsvpBadge = getScheduleRsvpBadge(event, rsvp);
             const tournamentInfo = getScheduleTournamentInfo(event);
             return (
               <Link key={event.eventKey} to={getGenericEventDetailPath(event, preferGameHubForStaff)} className="compact-schedule-row grid grid-cols-[82px_minmax(0,1fr)_auto] gap-3 px-3 py-2.5 transition hover:bg-primary-50">
@@ -2103,9 +2106,9 @@ function CompactScheduleList({ events, totalCount, visibleCount, pageSize, canSh
                     <div className="mt-0.5 truncate text-xs font-bold text-indigo-700">{tournamentInfo.label}</div>
                   ) : null}
                 </div>
-                <span className={`self-center rounded-full border px-2 py-1 text-[10px] font-extrabold uppercase tracking-[0.04em] ${rsvpBadgeClasses[rsvp]}`}>
-                  {rsvpLabels[rsvp]}
-                </span>
+                {rsvpBadge ? <span className={`self-center rounded-full border px-2 py-1 text-[10px] font-extrabold uppercase tracking-[0.04em] ${rsvpBadge.className}`}>
+                  {rsvpBadge.label}
+                </span> : null}
               </Link>
             );
           })}
@@ -2200,6 +2203,7 @@ function ScheduleEventCard({ event, preferGameHubForStaff }: {
   preferGameHubForStaff: boolean;
 }) {
   const rsvp = normalizeRsvpResponse(event.myRsvp);
+  const rsvpBadge = getScheduleRsvpBadge(event, rsvp);
   const eventTitle = getScheduleTitle(event);
   const defaultDetailPath = getScheduleEventDetailPath(event);
   const detailPath = getGenericEventDetailPath(event, preferGameHubForStaff) || defaultDetailPath;
@@ -2284,9 +2288,9 @@ function ScheduleEventCard({ event, preferGameHubForStaff }: {
             </span>
             {event.isCancelled ? <span className="inline-flex min-h-6 items-center rounded-full bg-rose-100 px-2 text-[11px] font-extrabold uppercase tracking-[0.04em] text-rose-800">Cancelled</span> : null}
             {hasPracticePacket ? <span className="inline-flex min-h-6 items-center rounded-full bg-blue-50 px-2 text-[11px] font-extrabold uppercase tracking-[0.04em] text-blue-700">Packet ready</span> : null}
-            <span className={`inline-flex min-h-6 items-center rounded-full border px-2 text-[11px] font-extrabold uppercase tracking-[0.04em] ${rsvpBadgeClasses[rsvp]}`}>
-              {rsvpLabels[rsvp]}
-            </span>
+            {rsvpBadge ? <span className={`inline-flex min-h-6 items-center rounded-full border px-2 text-[11px] font-extrabold uppercase tracking-[0.04em] ${rsvpBadge.className}`}>
+              {rsvpBadge.label}
+            </span> : null}
             {metadataPills.map((pill) => (
               <span key={pill} className="inline-flex min-h-6 items-center rounded-full bg-gray-100 px-2 text-[11px] font-extrabold uppercase tracking-[0.04em] text-gray-600">
                 {pill}
@@ -2425,7 +2429,19 @@ function getEventCardActionPills(event: ParentScheduleEvent | CalendarScheduleEn
 }
 
 function isScheduleAvailabilityNeeded(event: ParentScheduleEvent | CalendarScheduleEntry) {
-  return normalizeRsvpResponse(event.myRsvp) === 'not_responded' && canSubmitScheduleEventRsvp(event);
+  return isScheduleEventAvailabilityNeeded(event);
+}
+
+function getScheduleRsvpBadge(event: ParentScheduleEvent | CalendarScheduleEntry, rsvp = normalizeRsvpResponse(event.myRsvp)) {
+  const capability = getScheduleEventRsvpCapability(event);
+  if (capability === 'calendar_only') {
+    return { label: 'Calendar only', className: 'border-gray-200 bg-gray-100 text-gray-700' };
+  }
+  if (capability === 'locked') {
+    return { label: 'Availability closed', className: 'border-gray-200 bg-gray-100 text-gray-700' };
+  }
+  if (capability !== 'editable') return null;
+  return { label: rsvpLabels[rsvp], className: rsvpBadgeClasses[rsvp] };
 }
 
 function getEventMetadataPills(event: ParentScheduleEvent | CalendarScheduleEntry) {
@@ -2586,7 +2602,8 @@ function CalendarEventPicker({ day, entries, preferGameHubForStaff, onClose }: {
 
 function CalendarEventPickerRow({ entry, preferGameHubForStaff }: { entry: CalendarScheduleEntry; preferGameHubForStaff: boolean }) {
   const rsvp = normalizeRsvpResponse(entry.myRsvp);
-  const needsRsvp = entry.childRsvps.some((child) => normalizeRsvpResponse(child.myRsvp) === 'not_responded') || rsvp === 'not_responded';
+  const needsRsvp = getScheduleEventRsvpCapability(entry) === 'editable'
+    && (entry.childRsvps.some((child) => normalizeRsvpResponse(child.myRsvp) === 'not_responded') || rsvp === 'not_responded');
   const childLabel = entry.childNames.length ? entry.childNames.join(', ') : entry.childName;
   const actionLabel = entry.type === 'practice' ? 'Open practice' : 'Open game';
   const tournamentInfo = getScheduleTournamentInfo(entry);

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -12,6 +12,7 @@ const scheduleServiceMocks = vi.hoisted(() => ({
   claimParentScheduleAssignmentSlot: vi.fn(),
   createScheduleAssignment: vi.fn(),
   createParentScheduleRideOffer: vi.fn(),
+  enableRsvpForImportedCalendarEvent: vi.fn(),
   loadScheduleStatTrackerConfigsForApp: vi.fn<(...args: any[]) => Promise<any[]>>(() => Promise.resolve([{ id: 'cfg-basketball', name: 'Basketball' }])),
   loadParentPracticePacket: vi.fn(),
   loadStaffPracticePacket: vi.fn<(...args: any[]) => Promise<any>>(() => Promise.resolve({
@@ -1393,6 +1394,64 @@ describe('ScheduleEventDetail nav visibility', () => {
     expect(screen.queryByRole('button', { name: 'Going' })).toBeNull();
     expect(screen.queryByLabelText('Availability note')).toBeNull();
     expect(screen.getByTestId('event-route').textContent).toBe('/schedule/team-1/game-1?childId=player-1&section=availability');
+  });
+
+  it.each([
+    ['game', { type: 'game', opponent: 'Wolves', title: null }],
+    ['practice', { type: 'practice', opponent: null, title: 'Skills practice' }]
+  ])('lets authorized staff enable RSVP for an imported calendar %s exactly once', async (_label, eventOverrides) => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        ...eventOverrides,
+        id: 'calendar-uid-1',
+        isDbGame: false,
+        isImported: true,
+        sourceType: 'calendar',
+        sourceLabel: 'Imported calendar',
+        isTeamStaff: true
+      })],
+      children: []
+    });
+    scheduleServiceMocks.enableRsvpForImportedCalendarEvent.mockResolvedValue('tracked-event-1');
+
+    renderScheduleEventDetailWithLocation('/schedule/team-1/calendar-uid-1?childId=player-1&section=availability');
+
+    expect(await screen.findByText('Calendar-only event')).toBeTruthy();
+    expect(screen.queryByText('RSVP needed')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Enable RSVP' }));
+
+    expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('adds a tracked copy'));
+    await waitFor(() => {
+      expect(scheduleServiceMocks.enableRsvpForImportedCalendarEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'calendar-uid-1', type: eventOverrides.type }),
+        auth.user
+      );
+      expect(screen.getByTestId('event-route').textContent).toBe('/schedule/team-1/tracked-event-1?childId=player-1&section=availability');
+    });
+    confirmSpy.mockRestore();
+  });
+
+  it('explains calendar-only RSVP limits to parents without exposing the staff mutation', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        id: 'calendar-uid-1',
+        isDbGame: false,
+        isImported: true,
+        sourceType: 'calendar',
+        sourceLabel: 'Imported calendar',
+        isTeamStaff: false
+      })],
+      children: []
+    });
+
+    renderScheduleEventDetailWithLocation('/schedule/team-1/calendar-uid-1?childId=player-1&section=availability');
+
+    expect(await screen.findByText('Calendar-only event')).toBeTruthy();
+    expect(screen.queryByText('RSVP needed')).toBeNull();
+    expect(screen.getByText('Ask a coach or team admin to enable RSVP for this event.')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Enable RSVP' })).toBeNull();
+    expect(scheduleServiceMocks.enableRsvpForImportedCalendarEvent).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -1409,6 +1409,7 @@ describe('ScheduleEventDetail nav visibility', () => {
         isImported: true,
         sourceType: 'calendar',
         sourceLabel: 'Imported calendar',
+        isTeamAdmin: true,
         isTeamStaff: true
       })],
       children: []
@@ -1432,7 +1433,10 @@ describe('ScheduleEventDetail nav visibility', () => {
     confirmSpy.mockRestore();
   });
 
-  it('explains calendar-only RSVP limits to parents without exposing the staff mutation', async () => {
+  it.each([
+    ['parents', { isTeamAdmin: false, isTeamStaff: false }],
+    ['coach-only staff', { isTeamAdmin: false, isTeamStaff: true }]
+  ])('explains calendar-only RSVP limits to %s without exposing the owner/admin mutation', async (_label, access) => {
     scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
       events: [buildEvent({
         id: 'calendar-uid-1',
@@ -1440,7 +1444,7 @@ describe('ScheduleEventDetail nav visibility', () => {
         isImported: true,
         sourceType: 'calendar',
         sourceLabel: 'Imported calendar',
-        isTeamStaff: false
+        ...access
       })],
       children: []
     });
@@ -1449,7 +1453,7 @@ describe('ScheduleEventDetail nav visibility', () => {
 
     expect(await screen.findByText('Calendar-only event')).toBeTruthy();
     expect(screen.queryByText('RSVP needed')).toBeNull();
-    expect(screen.getByText('Ask a coach or team admin to enable RSVP for this event.')).toBeTruthy();
+    expect(screen.getByText('Ask a team owner or admin to enable RSVP for this event.')).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Enable RSVP' })).toBeNull();
     expect(scheduleServiceMocks.enableRsvpForImportedCalendarEvent).not.toHaveBeenCalled();
   });

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -1290,7 +1290,7 @@ function AvailabilitySection({ event, rsvp, availabilityNote, onAvailabilityNote
           <ReadOnlyAvailabilityPanel event={event} rsvp={visibleRsvp} />
           {isCalendarOnly ? (
             <div className="border-b border-gray-200 bg-white px-3 py-3 sm:px-4">
-              {event.isTeamStaff ? (
+              {event.isTeamAdmin ? (
                 <>
                   <p className="text-sm font-semibold leading-5 text-gray-600">Create a tracked copy of this event so families can respond. The imported calendar entry will be hidden after the tracked copy loads.</p>
                   <button
@@ -1316,7 +1316,7 @@ function AvailabilitySection({ event, rsvp, availabilityNote, onAvailabilityNote
                   </button>
                 </>
               ) : (
-                <p className="text-sm font-semibold leading-5 text-gray-600">Ask a coach or team admin to enable RSVP for this event.</p>
+                <p className="text-sm font-semibold leading-5 text-gray-600">Ask a team owner or admin to enable RSVP for this event.</p>
               )}
               {materializationError ? <div className="mt-2"><Status tone="error" message={materializationError} /></div> : null}
             </div>

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -1,5 +1,5 @@
 import { Suspense, createContext, lazy, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from 'react';
-import { Link, useParams, useSearchParams } from 'react-router-dom';
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { CalendarDays, ChevronDown, ChevronLeft, ClipboardCheck, ExternalLink, FileText, Radio, RefreshCw, Share2, Users, Video, type LucideIcon } from 'lucide-react';
 import {
   cancelPracticeOccurrenceForApp,
@@ -25,6 +25,7 @@ import {
   saveStaffPracticePacket,
   updateGameScore,
   createStaffRsvpAvailabilityLoader,
+  enableRsvpForImportedCalendarEvent,
   type PracticeAttendancePlayer,
   type StaffPracticeAttendance,
   type StaffPracticePacket,
@@ -79,6 +80,7 @@ import {
   getScheduleForecastHref,
   getScheduleLocationLabel,
   canSubmitScheduleEventRsvp,
+  getScheduleEventRsvpCapability,
   isScheduleAssignmentOpen,
   getScheduleTitle,
   getLiveClockViewModel,
@@ -338,6 +340,7 @@ export function shouldAutosaveGeneratedLineupDraft(existingGamePlan: Record<stri
 
 export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
   const { teamId = '', eventId = '' } = useParams();
+  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const decodedTeamId = decodeURIComponent(teamId);
   const decodedEventId = decodeURIComponent(eventId);
@@ -668,6 +671,16 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
   }
 
   const rsvp = normalizeRsvpResponse(selectedEvent.myRsvp);
+  const rsvpCapability = getScheduleEventRsvpCapability(selectedEvent);
+  const rsvpPresentation = rsvpCapability === 'calendar_only'
+    ? { label: 'Calendar only', className: 'border-gray-200 bg-gray-100 text-gray-700' }
+    : rsvpCapability === 'locked'
+      ? { label: 'Availability closed', className: 'border-gray-200 bg-gray-100 text-gray-700' }
+      : rsvpCapability === 'cancelled'
+        ? { label: 'Cancelled', className: 'border-rose-200 bg-rose-50 text-rose-700' }
+        : rsvpCapability === 'untracked'
+          ? { label: 'Availability unavailable', className: 'border-gray-200 bg-gray-100 text-gray-700' }
+          : { label: rsvpLabels[rsvp], className: rsvpBadgeClasses[rsvp] };
   const title = getScheduleTitle(selectedEvent);
   const hasPracticePacket = selectedEvent.type === 'practice' && Boolean(selectedEvent.practiceHomePacketSummary);
   const attentionItems = getAttentionItems(selectedEvent, rsvp).filter((item) => item.section !== 'availability' && item.title !== 'Practice packet ready');
@@ -744,8 +757,8 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
               ) : (
                 <CompactMeta icon={Users} value={`${selectedEvent.childName} · ${selectedEvent.teamName}`} />
               )}
-              rsvpLabel={rsvpLabels[rsvp]}
-              rsvpClassName={rsvpBadgeClasses[rsvp]}
+              rsvpLabel={rsvpPresentation.label}
+              rsvpClassName={rsvpPresentation.className}
               briefPieces={getEventBriefPieces(selectedEvent)}
             />
             <button
@@ -795,6 +808,13 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
             onAvailabilityNoteChange={setAvailabilityNote}
             attentionItems={attentionItems}
             onSelectSection={selectSection}
+            onEventMaterialized={(trackedEventId) => {
+              const childId = String(selectedEvent.childId || '').trim();
+              const query = new URLSearchParams();
+              if (childId) query.set('childId', childId);
+              query.set('section', 'availability');
+              navigate(`/schedule/${encodeURIComponent(selectedEvent.teamId)}/${encodeURIComponent(trackedEventId)}?${query.toString()}`);
+            }}
           />
         ) : null}
         {resolvedActiveSection === 'rideshare' ? <RideshareSection /> : null}
@@ -1138,15 +1158,18 @@ function PracticePacketPrompt({ event, onOpen }: { event: ParentScheduleEvent; o
   );
 }
 
-function AvailabilitySection({ event, rsvp, availabilityNote, onAvailabilityNoteChange, attentionItems, onSelectSection }: {
+function AvailabilitySection({ event, rsvp, availabilityNote, onAvailabilityNoteChange, attentionItems, onSelectSection, onEventMaterialized }: {
   event: ParentScheduleEvent;
   rsvp: RsvpResponse;
   availabilityNote: string;
   onAvailabilityNoteChange: (note: string) => void;
   attentionItems: AttentionItem[];
   onSelectSection: (sectionId: EventDetailSectionId) => void;
+  onEventMaterialized: (trackedEventId: string) => void;
 }) {
-  const { childEvents } = useScheduleEventDetailContext();
+  const { auth, childEvents } = useScheduleEventDetailContext();
+  const [materializing, setMaterializing] = useState(false);
+  const [materializationError, setMaterializationError] = useState('');
   const matchingChildEvents = childEvents.filter((childEvent) => (
     childEvent.teamId === event.teamId && childEvent.id === event.id && Boolean(childEvent.childId) && childEvent.isLinkedParentChild === true
   ));
@@ -1176,6 +1199,17 @@ function AvailabilitySection({ event, rsvp, availabilityNote, onAvailabilityNote
   const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(staffRsvpEventScopeKey), [staffRsvpEventScopeKey]);
   const staffRsvp = useStaffRsvpBreakdown(staffRsvpLoader);
   const showTeamRsvpTools = event.isDbGame && Boolean(event.isTeamAdmin || event.isTeamRsvpReminderManager);
+  const rsvpCapability = getScheduleEventRsvpCapability(event);
+  const isCalendarOnly = rsvpCapability === 'calendar_only';
+  const availabilityPresentation = rsvpCapability === 'calendar_only'
+    ? { label: 'Calendar only', className: 'border-gray-200 bg-gray-100 text-gray-700' }
+    : rsvpCapability === 'locked'
+      ? { label: 'Closed', className: 'border-gray-200 bg-gray-100 text-gray-700' }
+      : rsvpCapability === 'cancelled'
+        ? { label: 'Cancelled', className: 'border-rose-200 bg-rose-50 text-rose-700' }
+        : rsvpCapability === 'untracked'
+          ? { label: 'Unavailable', className: 'border-gray-200 bg-gray-100 text-gray-700' }
+          : { label: rsvpLabels[visibleRsvp], className: rsvpBadgeClasses[visibleRsvp] };
   const availabilitySummary = showTeamRsvpTools ? (staffRsvp.breakdown?.counts || event.rsvpSummary) : event.rsvpSummary;
 
   return (
@@ -1185,8 +1219,8 @@ function AvailabilitySection({ event, rsvp, availabilityNote, onAvailabilityNote
           <h2 className="app-section-title">Availability</h2>
           <div className="mt-0.5 text-xs font-semibold text-gray-500">{formatRsvpSummary(availabilitySummary)}</div>
         </div>
-        <span className={`mt-0.5 inline-flex min-h-6 flex-none items-center rounded-full border px-2 text-[11px] font-extrabold uppercase tracking-[0.04em] ${rsvpBadgeClasses[visibleRsvp]}`}>
-          {rsvpLabels[visibleRsvp]}
+        <span className={`mt-0.5 inline-flex min-h-6 flex-none items-center rounded-full border px-2 text-[11px] font-extrabold uppercase tracking-[0.04em] ${availabilityPresentation.className}`}>
+          {availabilityPresentation.label}
         </span>
       </div>
       {familyRsvpAvailable ? (
@@ -1252,7 +1286,42 @@ function AvailabilitySection({ event, rsvp, availabilityNote, onAvailabilityNote
           />
         </>
       ) : (
-        <ReadOnlyAvailabilityPanel event={event} rsvp={visibleRsvp} />
+        <>
+          <ReadOnlyAvailabilityPanel event={event} rsvp={visibleRsvp} />
+          {isCalendarOnly ? (
+            <div className="border-b border-gray-200 bg-white px-3 py-3 sm:px-4">
+              {event.isTeamStaff ? (
+                <>
+                  <p className="text-sm font-semibold leading-5 text-gray-600">Create a tracked copy of this event so families can respond. The imported calendar entry will be hidden after the tracked copy loads.</p>
+                  <button
+                    type="button"
+                    className="secondary-button mt-3 !min-h-11 text-sm"
+                    disabled={materializing}
+                    onClick={async () => {
+                      const eventLabel = event.type === 'practice' ? 'practice' : 'game';
+                      if (!window.confirm(`Enable RSVP for this imported ${eventLabel}? This adds a tracked copy to the team schedule so families can respond.`)) return;
+                      setMaterializationError('');
+                      setMaterializing(true);
+                      try {
+                        const trackedEventId = await enableRsvpForImportedCalendarEvent(event, auth.user);
+                        onEventMaterialized(trackedEventId);
+                      } catch (nextError: any) {
+                        setMaterializationError(nextError?.message || 'Unable to enable RSVP for this event.');
+                      } finally {
+                        setMaterializing(false);
+                      }
+                    }}
+                  >
+                    {materializing ? 'Enabling RSVP…' : 'Enable RSVP'}
+                  </button>
+                </>
+              ) : (
+                <p className="text-sm font-semibold leading-5 text-gray-600">Ask a coach or team admin to enable RSVP for this event.</p>
+              )}
+              {materializationError ? <div className="mt-2"><Status tone="error" message={materializationError} /></div> : null}
+            </div>
+          ) : null}
+        </>
       )}
       <div className="px-3 pb-3 sm:px-4">
         {rsvpWorkflow.message ? <Status tone="success" message={rsvpWorkflow.message} /> : null}

--- a/apps/app/src/styles/index.css
+++ b/apps/app/src/styles/index.css
@@ -535,7 +535,9 @@
   padding: 8px;
 }
 
-.desktop-app-page .profile-page-web .profile-section-nav button {
+.desktop-app-page .profile-page-web .profile-section-nav a {
+  display: flex;
+  align-items: center;
   justify-content: flex-start;
   border-radius: 10px;
   padding-left: 12px;

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -705,9 +705,9 @@ test('profile exposes account, notification, invite, verification, password, upl
     await expect(page.locator('.profile-summary-card img')).toHaveAttribute('src', mockAvatarUrl);
     await expect.poll(async () => page.evaluate(() => window.__appProfileCalls.profileLoads)).toBeGreaterThan(0);
 
-    const alertsTab = page.getByRole('button', { name: 'Alerts', exact: true });
+    const alertsTab = page.getByRole('link', { name: 'Notifications', exact: true });
     await alertsTab.click();
-    await expect(alertsTab).toHaveAttribute('aria-pressed', 'true');
+    await expect(alertsTab).toHaveAttribute('aria-current', 'page');
     await expect.poll(async () => page.evaluate(() => window.__appProfileCalls.pushModuleLoads)).toBe(1);
     await expect(page.getByText('Per-team alerts for live chat, score updates, and schedule changes.')).toBeVisible();
     await expect(page.getByLabel('Team')).toHaveValue('team-1');
@@ -724,7 +724,7 @@ test('profile exposes account, notification, invite, verification, password, upl
     await page.getByRole('button', { name: 'Save preferences' }).click();
     await expect(page.getByText('Notification preferences saved.')).toBeVisible();
 
-    await page.getByRole('button', { name: 'Invites', exact: true }).click();
+    await page.getByRole('link', { name: 'Invites', exact: true }).click();
     await expect(page.getByRole('button', { name: 'Create invite' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Show more codes' })).toBeVisible();
     await page.getByLabel('Recipient email').fill('friend@example.com');
@@ -756,7 +756,7 @@ test('profile exposes account, notification, invite, verification, password, upl
 
     await page.goto(appUrl(baseURL, '/profile/settings'), { waitUntil: 'domcontentloaded' });
 
-    await page.getByRole('button', { name: 'Security', exact: true }).click();
+    await page.getByRole('link', { name: 'Sign-in & security', exact: true }).click();
     await expect(page.getByText('Email not verified')).toBeVisible();
     await expect(page.getByText('Set a password')).toBeVisible();
     await page.locator('input[placeholder="New password"]').fill('new-password');
@@ -848,7 +848,7 @@ test('profile keeps destructive alert actions disabled until a failed team load 
     });
     await page.goto(appUrl(baseURL, '/profile/settings'), { waitUntil: 'domcontentloaded' });
 
-    await page.getByRole('button', { name: 'Alerts', exact: true }).click();
+    await page.getByRole('link', { name: 'Notifications', exact: true }).click();
     await expect(page.getByLabel('Team')).toHaveValue('team-1');
     await page.getByLabel('Team').selectOption('team-2');
 
@@ -905,7 +905,7 @@ test('profile alerts recover from blocked native notification permissions', asyn
     });
     await page.goto(appUrl(baseURL, '/profile/settings'), { waitUntil: 'domcontentloaded' });
 
-    await page.getByRole('button', { name: 'Alerts', exact: true }).click();
+    await page.getByRole('link', { name: 'Notifications', exact: true }).click();
     await expect(page.getByText('Notifications are off in device settings')).toBeVisible();
     await page.getByRole('button', { name: 'Open device settings' }).first().click();
     await expect.poll(async () => page.evaluate(() => window.__appProfileCalls.openPushSettings)).toBe(1);

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -469,6 +469,10 @@ async function mockAppModules(page, { user = null, emailLink = false } = {}) {
                     return 'imported-practice';
                 }
 
+                export async function enableRsvpForImportedCalendarEvent() {
+                    return 'calendar-materialized-event';
+                }
+
                 export async function loadParentSchedule() {
                     return { children: [], events: [] };
                 }

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -677,6 +677,7 @@ async function mockHomePlayerModules(page, { switchableSocialTargets = false, fa
                 export async function createScheduledTournamentBlockForApp() { return { batchId: 'batch-new', gameIds: [] }; }
                 export async function createScheduleImportGame() { return 'import-game'; }
                 export async function createScheduleImportPractice() { return 'import-practice'; }
+                export async function enableRsvpForImportedCalendarEvent() { return 'calendar-materialized-event'; }
                 export async function finalizeScheduleImportBatch() { return { success: true }; }
                 export async function cancelPracticeOccurrenceForApp() { return { cancelled: true }; }
                 export async function cancelScheduledGameForApp() { return { cancelled: true }; }

--- a/tests/smoke/app-performance-timers.spec.js
+++ b/tests/smoke/app-performance-timers.spec.js
@@ -209,6 +209,10 @@ async function mockScheduleAppModules(page) {
                     return 'import-practice';
                 }
 
+                export async function enableRsvpForImportedCalendarEvent() {
+                    return 'calendar-materialized-event';
+                }
+
                 export async function finalizeScheduleImportBatch() {
                     return { ok: true };
                 }

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -576,6 +576,12 @@ async function mockScheduleModules(page, options = {}) {
                     return { going: events.length, maybe: 0, notGoing: 0, notResponded: 0 };
                 }
 
+                export async function enableRsvpForImportedCalendarEvent(event) {
+                    const trackedEventId = 'calendar-materialized-event';
+                    window.__scheduleCalls.materializedEvent = { eventId: event.id, trackedEventId };
+                    return trackedEventId;
+                }
+
                 export async function updateGameScore(teamId, gameId, score, user) {
                     const payload = {
                         homeScore: Number(score?.homeScore ?? 0),

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -500,6 +500,10 @@ async function mockTeamsModules(page, { scenario = '', managedTeam = false, rost
                     return { events: [] };
                 }
 
+                export async function enableRsvpForImportedCalendarEvent() {
+                    return 'calendar-materialized-event';
+                }
+
                 export async function sendStaffRsvpReminder() {
                     return { messageId: 'message-1', emailRecipientCount: 0 };
                 }

--- a/tests/unit/app-profile-invites.test.tsx
+++ b/tests/unit/app-profile-invites.test.tsx
@@ -213,7 +213,7 @@ describe('Profile invites', () => {
     publicActionsMocks.sharePublicUrl.mockResolvedValue('shared');
     renderProfile();
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Invites' }));
+    fireEvent.click(await screen.findByRole('link', { name: 'Invites' }));
     fireEvent.change(screen.getByLabelText('Recipient email'), { target: { value: 'coach@example.com' } });
     fireEvent.click(screen.getByRole('button', { name: 'Create invite' }));
 
@@ -233,7 +233,7 @@ describe('Profile invites', () => {
   it('requires an email or phone before generating a friend invite', async () => {
     renderProfile();
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Invites' }));
+    fireEvent.click(await screen.findByRole('link', { name: 'Invites' }));
     fireEvent.click(screen.getByRole('button', { name: 'Create invite' }));
 
     expect(await screen.findByText('Enter an email or phone number for the invite.')).toBeTruthy();
@@ -244,7 +244,7 @@ describe('Profile invites', () => {
     publicActionsMocks.sharePublicUrl.mockResolvedValueOnce('copied').mockResolvedValueOnce('cancelled');
     renderProfile();
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Invites' }));
+    fireEvent.click(await screen.findByRole('link', { name: 'Invites' }));
 
     const shareButtons = await screen.findAllByRole('button', { name: /Share saved invite link/ });
     expect(shareButtons).toHaveLength(1);
@@ -290,7 +290,7 @@ describe('Profile invites', () => {
 
     renderProfile();
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Invites' }));
+    fireEvent.click(await screen.findByRole('link', { name: 'Invites' }));
     fireEvent.click(await screen.findByRole('button', { name: /Share saved invite link for ACTIVE123/ }));
 
     await waitFor(() => expect(publicActionsMocks.sharePublicUrl).toHaveBeenCalledWith(expect.objectContaining({
@@ -318,7 +318,7 @@ describe('Profile invites', () => {
 
     renderProfile();
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Invites' }));
+    fireEvent.click(await screen.findByRole('link', { name: 'Invites' }));
 
     expect(await screen.findByLabelText('Copy saved invite code RECENT1')).toBeTruthy();
     expect(screen.queryByLabelText('Copy saved invite code OLDER4')).toBeNull();
@@ -429,7 +429,7 @@ describe('Profile invites', () => {
 
     renderProfile();
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Alerts' }));
+    fireEvent.click(await screen.findByRole('link', { name: 'Notifications' }));
 
     await waitFor(() => expect(profileServiceMocks.loadNotificationTeams).toHaveBeenCalledTimes(1));
     expect(screen.getByText('Loading your alert teams…')).toBeTruthy();
@@ -458,7 +458,7 @@ describe('Profile invites', () => {
 
     renderProfile();
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Alerts' }));
+    fireEvent.click(await screen.findByRole('link', { name: 'Notifications' }));
 
     expect(await screen.findByText('No team alerts available yet')).toBeTruthy();
     expect(screen.getByText('Join or create a team first, then come back here to turn on game-day and team update alerts.')).toBeTruthy();
@@ -476,7 +476,7 @@ describe('Profile invites', () => {
 
     renderProfile();
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Alerts' }));
+    fireEvent.click(await screen.findByRole('link', { name: 'Notifications' }));
 
     expect(await screen.findByText('Alerts unavailable')).toBeTruthy();
     expect(screen.getByText('network offline')).toBeTruthy();
@@ -497,7 +497,7 @@ describe('Profile invites', () => {
 
     renderProfile();
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Alerts' }));
+    fireEvent.click(await screen.findByRole('link', { name: 'Notifications' }));
 
     await waitFor(() => expect((screen.getByLabelText('Team') as HTMLSelectElement).value).toBe('team-1'));
     await waitFor(() => expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledTimes(1));
@@ -524,7 +524,7 @@ describe('Profile invites', () => {
 
     renderProfile();
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Alerts' }));
+    fireEvent.click(await screen.findByRole('link', { name: 'Notifications' }));
 
     await waitFor(() => expect((screen.getByLabelText('Team') as HTMLSelectElement).value).toBe('team-1'));
     const gameDayButton = await screen.findByRole('button', { name: 'Turn on game-day alerts' });
@@ -549,7 +549,7 @@ describe('Profile invites', () => {
 
     renderProfile();
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Alerts' }));
+    fireEvent.click(await screen.findByRole('link', { name: 'Notifications' }));
 
     await waitFor(() => expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledTimes(1));
     const teamSelect = await screen.findByLabelText('Team');
@@ -591,7 +591,7 @@ describe('Profile invites', () => {
 
     renderProfile();
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Alerts' }));
+    fireEvent.click(await screen.findByRole('link', { name: 'Notifications' }));
 
     await waitFor(() => expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledTimes(1));
     const teamSelect = await screen.findByLabelText('Team') as HTMLSelectElement;
@@ -634,7 +634,7 @@ describe('Profile invites', () => {
 
     renderProfile();
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Alerts' }));
+    fireEvent.click(await screen.findByRole('link', { name: 'Notifications' }));
 
     await waitFor(() => expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledTimes(1));
     const teamSelect = await screen.findByLabelText('Team');
@@ -670,7 +670,7 @@ describe('Profile invites', () => {
 
     renderProfile();
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Alerts' }));
+    fireEvent.click(await screen.findByRole('link', { name: 'Notifications' }));
 
     await waitFor(() => expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledTimes(1));
     fireEvent.change(await screen.findByLabelText('Team'), { target: { value: 'team-2' } });
@@ -708,7 +708,7 @@ describe('Profile invites', () => {
 
     renderProfile({ strictMode: true });
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Alerts' }));
+    fireEvent.click(await screen.findByRole('link', { name: 'Notifications' }));
 
     await waitFor(() => expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledTimes(1));
     expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledWith('user-1', 'team-1');
@@ -738,7 +738,7 @@ describe('Profile invites', () => {
 
     renderProfile();
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Alerts' }));
+    fireEvent.click(await screen.findByRole('link', { name: 'Notifications' }));
 
     expect(await screen.findByText('Notifications are off in device settings')).toBeTruthy();
     fireEvent.click(screen.getAllByRole('button', { name: 'Open device settings' })[0]);
@@ -763,7 +763,7 @@ describe('Profile invites', () => {
 
     renderProfile();
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Alerts' }));
+    fireEvent.click(await screen.findByRole('link', { name: 'Notifications' }));
     await screen.findByText('Notifications are off in device settings');
 
     const openSettingsButton = await screen.findByRole('button', { name: 'Open device settings to finish alerts' });

--- a/tests/unit/app-profile-section-restore.test.tsx
+++ b/tests/unit/app-profile-section-restore.test.tsx
@@ -175,13 +175,13 @@ describe('Profile section restore from URL', () => {
   it('restores alerts section and selects the correct team when mounted with ?section=alerts&teamId=team-2', async () => {
     renderProfileAt('?section=alerts&teamId=team-2');
 
-    // The Alerts section nav button should be visually active (aria-pressed)
-    const alertsButton = await screen.findByRole('button', { name: 'Alerts' });
-    expect(alertsButton.getAttribute('aria-pressed')).toBe('true');
+    // The Notifications section link should be visually and semantically active.
+    const alertsButton = await screen.findByRole('link', { name: 'Notifications' });
+    expect(alertsButton.getAttribute('aria-current')).toBe('page');
 
     // Account button should not be active
-    const accountButton = screen.getByRole('button', { name: 'Account' });
-    expect(accountButton.getAttribute('aria-pressed')).toBe('false');
+    const accountButton = screen.getByRole('link', { name: 'Profile' });
+    expect(accountButton.getAttribute('aria-current')).toBeNull();
 
     // Wait for teams to load and team-2 to be selected
     await waitFor(() => {
@@ -200,8 +200,8 @@ describe('Profile section restore from URL', () => {
     renderProfileAt('?section=alerts&teamId=nonexistent-team');
 
     // Should still show the Alerts section
-    const alertsButton = await screen.findByRole('button', { name: 'Alerts' });
-    expect(alertsButton.getAttribute('aria-pressed')).toBe('true');
+    const alertsButton = await screen.findByRole('link', { name: 'Notifications' });
+    expect(alertsButton.getAttribute('aria-current')).toBe('page');
 
     // Should fall back to the first team (team-1)
     await waitFor(() => {
@@ -219,11 +219,11 @@ describe('Profile section restore from URL', () => {
   it('defaults to the account section when no section param is in the URL', async () => {
     renderProfileAt('');
 
-    const accountButton = await screen.findByRole('button', { name: 'Account' });
-    expect(accountButton.getAttribute('aria-pressed')).toBe('true');
+    const accountButton = await screen.findByRole('link', { name: 'Profile' });
+    expect(accountButton.getAttribute('aria-current')).toBe('page');
 
-    const alertsButton = screen.getByRole('button', { name: 'Alerts' });
-    expect(alertsButton.getAttribute('aria-pressed')).toBe('false');
+    const alertsButton = screen.getByRole('link', { name: 'Notifications' });
+    expect(alertsButton.getAttribute('aria-current')).toBeNull();
 
     // Account form should be visible
     expect(screen.getByRole('button', { name: 'Save profile' })).toBeTruthy();
@@ -234,8 +234,8 @@ describe('Profile section restore from URL', () => {
   it('defaults to the account section when an invalid section param is given', async () => {
     renderProfileAt('?section=badvalue');
 
-    const accountButton = await screen.findByRole('button', { name: 'Account' });
-    expect(accountButton.getAttribute('aria-pressed')).toBe('true');
+    const accountButton = await screen.findByRole('link', { name: 'Profile' });
+    expect(accountButton.getAttribute('aria-current')).toBe('page');
     expect(screen.getByRole('button', { name: 'Save profile' })).toBeTruthy();
   });
 });

--- a/tests/unit/app-public-team-search.test.tsx
+++ b/tests/unit/app-public-team-search.test.tsx
@@ -95,6 +95,23 @@ describe('PublicTeamSearch', () => {
         expect(getPublicTeamsPage).not.toHaveBeenCalled();
     });
 
+    it('uses a smaller page and skips roster-count fan-out for embedded discovery', async () => {
+        renderSearch({ pageSize: 12, showRosterCounts: false });
+
+        expect(getPublicTeamsPage).not.toHaveBeenCalled();
+        fireEvent.click(screen.getByRole('button', { name: /Browse all public teams/i }));
+
+        await waitFor(() => expect(getPublicTeamsPage).toHaveBeenCalledWith({
+            searchText: undefined,
+            cursor: null,
+            includeRosterCounts: false,
+            pageSize: 12
+        }));
+        expect(await screen.findByText('Atlanta United')).toBeTruthy();
+        expect(hydratePublicTeamRosterCounts).not.toHaveBeenCalled();
+        expect(screen.queryByText(/^(Loading roster count|Roster count unavailable|\d+ players?)$/i)).toBeNull();
+    });
+
     it('keeps the public browse route decoupled from the private Teams page module', () => {
         const source = readFileSync(resolve(import.meta.dirname, '../../apps/app/src/components/PublicTeamSearch.tsx'), 'utf8');
 


### PR DESCRIPTION
## Summary

- Let Home render its primary content without waiting for every secondary schedule/action request, and preserve a recoverable “Needs refresh” state across unsuccessful retries.
- Make Discover teams search-first, cap result work at 12 teams, and avoid eager roster fan-out.
- Replace the profile’s disconnected settings affordances with URL-backed sub-navigation and one clear Edit profile action.
- Give imported games and practices the same RSVP entry point as native events; authorized team owners/admins materialize an idempotent tracked occurrence before saving availability.

## Why

The app could feel stalled because secondary Home requests held the whole view open, Discover did unnecessary work before the user searched, profile settings lacked clear information architecture, and imported calendar events used a different RSVP workflow. This change aligns those paths with the existing native schedule/profile patterns while preserving Firestore authorization boundaries.

## Review fixes

- Restrict imported-event materialization to team owners/admins, matching game-create rules.
- Include the occurrence start time in materialization IDs so recurring calendar entries sharing a UID remain distinct.
- Keep Home’s failed-detail marker until a secondary refresh succeeds.
- Keep every Playwright `scheduleService` route mock synchronized with the new named export; this fixes the preview telemetry smoke’s lazy event-detail import.

## Verification

Validated exact head `88bb14d2987e7e97e6f79316d7429336f4ed3ae8` against base `196cd6da307eed43cd454487bb447ca5457ae5fa`:

- 470 focused app tests passed
- full app suite: 155 files / 1,768 tests passed
- full repository unit suite: 739 files / 5,611 tests passed; 154 intentional skips
- ESLint: zero errors
- TypeScript production build passed
- bundle visualizer and cold-start budget passed (49.1 KB entry; 381.7 KB initial gzip)
- 52 staged Playwright smokes passed on the reconciled head: all 22 schedule/RSVP cases plus all 30 Home telemetry, performance, profile, and Teams cases
- the exact CI failure reproduced locally before the mock fix and passed afterward with all six Home workflow timers recorded
- `git diff --check` passed and the worktree was clean before push

### Test-isolation notes

- One deliberately over-parallel local run (two Vitest pools plus the minified build) starved the private-AI DOM test. The discriminating file passed 12/12 with no code change, and the exact full repository command passed standalone.
- The first preview CI run exposed a deterministic stale-mock interface failure. It was classified from job logs, reproduced exactly, fixed across all four affected route mocks, and revalidated before the fast-forward push.