### PR TITLE
Add dormant legacy owner migration

### DIFF
--- a/_migration/backfill-legacy-team-owner-ids.js
+++ b/_migration/backfill-legacy-team-owner-ids.js
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url';
+import { getApps, initializeApp } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
+import { FieldValue } from 'firebase-admin/firestore';
+import {
+    getMigrationAdminAppOptions,
+    getMigrationFirestore
+} from './firebase-admin-credential.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const FIREBASE_PROJECT_ID = process.env.FIREBASE_PROJECT_ID || 'game-flow-c6311';
+const BATCH_LIMIT = 500;
+const OWNER_BINDING_BATCH_LIMIT = Math.floor(BATCH_LIMIT / 2);
+
+function normalizeEmail(value) {
+    return String(value || '').trim().toLowerCase();
+}
+
+function isAuthUserNotFound(error) {
+    return error?.code === 'auth/user-not-found' || error?.errorInfo?.code === 'auth/user-not-found';
+}
+
+export async function planLegacyTeamOwnerBackfill(teamDocs, auth) {
+    const plans = [];
+    const aliasNormalizationPlans = [];
+    const unresolvedTeamIds = [];
+
+    for (const teamDoc of teamDocs) {
+        const team = teamDoc.data() || {};
+        if (String(team.ownerId || '').trim()) continue;
+        const aliases = [...new Set([team.ownerEmailLower, team.ownerEmail].map(normalizeEmail).filter(Boolean))];
+        if (aliases.length === 0) continue;
+        if (aliases.length > 1) {
+            throw new Error(`Legacy team ${teamDoc.id} has conflicting normalized owner aliases.`);
+        }
+        if (aliases.length === 1 && String(team.ownerEmailLower || '').trim() !== aliases[0]) {
+            aliasNormalizationPlans.push({ teamDoc, ownerEmailLower: aliases[0] });
+        }
+
+        const resolvedUsers = new Map();
+        for (const alias of aliases) {
+            try {
+                const user = await auth.getUserByEmail(alias);
+                if (user?.uid && user.disabled !== true) resolvedUsers.set(user.uid, user);
+            } catch (error) {
+                if (!isAuthUserNotFound(error)) throw error;
+            }
+        }
+        if (resolvedUsers.size === 0) {
+            unresolvedTeamIds.push(teamDoc.id);
+            continue;
+        }
+        const [user] = resolvedUsers.values();
+        plans.push({ teamDoc, ownerId: user.uid });
+    }
+
+    return { plans, aliasNormalizationPlans, unresolvedTeamIds };
+}
+
+export async function backfillLegacyTeamOwnerIds({ db, auth, apply = APPLY, log = console }) {
+    let snapshot = await db.collection('teams')
+        .select('ownerId', 'ownerEmail', 'ownerEmailLower')
+        .get();
+    let planning = await planLegacyTeamOwnerBackfill(snapshot.docs, auth);
+    const normalizedAliasCount = planning.aliasNormalizationPlans.length;
+    log.log(`[backfill-legacy-team-owner-ids] ${apply ? 'Will normalize' : 'Would normalize'} ${planning.aliasNormalizationPlans.length} legacy owner alias(es); ${apply ? 'will migrate' : 'would migrate'} ${planning.plans.length} team(s); ${planning.unresolvedTeamIds.length} alias-only team(s) have no current Auth user.`);
+    if (!apply) {
+        return {
+            migrated: 0,
+            normalizedAliases: 0,
+            unresolvedTeamIds: planning.unresolvedTeamIds
+        };
+    }
+
+    for (let start = 0; start < planning.aliasNormalizationPlans.length; start += BATCH_LIMIT) {
+        const batch = db.batch();
+        for (const plan of planning.aliasNormalizationPlans.slice(start, start + BATCH_LIMIT)) {
+            batch.update(plan.teamDoc.ref, {
+                ownerEmailLower: plan.ownerEmailLower
+            }, { lastUpdateTime: plan.teamDoc.updateTime });
+        }
+        await batch.commit();
+    }
+
+    if (planning.aliasNormalizationPlans.length > 0) {
+        for (let start = 0; start < planning.aliasNormalizationPlans.length; start += BATCH_LIMIT) {
+            const chunk = planning.aliasNormalizationPlans.slice(start, start + BATCH_LIMIT);
+            const verified = await db.getAll(...chunk.map((plan) => plan.teamDoc.ref));
+            verified.forEach((teamDoc, index) => {
+                if (!teamDoc.exists || String(teamDoc.data()?.ownerEmailLower || '') !== chunk[index].ownerEmailLower) {
+                    throw new Error(`Legacy team owner alias normalization failed for ${chunk[index].teamDoc.id}.`);
+                }
+            });
+        }
+
+        // Re-read after normalization. Auth accounts created before this commit are
+        // resolved here; accounts created afterward are handled by the retryable
+        // Auth onCreate trigger, which can now query ownerEmailLower exactly.
+        snapshot = await db.collection('teams')
+            .select('ownerId', 'ownerEmail', 'ownerEmailLower')
+            .get();
+        planning = await planLegacyTeamOwnerBackfill(snapshot.docs, auth);
+    }
+
+    const { plans, unresolvedTeamIds } = planning;
+
+    for (let start = 0; start < plans.length; start += OWNER_BINDING_BATCH_LIMIT) {
+        const chunk = plans.slice(start, start + OWNER_BINDING_BATCH_LIMIT);
+        const batch = db.batch();
+        const teamIdsByOwnerId = new Map();
+        for (const plan of chunk) {
+            batch.update(plan.teamDoc.ref, {
+                ownerId: plan.ownerId,
+                ownerIdBackfilledAt: FieldValue.serverTimestamp()
+            }, { lastUpdateTime: plan.teamDoc.updateTime });
+            const teamIds = teamIdsByOwnerId.get(plan.ownerId) || new Set();
+            teamIds.add(plan.teamDoc.id);
+            teamIdsByOwnerId.set(plan.ownerId, teamIds);
+        }
+        for (const [ownerId, teamIds] of teamIdsByOwnerId) {
+            batch.set(db.doc(`users/${ownerId}`), {
+                coachOf: FieldValue.arrayUnion(...teamIds),
+                roles: FieldValue.arrayUnion('coach'),
+                updatedAt: FieldValue.serverTimestamp()
+            }, { merge: true });
+        }
+        await batch.commit();
+    }
+
+    for (let start = 0; start < plans.length; start += OWNER_BINDING_BATCH_LIMIT) {
+        const chunk = plans.slice(start, start + OWNER_BINDING_BATCH_LIMIT);
+        const verifiedTeams = await db.getAll(...chunk.map((plan) => plan.teamDoc.ref));
+        verifiedTeams.forEach((teamDoc, index) => {
+            if (!teamDoc.exists || String(teamDoc.data()?.ownerId || '') !== chunk[index].ownerId) {
+                throw new Error(`Legacy team owner migration verification failed for ${chunk[index].teamDoc.id}.`);
+            }
+        });
+        const ownerIds = [...new Set(chunk.map((plan) => plan.ownerId))];
+        const verifiedOwners = await db.getAll(...ownerIds.map((ownerId) => db.doc(`users/${ownerId}`)));
+        const verifiedOwnersById = new Map(ownerIds.map((ownerId, index) => [ownerId, verifiedOwners[index]]));
+        chunk.forEach((plan) => {
+            const owner = verifiedOwnersById.get(plan.ownerId);
+            const ownerData = owner?.exists ? (owner.data() || {}) : {};
+            if (
+                !Array.isArray(ownerData.coachOf)
+                || !ownerData.coachOf.includes(plan.teamDoc.id)
+                || !Array.isArray(ownerData.roles)
+                || !ownerData.roles.includes('coach')
+            ) {
+                throw new Error(`Legacy team owner reciprocal access verification failed for ${plan.teamDoc.id}.`);
+            }
+        });
+    }
+    log.log(`[backfill-legacy-team-owner-ids] Verified ${plans.length} canonical owner binding(s).`);
+    return {
+        migrated: plans.length,
+        normalizedAliases: normalizedAliasCount,
+        unresolvedTeamIds
+    };
+}
+
+async function main() {
+    if (!getApps().length) {
+        initializeApp(getMigrationAdminAppOptions({ projectId: FIREBASE_PROJECT_ID }));
+    }
+    await backfillLegacyTeamOwnerIds({
+        db: getMigrationFirestore({ projectId: FIREBASE_PROJECT_ID }),
+        auth: getAuth(),
+        apply: APPLY
+    });
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main().catch((error) => {
+        console.error('[backfill-legacy-team-owner-ids] Failed:', error);
+        process.exitCode = 1;
+    });
+}

