### PR TITLE
Align P10 trusted navigation routes

### DIFF
--- a/scripts/parent-coverage-contract.mjs
+++ b/scripts/parent-coverage-contract.mjs
@@ -73,7 +73,17 @@ const workflowCapabilities = new Map(Object.entries({
     P07: { mode: 'readOnly', routes: ['/auth'], actions: ['clickAndExpectGoogleAuth'] },
     P08: { mode: 'lifecycle', routes: ['/home', '/accept-invite', '/parent-tools/access'], actions: ['fill', 'click'] },
     P09: { mode: 'reversible', routes: ['/parent-tools/access'], actions: ['fill', 'select', 'click'] },
-    P10: { mode: 'readOnly', routes: ['/home', '/parent-tools/*'], actions: ['clickAndExpectRoute'] },
+    P10: {
+        mode: 'readOnly',
+        routes: [
+            '/home',
+            '/parent-tools', '/parent-tools/*',
+            '/schedule', '/schedule/*',
+            '/messages', '/messages/*',
+            '/profile', '/profile/*'
+        ],
+        actions: ['clickAndExpectRoute']
+    },
     P11: { mode: 'readOnly', routes: ['/teams/{TEAM_ID}', '/players/{TEAM_ID}/{PLAYER_ID}'], actions: [] },
     P12: { mode: 'reversible', routes: ['/profile/settings'], actions: ['rememberControl', 'fill', 'click', 'restoreControl'] },
     P13: { mode: 'reversible', routes: ['/profile/settings'], actions: ['click', 'uploadSyntheticImage'] },

--- a/tests/unit/parent-coverage-contract.test.js
+++ b/tests/unit/parent-coverage-contract.test.js
@@ -195,6 +195,36 @@ describe('parent coverage contract boundary', () => {
         expect(() => validateContract(reversible, catalog, 'P13')).toThrow(/cleanup action uploadSyntheticImage is not allowed/);
     });
 
+    it('keeps P10 home action destinations inside its trusted read-only routes', () => {
+        const homeAction = validContract({
+            workflowId: 'P10',
+            title: catalog.workflows[9].title,
+            actors: ['primary'],
+            steps: [
+                { action: 'goto', actor: 'primary', route: '/home' },
+                {
+                    action: 'expectText', actor: 'primary',
+                    target: { kind: 'text', name: 'Action queue', exact: true }, value: 'Action'
+                },
+                {
+                    action: 'clickAndExpectRoute', actor: 'primary',
+                    target: { kind: 'role', role: 'link', name: 'Schedule', exact: true },
+                    route: '/schedule'
+                }
+            ]
+        });
+
+        expect(validateContract(homeAction, catalog, 'P10').workflowId).toBe('P10');
+        for (const route of [
+            '/parent-tools', '/parent-tools/tasks', '/schedule', '/schedule/team-1/event-1',
+            '/messages', '/messages/team-1', '/profile', '/profile/settings'
+        ]) {
+            expect(workflowRouteAllowed('P10', route)).toBe(true);
+        }
+        expect(workflowRouteAllowed('P10', '/teams')).toBe(false);
+        expect(workflowRouteAllowed('P10', '/ai')).toBe(false);
+    });
+
     it('allows credential fills without putting credentials in the contract', () => {
         const signup = validContract({
             workflowId: 'P02',

--- a/tests/unit/parent-coverage-contract.test.js
+++ b/tests/unit/parent-coverage-contract.test.js
@@ -221,8 +221,9 @@ describe('parent coverage contract boundary', () => {
         ]) {
             expect(workflowRouteAllowed('P10', route)).toBe(true);
         }
-        expect(workflowRouteAllowed('P10', '/teams')).toBe(false);
-        expect(workflowRouteAllowed('P10', '/ai')).toBe(false);
+        for (const route of ['/teams', '/teams/team-1', '/ai', '/ai/private']) {
+            expect(workflowRouteAllowed('P10', route)).toBe(false);
+        }
     });
 
     it('allows credential fills without putting credentials in the contract', () => {


### PR DESCRIPTION
## Summary

- Align the P10 home-action evidence matrix with its trusted read-only route allowlist.
- Permit only the actual Family, Schedule, Messages, and Profile roots and descendants.
- Keep unrelated routes such as Teams and AI denied.

## Root cause

The P10 evidence matrix required a home action to navigate to schedule, messages, profile, or parent tools, while its capability boundary allowed only home and parent-tools descendants. The protected validator therefore rejected a legitimate Schedule navigation before the functional test could run.

## Tests

- Reproduced the failure before the fix: step 3 route is outside the trusted P10 capability.
- Ran all five parent-coverage unit suites: 75 tests passed.

## Production safety

- Read-only route validation only; no mutation, authorization, credential, retention, or cleanup behavior changed.
- Target names remain constrained to the P10 home-action allowlist.
- Regression coverage proves Teams and AI remain outside the boundary.

## Manual testing

- Not applicable; this changes the declarative protected-test validator, not product UI.