### PR TITLE
Recover missing staff teams in production

### DIFF
--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -306,6 +306,7 @@ describe('parent schedule child scope', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getNativeAuthIdToken).mockRejectedValue(new Error('REST auth unavailable in isolated staff-scope tests'));
     vi.mocked(isTeamActive).mockImplementation((team: any) => (
       team?.active !== false &&
       team?.archived !== true &&

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -582,6 +582,46 @@ describe('parent schedule child scope', () => {
     expect(scope.isPartial).toBe(false);
   });
 
+  it('recovers a profile-declared coach team when the web SDK reports an empty complete result', async () => {
+    const previousFetch = globalThis.fetch;
+    const coachUser = { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'], coachOf: [] } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: ['team-owned'] } as any);
+    vi.mocked(getStaffTeams).mockResolvedValue({ teams: [], isPartial: false } as any);
+    vi.mocked(getNativeAuthIdToken).mockResolvedValue('web-token' as any);
+    (globalThis as any).fetch = vi.fn(async (_input: any, init?: RequestInit) => {
+      if (init?.body) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => []
+        } as any;
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          name: 'projects/allplays-test/databases/(default)/documents/teams/team-owned',
+          fields: {
+            name: { stringValue: 'Vipers' },
+            active: { booleanValue: true }
+          }
+        })
+      } as any;
+    });
+
+    try {
+      const scope = await loadParentScheduleScope(coachUser);
+
+      expect(getStaffTeams).toHaveBeenCalledTimes(1);
+      expect(getNativeAuthIdToken).toHaveBeenCalledWith(true);
+      expect(scope.staffTeams).toEqual([{ teamId: 'team-owned', teamName: 'Vipers' }]);
+      expect(scope.staffTeamsPartial).toBe(false);
+      expect(scope.isPartial).toBe(false);
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+
   it('retries partial owner and admin discovery when the profile has no coach links', async () => {
     const staffUser = { uid: 'staff-1', email: 'staff@example.com', roles: ['coach'], coachOf: [] } as any;
     vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: [] } as any);

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -1701,6 +1701,34 @@ type StaffTeamsLoadResult = {
   isPartial: boolean;
 };
 
+async function loadStaffTeamsFromRest(user: AuthUser): Promise<StaffTeamsLoadResult> {
+  const coachTeamIds = Array.isArray(user.coachOf) ? user.coachOf.map(compactString).filter(Boolean) : [];
+  const normalizedEmail = normalizeEmail(user.email);
+  const ownerEmailCandidates = Array.from(new Set([compactString(user.email), normalizedEmail].filter(Boolean)));
+  const ownerEmailLookups = ownerEmailCandidates.map((ownerEmail) =>
+    nativeRunQuery('teams', 'ownerEmail', 'EQUAL', ownerEmail)
+  );
+  const queryResults = await Promise.allSettled([
+    nativeRunQuery('teams', 'ownerId', 'EQUAL', user.uid),
+    ...(normalizedEmail ? [
+      nativeRunQuery('teams', 'adminEmails', 'ARRAY_CONTAINS', normalizedEmail),
+      nativeRunQuery('teams', 'ownerEmailLower', 'EQUAL', normalizedEmail)
+    ] : []),
+    ...ownerEmailLookups
+  ]);
+  const coachTeamResults = await Promise.allSettled(
+    coachTeamIds.map((teamId) => nativeGetDocument(`teams/${encodeURIComponent(teamId)}`))
+  );
+  const isPartial = [...queryResults, ...coachTeamResults].some((result) => result.status === 'rejected');
+  const teamsById = new Map<string, any>();
+  const queryTeams = queryResults.flatMap((result) => result.status === 'fulfilled' ? result.value : []);
+  const coachTeams = coachTeamResults.flatMap((result) => result.status === 'fulfilled' && result.value ? [result.value] : []);
+  [...queryTeams, ...coachTeams].forEach((team) => {
+    if (team?.id && isTeamActive(team) && isTeamStaff(team, user)) teamsById.set(team.id, team);
+  });
+  return { teams: [...teamsById.values()], isPartial };
+}
+
 async function loadStaffTeams(user: AuthUser): Promise<StaffTeamsLoadResult> {
   return readWithNativeFallback(
     'staff teams',
@@ -1717,33 +1745,7 @@ async function loadStaffTeams(user: AuthUser): Promise<StaffTeamsLoadResult> {
       });
       return { teams: [...teamsById.values()], isPartial: staffTeamResult.isPartial };
     },
-    async () => {
-      const coachTeamIds = Array.isArray(user.coachOf) ? user.coachOf.map(compactString).filter(Boolean) : [];
-      const normalizedEmail = normalizeEmail(user.email);
-      const ownerEmailCandidates = Array.from(new Set([compactString(user.email), normalizedEmail].filter(Boolean)));
-      const ownerEmailLookups = ownerEmailCandidates.map((ownerEmail) =>
-        nativeRunQuery('teams', 'ownerEmail', 'EQUAL', ownerEmail)
-      );
-      const queryResults = await Promise.allSettled([
-        nativeRunQuery('teams', 'ownerId', 'EQUAL', user.uid),
-        ...(normalizedEmail ? [
-          nativeRunQuery('teams', 'adminEmails', 'ARRAY_CONTAINS', normalizedEmail),
-          nativeRunQuery('teams', 'ownerEmailLower', 'EQUAL', normalizedEmail)
-        ] : []),
-        ...ownerEmailLookups
-      ]);
-      const coachTeamResults = await Promise.allSettled(
-        coachTeamIds.map((teamId) => nativeGetDocument(`teams/${encodeURIComponent(teamId)}`))
-      );
-      const isPartial = [...queryResults, ...coachTeamResults].some((result) => result.status === 'rejected');
-      const teamsById = new Map<string, any>();
-      const queryTeams = queryResults.flatMap((result) => result.status === 'fulfilled' ? result.value : []);
-      const coachTeams = coachTeamResults.flatMap((result) => result.status === 'fulfilled' && result.value ? [result.value] : []);
-      [...queryTeams, ...coachTeams].forEach((team) => {
-        if (team?.id && isTeamActive(team) && isTeamStaff(team, user)) teamsById.set(team.id, team);
-      });
-      return { teams: [...teamsById.values()], isPartial };
-    }
+    () => loadStaffTeamsFromRest(user)
   );
 }
 