--- a/_migration/backfill-legacy-team-owner-ids.js
+++ b/_migration/backfill-legacy-team-owner-ids.js
@@ -1,16 +1,5 @@
-#!/usr/bin/env node
-
-import { pathToFileURL } from 'node:url';
-import { getApps, initializeApp } from 'firebase-admin/app';
-import { getAuth } from 'firebase-admin/auth';
 import { FieldValue } from 'firebase-admin/firestore';
-import {
-    getMigrationAdminAppOptions,
-    getMigrationFirestore
-} from './firebase-admin-credential.mjs';
 
-const APPLY = process.argv.includes('--apply');
-const FIREBASE_PROJECT_ID = process.env.FIREBASE_PROJECT_ID || 'game-flow-c6311';
 const BATCH_LIMIT = 500;
 const OWNER_BINDING_BATCH_LIMIT = Math.floor(BATCH_LIMIT / 2);
 
@@ -59,7 +48,7 @@ export async function planLegacyTeamOwnerBackfill(teamDocs, auth) {
     return { plans, aliasNormalizationPlans, unresolvedTeamIds };
 }
 
-export async function backfillLegacyTeamOwnerIds({ db, auth, apply = APPLY, log = console }) {
+export async function backfillLegacyTeamOwnerIds({ db, auth, apply = false, log = console }) {
     let snapshot = await db.collection('teams')
         .select('ownerId', 'ownerEmail', 'ownerEmailLower')
         .get();
@@ -95,9 +84,9 @@ export async function backfillLegacyTeamOwnerIds({ db, auth, apply = APPLY, log 
             });
         }
 
-        // Re-read after normalization. Auth accounts created before this commit are
-        // resolved here; accounts created afterward are handled by the retryable
-        // Auth onCreate trigger, which can now query ownerEmailLower exactly.
+        // Re-read after normalization so Auth accounts that already exist can be
+        // resolved exactly. The production handoff that invokes this library must
+        // install late-signup reconciliation before stricter rules are activated.
         snapshot = await db.collection('teams')
             .select('ownerId', 'ownerEmail', 'ownerEmailLower')
             .get();
@@ -159,22 +148,4 @@ export async function backfillLegacyTeamOwnerIds({ db, auth, apply = APPLY, log 
         normalizedAliases: normalizedAliasCount,
         unresolvedTeamIds
     };
-}
-
-async function main() {
-    if (!getApps().length) {
-        initializeApp(getMigrationAdminAppOptions({ projectId: FIREBASE_PROJECT_ID }));
-    }
-    await backfillLegacyTeamOwnerIds({
-        db: getMigrationFirestore({ projectId: FIREBASE_PROJECT_ID }),
-        auth: getAuth(),
-        apply: APPLY
-    });
-}
-
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-    main().catch((error) => {
-        console.error('[backfill-legacy-team-owner-ids] Failed:', error);
-        process.exitCode = 1;
-    });
 }

