### PR TITLE
Verify production staff fixture discovery

### DIFF
--- a/scripts/maintain-production-smoke-parent-fixture.mjs
+++ b/scripts/maintain-production-smoke-parent-fixture.mjs
@@ -1,7 +1,10 @@
 import { pathToFileURL } from 'node:url';
 import {
     createFirebaseRestSession,
+    findFirestoreDocumentsByStringArrayContains,
+    findFirestoreDocumentsByStringField,
     getFirestoreDocument,
+    getFirestoreDocumentPath,
     patchFirestoreDocumentFields
 } from '../tests/smoke/helpers/firebase-rest.js';
 import { assertSmokeFixtureIdentifier } from './maintain-production-smoke-official-fixture.mjs';
@@ -174,16 +177,27 @@ export function buildActiveTeamPatch() {
     };
 }
 
-export function inspectStaffTeamDiscovery(teamDocument, { uid, email }) {
+export function inspectStaffTeamDiscovery(
+    teamDocument,
+    staffDocument,
+    { uid, email, teamId, ownerQueryFound = false, adminQueryFound = false }
+) {
     const fields = teamDocument?.fields || {};
+    const staffFields = staffDocument?.fields || {};
     const normalizedEmail = String(email || '').trim().toLowerCase();
     const ownsTeam = Boolean(uid) && getStringField(fields, 'ownerId') === uid;
     const hasCanonicalAdminEmail = Boolean(normalizedEmail) && getArrayValues(fields.adminEmails)
         .some((value) => String(value?.stringValue || '') === normalizedEmail);
+    const hasCoachTeamId = Boolean(teamId) && hasStringValue(staffFields.coachOf, teamId);
+    const directCoachDiscovery = hasCoachTeamId && (ownsTeam || hasCanonicalAdminEmail);
     return {
-        ready: ownsTeam || hasCanonicalAdminEmail,
+        ready: ownerQueryFound || adminQueryFound || directCoachDiscovery,
         ownsTeam,
-        hasCanonicalAdminEmail
+        hasCanonicalAdminEmail,
+        hasCoachTeamId,
+        ownerQueryFound,
+        adminQueryFound,
+        directCoachDiscovery
     };
 }
 
@@ -197,6 +211,46 @@ export function buildCanonicalStaffAccessPatch(teamDocument, email) {
         fields: {
             adminEmails: buildStringArray([...adminEmails, normalizedEmail])
         }
+    };
+}
+
+export function buildCanonicalStaffProfilePatch(staffDocument, teamId) {
+    if (!teamId) throw new Error('Canonical staff team ID is required');
+    const coachTeamIds = getArrayValues(staffDocument?.fields?.coachOf)
+        .map((value) => String(value?.stringValue || ''))
+        .filter((value) => value.trim() !== teamId);
+    return {
+        fields: {
+            coachOf: buildStringArray([...coachTeamIds, teamId])
+        }
+    };
+}
+
+function queryContainsDocument(documents, documentPath) {
+    return documents.some((document) => getFirestoreDocumentPath(document) === documentPath);
+}
+
+async function queryStaffTeamDiscovery(session, teamId, email) {
+    const normalizedEmail = String(email || '').trim().toLowerCase();
+    const teamPath = `teams/${teamId}`;
+    const [ownerResult, adminResult] = await Promise.allSettled([
+        findFirestoreDocumentsByStringField(session, 'teams', 'ownerId', session.localId),
+        normalizedEmail
+            ? findFirestoreDocumentsByStringArrayContains(
+                session,
+                'teams',
+                'adminEmails',
+                normalizedEmail
+            )
+            : Promise.resolve([])
+    ]);
+    return {
+        ownerQueryFound: ownerResult.status === 'fulfilled' &&
+            queryContainsDocument(ownerResult.value, teamPath),
+        adminQueryFound: adminResult.status === 'fulfilled' &&
+            queryContainsDocument(adminResult.value, teamPath),
+        ownerQueryFailed: ownerResult.status === 'rejected',
+        adminQueryFailed: adminResult.status === 'rejected'
     };
 }
 
