### PR TITLE
Stabilize production write smoke coverage

### DIFF
--- a/tests/smoke/app-authenticated-extended.spec.js
+++ b/tests/smoke/app-authenticated-extended.spec.js
@@ -13,9 +13,11 @@ import {
     deleteFirestoreDocument,
     deleteFirestoreDocumentsByStringField,
     deleteFirestoreDocumentsByStringFields,
+    deleteSmokeMediaByTitle,
     findFirestoreDocumentsByStringField,
     getFirestoreDocument,
     getFirestoreDocumentPath,
+    listFirestoreDocuments,
     restoreFirestoreDocument,
     runSmokeCleanup
 } from './helpers/firebase-rest.js';
@@ -134,6 +136,57 @@ async function openRoute(page, route) {
     await expect.poll(() => new URL(page.url()).hash, { timeout: 20_000 }).toContain(`#${route.split('?')[0]}`);
 }
 
+async function findSmokeChatMessages(text) {
+    const rootMessagesPath = `teams/${config.teamId}/chatMessages`;
+    const rootMessages = await findFirestoreDocumentsByStringField(
+        staffRestSession,
+        rootMessagesPath,
+        'text',
+        text
+    );
+    const conversations = await listFirestoreDocuments(
+        staffRestSession,
+        `teams/${config.teamId}/chatConversations`
+    );
+    const nestedMessages = await Promise.all(conversations.map((conversation) => (
+        findFirestoreDocumentsByStringField(
+            staffRestSession,
+            `${getFirestoreDocumentPath(conversation)}/chatMessages`,
+            'text',
+            text
+        )
+    )));
+    return [...rootMessages, ...nestedMessages.flat()];
+}
+
+async function deleteSmokeChatMessages(text) {
+    const messages = await findSmokeChatMessages(text);
+    await Promise.all(messages.map((message) => (
+        deleteFirestoreDocument(staffRestSession, getFirestoreDocumentPath(message))
+    )));
+    return messages.length;
+}
+
+async function openWritableMediaAlbum(page) {
+    await openRoute(page, `/teams/${encodeURIComponent(config.teamId)}/media`);
+    const photoButton = page.getByRole('button', { name: 'Photo', exact: true });
+    if (await photoButton.waitFor({ state: 'visible', timeout: 15_000 }).then(() => true).catch(() => false)) {
+        return photoButton;
+    }
+
+    const refreshMedia = page.getByRole('button', { name: 'Refresh media' });
+    if (await refreshMedia.waitFor({ state: 'visible', timeout: 5_000 }).then(() => true).catch(() => false)) {
+        await refreshMedia.click({ timeout: LIVE_ACTION_TIMEOUT_MS });
+    } else {
+        await page.reload({ waitUntil: 'domcontentloaded', timeout: LIVE_ACTION_TIMEOUT_MS });
+    }
+    await expect(
+        photoButton,
+        'The existing smoke media album must become writable after one bounded read-only refresh'
+    ).toBeVisible({ timeout: LIVE_ACTION_TIMEOUT_MS });
+    return photoButton;
+}
+
 test('staff smoke writes are deterministic and removed after validation', async () => {
     test.setTimeout(300_000);
     const playerName = `${smokePrefix}-player`;
@@ -170,6 +223,10 @@ test('staff smoke writes are deterministic and removed after validation', async 
                     body: chatText
                 }
             )
+        },
+        {
+            recordType: 'chat-message',
+            cleanup: () => deleteSmokeChatMessages(chatText)
         }
     ];
 