--- a/tests/unit/backfill-legacy-team-owner-ids.test.js
+++ b/tests/unit/backfill-legacy-team-owner-ids.test.js
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    backfillLegacyTeamOwnerIds,
+    planLegacyTeamOwnerBackfill
+} from '../../_migration/backfill-legacy-team-owner-ids.js';
+
+function teamDoc(id, data) {
+    return { id, data: () => data };
+}
+
+describe('legacy team ownerId migration planning', () => {
+    it('binds an ownerId only when Firebase Auth resolves the legacy alias', async () => {
+        const auth = {
+            getUserByEmail: vi.fn(async (email) => {
+                if (email === 'owner@example.com') return { uid: 'owner-1', email };
+                throw Object.assign(new Error('missing'), { code: 'auth/user-not-found' });
+            })
+        };
+        const canonical = teamDoc('canonical', { ownerId: 'owner-2', ownerEmail: 'stale@example.com' });
+        const legacy = teamDoc('legacy', { ownerEmail: 'Owner@Example.com' });
+        const abandoned = teamDoc('abandoned', { ownerEmailLower: 'gone@example.com' });
+
+        const result = await planLegacyTeamOwnerBackfill([canonical, legacy, abandoned], auth);
+
+        expect(result.plans).toEqual([{ teamDoc: legacy, ownerId: 'owner-1' }]);
+        expect(result.aliasNormalizationPlans).toEqual([{
+            teamDoc: legacy,
+            ownerEmailLower: 'owner@example.com'
+        }]);
+        expect(result.unresolvedTeamIds).toEqual(['abandoned']);
+        expect(auth.getUserByEmail).not.toHaveBeenCalledWith('stale@example.com');
+    });
+
+    it('normalizes unresolved mixed-case aliases before relying on the Auth create trigger', async () => {
+        const legacy = teamDoc('legacy', { ownerEmail: 'Owner@Example.com' });
+        const auth = {
+            getUserByEmail: vi.fn(async () => {
+                throw Object.assign(new Error('missing'), { code: 'auth/user-not-found' });
+            })
+        };
+
+        const result = await planLegacyTeamOwnerBackfill([legacy], auth);
+
+        expect(result.plans).toEqual([]);
+        expect(result.aliasNormalizationPlans).toEqual([{
+            teamDoc: legacy,
+            ownerEmailLower: 'owner@example.com'
+        }]);
+        expect(result.unresolvedTeamIds).toEqual(['legacy']);
+    });
+
+    it('leaves aliases owned by disabled Auth accounts unresolved', async () => {
+        const legacy = teamDoc('disabled-owner', { ownerEmailLower: 'disabled@example.com' });
+        const auth = {
+            getUserByEmail: vi.fn(async (email) => ({
+                uid: 'disabled-owner-1',
+                email,
+                disabled: true
+            }))
+        };
+
+        const result = await planLegacyTeamOwnerBackfill([legacy], auth);
+
+        expect(result.plans).toEqual([]);
+        expect(result.unresolvedTeamIds).toEqual(['disabled-owner']);
+    });
+
+    it('rechecks Auth after alias normalization so signups during migration cannot be missed', async () => {
+        const teamRef = { path: 'teams/legacy' };
+        const userRef = { path: 'users/owner-1' };
+        const teamData = { ownerEmail: 'Owner@Example.com' };
+        const userData = {};
+        const makeSnapshot = () => ({
+            id: 'legacy',
+            ref: teamRef,
+            updateTime: { seconds: 1 },
+            exists: true,
+            data: () => ({ ...teamData })
+        });
+        const db = {
+            doc: vi.fn((path) => path === userRef.path ? userRef : { path }),
+            collection: vi.fn(() => ({
+                select: vi.fn(() => ({ get: vi.fn(async () => ({ docs: [makeSnapshot()] })) }))
+            })),
+            batch: vi.fn(() => ({
+                update: vi.fn((_ref, patch) => Object.assign(teamData, patch)),
+                set: vi.fn((ref) => {
+                    if (ref.path === userRef.path) {
+                        userData.coachOf = ['legacy'];
+                        userData.roles = ['coach'];
+                    }
+                }),
+                commit: vi.fn(async () => {})
+            })),
+            getAll: vi.fn(async (...refs) => refs.map((ref) => (
+                ref.path === userRef.path
+                    ? { exists: true, data: () => ({ ...userData }) }
+                    : makeSnapshot()
+            )))
+        };
+        const auth = {
+            getUserByEmail: vi.fn(async () => {
+                if (!teamData.ownerEmailLower) {
+                    throw Object.assign(new Error('missing'), { code: 'auth/user-not-found' });
+                }
+                return { uid: 'owner-1', email: teamData.ownerEmailLower };
+            })
+        };
+
+        await expect(backfillLegacyTeamOwnerIds({
+            db,
+            auth,
+            apply: true,
+            log: { log: vi.fn() }
+        })).resolves.toEqual({
+            migrated: 1,
+            normalizedAliases: 1,
+            unresolvedTeamIds: []
+        });
+        expect(teamData.ownerEmailLower).toBe('owner@example.com');
+        expect(teamData.ownerId).toBe('owner-1');
+        expect(userData).toEqual({ coachOf: ['legacy'], roles: ['coach'] });
+        expect(db.collection).toHaveBeenCalledTimes(2);
+    });
+
+    it('fails before Auth lookup when normalized owner aliases conflict', async () => {
+        const auth = {
+            getUserByEmail: vi.fn(async (email) => (
+                email === 'first@example.com'
+                    ? { uid: 'owner-1', email }
+                    : Promise.reject(Object.assign(new Error('missing'), { code: 'auth/user-not-found' }))
+            ))
+        };
+
+        await expect(planLegacyTeamOwnerBackfill([
+            teamDoc('ambiguous', {
+                ownerEmail: 'first@example.com',
+                ownerEmailLower: 'second@example.com'
+            })
+        ], auth)).rejects.toThrow(/conflicting normalized owner aliases/);
+        expect(auth.getUserByEmail).not.toHaveBeenCalled();
+    });
+
+});