@@ -264,37 +318,76 @@ async function main() {
         })
     ]);
 
-    let [adminDocument, teamDocument] = await Promise.all([
+    let [adminDocument, staffDocument, teamDocument] = await Promise.all([
         getFirestoreDocument(adminSession, `users/${adminSession.localId}`),
+        getFirestoreDocument(staffSession, `users/${staffSession.localId}`),
         getFirestoreDocument(staffSession, `teams/${teamId}`)
     ]);
     if (!adminDocument || !isGlobalAdmin(adminDocument)) {
         throw new Error('The admin smoke account is not authorized to maintain fixture membership');
     }
-    if (!teamDocument || !isAuthorizedFixtureManager(teamDocument, staffSession, staffEmail)) {
+    const canonicalStaffEmail = String(staffSession.email || staffEmail).trim().toLowerCase();
+    if (!teamDocument || !isAuthorizedFixtureManager(teamDocument, staffSession, canonicalStaffEmail)) {
         throw new Error('The staff smoke account is not an owner or administrator of the fixture team');
     }
-    let staffDiscovery = inspectStaffTeamDiscovery(teamDocument, {
+    if (!staffDocument) {
+        throw new Error('The staff smoke user profile does not exist');
+    }
+    let staffQueryDiscovery = await queryStaffTeamDiscovery(
+        staffSession,
+        teamId,
+        canonicalStaffEmail
+    );
+    let staffDiscovery = inspectStaffTeamDiscovery(teamDocument, staffDocument, {
         uid: staffSession.localId,
-        email: staffEmail
+        email: canonicalStaffEmail,
+        teamId,
+        ...staffQueryDiscovery
     });
-    if (mode === 'repair' && !staffDiscovery.ready) {
-        await patchFirestoreDocumentFields(
-            adminSession,
-            `teams/${teamId}`,
-            buildCanonicalStaffAccessPatch(teamDocument, staffEmail).fields,
-            { updateTime: String(teamDocument.updateTime || '') }
+    if (mode === 'repair' && (
+        !staffDiscovery.hasCanonicalAdminEmail ||
+        !staffDiscovery.hasCoachTeamId ||
+        !staffDiscovery.ready
+    )) {
+        if (!staffDiscovery.hasCanonicalAdminEmail) {
+            await patchFirestoreDocumentFields(
+                adminSession,
+                `teams/${teamId}`,
+                buildCanonicalStaffAccessPatch(teamDocument, canonicalStaffEmail).fields,
+                { updateTime: String(teamDocument.updateTime || '') }
+            );
+        }
+        if (!staffDiscovery.hasCoachTeamId) {
+            await patchFirestoreDocumentFields(
+                adminSession,
+                `users/${staffSession.localId}`,
+                buildCanonicalStaffProfilePatch(staffDocument, teamId).fields,
+                { updateTime: String(staffDocument.updateTime || '') }
+            );
+        }
+        [staffDocument, teamDocument] = await Promise.all([
+            getFirestoreDocument(staffSession, `users/${staffSession.localId}`),
+            getFirestoreDocument(staffSession, `teams/${teamId}`)
+        ]);
+        staffQueryDiscovery = await queryStaffTeamDiscovery(
+            staffSession,
+            teamId,
+            canonicalStaffEmail
         );
-        teamDocument = await getFirestoreDocument(staffSession, `teams/${teamId}`);
-        staffDiscovery = inspectStaffTeamDiscovery(teamDocument, {
+        staffDiscovery = inspectStaffTeamDiscovery(teamDocument, staffDocument, {
             uid: staffSession.localId,
-            email: staffEmail
+            email: canonicalStaffEmail,
+            teamId,
+            ...staffQueryDiscovery
         });
     }
     if (!staffDiscovery.ready) {
         throw new Error(
-            `The staff smoke account is not queryable by canonical team access ` +
-            `(owner=${staffDiscovery.ownsTeam}, canonical-admin=${staffDiscovery.hasCanonicalAdminEmail})`
+            `The staff smoke account is not discoverable by the app's team access paths ` +
+            `(owner=${staffDiscovery.ownsTeam}, canonical-admin=${staffDiscovery.hasCanonicalAdminEmail}, ` +
+            `coach-link=${staffDiscovery.hasCoachTeamId}, owner-query=${staffDiscovery.ownerQueryFound}, ` +
+            `admin-query=${staffDiscovery.adminQueryFound}, owner-query-failed=${staffQueryDiscovery.ownerQueryFailed}, ` +
+            `admin-query-failed=${staffQueryDiscovery.adminQueryFailed})`
         );
     }
 
@@ -383,7 +476,11 @@ async function main() {
         );
     }
 
-    console.log(`Parent fixture ${mode} passed with a linked active player.`);
+    console.log(
+        `Parent fixture ${mode} passed with a linked active player and app-discoverable staff team ` +
+        `(owner-query=${staffDiscovery.ownerQueryFound}, admin-query=${staffDiscovery.adminQueryFound}, ` +
+        `coach-link=${staffDiscovery.hasCoachTeamId}).`
+    );
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/tests/smoke/helpers/firebase-rest.js
+++ b/tests/smoke/helpers/firebase-rest.js
@@ -93,7 +93,8 @@ export async function createFirebaseRestSession({ appBaseUrl, email, password })
         projectId: config.projectId,
         storageBucket: config.storageBucket || '',
         idToken: auth.idToken,
-        localId: auth.localId
+        localId: auth.localId,
+        email: String(auth.email || email || '').trim()
     };
 }
 
@@ -150,6 +151,41 @@ function buildStructuredQuery(collectionPath, fields) {
     };
 }
 
+function buildSingleStringFieldQuery(collectionPath, fieldName, operator, stringValue) {
+    const { parentPath, structuredQuery } = buildStructuredQuery(collectionPath, {
+        [fieldName]: stringValue
+    });
+    structuredQuery.where.fieldFilter.op = operator;
+    return { parentPath, structuredQuery };
+}
+
+async function runFirestoreStringFieldQuery(
+    session,
+    collectionPath,
+    fieldName,
+    expectedValue,
+    operator
+) {
+    const { parentPath, structuredQuery } = buildSingleStringFieldQuery(
+        collectionPath,
+        fieldName,
+        operator,
+        expectedValue
+    );
+    const parentSuffix = parentPath ? `/${encodeDocumentPath(parentPath)}` : '';
+    const url = `${firestoreApiOrigin}/v1/projects/${encodeURIComponent(session.projectId)}/databases/(default)/documents${parentSuffix}:runQuery`;
+    const response = await fetchFirebase(url, {
+        method: 'POST',
+        headers: {
+            authorization: `Bearer ${session.idToken}`,
+            'content-type': 'application/json'
+        },
+        body: JSON.stringify({ structuredQuery })
+    }, { retrySafe: true });
+    const payload = await readJson(response, 'Firestore smoke filtered query');
+    return payload.map((entry) => entry.document).filter(Boolean);
+}
+
 export async function findFirestoreDocumentsByStringFields(session, collectionPath, fields) {
     const entries = Object.entries(fields);
     if (!entries.length) throw new Error('Firestore smoke query requires at least one field');
@@ -177,9 +213,35 @@ export async function findFirestoreDocumentsByStringFields(session, collectionPa
 }
 
 export async function findFirestoreDocumentsByStringField(session, collectionPath, fieldName, expectedValue) {
-    return findFirestoreDocumentsByStringFields(session, collectionPath, {
-        [fieldName]: expectedValue
-    });
+    const documents = await runFirestoreStringFieldQuery(
+        session,
+        collectionPath,
+        fieldName,
+        expectedValue,
+        'EQUAL'
+    );
+    return documents.filter(
+        (document) => getFirestoreStringField(document, fieldName) === String(expectedValue)
+    );
+}
+
+export async function findFirestoreDocumentsByStringArrayContains(
+    session,
+    collectionPath,
+    fieldName,
+    expectedValue
+) {
+    const documents = await runFirestoreStringFieldQuery(
+        session,
+        collectionPath,
+        fieldName,
+        expectedValue,
+        'ARRAY_CONTAINS'
+    );
+    return documents.filter((document) => (
+        (document?.fields?.[fieldName]?.arrayValue?.values || [])
+            .some((value) => String(value?.stringValue || '') === String(expectedValue))
+    ));
 }
 
 export function getFirestoreDocumentPath(document) {

--- a/tests/unit/production-smoke-official-fixture.test.js
+++ b/tests/unit/production-smoke-official-fixture.test.js
@@ -11,6 +11,7 @@ import {
     FIREBASE_REST_REQUEST_TIMEOUT_MS,
     createFirebaseRestSession,
     deleteFirestoreDocument,
+    findFirestoreDocumentsByStringArrayContains,
     isEmptyFirestoreDocument,
     patchFirestoreDocumentFields,
     restoreFirestoreDocumentFields
@@ -314,7 +315,8 @@ describe('production officials smoke fixture maintenance', () => {
                 ok: true,
                 json: vi.fn().mockResolvedValue({
                     idToken: 'redacted-token',
-                    localId: 'smoke-user'
+                    localId: 'smoke-user',
+                    email: 'Canonical.Smoke@example.com'
                 })
             });
 
@@ -326,7 +328,8 @@ describe('production officials smoke fixture maintenance', () => {
             projectId: 'runtime-project',
             storageBucket: 'runtime-bucket',
             idToken: 'redacted-token',
-            localId: 'smoke-user'
+            localId: 'smoke-user',
+            email: 'Canonical.Smoke@example.com'
         });
 
         expect(fetchMock.mock.calls[0][0]).toBe('https://allplays.ai/__/firebase/init.json');
@@ -369,6 +372,44 @@ describe('production officials smoke fixture maintenance', () => {
 
         expect(fetchMock).toHaveBeenCalledTimes(2);
         expect(fetchMock.mock.calls[1][1].method).toBe('POST');
+    });
+
+    it('runs the same array-contains query used for staff team discovery', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+            ok: true,
+            json: vi.fn().mockResolvedValue([
+                {
+                    document: {
+                        name: 'projects/runtime-project/databases/(default)/documents/teams/smoke-team',
+                        fields: {
+                            adminEmails: {
+                                arrayValue: {
+                                    values: [{ stringValue: 'coach@example.com' }]
+                                }
+                            }
+                        }
+                    }
+                }
+            ])
+        });
+
+        await expect(findFirestoreDocumentsByStringArrayContains(
+            { projectId: 'runtime-project', idToken: 'redacted-token' },
+            'teams',
+            'adminEmails',
+            'coach@example.com'
+        )).resolves.toHaveLength(1);
+
+        expect(fetchMock.mock.calls[0][0]).toBe(
+            'https://firestore.googleapis.com/v1/projects/runtime-project/databases/(default)/documents:runQuery'
+        );
+        expect(JSON.parse(fetchMock.mock.calls[0][1].body).structuredQuery.where).toEqual({
+            fieldFilter: {
+                field: { fieldPath: 'adminEmails' },
+                op: 'ARRAY_CONTAINS',
+                value: { stringValue: 'coach@example.com' }
+            }
+        });
     });
 
     it('keeps production fixture credentials on an exact default-branch manual workflow', () => {

--- a/tests/unit/production-smoke-parent-fixture.test.js
+++ b/tests/unit/production-smoke-parent-fixture.test.js
@@ -5,6 +5,7 @@ import {
     buildActivePlayerPatch,
     buildActiveTeamPatch,
     buildCanonicalStaffAccessPatch,
+    buildCanonicalStaffProfilePatch,
     buildParentMembershipPatch,
     inspectParentFixture,
     inspectStaffTeamDiscovery
@@ -55,6 +56,15 @@ function buildPlayerDocument({
     };
 }
 
+function buildStaffDocument({ coachOf = [] } = {}) {
+    return {
+        updateTime: '2026-07-29T18:00:00.000Z',
+        fields: {
+            coachOf: stringArray(coachOf)
+        }
+    };
+}
+
 function buildTeamDocument({
     active = true,
     archived = false,
@@ -84,30 +94,72 @@ describe('production parent smoke fixture maintenance', () => {
             adminEmails: [' Coach@Example.com ', 'other@example.com']
         });
 
-        expect(inspectStaffTeamDiscovery(legacyTeam, {
+        expect(inspectStaffTeamDiscovery(legacyTeam, buildStaffDocument(), {
             uid: 'staff-1',
-            email: 'coach@example.com'
+            email: 'coach@example.com',
+            teamId
         })).toEqual({
             ready: false,
             ownsTeam: false,
-            hasCanonicalAdminEmail: false
+            hasCanonicalAdminEmail: false,
+            hasCoachTeamId: false,
+            ownerQueryFound: false,
+            adminQueryFound: false,
+            directCoachDiscovery: false
         });
         expect(buildCanonicalStaffAccessPatch(legacyTeam, ' Coach@Example.com ')).toEqual({
             fields: {
                 adminEmails: stringArray(['other@example.com', 'coach@example.com'])
             }
         });
-        expect(inspectStaffTeamDiscovery(buildTeamDocument({ ownerId: 'staff-1' }), {
+        expect(inspectStaffTeamDiscovery(buildTeamDocument({ ownerId: 'staff-1' }), buildStaffDocument(), {
             uid: 'staff-1',
-            email: 'coach@example.com'
+            email: 'coach@example.com',
+            teamId,
+            ownerQueryFound: true
         }).ready).toBe(true);
         expect(inspectStaffTeamDiscovery(buildTeamDocument({
             ownerId: 'other-owner',
             adminEmails: ['coach@example.com']
-        }), {
+        }), buildStaffDocument(), {
             uid: 'staff-1',
-            email: 'COACH@example.com'
+            email: 'COACH@example.com',
+            teamId,
+            adminQueryFound: true
         }).ready).toBe(true);
+    });
+
+    it('repairs the canonical coach link used when staff collection queries are partial', () => {
+        const teamDocument = buildTeamDocument({
+            ownerId: 'other-owner',
+            adminEmails: ['coach@example.com']
+        });
+        const staffDocument = buildStaffDocument({ coachOf: ['other-team'] });
+
+        expect(inspectStaffTeamDiscovery(teamDocument, staffDocument, {
+            uid: 'staff-1',
+            email: 'coach@example.com',
+            teamId
+        }).ready).toBe(false);
+        expect(buildCanonicalStaffProfilePatch(staffDocument, teamId)).toEqual({
+            fields: {
+                coachOf: stringArray(['other-team', teamId])
+            }
+        });
+        expect(inspectStaffTeamDiscovery(
+            teamDocument,
+            buildStaffDocument({ coachOf: [teamId] }),
+            {
+                uid: 'staff-1',
+                email: 'coach@example.com',
+                teamId
+            }
+        )).toMatchObject({
+            ready: true,
+            hasCanonicalAdminEmail: true,
+            hasCoachTeamId: true,
+            directCoachDiscovery: true
+        });
     });
 
     it('rejects global and team-level privileges for parent-only coverage', () => {


### PR DESCRIPTION
## What changed

- make the protected fixture audit execute the same owner/admin Firestore queries used by the app
- repair the smoke staff profile with a canonical `coachOf` fallback while preserving unrelated teams
- derive canonical access from the authenticated Firebase email and report non-secret discovery evidence
- add regression coverage for exact array-contains queries and staff fallback repair

## Why

The previous fixture repair inferred app discoverability from a direct team read. Production showed that was a false positive: direct access succeeded while the `/teams` collection path did not surface the smoke team.

## Verification

- `npx vitest run tests/unit/production-smoke-parent-fixture.test.js tests/unit/production-smoke-official-fixture.test.js tests/unit/preview-deploy-trust-boundary.test.js --reporter=verbose` (48 passed)
- `npm test` (5,620 passed; 154 skipped)
- `npm run app:build` (passed, including bundle checks)
- `git diff --check`