### PR TITLE
Keep team access visible when chat loading fails

### DIFF
--- a/.github/workflows/scheduled-prod-smoke.yml
+++ b/.github/workflows/scheduled-prod-smoke.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     - cron: '23 7 * * *'
   workflow_dispatch:
+    inputs:
+      extended_writes:
+        description: Run reversible production write checks for this manual invocation
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -60,7 +66,7 @@ jobs:
           SMOKE_APP_BOOT_URL: https://allplays.ai/app/
           SMOKE_APP_BASE_URL: https://allplays.ai/app/
           SMOKE_SUITE: extended-production
-          SMOKE_EXTENDED_WRITES: ${{ vars.SMOKE_EXTENDED_WRITES_ENABLED }}
+          SMOKE_EXTENDED_WRITES: ${{ github.event_name == 'workflow_dispatch' && (inputs.extended_writes && '1' || '0') || vars.SMOKE_EXTENDED_WRITES_ENABLED }}
           SMOKE_RUN_ID: ${{ github.run_id }}
           SMOKE_TEAM_ID: ${{ vars.SMOKE_TEAM_ID }}
           SMOKE_GAME_ID: ${{ vars.SMOKE_GAME_ID }}

--- a/apps/app/src/lib/homeService.ts
+++ b/apps/app/src/lib/homeService.ts
@@ -140,25 +140,41 @@ export async function loadParentTeamsSummaryBootstrap(
     async () => {
       const timer = startUxTimer('teams summary load');
       try {
-        const [chatInbox, scheduleScope] = await Promise.all([
-          loadChatInbox(user, { includeLastMessages: false }).catch((error) => {
+        const [chatInboxResult, scheduleScope] = await Promise.all([
+          loadChatInbox(user, { includeLastMessages: false })
+            .then((chatInbox) => ({ chatInbox, error: null }))
+            .catch((error) => ({
+              chatInbox: { teams: [] },
+              error: toAppServiceError(error, 'Unable to load team chat.')
+            })),
+          loadParentScheduleScope(user).catch((error) => {
             throw toAppServiceError(error, 'Unable to load teams.');
-          }),
-          loadParentScheduleScope(user)
+          })
         ]);
+        const hasScheduleTeams = scheduleScope.children.length > 0
+          || Boolean(scheduleScope.staffTeams?.length);
+        if (chatInboxResult.error && scheduleScope.staffTeamsPartial && !hasScheduleTeams) {
+          throw chatInboxResult.error;
+        }
+        if (chatInboxResult.error) {
+          logger.warn('Team chat summary failed; using schedule access for the team chooser.', {
+            error: chatInboxResult.error
+          });
+        }
         const model = buildParentHomeModel({
           children: scheduleScope.children,
           events: [],
           inboxTeams: mergeTeamSummaries(
             normalizeStaffTeams({ children: [], events: [], staffTeams: scheduleScope.staffTeams }),
-            normalizeInboxTeams(chatInbox.teams || [])
+            normalizeInboxTeams(chatInboxResult.chatInbox.teams || [])
           ),
           fees: []
         });
         timer.end({
           children: scheduleScope.children.length,
           teams: model.teams.length,
-          inboxTeams: chatInbox.teams?.length || 0
+          inboxTeams: chatInboxResult.chatInbox.teams?.length || 0,
+          chatPartial: Boolean(chatInboxResult.error)
         });
         return {
           home: model,

--- a/scripts/maintain-production-smoke-parent-fixture.mjs
+++ b/scripts/maintain-production-smoke-parent-fixture.mjs
@@ -174,6 +174,32 @@ export function buildActiveTeamPatch() {
     };
 }
 
+export function inspectStaffTeamDiscovery(teamDocument, { uid, email }) {
+    const fields = teamDocument?.fields || {};
+    const normalizedEmail = String(email || '').trim().toLowerCase();
+    const ownsTeam = Boolean(uid) && getStringField(fields, 'ownerId') === uid;
+    const hasCanonicalAdminEmail = Boolean(normalizedEmail) && getArrayValues(fields.adminEmails)
+        .some((value) => String(value?.stringValue || '') === normalizedEmail);
+    return {
+        ready: ownsTeam || hasCanonicalAdminEmail,
+        ownsTeam,
+        hasCanonicalAdminEmail
+    };
+}
+
+export function buildCanonicalStaffAccessPatch(teamDocument, email) {
+    const normalizedEmail = String(email || '').trim().toLowerCase();
+    if (!normalizedEmail) throw new Error('Canonical staff email is required');
+    const adminEmails = getArrayValues(teamDocument?.fields?.adminEmails)
+        .map((value) => String(value?.stringValue || ''))
+        .filter((value) => value.trim().toLowerCase() !== normalizedEmail);
+    return {
+        fields: {
+            adminEmails: buildStringArray([...adminEmails, normalizedEmail])
+        }
+    };
+}
+
 function isAuthorizedFixtureManager(teamDocument, session, staffEmail) {
     const fields = teamDocument?.fields || {};
     if (getStringField(fields, 'ownerId') === session.localId) return true;
@@ -247,6 +273,29 @@ async function main() {
     }
     if (!teamDocument || !isAuthorizedFixtureManager(teamDocument, staffSession, staffEmail)) {
         throw new Error('The staff smoke account is not an owner or administrator of the fixture team');
+    }
+    let staffDiscovery = inspectStaffTeamDiscovery(teamDocument, {
+        uid: staffSession.localId,
+        email: staffEmail
+    });
+    if (mode === 'repair' && !staffDiscovery.ready) {
+        await patchFirestoreDocumentFields(
+            adminSession,
+            `teams/${teamId}`,
+            buildCanonicalStaffAccessPatch(teamDocument, staffEmail).fields,
+            { updateTime: String(teamDocument.updateTime || '') }
+        );
+        teamDocument = await getFirestoreDocument(staffSession, `teams/${teamId}`);
+        staffDiscovery = inspectStaffTeamDiscovery(teamDocument, {
+            uid: staffSession.localId,
+            email: staffEmail
+        });
+    }
+    if (!staffDiscovery.ready) {
+        throw new Error(
+            `The staff smoke account is not queryable by canonical team access ` +
+            `(owner=${staffDiscovery.ownsTeam}, canonical-admin=${staffDiscovery.hasCanonicalAdminEmail})`
+        );
     }
 
     const playerPath = `teams/${teamId}/players/${playerId}`;

--- a/tests/unit/app-home-service.test.js
+++ b/tests/unit/app-home-service.test.js
@@ -364,8 +364,25 @@ describe('React app Home service', () => {
         expect(home.actionItems.map((item) => item.kind)).toEqual(expect.arrayContaining(['fee', 'message']));
     });
 
-    it('throws a typed network error when the Teams summary chat load fails', async () => {
+    it('keeps schedule-discovered teams visible when the optional chat summary fails', async () => {
         chatMocks.loadChatInbox.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+        const { loadParentTeamsSummary } = await import('../../apps/app/src/lib/homeService.ts');
+
+        const home = await loadParentTeamsSummary(user, { force: true });
+
+        expect(chatMocks.loadChatInbox).toHaveBeenCalledWith(user, { includeLastMessages: false });
+        expect(home.teams).toEqual([
+            expect.objectContaining({
+                teamId: 'team-1',
+                teamName: 'Bears',
+                players: [expect.objectContaining({ playerId: 'player-1' })]
+            })
+        ]);
+        expect(home.metrics.teams).toBe(1);
+    });
+
+    it('still fails the Teams summary when the authoritative schedule access scope fails', async () => {
+        scheduleMocks.loadParentScheduleScope.mockRejectedValueOnce(new TypeError('Failed to fetch'));
         const { loadParentTeamsSummary } = await import('../../apps/app/src/lib/homeService.ts');
 
         await expect(loadParentTeamsSummary(user, { force: true })).rejects.toMatchObject({
@@ -373,8 +390,53 @@ describe('React app Home service', () => {
             type: 'network',
             message: 'Failed to fetch'
         });
+    });
 
-        expect(chatMocks.loadChatInbox).toHaveBeenCalledWith(user, { includeLastMessages: false });
+    it('fails instead of caching an empty chooser when chat and staff discovery are both partial', async () => {
+        chatMocks.loadChatInbox.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+        scheduleMocks.loadParentScheduleScope.mockResolvedValueOnce({
+            profile: { id: 'profile-user-1' },
+            children: [],
+            staffTeams: [],
+            staffTeamsPartial: true,
+            isPartial: true
+        });
+        const { loadParentTeamsSummary } = await import('../../apps/app/src/lib/homeService.ts');
+
+        await expect(loadParentTeamsSummary(user, { force: true })).rejects.toMatchObject({
+            name: 'AppServiceError',
+            type: 'network',
+            message: 'Failed to fetch'
+        });
+    });
+
+    it('keeps parent-linked teams visible when chat fails and only staff discovery is partial', async () => {
+        chatMocks.loadChatInbox.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+        scheduleMocks.loadParentScheduleScope.mockResolvedValueOnce({
+            profile: { id: 'profile-user-1' },
+            children: [
+                {
+                    teamId: 'team-1',
+                    teamName: 'Bears',
+                    playerId: 'player-1',
+                    playerName: 'Pat Star'
+                }
+            ],
+            staffTeams: [],
+            staffTeamsPartial: true,
+            isPartial: true
+        });
+        const { loadParentTeamsSummary } = await import('../../apps/app/src/lib/homeService.ts');
+
+        const home = await loadParentTeamsSummary(user, { force: true });
+
+        expect(home.teams).toEqual([
+            expect.objectContaining({
+                teamId: 'team-1',
+                teamName: 'Bears',
+                players: [expect.objectContaining({ playerId: 'player-1' })]
+            })
+        ]);
     });
 
     it('uses the shared parent scope resolver for the fast Teams summary', async () => {

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -413,8 +413,11 @@ describe('preview deployment workflow trust boundary', () => {
         expect(scheduledProdSmokeWorkflow).not.toContain("cron: '*/15 * * * *'");
         expect(scheduledProdSmokeWorkflow).toContain('cancel-in-progress: false');
         expect(scheduledProdSmokeWorkflow).toContain(
-            'SMOKE_EXTENDED_WRITES: ${{ vars.SMOKE_EXTENDED_WRITES_ENABLED }}'
+            "SMOKE_EXTENDED_WRITES: ${{ github.event_name == 'workflow_dispatch' && (inputs.extended_writes && '1' || '0') || vars.SMOKE_EXTENDED_WRITES_ENABLED }}"
         );
+        expect(scheduledProdSmokeWorkflow).toContain('extended_writes:');
+        expect(scheduledProdSmokeWorkflow).toContain('type: boolean');
+        expect(scheduledProdSmokeWorkflow).toContain('default: false');
         expect(scheduledProdSmokeWorkflow).not.toContain("SMOKE_EXTENDED_WRITES: '1'");
     });
 

--- a/tests/unit/production-smoke-parent-fixture.test.js
+++ b/tests/unit/production-smoke-parent-fixture.test.js
@@ -4,8 +4,10 @@ import {
     assertUnprivilegedParentFixture,
     buildActivePlayerPatch,
     buildActiveTeamPatch,
+    buildCanonicalStaffAccessPatch,
     buildParentMembershipPatch,
-    inspectParentFixture
+    inspectParentFixture,
+    inspectStaffTeamDiscovery
 } from '../../scripts/maintain-production-smoke-parent-fixture.mjs';
 
 const workflowSource = readFileSync('.github/workflows/production-smoke-fixture.yml', 'utf8');
@@ -56,14 +58,18 @@ function buildPlayerDocument({
 function buildTeamDocument({
     active = true,
     archived = false,
-    status = 'active'
+    status = 'active',
+    ownerId = '',
+    adminEmails = []
 } = {}) {
     return {
         updateTime: '2026-07-29T18:00:00.000Z',
         fields: {
             active: { booleanValue: active },
             archived: { booleanValue: archived },
-            status: { stringValue: status }
+            status: { stringValue: status },
+            ownerId: { stringValue: ownerId },
+            adminEmails: stringArray(adminEmails)
         }
     };
 }
@@ -72,6 +78,38 @@ const teamId = 'allplays-smoke-team-v1';
 const playerId = 'allplays-smoke-player-v1';
 
 describe('production parent smoke fixture maintenance', () => {
+    it('requires the exact normalized admin value used by app discovery and Firestore rules', () => {
+        const legacyTeam = buildTeamDocument({
+            ownerId: 'other-owner',
+            adminEmails: [' Coach@Example.com ', 'other@example.com']
+        });
+
+        expect(inspectStaffTeamDiscovery(legacyTeam, {
+            uid: 'staff-1',
+            email: 'coach@example.com'
+        })).toEqual({
+            ready: false,
+            ownsTeam: false,
+            hasCanonicalAdminEmail: false
+        });
+        expect(buildCanonicalStaffAccessPatch(legacyTeam, ' Coach@Example.com ')).toEqual({
+            fields: {
+                adminEmails: stringArray(['other@example.com', 'coach@example.com'])
+            }
+        });
+        expect(inspectStaffTeamDiscovery(buildTeamDocument({ ownerId: 'staff-1' }), {
+            uid: 'staff-1',
+            email: 'coach@example.com'
+        }).ready).toBe(true);
+        expect(inspectStaffTeamDiscovery(buildTeamDocument({
+            ownerId: 'other-owner',
+            adminEmails: ['coach@example.com']
+        }), {
+            uid: 'staff-1',
+            email: 'COACH@example.com'
+        }).ready).toBe(true);
+    });
+
     it('rejects global and team-level privileges for parent-only coverage', () => {
         const teamDocument = buildTeamDocument();
         teamDocument.fields.ownerId = { stringValue: 'owner-1' };


### PR DESCRIPTION
## Summary

- keep the Teams chooser usable when optional chat summary loading fails but authoritative schedule/team access succeeds
- audit and repair the protected production fixture so staff access uses the canonical admin email required by app queries
- add an explicit manual `extended_writes` input so agents can run isolated production mutations without toggling shared variables

## Root cause

Production validation showed direct fixture reads succeeding while the Teams chooser, roster controls, and Team Media controls were unavailable. The chooser treated an optional chat summary failure as a fatal team-access failure, and fixture audit accepted case-insensitive admin entries that app collection queries cannot discover.

## Verification

- `npm test -- --run` — 739 files passed, 3 skipped; 5,616 tests passed, 154 skipped
- `npm run app:build` — TypeScript, Vite production build, visualizer, and bundle budget passed
- focused Home, fixture, and workflow regressions — 50 passed
- production fixture audit — team/event/parent/player fixture intact
- production write smoke — own-profile and linked-player image storage/document writes passed; remaining staff team failures reproduce the canonical access mismatch repaired here

## Production follow-up

After merge/deploy, run the protected fixture workflow in repair mode, then dispatch scheduled production smoke with `extended_writes=true` and verify cleanup plus all image/schedule paths.