### PR TITLE
Bound production smoke network waits

### DIFF
--- a/tests/smoke/app-authenticated-extended.spec.js
+++ b/tests/smoke/app-authenticated-extended.spec.js
@@ -30,6 +30,7 @@ const secretValues = [
     config.parentEmail,
     config.parentPassword
 ];
+const LIVE_ACTION_TIMEOUT_MS = 25_000;
 
 test.skip(!extendedEnabled, 'SMOKE_EXTENDED_WRITES=1 is required');
 test.describe.configure({ mode: 'serial' });
@@ -122,6 +123,7 @@ test.afterAll(async () => {
 
 async function withAuthenticatedPage(session, callback) {
     const { page, issues } = session;
+    page.setDefaultTimeout(LIVE_ACTION_TIMEOUT_MS);
     await callback(page);
     expect(issues.map((issue) => redactSmokeDiagnostic(issue, secretValues))).toEqual([]);
 }
@@ -180,36 +182,38 @@ test('staff smoke writes are deterministic and removed after validation', async 
             await expect(page.getByText(`${playerName} added to roster.`)).toBeVisible({ timeout: 20_000 });
             await expect(page.getByText(playerName, { exact: true })).toBeVisible();
 
-            await openRoute(
-                page,
-                `/schedule?scope=staff&teamId=${encodeURIComponent(config.teamId)}`
-            );
-            const scheduleTools = page.locator('section[aria-label="Manage schedule tools"]');
-            await expect(scheduleTools).toBeVisible({ timeout: 25_000 });
-            const manageSchedule = scheduleTools.locator('button[aria-controls]').first();
-            await expect(manageSchedule).toBeVisible({ timeout: 25_000 });
-            await manageSchedule.click({ timeout: 25_000 });
-            await expect(manageSchedule).toHaveAttribute('aria-expanded', 'true', { timeout: 25_000 });
-            const createGame = page.locator('section[aria-label="Create game"]');
-            await expect(createGame).toBeVisible({ timeout: 25_000 });
-            await createGame.getByLabel('Opponent').fill(opponentName);
-            await createGame.getByRole('button', { name: 'Create game' }).click();
-            await expect(page.getByText('Game created and schedule refreshed.')).toBeVisible({ timeout: 30_000 });
-            await expect(page.getByText(opponentName, { exact: false }).first()).toBeVisible();
-            const createdEvents = await findFirestoreDocumentsByStringField(
-                staffRestSession,
-                `teams/${config.teamId}/games`,
-                'opponent',
-                opponentName
-            );
-            expect(createdEvents).toHaveLength(1);
-            const createdEventId = getFirestoreDocumentPath(createdEvents[0]).split('/').pop();
-            expect(createdEventId).toBeTruthy();
-            await openRoute(
-                page,
-                `/schedule/${encodeURIComponent(config.teamId)}/${encodeURIComponent(createdEventId)}?section=game`
-            );
-            await expect(page.locator('main')).toContainText(opponentName);
+            await test.step('create and verify a schedule game', async () => {
+                await openRoute(
+                    page,
+                    `/schedule?scope=staff&teamId=${encodeURIComponent(config.teamId)}`
+                );
+                const scheduleTools = page.locator('section[aria-label="Manage schedule tools"]');
+                await expect(scheduleTools).toBeVisible({ timeout: 25_000 });
+                const manageSchedule = scheduleTools.locator('button[aria-controls]').first();
+                await expect(manageSchedule).toBeVisible({ timeout: 25_000 });
+                await manageSchedule.click({ timeout: 25_000 });
+                await expect(manageSchedule).toHaveAttribute('aria-expanded', 'true', { timeout: 25_000 });
+                const createGame = page.locator('section[aria-label="Create game"]');
+                await expect(createGame).toBeVisible({ timeout: 25_000 });
+                await createGame.getByLabel('Opponent').fill(opponentName);
+                await createGame.getByRole('button', { name: 'Create game' }).click();
+                await expect(page.getByText('Game created and schedule refreshed.')).toBeVisible({ timeout: 30_000 });
+                await expect(page.getByText(opponentName, { exact: false }).first()).toBeVisible();
+                const createdEvents = await findFirestoreDocumentsByStringField(
+                    staffRestSession,
+                    `teams/${config.teamId}/games`,
+                    'opponent',
+                    opponentName
+                );
+                expect(createdEvents).toHaveLength(1);
+                const createdEventId = getFirestoreDocumentPath(createdEvents[0]).split('/').pop();
+                expect(createdEventId).toBeTruthy();
+                await openRoute(
+                    page,
+                    `/schedule/${encodeURIComponent(config.teamId)}/${encodeURIComponent(createdEventId)}?section=game`
+                );
+                await expect(page.locator('main')).toContainText(opponentName);
+            });
 
             await openRoute(page, `/messages/${encodeURIComponent(config.teamId)}`);
             const composer = page.locator('.chat-composer-textarea');

--- a/tests/smoke/app-authenticated-image-writes.spec.js
+++ b/tests/smoke/app-authenticated-image-writes.spec.js
@@ -92,10 +92,12 @@ async function openRoute(page, route) {
 async function openWritableMediaAlbum(page) {
     await openRoute(page, `/teams/${encodeURIComponent(config.teamId)}/media`);
     const photoButton = page.getByRole('button', { name: 'Photo', exact: true });
-    if (await photoButton.isVisible({ timeout: 15_000 }).catch(() => false)) return photoButton;
+    if (await photoButton.waitFor({ state: 'visible', timeout: 15_000 }).then(() => true).catch(() => false)) {
+        return photoButton;
+    }
 
     const refreshMedia = page.getByRole('button', { name: 'Refresh media' });
-    if (await refreshMedia.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    if (await refreshMedia.waitFor({ state: 'visible', timeout: 5_000 }).then(() => true).catch(() => false)) {
         await refreshMedia.click({ timeout: LIVE_ACTION_TIMEOUT_MS });
     } else {
         await page.reload({ waitUntil: 'domcontentloaded', timeout: LIVE_ACTION_TIMEOUT_MS });

--- a/tests/smoke/app-authenticated-image-writes.spec.js
+++ b/tests/smoke/app-authenticated-image-writes.spec.js
@@ -29,6 +29,7 @@ const runId = String(config.runId || '').replace(/[^A-Za-z0-9_-]/g, '').slice(0,
 const attemptNonce = randomUUID().replace(/-/g, '');
 const smokePrefix = `allplays-smoke-${runId}-${attemptNonce}`;
 const secretValues = [config.staffEmail, config.staffPassword, config.parentEmail, config.parentPassword];
+const LIVE_ACTION_TIMEOUT_MS = 25_000;
 
 test.skip(!extendedEnabled, 'SMOKE_EXTENDED_WRITES=1 is required');
 
@@ -77,6 +78,7 @@ test.afterAll(async () => {
 
 async function withAuthenticatedPage(callback) {
     const { page, issues } = staffSession;
+    page.setDefaultTimeout(LIVE_ACTION_TIMEOUT_MS);
     await callback(page);
     expect(issues.map((issue) => redactSmokeDiagnostic(issue, secretValues))).toEqual([]);
 }
@@ -85,6 +87,24 @@ async function openRoute(page, route) {
     await page.goto(buildAppSmokeUrl(config.appBaseUrl, route), { waitUntil: 'domcontentloaded' });
     await expect(page.locator('main')).toBeVisible({ timeout: 25_000 });
     await expect.poll(() => new URL(page.url()).hash, { timeout: 20_000 }).toContain(`#${route.split('?')[0]}`);
+}
+
+async function openWritableMediaAlbum(page) {
+    await openRoute(page, `/teams/${encodeURIComponent(config.teamId)}/media`);
+    const photoButton = page.getByRole('button', { name: 'Photo', exact: true });
+    if (await photoButton.isVisible({ timeout: 15_000 }).catch(() => false)) return photoButton;
+
+    const refreshMedia = page.getByRole('button', { name: 'Refresh media' });
+    if (await refreshMedia.isVisible({ timeout: 5_000 }).catch(() => false)) {
+        await refreshMedia.click({ timeout: LIVE_ACTION_TIMEOUT_MS });
+    } else {
+        await page.reload({ waitUntil: 'domcontentloaded', timeout: LIVE_ACTION_TIMEOUT_MS });
+    }
+    await expect(
+        photoButton,
+        'The existing smoke media album must become writable after one bounded read-only refresh'
+    ).toBeVisible({ timeout: LIVE_ACTION_TIMEOUT_MS });
+    return photoButton;
 }
 
 async function restoreImageFieldsIfUnchanged(documentState, fieldNames = Object.keys(documentState.expectedFields)) {
@@ -208,9 +228,7 @@ test('staff image upload is persisted and removed after validation', async () =>
 
     try {
         await withAuthenticatedPage(async (page) => {
-            await openRoute(page, `/teams/${encodeURIComponent(config.teamId)}/media`);
-            const photoButton = page.getByRole('button', { name: 'Photo', exact: true });
-            await expect(photoButton, 'The smoke team must have an existing writable media album').toBeVisible({ timeout: 25_000 });
+            await openWritableMediaAlbum(page);
             const photoInput = page.locator('input[type="file"][accept="image/*"]');
             await photoInput.setInputFiles({
                 name: mediaName,

--- a/tests/smoke/helpers/firebase-rest.js
+++ b/tests/smoke/helpers/firebase-rest.js
@@ -1,6 +1,35 @@
 const firestoreApiOrigin = 'https://firestore.googleapis.com';
 const identityToolkitOrigin = 'https://identitytoolkit.googleapis.com';
 const firebaseStorageOrigin = 'https://firebasestorage.googleapis.com';
+export const FIREBASE_REST_REQUEST_TIMEOUT_MS = 30_000;
+const FIREBASE_REST_RETRY_ATTEMPTS = 2;
+
+async function fetchFirebase(input, init = {}, { retrySafe = false } = {}) {
+    const attempts = retrySafe ? FIREBASE_REST_RETRY_ATTEMPTS : 1;
+    let lastError;
+
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+        try {
+            const response = await fetch(input, {
+                ...init,
+                signal: AbortSignal.timeout(FIREBASE_REST_REQUEST_TIMEOUT_MS)
+            });
+            const retryableStatus = response.status === 429 || response.status >= 500;
+            if (!retrySafe || !retryableStatus || attempt === attempts) return response;
+            await response.arrayBuffer().catch(() => {});
+        } catch (error) {
+            lastError = error;
+            if (!retrySafe || attempt === attempts) {
+                throw new Error(
+                    `Firebase smoke request failed within ${FIREBASE_REST_REQUEST_TIMEOUT_MS}ms`,
+                    { cause: error }
+                );
+            }
+        }
+    }
+
+    throw lastError || new Error('Firebase smoke request failed');
+}
 
 function encodeDocumentPath(path) {
     return String(path || '')
@@ -19,16 +48,16 @@ async function readJson(response, operation) {
 
 async function loadFirebaseSmokeConfig(appBaseUrl) {
     const origin = new URL(appBaseUrl).origin;
-    const hostingResponse = await fetch(`${origin}/__/firebase/init.json`, {
+    const hostingResponse = await fetchFirebase(`${origin}/__/firebase/init.json`, {
         headers: { accept: 'application/json' }
-    });
+    }, { retrySafe: true });
     if (hostingResponse.ok) {
         return hostingResponse.json();
     }
 
-    const runtimeResponse = await fetch(`${origin}/.well-known/allplays-runtime-config.json`, {
+    const runtimeResponse = await fetchFirebase(`${origin}/.well-known/allplays-runtime-config.json`, {
         headers: { accept: 'application/json' }
-    });
+    }, { retrySafe: true });
     const runtimeConfig = await readJson(runtimeResponse, 'AllPlays smoke runtime configuration load');
     return runtimeConfig.firebase || runtimeConfig.firebasePrimary || {};
 }
@@ -40,7 +69,7 @@ export async function createFirebaseRestSession({ appBaseUrl, email, password })
         throw new Error('Firebase smoke configuration is incomplete');
     }
 
-    const authResponse = await fetch(
+    const authResponse = await fetchFirebase(
         `${identityToolkitOrigin}/v1/accounts:signInWithPassword?key=${encodeURIComponent(config.apiKey)}`,
         {
             method: 'POST',
@@ -53,7 +82,8 @@ export async function createFirebaseRestSession({ appBaseUrl, email, password })
                 password,
                 returnSecureToken: true
             })
-        }
+        },
+        { retrySafe: true }
     );
     const auth = await readJson(authResponse, 'Firebase smoke authentication');
     if (!auth.idToken || !auth.localId) {
@@ -80,9 +110,9 @@ export async function listFirestoreDocuments(session, collectionPath) {
     const documents = [];
     let pageToken = '';
     do {
-        const response = await fetch(documentsUrl(session, collectionPath, pageToken), {
+        const response = await fetchFirebase(documentsUrl(session, collectionPath, pageToken), {
             headers: { authorization: `Bearer ${session.idToken}` }
-        });
+        }, { retrySafe: true });
         if (response.status === 404) return documents;
         const payload = await readJson(response, 'Firestore smoke collection read');
         documents.push(...(payload.documents || []));
@@ -130,14 +160,14 @@ export async function findFirestoreDocumentsByStringFields(session, collectionPa
     );
     const parentSuffix = parentPath ? `/${encodeDocumentPath(parentPath)}` : '';
     const url = `${firestoreApiOrigin}/v1/projects/${encodeURIComponent(session.projectId)}/databases/(default)/documents${parentSuffix}:runQuery`;
-    const response = await fetch(url, {
+    const response = await fetchFirebase(url, {
         method: 'POST',
         headers: {
             authorization: `Bearer ${session.idToken}`,
             'content-type': 'application/json'
         },
         body: JSON.stringify({ structuredQuery })
-    });
+    }, { retrySafe: true });
     const payload = await readJson(response, 'Firestore smoke filtered query');
     return payload
         .map((entry) => entry.document)
@@ -168,10 +198,10 @@ export async function deleteFirestoreDocument(session, documentPath, { updateTim
     if (updateTime) {
         url.searchParams.set('currentDocument.updateTime', updateTime);
     }
-    const response = await fetch(url, {
+    const response = await fetchFirebase(url, {
         method: 'DELETE',
         headers: { authorization: `Bearer ${session.idToken}` }
-    });
+    }, { retrySafe: true });
     if (!response.ok && response.status !== 404) {
         throw new Error(`Firestore smoke cleanup failed with status ${response.status}`);
     }
@@ -179,9 +209,9 @@ export async function deleteFirestoreDocument(session, documentPath, { updateTim
 
 export async function getFirestoreDocument(session, documentPath) {
     const url = `${firestoreApiOrigin}/v1/projects/${encodeURIComponent(session.projectId)}/databases/(default)/documents/${encodeDocumentPath(documentPath)}`;
-    const response = await fetch(url, {
+    const response = await fetchFirebase(url, {
         headers: { authorization: `Bearer ${session.idToken}` }
-    });
+    }, { retrySafe: true });
     if (response.status === 404) return null;
     return readJson(response, 'Firestore smoke document read');
 }
@@ -206,7 +236,7 @@ export async function patchFirestoreDocumentFields(
     if (updateTime) {
         url.searchParams.set('currentDocument.updateTime', updateTime);
     }
-    const response = await fetch(url, {
+    const response = await fetchFirebase(url, {
         method: 'PATCH',
         headers: {
             authorization: `Bearer ${session.idToken}`,
@@ -240,7 +270,7 @@ export async function restoreFirestoreDocumentFields(
         url.searchParams.set('currentDocument.updateTime', updateTime);
     }
     const originalFields = originalDocument?.fields || {};
-    const response = await fetch(url, {
+    const response = await fetchFirebase(url, {
         method: 'PATCH',
         headers: {
             authorization: `Bearer ${session.idToken}`,
@@ -262,7 +292,7 @@ export async function createFirestoreDocument(session, documentPath, fields) {
         `${firestoreApiOrigin}/v1/projects/${encodeURIComponent(session.projectId)}/databases/(default)/documents/${encodeDocumentPath(documentPath)}`
     );
     url.searchParams.set('currentDocument.exists', 'false');
-    const response = await fetch(url, {
+    const response = await fetchFirebase(url, {
         method: 'PATCH',
         headers: {
             authorization: `Bearer ${session.idToken}`,
@@ -279,7 +309,7 @@ export async function restoreFirestoreDocument(session, documentPath, originalDo
         return;
     }
     const url = `${firestoreApiOrigin}/v1/projects/${encodeURIComponent(session.projectId)}/databases/(default)/documents/${encodeDocumentPath(documentPath)}`;
-    const response = await fetch(url, {
+    const response = await fetchFirebase(url, {
         method: 'PATCH',
         headers: {
             authorization: `Bearer ${session.idToken}`,
@@ -312,7 +342,7 @@ export async function uploadFirebaseStorageObject(session, storagePath, body, co
     );
     url.searchParams.set('uploadType', 'media');
     url.searchParams.set('name', storagePath);
-    const response = await fetch(url, {
+    const response = await fetchFirebase(url, {
         method: 'POST',
         headers: {
             authorization: `Bearer ${session.idToken}`,
@@ -327,10 +357,10 @@ export async function deleteFirebaseStorageObject(session, storagePath) {
     if (!storagePath) return;
     if (!session.storageBucket) throw new Error('Firebase smoke storage bucket is unavailable');
     const url = `${firebaseStorageOrigin}/v0/b/${encodeURIComponent(session.storageBucket)}/o/${encodeURIComponent(storagePath)}`;
-    const response = await fetch(url, {
+    const response = await fetchFirebase(url, {
         method: 'DELETE',
         headers: { authorization: `Bearer ${session.idToken}` }
-    });
+    }, { retrySafe: true });
     if (!response.ok && response.status !== 404) {
         throw new Error(`Firebase smoke storage cleanup failed with status ${response.status}`);
     }

--- a/tests/smoke/helpers/firebase-rest.js
+++ b/tests/smoke/helpers/firebase-rest.js
@@ -82,8 +82,7 @@ export async function createFirebaseRestSession({ appBaseUrl, email, password })
                 password,
                 returnSecureToken: true
             })
-        },
-        { retrySafe: true }
+        }
     );
     const auth = await readJson(authResponse, 'Firebase smoke authentication');
     if (!auth.idToken || !auth.localId) {

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -476,6 +476,8 @@ describe('preview deployment workflow trust boundary', () => {
         expect(imageWorkflow).toContain("recordType: 'team-media'");
         expect(imageWorkflow).toContain('await openWritableMediaAlbum(page)');
         expect(imageWriteProductionSmoke).toContain("getByRole('button', { name: 'Refresh media' })");
+        expect(imageWriteProductionSmoke).toContain("waitFor({ state: 'visible', timeout: 15_000 })");
+        expect(imageWriteProductionSmoke).not.toContain('isVisible({ timeout:');
         expect(imageWriteProductionSmoke).toContain('page.setDefaultTimeout(LIVE_ACTION_TIMEOUT_MS)');
         expect(imageWorkflow).toContain('input[type="file"][accept="image/*"]');
         expect(imageWorkflow).toContain("getByText('Uploaded', { exact: true })");

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -468,10 +468,15 @@ describe('preview deployment workflow trust boundary', () => {
         expect(staffWorkflow).toContain("locator('button[aria-controls]').first()");
         expect(staffWorkflow).toContain('manageSchedule.click({ timeout: 25_000 })');
         expect(staffWorkflow).toContain("toHaveAttribute('aria-expanded', 'true'");
+        expect(staffWorkflow).toContain("test.step('create and verify a schedule game'");
+        expect(extendedProductionSmoke).toContain('page.setDefaultTimeout(LIVE_ACTION_TIMEOUT_MS)');
         expect(staffWorkflow).not.toContain('input[type="file"][accept="image/*"]');
         expect(imageWriteProductionSmoke).not.toContain("test.describe.configure({ mode: 'serial' })");
         expect(scheduledProdSmokeWorkflow).toContain('tests/smoke/app-authenticated-image-writes.spec.js');
         expect(imageWorkflow).toContain("recordType: 'team-media'");
+        expect(imageWorkflow).toContain('await openWritableMediaAlbum(page)');
+        expect(imageWriteProductionSmoke).toContain("getByRole('button', { name: 'Refresh media' })");
+        expect(imageWriteProductionSmoke).toContain('page.setDefaultTimeout(LIVE_ACTION_TIMEOUT_MS)');
         expect(imageWorkflow).toContain('input[type="file"][accept="image/*"]');
         expect(imageWorkflow).toContain("getByText('Uploaded', { exact: true })");
         expect(imageWorkflow).toContain("getByText('Media item deleted.')");

--- a/tests/unit/production-smoke-official-fixture.test.js
+++ b/tests/unit/production-smoke-official-fixture.test.js
@@ -347,6 +347,30 @@ describe('production officials smoke fixture maintenance', () => {
         });
     });
 
+    it('does not retry authentication POST requests when their result is uncertain', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch')
+            .mockResolvedValueOnce({
+                ok: true,
+                json: vi.fn().mockResolvedValue({
+                    apiKey: 'runtime-api-key',
+                    projectId: 'runtime-project'
+                })
+            })
+            .mockResolvedValueOnce({
+                ok: false,
+                status: 503
+            });
+
+        await expect(createFirebaseRestSession({
+            appBaseUrl: 'https://allplays.ai/app/',
+            email: 'smoke@example.com',
+            password: 'exact password'
+        })).rejects.toThrow('Firebase smoke authentication failed with status 503');
+
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(fetchMock.mock.calls[1][1].method).toBe('POST');
+    });
+
     it('keeps production fixture credentials on an exact default-branch manual workflow', () => {
         expect(workflowSource).toContain('workflow_dispatch:');
         expect(workflowSource).not.toContain('pull_request:');

--- a/tests/unit/production-smoke-official-fixture.test.js
+++ b/tests/unit/production-smoke-official-fixture.test.js
@@ -8,6 +8,7 @@ import {
     officialFixtureSlotId
 } from '../../scripts/maintain-production-smoke-official-fixture.mjs';
 import {
+    FIREBASE_REST_REQUEST_TIMEOUT_MS,
     createFirebaseRestSession,
     deleteFirestoreDocument,
     isEmptyFirestoreDocument,
@@ -253,6 +254,33 @@ describe('production officials smoke fixture maintenance', () => {
             method: 'DELETE',
             headers: { authorization: 'Bearer redacted-token' }
         });
+    });
+
+    it('bounds Firebase requests and retries only retry-safe cleanup operations', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch')
+            .mockResolvedValueOnce({
+                ok: false,
+                status: 503,
+                arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(0))
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                status: 200
+            });
+
+        await deleteFirestoreDocument(
+            {
+                projectId: 'smoke-project',
+                idToken: 'redacted-token'
+            },
+            'teams/allplays-smoke-team-v1/games/allplays-smoke-game-v1'
+        );
+
+        expect(FIREBASE_REST_REQUEST_TIMEOUT_MS).toBe(30_000);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        for (const [, request] of fetchMock.mock.calls) {
+            expect(request.signal).toBeInstanceOf(AbortSignal);
+        }
     });
 
     it('distinguishes an empty interrupted image document from a metadata-bearing fixture', () => {


### PR DESCRIPTION
## What changed

- bound Firebase REST requests and retry only safe reads and deletes
- bound authenticated browser actions and name the schedule-write step
- allow one read-only media refresh before failing the existing-album assertion
- add regression coverage for network bounds, retries, and upload fixture recovery

## Root cause

The extended production harness used unbounded Node fetch calls. A transient Firestore read or cleanup could consume the entire five-minute test, hiding the completed action. The team-media assertion also failed immediately on one stale album read even though the same fixture had just passed the core smoke.

## Validation

- Full unit suite: 739 files passed, 5,611 tests passed, 154 expected skips
- Focused regression suite: 47/47 passed
- Playwright discovery: 5 extended authenticated tests parsed
- node --check on all changed smoke files
- git diff --check