@@ -3030,12 +3032,13 @@ export async function loadParentScheduleScope(user: AuthUser | null): Promise<Pa
     ...(Array.isArray((profile as any).coachOf) ? (profile as any).coachOf : [])
   ].map(compactString).filter(Boolean);
   const uniqueDeclaredCoachTeamIds = [...new Set(declaredCoachTeamIds)];
+  const staffUser = {
+    ...user,
+    coachOf: uniqueDeclaredCoachTeamIds
+  };
   if (staffTeamResult.isPartial) {
     try {
-      const retryResult = await loadStaffTeams({
-        ...user,
-        coachOf: uniqueDeclaredCoachTeamIds
-      });
+      const retryResult = await loadStaffTeams(staffUser);
       const teamsById = new Map<string, any>();
       [...staffTeamResult.teams, ...retryResult.teams].forEach((team: any) => {
         const teamId = compactString(team?.id);
@@ -3044,6 +3047,24 @@ export async function loadParentScheduleScope(user: AuthUser | null): Promise<Pa
       staffTeamResult = {
         teams: [...teamsById.values()],
         isPartial: retryResult.isPartial
+      };
+    } catch {
+      staffTeamResult = { ...staffTeamResult, isPartial: true };
+    }
+  }
+  const discoveredStaffTeamIds = new Set(staffTeamResult.teams.map((team: any) => compactString(team?.id)).filter(Boolean));
+  const hasMissingDeclaredCoachTeam = uniqueDeclaredCoachTeamIds.some((teamId) => !discoveredStaffTeamIds.has(teamId));
+  if (staffTeamResult.isPartial || hasMissingDeclaredCoachTeam) {
+    try {
+      const restResult = await loadStaffTeamsFromRest(staffUser);
+      const teamsById = new Map<string, any>();
+      [...staffTeamResult.teams, ...restResult.teams].forEach((team: any) => {
+        const teamId = compactString(team?.id);
+        if (teamId) teamsById.set(teamId, team);
+      });
+      staffTeamResult = {
+        teams: [...teamsById.values()],
+        isPartial: restResult.isPartial
       };
     } catch {
       staffTeamResult = { ...staffTeamResult, isPartial: true };

--- a/tests/smoke/app-authenticated-extended.spec.js
+++ b/tests/smoke/app-authenticated-extended.spec.js
@@ -17,6 +17,7 @@ import {
     findFirestoreDocumentsByStringField,
     getFirestoreDocument,
     getFirestoreDocumentPath,
+    patchFirestoreDocumentFields,
     restoreFirestoreDocument,
     runSmokeCleanup
 } from './helpers/firebase-rest.js';
@@ -185,10 +186,21 @@ async function findSmokeChatMessages(text) {
     return [...rootMessages, ...nestedMessages.flat()];
 }
 
-async function deleteSmokeChatMessages(text) {
-    const messages = await findSmokeChatMessages(text);
+async function softDeleteSmokeChatMessage(documentPath) {
+    const message = await getFirestoreDocument(staffRestSession, documentPath);
+    if (!message || message?.fields?.deleted?.booleanValue === true) return;
+    await patchFirestoreDocumentFields(staffRestSession, documentPath, {
+        deleted: { booleanValue: true }
+    });
+}
+
+async function softDeleteSmokeChatMessages(...texts) {
+    const messageGroups = await Promise.all(texts.map((text) => findSmokeChatMessages(text)));
+    const messages = [
+        ...new Map(messageGroups.flat().map((message) => [getFirestoreDocumentPath(message), message])).values()
+    ];
     await Promise.all(messages.map((message) => (
-        deleteFirestoreDocument(staffRestSession, getFirestoreDocumentPath(message))
+        softDeleteSmokeChatMessage(getFirestoreDocumentPath(message))
     )));
     return messages.length;
 }
@@ -213,7 +225,7 @@ async function openWritableMediaAlbum(page) {
     return photoButton;
 }
 
-test('staff smoke writes are deterministic and removed after validation', async () => {
+test('staff smoke writes are deterministic and reversed or soft-deleted after validation', async () => {
     test.setTimeout(300_000);
     const playerName = `${smokePrefix}-player`;
     const opponentName = `${smokePrefix}-opponent`;
@@ -252,7 +264,7 @@ test('staff smoke writes are deterministic and removed after validation', async 
         },
         {
             recordType: 'chat-message',
-            cleanup: () => deleteSmokeChatMessages(chatText)
+            cleanup: () => softDeleteSmokeChatMessages(chatText, editedChatText)
         }
     ];
 
@@ -310,7 +322,7 @@ test('staff smoke writes are deterministic and removed after validation', async 
             const chatDocumentPath = getFirestoreDocumentPath(chatDocuments[0]);
             cleanupTasks.push({
                 recordType: 'chat-message',
-                cleanup: () => deleteFirestoreDocument(staffRestSession, chatDocumentPath)
+                cleanup: () => softDeleteSmokeChatMessage(chatDocumentPath)
             });
 
             const messageRow = page.locator('.message-row-measure').filter({ hasText: chatText });
@@ -325,6 +337,9 @@ test('staff smoke writes are deterministic and removed after validation', async 
             page.once('dialog', (dialog) => dialog.accept());
             await editedRow.getByRole('button', { name: 'Delete' }).click();
             await expect(editedRow.getByText('Message removed')).toBeVisible({ timeout: 20_000 });
+            await expect.poll(async () => (
+                await getFirestoreDocument(staffRestSession, chatDocumentPath)
+            )?.fields?.deleted?.booleanValue).toBe(true);
 
             await openRoute(page, `/schedule/${encodeURIComponent(config.teamId)}/${encodeURIComponent(config.eventId)}?section=game`);
             const trackerLaunch = page.getByTestId('standard-tracker-launch');

--- a/tests/unit/preview-deploy-trust-boundary.test.js
+++ b/tests/unit/preview-deploy-trust-boundary.test.js
@@ -423,7 +423,7 @@ describe('preview deployment workflow trust boundary', () => {
 
     it('verifies and removes chat notifications in the same reversible smoke workflow', () => {
         const staffWorkflowStart = extendedProductionSmoke.indexOf(
-            "test('staff smoke writes are deterministic and removed after validation'"
+            "test('staff smoke writes are deterministic and reversed or soft-deleted after validation'"
         );
         const parentWorkflowStart = extendedProductionSmoke.indexOf(
             "test('parent smoke writes restore or remove every touched record'"
@@ -445,7 +445,10 @@ describe('preview deployment workflow trust boundary', () => {
             'listFirestoreDocuments(\n        staffRestSession,\n        `teams/${config.teamId}/chatConversations`'
         );
         expect(extendedProductionSmoke).toContain('`${getFirestoreDocumentPath(conversation)}/chatMessages`');
-        expect(extendedProductionSmoke).toContain('cleanup: () => deleteSmokeChatMessages(chatText)');
+        expect(extendedProductionSmoke).toContain('cleanup: () => softDeleteSmokeChatMessages(chatText, editedChatText)');
+        expect(extendedProductionSmoke).toContain('cleanup: () => softDeleteSmokeChatMessage(chatDocumentPath)');
+        expect(extendedProductionSmoke).toContain("deleted: { booleanValue: true }");
+        expect(extendedProductionSmoke).not.toContain('deleteFirestoreDocument(staffRestSession, chatDocumentPath)');
         const notificationAssertion = staffWorkflow.indexOf('const messageDeepLink');
         const cleanupCall = staffWorkflow.indexOf('await runSmokeCleanup(runId, cleanupTasks)');
         expect(notificationAssertion).toBeGreaterThanOrEqual(0);
@@ -454,7 +457,7 @@ describe('preview deployment workflow trust boundary', () => {
 
     it('keeps production image writes isolated and always schedules cleanup', () => {
         const staffWorkflowStart = extendedProductionSmoke.indexOf(
-            "test('staff smoke writes are deterministic and removed after validation'"
+            "test('staff smoke writes are deterministic and reversed or soft-deleted after validation'"
         );
         const imageWorkflowStart = extendedProductionSmoke.indexOf(
             "test('staff image upload is persisted and removed after validation'"


### PR DESCRIPTION
## What changed
- cross-check profile-declared coach teams with authenticated Firestore REST when the web SDK returns an empty complete result
- reuse the canonical REST staff discovery path for native fallback and web reconciliation
- make production chat smoke cleanup follow the product's intentional soft-delete contract and verify the persisted tombstone
- add regressions for empty-success staff discovery and smoke cleanup behavior

## Root cause
The first retry only ran when staff discovery reported `isPartial`. In production, the web SDK returned `{ teams: [], isPartial: false }` before the freshly loaded profile coach link was considered, so `/teams` cached an empty model. Separately, the extended smoke attempted a hard delete that Firestore rules intentionally do not allow for chat messages.

## Verification
- `npx vitest run apps/app/src/lib/scheduleService.test.ts -t "parent schedule child scope" --reporter=verbose` (18 passed)
- `npx vitest run tests/unit/preview-deploy-trust-boundary.test.js tests/unit/production-smoke-auth-setup-timeout.test.js --reporter=verbose` (35 passed)
- `npm run app:build`
- `git diff --check`

## Production validation
After merge and exact-SHA deploy, rerun fixture repair and the protected expanded production smoke suite.