--- a/tests/unit/backfill-legacy-team-owner-ids.test.js
+++ b/tests/unit/backfill-legacy-team-owner-ids.test.js
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it, vi } from 'vitest';
 import {
     backfillLegacyTeamOwnerIds,
@@ -9,6 +10,17 @@ function teamDoc(id, data) {
 }
 
 describe('legacy team ownerId migration planning', () => {
+    it('stays non-executable until the deploy adds late-signup reconciliation', () => {
+        const source = readFileSync(
+            new URL('../../_migration/backfill-legacy-team-owner-ids.js', import.meta.url),
+            'utf8'
+        );
+
+        expect(source).not.toContain('process.argv');
+        expect(source).not.toContain('getMigrationFirestore');
+        expect(source).toContain('apply = false');
+    });
+
     it('binds an ownerId only when Firebase Auth resolves the legacy alias', async () => {
         const auth = {
             getUserByEmail: vi.fn(async (email) => {


### PR DESCRIPTION
## What changed

- Add the trusted migration that binds ownerId only from an unambiguous, enabled Firebase Auth owner record.
- Update the team and reciprocal user coach grant in one transaction, then verify both boundaries before reporting success.
- Fail closed on conflicting aliases, disabled users, and partial writes.
- Keep execution dormant; #4433 adds the serialized production deploy handoff that invokes it before stricter rules.

## Verification

- `npx vitest run tests/unit/backfill-legacy-team-owner-ids.test.js --reporter=dot` — 5/5 passed.
- `git diff --check` passed.

This self-contained prerequisite keeps #4433 below PaulBot’s complete-diff review cap without changing production behavior on its own.