### PR TITLE
Retry partial staff team discovery

### DIFF
--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -543,19 +543,67 @@ describe('parent schedule child scope', () => {
   it('marks parent scope partial when the authoritative staff-team read fails', async () => {
     const coachUser = { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'], coachOf: ['team-owned'] } as any;
     vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: ['team-owned'] } as any);
-    vi.mocked(getStaffTeams).mockRejectedValueOnce(new Error('network unavailable'));
+    vi.mocked(getStaffTeams)
+      .mockRejectedValueOnce(new Error('network unavailable'))
+      .mockRejectedValueOnce(new Error('network unavailable'));
 
     const scope = await loadParentScheduleScope(coachUser);
 
     expect(scope.isPartial).toBe(true);
     expect(scope.staffTeamsPartial).toBe(true);
     expect(scope.staffTeams).toEqual([]);
+    expect(getStaffTeams).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries partial staff discovery with coach links from the freshly loaded profile', async () => {
+    const coachUser = { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'], coachOf: [] } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: ['team-owned'] } as any);
+    vi.mocked(getStaffTeams)
+      .mockResolvedValueOnce({ teams: [], isPartial: true } as any)
+      .mockResolvedValueOnce({
+        teams: [{ id: 'team-owned', name: 'Vipers', active: true }],
+        isPartial: false
+      } as any);
+
+    const scope = await loadParentScheduleScope(coachUser);
+
+    expect(getStaffTeams).toHaveBeenNthCalledWith(1, {
+      userId: 'coach-1',
+      email: 'coach@example.com',
+      coachTeamIds: []
+    });
+    expect(getStaffTeams).toHaveBeenNthCalledWith(2, {
+      userId: 'coach-1',
+      email: 'coach@example.com',
+      coachTeamIds: ['team-owned']
+    });
+    expect(scope.staffTeams).toEqual([{ teamId: 'team-owned', teamName: 'Vipers' }]);
+    expect(scope.staffTeamsPartial).toBe(false);
+    expect(scope.isPartial).toBe(false);
+  });
+
+  it('clears the staff partial flag when a rejected discovery succeeds on retry', async () => {
+    const coachUser = { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'], coachOf: [] } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: ['team-owned'] } as any);
+    vi.mocked(getStaffTeams)
+      .mockRejectedValueOnce(new Error('initial Firebase read unavailable'))
+      .mockResolvedValueOnce({
+        teams: [{ id: 'team-owned', name: 'Vipers', active: true }],
+        isPartial: false
+      } as any);
+
+    const scope = await loadParentScheduleScope(coachUser);
+
+    expect(getStaffTeams).toHaveBeenCalledTimes(2);
+    expect(scope.staffTeams).toEqual([{ teamId: 'team-owned', teamName: 'Vipers' }]);
+    expect(scope.staffTeamsPartial).toBe(false);
+    expect(scope.isPartial).toBe(false);
   });
 
   it('marks web staff scope partial when a coach-team document read is incomplete', async () => {
     const coachUser = { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'], coachOf: ['team-owned', 'team-missing'] } as any;
     vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: coachUser.coachOf } as any);
-    vi.mocked(getStaffTeams).mockResolvedValueOnce({
+    vi.mocked(getStaffTeams).mockResolvedValue({
       teams: [{ id: 'team-owned', name: 'Vipers', ownerId: 'coach-1', active: true }],
       isPartial: true
     } as any);
@@ -565,6 +613,7 @@ describe('parent schedule child scope', () => {
     expect(scope.isPartial).toBe(true);
     expect(scope.staffTeamsPartial).toBe(true);
     expect(scope.staffTeams).toEqual([{ teamId: 'team-owned', teamName: 'Vipers' }]);
+    expect(getStaffTeams).toHaveBeenCalledTimes(2);
   });
 
   it('keeps repeated direct schedule refreshes partial when staff discovery fails', async () => {

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -582,6 +582,35 @@ describe('parent schedule child scope', () => {
     expect(scope.isPartial).toBe(false);
   });
 
+  it('retries partial owner and admin discovery when the profile has no coach links', async () => {
+    const staffUser = { uid: 'staff-1', email: 'staff@example.com', roles: ['coach'], coachOf: [] } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: [] } as any);
+    vi.mocked(getStaffTeams)
+      .mockResolvedValueOnce({ teams: [], isPartial: true } as any)
+      .mockResolvedValueOnce({
+        teams: [
+          { id: 'team-owned', name: 'Owned Team', ownerId: 'staff-1', active: true },
+          { id: 'team-admin', name: 'Admin Team', adminEmails: ['staff@example.com'], active: true }
+        ],
+        isPartial: false
+      } as any);
+
+    const scope = await loadParentScheduleScope(staffUser);
+
+    expect(getStaffTeams).toHaveBeenCalledTimes(2);
+    expect(getStaffTeams).toHaveBeenNthCalledWith(2, {
+      userId: 'staff-1',
+      email: 'staff@example.com',
+      coachTeamIds: []
+    });
+    expect(scope.staffTeams).toEqual([
+      { teamId: 'team-owned', teamName: 'Owned Team' },
+      { teamId: 'team-admin', teamName: 'Admin Team' }
+    ]);
+    expect(scope.staffTeamsPartial).toBe(false);
+    expect(scope.isPartial).toBe(false);
+  });
+
   it('clears the staff partial flag when a rejected discovery succeeds on retry', async () => {
     const coachUser = { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'], coachOf: [] } as any;
     vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: ['team-owned'] } as any);

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -3030,13 +3030,7 @@ export async function loadParentScheduleScope(user: AuthUser | null): Promise<Pa
     ...(Array.isArray((profile as any).coachOf) ? (profile as any).coachOf : [])
   ].map(compactString).filter(Boolean);
   const uniqueDeclaredCoachTeamIds = [...new Set(declaredCoachTeamIds)];
-  const discoveredStaffTeamIds = new Set(
-    staffTeamResult.teams.map((team: any) => compactString(team?.id)).filter(Boolean)
-  );
-  const isMissingDeclaredCoachTeam = uniqueDeclaredCoachTeamIds.some(
-    (teamId) => !discoveredStaffTeamIds.has(teamId)
-  );
-  if (staffTeamResult.isPartial && isMissingDeclaredCoachTeam) {
+  if (staffTeamResult.isPartial) {
     try {
       const retryResult = await loadStaffTeams({
         ...user,

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -3014,18 +3014,48 @@ export async function loadParentScheduleScope(user: AuthUser | null): Promise<Pa
       staffTeams: []
     };
   }
-  let isPartial = false;
-  const [profile, staffTeamResult] = await Promise.all([
+  let profileLoadPartial = false;
+  const [profile, initialStaffTeamResult] = await Promise.all([
     loadProfileDocument(user.uid).catch(() => {
-      isPartial = true;
+      profileLoadPartial = true;
       return {};
     }),
     loadStaffTeams(user).catch(() => {
-      isPartial = true;
       return { teams: [], isPartial: true };
     })
   ]);
-  if (staffTeamResult.isPartial) isPartial = true;
+  let staffTeamResult = initialStaffTeamResult;
+  const declaredCoachTeamIds = [
+    ...(Array.isArray(user.coachOf) ? user.coachOf : []),
+    ...(Array.isArray((profile as any).coachOf) ? (profile as any).coachOf : [])
+  ].map(compactString).filter(Boolean);
+  const uniqueDeclaredCoachTeamIds = [...new Set(declaredCoachTeamIds)];
+  const discoveredStaffTeamIds = new Set(
+    staffTeamResult.teams.map((team: any) => compactString(team?.id)).filter(Boolean)
+  );
+  const isMissingDeclaredCoachTeam = uniqueDeclaredCoachTeamIds.some(
+    (teamId) => !discoveredStaffTeamIds.has(teamId)
+  );
+  if (staffTeamResult.isPartial && isMissingDeclaredCoachTeam) {
+    try {
+      const retryResult = await loadStaffTeams({
+        ...user,
+        coachOf: uniqueDeclaredCoachTeamIds
+      });
+      const teamsById = new Map<string, any>();
+      [...staffTeamResult.teams, ...retryResult.teams].forEach((team: any) => {
+        const teamId = compactString(team?.id);
+        if (teamId) teamsById.set(teamId, team);
+      });
+      staffTeamResult = {
+        teams: [...teamsById.values()],
+        isPartial: retryResult.isPartial
+      };
+    } catch {
+      staffTeamResult = { ...staffTeamResult, isPartial: true };
+    }
+  }
+  let isPartial = profileLoadPartial || staffTeamResult.isPartial;
   const childResult = await resolveParentScheduleChildren(user, profile as Record<string, unknown>);
   if (childResult.isPartial) isPartial = true;
   return {


### PR DESCRIPTION
## What changed
- retry incomplete staff-team discovery once after the current profile has loaded
- include profile `coachOf` IDs in the retry so owner/admin query races cannot cache an empty team chooser
- preserve partial-state reporting when the retry remains incomplete
- add regression coverage for recovery and persistent failure

## Root cause
The initial profile and staff-team reads ran in parallel. When the owner/admin query was transiently partial, the first staff query could not use the canonical `coachOf` IDs that had just loaded from the profile, so the app cached an empty team list.

## Validation
- `npx vitest run src/lib/scheduleService.test.ts src/lib/homeService.test.ts --reporter=dot` (159 passed)
- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings only)
- `git diff --check`