### PR TITLE
Allow protected lookup for missing census team

### DIFF
--- a/scripts/maintain-parent-coverage-invite.mjs
+++ b/scripts/maintain-parent-coverage-invite.mjs
@@ -91,12 +91,22 @@ export function inspectRedemptionFixture(teamDocument, playerDocument, { staffUi
     };
 }
 
-async function ensureRedemptionFixture(mode, staffSession, staffEmail, teamId, playerId) {
+async function ensureRedemptionFixture(
+    mode,
+    lookupSession,
+    staffSession,
+    staffEmail,
+    teamId,
+    playerId
+) {
     assertSmokeFixtureIdentifier(teamId, 'Redemption team ID');
     assertSmokeFixtureIdentifier(playerId, 'Redemption player ID');
     const teamPath = `teams/${teamId}`;
     const playerPath = `${teamPath}/players/${playerId}`;
-    let teamDocument = await getFirestoreDocument(staffSession, teamPath);
+    // A team manager cannot read a nonexistent team path under production
+    // rules. Use the protected admin only to distinguish missing from an
+    // existing collision; all fixture writes still use the staff session.
+    let teamDocument = await getFirestoreDocument(lookupSession, teamPath);
     if (teamDocument && stringValue(teamDocument.fields, 'fixtureType') !== redemptionFixtureMarker) {
         throw new Error('redemption team ID collides with a non-census fixture');
     }
@@ -198,6 +208,7 @@ async function main() {
     ]);
     await ensureRedemptionFixture(
         mode,
+        session,
         staffSession,
         staffEmail,
         redemptionTeamId,

--- a/tests/unit/parent-coverage-invite.test.js
+++ b/tests/unit/parent-coverage-invite.test.js
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import {
     buildRedemptionPlayerFields,
@@ -23,6 +24,15 @@ function invite(overrides = {}) {
 }
 
 describe('parent coverage lifecycle invite selection', () => {
+    it('uses admin only to discover a missing redemption team before staff-owned writes', () => {
+        const source = readFileSync('scripts/maintain-parent-coverage-invite.mjs', 'utf8');
+
+        expect(source).toContain('let teamDocument = await getFirestoreDocument(lookupSession, teamPath);');
+        expect(source).toMatch(/ensureRedemptionFixture\(\s*mode,\s*session,\s*staffSession,/);
+        expect(source).toContain('createFirestoreDocument(staffSession, teamPath');
+        expect(source).toContain('createFirestoreDocument(\n            staffSession,\n            playerPath');
+    });
+
     it('accepts only a matching unused invite with useful remaining lifetime', () => {
         const now = Date.parse('2026-08-02T00:00:00.000Z');
         const matches = (document, recipient = 'lifecycle@example.com', purpose = 'signup') =>


### PR DESCRIPTION
## Summary
- use the protected admin session only to distinguish a missing redemption team from an existing collision
- keep team and player creation under the protected staff account and normal Firestore rules
- preserve exact ownership, privacy, active-state, and purpose-marker validation

## Validation
- `npm run test:unit:ci` (root suite plus 183 Firestore/Storage rules tests)
- 15 focused parent coverage tests
- `node --check scripts/maintain-parent-coverage-invite.mjs`
- `git diff --check`

## Production safety
- the admin session performs a read only; it cannot create or modify the redemption fixture
- all fixture writes remain staff-authenticated and fail closed on collisions
- no Gmail, mailbox, or email-delivery access is used