@@ -222,12 +279,7 @@ test('staff smoke writes are deterministic and removed after validation', async 
             await page.getByRole('button', { name: 'Send message' }).click();
             await expect(page.getByText(chatText, { exact: true })).toBeVisible({ timeout: 25_000 });
 
-            const chatDocuments = await findFirestoreDocumentsByStringField(
-                staffRestSession,
-                `teams/${config.teamId}/chatMessages`,
-                'text',
-                chatText
-            );
+            const chatDocuments = await findSmokeChatMessages(chatText);
             expect(chatDocuments).toHaveLength(1);
             const chatDocumentPath = getFirestoreDocumentPath(chatDocuments[0]);
             cleanupTasks.push({
@@ -275,6 +327,42 @@ test('staff smoke writes are deterministic and removed after validation', async 
             ).toBeVisible({ timeout: 25_000 });
             await messageDeepLink.getByRole('button').click();
             await expect.poll(() => new URL(page.url()).hash, { timeout: 20_000 }).toMatch(/^#\/messages(?:\/|\?)/);
+        });
+    } finally {
+        await runSmokeCleanup(runId, cleanupTasks);
+    }
+});
+
+test('staff image upload is persisted and removed after validation', async () => {
+    test.setTimeout(240_000);
+    const mediaName = `${smokePrefix}-media.png`;
+    const cleanupTasks = [{
+        recordType: 'team-media',
+        cleanup: () => deleteSmokeMediaByTitle(
+            staffRestSession,
+            `teams/${config.teamId}/mediaItems`,
+            mediaName
+        )
+    }];
+
+    try {
+        await withAuthenticatedPage(staffSession, async (page) => {
+            await openWritableMediaAlbum(page);
+            const photoInput = page.locator('input[type="file"][accept="image/*"]');
+            await photoInput.setInputFiles({
+                name: mediaName,
+                mimeType: 'image/png',
+                buffer: Buffer.from(
+                    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+                    'base64'
+                )
+            });
+            await expect(page.getByText('Uploaded', { exact: true })).toBeVisible({ timeout: 35_000 });
+            const deleteMedia = page.getByRole('button', { name: `Delete ${mediaName}` });
+            await expect(deleteMedia).toBeVisible({ timeout: 25_000 });
+            page.once('dialog', (dialog) => dialog.accept());
+            await deleteMedia.click();
+            await expect(page.getByText('Media item deleted.')).toBeVisible({ timeout: 25_000 });
         });
     } finally {
         await runSmokeCleanup(runId, cleanupTasks);

--- a/tests/smoke/app-authenticated-extended.spec.js
+++ b/tests/smoke/app-authenticated-extended.spec.js
@@ -17,7 +17,6 @@ import {
     findFirestoreDocumentsByStringField,
     getFirestoreDocument,
     getFirestoreDocumentPath,
-    listFirestoreDocuments,
     restoreFirestoreDocument,
     runSmokeCleanup
 } from './helpers/firebase-rest.js';
@@ -144,10 +143,37 @@ async function findSmokeChatMessages(text) {
         'text',
         text
     );
-    const conversations = await listFirestoreDocuments(
-        staffRestSession,
-        `teams/${config.teamId}/chatConversations`
-    );
+    const conversationsPath = `teams/${config.teamId}/chatConversations`;
+    // An unfiltered collection list can include participant-only friend chats,
+    // which Firestore must reject even for team staff. Mirror the moderator-safe
+    // inbox queries so the smoke test only asks for conversations staff may list.
+    const conversationGroups = await Promise.all([
+        findFirestoreDocumentsByStringField(
+            staffRestSession,
+            conversationsPath,
+            'type',
+            'team'
+        ),
+        findFirestoreDocumentsByStringField(
+            staffRestSession,
+            conversationsPath,
+            'type',
+            'group'
+        ),
+        findFirestoreDocumentsByStringField(
+            staffRestSession,
+            conversationsPath,
+            'directAccess',
+            'team_admin'
+        )
+    ]);
+    const conversations = [
+        ...new Map(
+            conversationGroups
+                .flat()
+                .map((conversation) => [getFirestoreDocumentPath(conversation), conversation])
+        ).values()
+    ];
     const nestedMessages = await Promise.all(conversations.map((conversation) => (
         findFirestoreDocumentsByStringField(
             staffRestSession,

--- a/tests/smoke/app-authenticated-image-writes.spec.js
+++ b/tests/smoke/app-authenticated-image-writes.spec.js
@@ -2,18 +2,13 @@ import { randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';
 import {
     AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS,
-    buildAppSmokeUrl,
-    closeAuthenticatedAppSession,
-    createAuthenticatedAppSession,
-    getAppSmokeConfig,
-    redactSmokeDiagnostic
+    getAppSmokeConfig
 } from './helpers/app-auth.js';
 import {
     createFirestoreDocument,
     createFirebaseRestSession,
     deleteFirebaseStorageObject,
     deleteFirestoreDocument,
-    deleteSmokeMediaByTitle,
     getFirestoreDocument,
     getFirestoreStringField,
     isEmptyFirestoreDocument,
@@ -28,16 +23,13 @@ const extendedEnabled = process.env.SMOKE_EXTENDED_WRITES === '1';
 const runId = String(config.runId || '').replace(/[^A-Za-z0-9_-]/g, '').slice(0, 48);
 const attemptNonce = randomUUID().replace(/-/g, '');
 const smokePrefix = `allplays-smoke-${runId}-${attemptNonce}`;
-const secretValues = [config.staffEmail, config.staffPassword, config.parentEmail, config.parentPassword];
-const LIVE_ACTION_TIMEOUT_MS = 25_000;
 
 test.skip(!extendedEnabled, 'SMOKE_EXTENDED_WRITES=1 is required');
 
-let staffSession;
 let staffRestSession;
 let parentRestSession;
 
-test.beforeAll(async ({ browser }) => {
+test.beforeAll(async () => {
     test.setTimeout(AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS);
     for (const [name, value] of Object.entries({
         SMOKE_RUN_ID: runId,
@@ -52,13 +44,7 @@ test.beforeAll(async ({ browser }) => {
         expect(value, `${name} is required for the reversible image suite`).toBeTruthy();
     }
 
-    [staffSession, staffRestSession, parentRestSession] = await Promise.all([
-        createAuthenticatedAppSession(browser, {
-            appBaseUrl: config.appBaseUrl,
-            email: config.staffEmail,
-            password: config.staffPassword,
-            roleLabel: 'staff image writes'
-        }),
+    [staffRestSession, parentRestSession] = await Promise.all([
         createFirebaseRestSession({
             appBaseUrl: config.appBaseUrl,
             email: config.staffEmail,
@@ -71,43 +57,6 @@ test.beforeAll(async ({ browser }) => {
         })
     ]);
 });
-
-test.afterAll(async () => {
-    await closeAuthenticatedAppSession(staffSession);
-});
-
-async function withAuthenticatedPage(callback) {
-    const { page, issues } = staffSession;
-    page.setDefaultTimeout(LIVE_ACTION_TIMEOUT_MS);
-    await callback(page);
-    expect(issues.map((issue) => redactSmokeDiagnostic(issue, secretValues))).toEqual([]);
-}
-
-async function openRoute(page, route) {
-    await page.goto(buildAppSmokeUrl(config.appBaseUrl, route), { waitUntil: 'domcontentloaded' });
-    await expect(page.locator('main')).toBeVisible({ timeout: 25_000 });
-    await expect.poll(() => new URL(page.url()).hash, { timeout: 20_000 }).toContain(`#${route.split('?')[0]}`);
-}
-
-async function openWritableMediaAlbum(page) {
-    await openRoute(page, `/teams/${encodeURIComponent(config.teamId)}/media`);
-    const photoButton = page.getByRole('button', { name: 'Photo', exact: true });
-    if (await photoButton.waitFor({ state: 'visible', timeout: 15_000 }).then(() => true).catch(() => false)) {
-        return photoButton;
-    }
-
-    const refreshMedia = page.getByRole('button', { name: 'Refresh media' });
-    if (await refreshMedia.waitFor({ state: 'visible', timeout: 5_000 }).then(() => true).catch(() => false)) {
-        await refreshMedia.click({ timeout: LIVE_ACTION_TIMEOUT_MS });
-    } else {
-        await page.reload({ waitUntil: 'domcontentloaded', timeout: LIVE_ACTION_TIMEOUT_MS });
-    }
-    await expect(
-        photoButton,
-        'The existing smoke media album must become writable after one bounded read-only refresh'
-    ).toBeVisible({ timeout: LIVE_ACTION_TIMEOUT_MS });
-    return photoButton;
-}
 
 async function restoreImageFieldsIfUnchanged(documentState, fieldNames = Object.keys(documentState.expectedFields)) {
     const expectedEntries = Object.entries(documentState.expectedFields)
@@ -215,42 +164,6 @@ async function reconcileDedicatedImageFixture(target) {
     // Path-only abandoned uploads are retained because their historical Storage
     // generation was not persisted and cannot be proven from current metadata.
 }
-
-test('staff image upload is persisted and removed after validation', async () => {
-    test.setTimeout(240_000);
-    const mediaName = `${smokePrefix}-media.png`;
-    const cleanupTasks = [{
-        recordType: 'team-media',
-        cleanup: () => deleteSmokeMediaByTitle(
-            staffRestSession,
-            `teams/${config.teamId}/mediaItems`,
-            mediaName
-        )
-    }];
-
-    try {
-        await withAuthenticatedPage(async (page) => {
-            await openWritableMediaAlbum(page);
-            const photoInput = page.locator('input[type="file"][accept="image/*"]');
-            await photoInput.setInputFiles({
-                name: mediaName,
-                mimeType: 'image/png',
-                buffer: Buffer.from(
-                    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
-                    'base64'
-                )
-            });
-            await expect(page.getByText('Uploaded', { exact: true })).toBeVisible({ timeout: 35_000 });
-            const deleteMedia = page.getByRole('button', { name: `Delete ${mediaName}` });
-            await expect(deleteMedia).toBeVisible({ timeout: 25_000 });
-            page.once('dialog', (dialog) => dialog.accept());
-            await deleteMedia.click();
-            await expect(page.getByText('Media item deleted.')).toBeVisible({ timeout: 25_000 });
-        });
-    } finally {
-        await runSmokeCleanup(runId, cleanupTasks);
-    }
-});
 
 test('profile image paths accept authenticated storage and document writes', async () => {
     test.setTimeout(120_000);

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -438,6 +438,12 @@ describe('preview deployment workflow trust boundary', () => {
         expect(staffWorkflow).toContain('body: chatText');
         expect(extendedProductionSmoke).toContain('async function findSmokeChatMessages(text)');
         expect(extendedProductionSmoke).toContain('`teams/${config.teamId}/chatConversations`');
+        expect(extendedProductionSmoke).toContain("'type',\n            'team'");
+        expect(extendedProductionSmoke).toContain("'type',\n            'group'");
+        expect(extendedProductionSmoke).toContain("'directAccess',\n            'team_admin'");
+        expect(extendedProductionSmoke).not.toContain(
+            'listFirestoreDocuments(\n        staffRestSession,\n        `teams/${config.teamId}/chatConversations`'
+        );
         expect(extendedProductionSmoke).toContain('`${getFirestoreDocumentPath(conversation)}/chatMessages`');
         expect(extendedProductionSmoke).toContain('cleanup: () => deleteSmokeChatMessages(chatText)');
         const notificationAssertion = staffWorkflow.indexOf('const messageDeepLink');

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -436,6 +436,10 @@ describe('preview deployment workflow trust boundary', () => {
         expect(staffWorkflow).toContain('`users/${parentRestSession.localId}/notificationInbox`');
         expect(staffWorkflow).toContain("category: 'liveChat'");
         expect(staffWorkflow).toContain('body: chatText');
+        expect(extendedProductionSmoke).toContain('async function findSmokeChatMessages(text)');
+        expect(extendedProductionSmoke).toContain('`teams/${config.teamId}/chatConversations`');
+        expect(extendedProductionSmoke).toContain('`${getFirestoreDocumentPath(conversation)}/chatMessages`');
+        expect(extendedProductionSmoke).toContain('cleanup: () => deleteSmokeChatMessages(chatText)');
         const notificationAssertion = staffWorkflow.indexOf('const messageDeepLink');
         const cleanupCall = staffWorkflow.indexOf('await runSmokeCleanup(runId, cleanupTasks)');
         expect(notificationAssertion).toBeGreaterThanOrEqual(0);
@@ -446,7 +450,7 @@ describe('preview deployment workflow trust boundary', () => {
         const staffWorkflowStart = extendedProductionSmoke.indexOf(
             "test('staff smoke writes are deterministic and removed after validation'"
         );
-        const imageWorkflowStart = imageWriteProductionSmoke.indexOf(
+        const imageWorkflowStart = extendedProductionSmoke.indexOf(
             "test('staff image upload is persisted and removed after validation'"
         );
         const profileImageWorkflowStart = imageWriteProductionSmoke.indexOf(
@@ -455,18 +459,19 @@ describe('preview deployment workflow trust boundary', () => {
         const parentWorkflowStart = extendedProductionSmoke.indexOf(
             "test('parent smoke writes restore or remove every touched record'"
         );
-        const staffWorkflow = extendedProductionSmoke.slice(staffWorkflowStart, parentWorkflowStart);
-        const imageWorkflow = imageWriteProductionSmoke.slice(imageWorkflowStart, profileImageWorkflowStart);
+        const staffWorkflow = extendedProductionSmoke.slice(staffWorkflowStart, imageWorkflowStart);
+        const imageWorkflow = extendedProductionSmoke.slice(imageWorkflowStart, parentWorkflowStart);
         const profileImageWorkflow = imageWriteProductionSmoke.slice(profileImageWorkflowStart);
         const reconciliationWorkflow = imageWriteProductionSmoke.slice(
             imageWriteProductionSmoke.indexOf('async function reconcileDedicatedImageFixture'),
-            imageWorkflowStart
+            profileImageWorkflowStart
         );
 
         expect(staffWorkflowStart).toBeGreaterThanOrEqual(0);
         expect(parentWorkflowStart).toBeGreaterThan(staffWorkflowStart);
-        expect(imageWorkflowStart).toBeGreaterThanOrEqual(0);
-        expect(profileImageWorkflowStart).toBeGreaterThan(imageWorkflowStart);
+        expect(imageWorkflowStart).toBeGreaterThan(staffWorkflowStart);
+        expect(parentWorkflowStart).toBeGreaterThan(imageWorkflowStart);
+        expect(profileImageWorkflowStart).toBeGreaterThanOrEqual(0);
         expect(staffWorkflow).toContain('section[aria-label="Manage schedule tools"]');
         expect(staffWorkflow).toContain("locator('button[aria-controls]').first()");
         expect(staffWorkflow).toContain('manageSchedule.click({ timeout: 25_000 })');
@@ -475,13 +480,14 @@ describe('preview deployment workflow trust boundary', () => {
         expect(extendedProductionSmoke).toContain('page.setDefaultTimeout(LIVE_ACTION_TIMEOUT_MS)');
         expect(staffWorkflow).not.toContain('input[type="file"][accept="image/*"]');
         expect(imageWriteProductionSmoke).not.toContain("test.describe.configure({ mode: 'serial' })");
+        expect(extendedProductionSmoke).toContain("test.describe.configure({ mode: 'serial' })");
         expect(scheduledProdSmokeWorkflow).toContain('tests/smoke/app-authenticated-image-writes.spec.js');
         expect(imageWorkflow).toContain("recordType: 'team-media'");
         expect(imageWorkflow).toContain('await openWritableMediaAlbum(page)');
-        expect(imageWriteProductionSmoke).toContain("getByRole('button', { name: 'Refresh media' })");
-        expect(imageWriteProductionSmoke).toContain("waitFor({ state: 'visible', timeout: 15_000 })");
-        expect(imageWriteProductionSmoke).not.toContain('isVisible({ timeout:');
-        expect(imageWriteProductionSmoke).toContain('page.setDefaultTimeout(LIVE_ACTION_TIMEOUT_MS)');
+        expect(imageWorkflow).toContain('withAuthenticatedPage(staffSession');
+        expect(extendedProductionSmoke).toContain("getByRole('button', { name: 'Refresh media' })");
+        expect(extendedProductionSmoke).toContain("waitFor({ state: 'visible', timeout: 15_000 })");
+        expect(extendedProductionSmoke).not.toContain('isVisible({ timeout:');
         expect(imageWorkflow).toContain('input[type="file"][accept="image/*"]');
         expect(imageWorkflow).toContain("getByText('Uploaded', { exact: true })");
         expect(imageWorkflow).toContain("getByText('Media item deleted.')");

--- a/tests/unit/production-smoke-auth-setup-timeout.test.js
+++ b/tests/unit/production-smoke-auth-setup-timeout.test.js
@@ -12,7 +12,7 @@ describe('production smoke authenticated setup timeout', () => {
     it('uses an explicit bounded setup budget for every credentialed role suite', () => {
         expect(helper).toContain('export const AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS = 240_000;');
 
-        for (const source of [authenticatedCore, adminCore, authenticatedExtended, authenticatedImageWrites, legacyAuthenticatedCore]) {
+        for (const source of [authenticatedCore, adminCore, authenticatedExtended, legacyAuthenticatedCore]) {
             expect(source).toContain('AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS');
             expect(source).toMatch(
                 /test\.beforeAll\(async \(\{ browser \}\) => \{\s+test\.setTimeout\(AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS\);/
@@ -25,6 +25,14 @@ describe('production smoke authenticated setup timeout', () => {
             expect(boundedSetup).toMatch(/createAuthenticatedAppSession(?:s)?\(browser,/);
             expect(source).toMatch(/test\.afterAll\(async \(\) => \{[\s\S]*?closeAuthenticatedAppSession\(/);
         }
+
+        expect(authenticatedImageWrites).toContain('AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS');
+        expect(authenticatedImageWrites).toMatch(
+            /test\.beforeAll\(async \(\) => \{\s+test\.setTimeout\(AUTHENTICATED_SMOKE_SETUP_TIMEOUT_MS\);/
+        );
+        expect(authenticatedImageWrites).toContain('createFirebaseRestSession({');
+        expect(authenticatedImageWrites).not.toContain('createAuthenticatedAppSession');
+        expect(authenticatedImageWrites).not.toContain('closeAuthenticatedAppSession');
 
         for (const source of [authenticatedCore, authenticatedExtended]) {
             const boundedSetup = source.slice(


### PR DESCRIPTION
## Summary
- verify smoke chat writes in both legacy and conversation-scoped Firestore collections
- run Team Media upload coverage in the already-authorized staff browser session
- keep profile/player image storage checks REST-only and avoid an unnecessary third browser login
- update source contracts so the production validation topology cannot regress

## Validation
- `npx vitest run tests/unit/preview-deploy-trust-boundary.test.js tests/unit/production-smoke-auth-setup-timeout.test.js --reporter=verbose` (35 passed)
- `npx playwright test tests/smoke/app-authenticated-extended.spec.js tests/smoke/app-authenticated-image-writes.spec.js --config=playwright.smoke.config.js --project=smoke --list` (5 tests discovered)