### PR TITLE
Recover fresh web-session team access

### DIFF
--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -623,6 +623,43 @@ describe('parent schedule child scope', () => {
     }
   });
 
+  it('verifies an empty complete staff result for a coach even when profile hydration has no team links', async () => {
+    const previousFetch = globalThis.fetch;
+    const coachUser = { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'], coachOf: [] } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: [] } as any);
+    vi.mocked(getStaffTeams).mockResolvedValue({ teams: [], isPartial: false } as any);
+    vi.mocked(getNativeAuthIdToken).mockResolvedValue('web-token' as any);
+    (globalThis as any).fetch = vi.fn(async (_input: any, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(String(init.body)) : null;
+      const fieldPath = body?.structuredQuery?.where?.fieldFilter?.field?.fieldPath;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => fieldPath === 'ownerId' ? [{
+          document: {
+            name: 'projects/allplays-test/databases/(default)/documents/teams/team-owned',
+            fields: {
+              name: { stringValue: 'Vipers' },
+              ownerId: { stringValue: 'coach-1' },
+              active: { booleanValue: true }
+            }
+          }
+        }] : []
+      } as any;
+    });
+
+    try {
+      const scope = await loadParentScheduleScope(coachUser);
+
+      expect(getStaffTeams).toHaveBeenCalledTimes(1);
+      expect(scope.staffTeams).toEqual([{ teamId: 'team-owned', teamName: 'Vipers' }]);
+      expect(scope.staffTeamsPartial).toBe(false);
+      expect(scope.isPartial).toBe(false);
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+
   it('retries partial owner and admin discovery when the profile has no coach links', async () => {
     const staffUser = { uid: 'staff-1', email: 'staff@example.com', roles: ['coach'], coachOf: [] } as any;
     vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: [] } as any);

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -3054,7 +3054,12 @@ export async function loadParentScheduleScope(user: AuthUser | null): Promise<Pa
   }
   const discoveredStaffTeamIds = new Set(staffTeamResult.teams.map((team: any) => compactString(team?.id)).filter(Boolean));
   const hasMissingDeclaredCoachTeam = uniqueDeclaredCoachTeamIds.some((teamId) => !discoveredStaffTeamIds.has(teamId));
-  if (staffTeamResult.isPartial || hasMissingDeclaredCoachTeam) {
+  const hasStaffRole = Array.isArray(user.roles) && user.roles.some((role) => (
+    role === 'coach' || role === 'admin' || role === 'platformAdmin'
+  ));
+  const shouldVerifyEmptyStaffResult = staffTeamResult.teams.length === 0
+    && (hasStaffRole || uniqueDeclaredCoachTeamIds.length > 0 || user.isAdmin === true || user.isPlatformAdmin === true);
+  if (staffTeamResult.isPartial || hasMissingDeclaredCoachTeam || shouldVerifyEmptyStaffResult) {
     try {
       const restResult = await loadStaffTeamsFromRest(staffUser);
       const teamsById = new Map<string, any>();

--- a/apps/app/src/lib/teamDetailService.test.ts
+++ b/apps/app/src/lib/teamDetailService.test.ts
@@ -868,6 +868,8 @@ describe('team detail bootstrap loading', () => {
       active: true
     });
     authServiceMocks.getNativeAuthIdToken.mockResolvedValueOnce('web-token');
+    dbMocks.getRosterFieldDefinitions.mockResolvedValueOnce([]);
+    dbMocks.applyRosterCsvImportOperations.mockResolvedValueOnce([{ playerId: 'player-2' }]);
     (globalThis as any).fetch = vi.fn(async () => ({
       ok: true,
       status: 200,
@@ -891,6 +893,12 @@ describe('team detail bootstrap loading', () => {
         includeInactive: true
       }));
       expect(authServiceMocks.getNativeAuthIdToken).toHaveBeenCalledWith(true);
+
+      await expect(addRosterPlayerForApp('team-1', { uid: 'owner-1', roles: ['coach'] } as any, {
+        name: 'New Player'
+      })).resolves.toMatchObject({ playerId: 'player-2' });
+      expect(dbMocks.getTeam).toHaveBeenCalledTimes(1);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
     } finally {
       globalThis.fetch = previousFetch;
     }

--- a/apps/app/src/lib/teamDetailService.test.ts
+++ b/apps/app/src/lib/teamDetailService.test.ts
@@ -858,6 +858,44 @@ describe('team detail bootstrap loading', () => {
     expect(dbMocks.getConfigs).not.toHaveBeenCalled();
   });
 
+  it('recovers management access from the authoritative REST document when the web SDK returns a public projection', async () => {
+    const previousFetch = globalThis.fetch;
+    dbMocks.getTeam.mockResolvedValueOnce({
+      id: 'team-1',
+      name: 'Bears',
+      sport: 'Basketball',
+      isPublic: true,
+      active: true
+    });
+    authServiceMocks.getNativeAuthIdToken.mockResolvedValueOnce('web-token');
+    (globalThis as any).fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        name: 'projects/test-project/databases/(default)/documents/teams/team-1',
+        fields: {
+          name: { stringValue: 'Bears' },
+          sport: { stringValue: 'Basketball' },
+          ownerId: { stringValue: 'owner-1' },
+          active: { booleanValue: true }
+        }
+      })
+    }) as any);
+
+    try {
+      const model = await loadParentTeamDetailBootstrap('team-1', { uid: 'owner-1', roles: ['coach'] } as any);
+
+      expect(model.canManageTeam).toBe(true);
+      expect(model.team.ownerId).toBe('owner-1');
+      expect(dbMocks.getPlayersWithPrivateRosterContacts).toHaveBeenCalledWith('team-1', expect.objectContaining({
+        includeInactive: true
+      }));
+      expect(authServiceMocks.getNativeAuthIdToken).toHaveBeenCalledWith(true);
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+
   it('includes later-page players when the native roster fallback is paginated', async () => {
     const previousFetch = globalThis.fetch;
     nativeRuntimeState.isNative = true;

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -802,9 +802,13 @@ async function recoverAuthoritativeManagedTeam(
     });
     return null;
   });
-  return authoritativeTeam && hasFullTeamAccess(user, authoritativeTeam)
-    ? authoritativeTeam
-    : team;
+  if (!authoritativeTeam || !hasFullTeamAccess(user, authoritativeTeam)) return team;
+
+  const cachedSnapshot = teamDetailBaseSnapshotCache.get(cleanString(teamId));
+  if (cachedSnapshot) {
+    cacheTeamDetailBaseSnapshot({ ...cachedSnapshot, team: authoritativeTeam });
+  }
+  return authoritativeTeam;
 }
 
 async function loadTeamPlayers(teamId: string) {

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -778,6 +778,35 @@ async function loadTeamDocument(teamId: string) {
   );
 }
 
+async function recoverAuthoritativeManagedTeam(
+  teamId: string,
+  user: AuthUser | null,
+  team: Record<string, any> | null
+) {
+  if (!user?.uid || hasFullTeamAccess(user, team)) return team;
+  if (isNativeRuntime()) return team;
+  const hasStaffRole = Array.isArray(user.roles) && user.roles.some((role) => (
+    role === 'coach' || role === 'admin' || role === 'platformAdmin'
+  ));
+  const isPotentialManager = hasStaffRole
+    || (Array.isArray(user.coachOf) && user.coachOf.length > 0)
+    || user.isAdmin === true
+    || user.isPlatformAdmin === true;
+  if (!isPotentialManager) return team;
+
+  const authoritativeTeam = await nativeGetDocument(`teams/${encodeURIComponent(teamId)}`).catch((error) => {
+    logger.warn('Unable to verify authoritative team management access.', {
+      operation: 'team-management-access-recovery',
+      teamId,
+      error
+    });
+    return null;
+  });
+  return authoritativeTeam && hasFullTeamAccess(user, authoritativeTeam)
+    ? authoritativeTeam
+    : team;
+}
+
 async function loadTeamPlayers(teamId: string) {
   return readWithNativeFallback(
     `team players ${teamId}`,
@@ -1928,7 +1957,8 @@ export async function loadParentTeamDetail(
   options: { includeDeferredData?: boolean } = {}
 ): Promise<TeamDetailModel> {
   const includeDeferredData = options.includeDeferredData === true;
-  const { team, players: publicPlayers, games, configs } = await loadTeamDetailBaseSnapshot(teamId, { includeGamesAndConfigs: true });
+  const { team: loadedTeam, players: publicPlayers, games, configs } = await loadTeamDetailBaseSnapshot(teamId, { includeGamesAndConfigs: true });
+  const team = await recoverAuthoritativeManagedTeam(teamId, user, loadedTeam);
 
   if (!team) throw new Error('Team not found.');
 
@@ -1995,7 +2025,8 @@ async function loadTeamDetailOverviewSchedule(teamId: string, teamName: string, 
 }
 
 export async function loadParentTeamDetailBootstrap(teamId: string, user: AuthUser | null): Promise<TeamDetailModel> {
-  const { team, players: publicPlayers } = await loadTeamDetailBaseSnapshot(teamId, { includeGamesAndConfigs: false });
+  const { team: loadedTeam, players: publicPlayers } = await loadTeamDetailBaseSnapshot(teamId, { includeGamesAndConfigs: false });
+  const team = await recoverAuthoritativeManagedTeam(teamId, user, loadedTeam);
 
   if (!team) throw new Error('Team not found.');
 


### PR DESCRIPTION
## What changed
- verify an empty staff-team result for authenticated coach/admin roles through the authoritative Firebase REST path
- recover the canonical managed-team document when the web SDK returns a public projection after a fresh sign-in
- preserve existing parent and native behavior while restoring roster-management permissions
- add regressions for both production failure modes

## Root cause
Fresh web sessions could authenticate in Firebase Auth while the browser Firestore SDK returned an empty staff query or the sanitized public team projection. The app treated those successful-looking results as authoritative, so My Teams omitted the owned team and Team Detail lost `ownerId`, disabling Add player.

## Validation
- `npm run test:app -- src/lib/scheduleService.test.ts src/lib/teamDetailService.test.ts` (216 passed)
- `npm --prefix apps/app run build`
- `node scripts/verify-app-bundle-visualizer.mjs`
- `npm run app:check-bundle-size`
- `npx vitest run tests/unit/production-smoke-parent-fixture.test.js tests/unit/production-smoke-auth-setup-timeout.test.js tests/unit/preview-deploy-trust-boundary.test.js --reporter=verbose` (44 passed)