### PR TITLE
Restore managed MCP calendar schedule

### DIFF
--- a/functions/family-share-view-core.cjs
+++ b/functions/family-share-view-core.cjs
@@ -16,6 +16,9 @@ const CALENDAR_LOCATION_DIRECTIONS = new Set([
   'north', 'south', 'east', 'west',
   'northeast', 'northwest', 'southeast', 'southwest'
 ]);
+const GENERIC_CALENDAR_DISCRIMINATORS = new Set([
+  '', 'tbd', 'unknown', 'practice', 'game', 'training', 'workout', 'scrimmage'
+]);
 
 function compactText(value, maxLength = 240) {
   return String(value == null ? '' : value)
@@ -36,11 +39,35 @@ function hashFamilyShareCalendarEventUid(value) {
   return uid ? hashFamilyShareOpaqueValue('calendar-event-uid', uid) : '';
 }
 
+function normalizeFamilyShareCalendarEventType(value) {
+  return compactText(value, 32).toLowerCase() === 'practice' ? 'practice' : 'game';
+}
+
+function normalizeFamilyShareCalendarDiscriminator(value) {
+  const normalized = compactText(value, 300).replace(/\s+/g, ' ').toLowerCase();
+  return GENERIC_CALENDAR_DISCRIMINATORS.has(normalized) ? '' : normalized;
+}
+
+function hasMatchingFamilyShareCalendarDiscriminator(event, tracked, type) {
+  const eventLocation = normalizeFamilyShareCalendarDiscriminator(event?.location);
+  const trackedLocation = normalizeFamilyShareCalendarDiscriminator(tracked?.location);
+  if (eventLocation && eventLocation === trackedLocation) return true;
+
+  const field = type === 'practice' ? 'title' : 'opponent';
+  const eventValue = normalizeFamilyShareCalendarDiscriminator(event?.[field]);
+  const trackedValue = normalizeFamilyShareCalendarDiscriminator(tracked?.[field]);
+  return Boolean(eventValue && eventValue === trackedValue);
+}
+
 function isFamilyShareCalendarEventTracked(event = {}, trackedEvents = []) {
   const entries = [...(trackedEvents instanceof Set ? trackedEvents : (Array.isArray(trackedEvents) ? trackedEvents : []))]
     .map((tracked) => ({
       id: compactText(typeof tracked === 'object' ? tracked?.calendarEventUid : tracked, 512),
-      startsAt: typeof tracked === 'object' ? toIso(tracked?.date || tracked?.startsAt) : null
+      startsAt: typeof tracked === 'object' ? toIso(tracked?.date || tracked?.startsAt) : null,
+      type: typeof tracked === 'object' ? normalizeFamilyShareCalendarEventType(tracked?.type) : 'game',
+      location: typeof tracked === 'object' ? compactText(tracked?.location, 300) : '',
+      opponent: typeof tracked === 'object' ? compactText(tracked?.opponent, 240) : '',
+      title: typeof tracked === 'object' ? compactText(tracked?.title, 240) : ''
     }))
     .filter((tracked) => tracked.id);
   const eventIds = [event?.id, event?.eventKey]
@@ -48,6 +75,7 @@ function isFamilyShareCalendarEventTracked(event = {}, trackedEvents = []) {
     .filter(Boolean);
   const startsAt = toIso(event?.date || event?.startsAt);
   const uidHash = compactText(event?.calendarUidHash, 64);
+  const type = normalizeFamilyShareCalendarEventType(event?.type);
   for (const tracked of entries) {
     const occurrenceMatch = tracked.id.match(/^(.*)__(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z)$/);
     const baseId = occurrenceMatch?.[1] || tracked.id;
@@ -60,10 +88,15 @@ function isFamilyShareCalendarEventTracked(event = {}, trackedEvents = []) {
       if (occurrenceStartsAt ? occurrenceStartsAt === startsAt : !tracked.startsAt || tracked.startsAt === startsAt) return true;
       continue;
     }
-    // Prior public IDs are irreversible 32-hex hashes. Their embedded occurrence
-    // timestamp is the only stable correlation available after a provider edits
-    // mutable summary metadata, and mirrors the existing team/time conflict guard.
-    if (/^[a-f0-9]{32}$/i.test(baseId) && occurrenceStartsAt === startsAt) return true;
+    // Prior public IDs are irreversible 32-hex hashes. Require stable event shape
+    // in addition to their embedded occurrence timestamp so simultaneous events
+    // do not suppress one another after mutable summary metadata changes.
+    if (
+      /^[a-f0-9]{32}$/i.test(baseId)
+      && occurrenceStartsAt === startsAt
+      && tracked.type === type
+      && hasMatchingFamilyShareCalendarDiscriminator(event, tracked, type)
+    ) return true;
   }
   return false;
 }

--- a/functions/family-share-view-core.cjs
+++ b/functions/family-share-view-core.cjs
@@ -36,6 +36,27 @@ function hashFamilyShareCalendarEventUid(value) {
   return uid ? hashFamilyShareOpaqueValue('calendar-event-uid', uid) : '';
 }
 
+function isFamilyShareCalendarEventTracked(event = {}, trackedEvents = []) {
+  const entries = [...(trackedEvents instanceof Set ? trackedEvents : (Array.isArray(trackedEvents) ? trackedEvents : []))]
+    .map((tracked) => ({
+      id: compactText(typeof tracked === 'object' ? tracked?.calendarEventUid : tracked, 512),
+      startsAt: typeof tracked === 'object' ? toIso(tracked?.date || tracked?.startsAt) : null
+    }))
+    .filter((tracked) => tracked.id);
+  const eventId = compactText(event?.id || event?.eventKey, 256);
+  const startsAt = toIso(event?.date || event?.startsAt);
+  const uidHash = compactText(event?.calendarUidHash, 64);
+  for (const tracked of entries) {
+    if (tracked.startsAt && startsAt && tracked.startsAt !== startsAt) continue;
+    if (eventId && (tracked.id === eventId || (startsAt && tracked.id === `${eventId}__${startsAt}`))) return true;
+    if (!uidHash) continue;
+    const baseId = tracked.id
+      .replace(/__\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/, '');
+    if (hashFamilyShareCalendarEventUid(baseId) === uidHash) return true;
+  }
+  return false;
+}
+
 function toIso(value) {
   if (!value) return null;
   const candidate = typeof value.toDate === 'function' ? value.toDate() : value;
@@ -507,6 +528,7 @@ module.exports = {
   buildFamilySharePresentation,
   getFamilyShareCalendarDedupTimestamps,
   hashFamilyShareCalendarEventUid,
+  isFamilyShareCalendarEventTracked,
   parseBoundedIcsEvents,
   sanitizeFamilyShareViewResponse
 };

--- a/functions/family-share-view-core.cjs
+++ b/functions/family-share-view-core.cjs
@@ -43,14 +43,18 @@ function isFamilyShareCalendarEventTracked(event = {}, trackedEvents = []) {
       startsAt: typeof tracked === 'object' ? toIso(tracked?.date || tracked?.startsAt) : null
     }))
     .filter((tracked) => tracked.id);
-  const eventId = compactText(event?.id || event?.eventKey, 256);
+  const eventIds = [event?.id || event?.eventKey, event?.legacyOpaqueId]
+    .map((id) => compactText(id, 256))
+    .filter(Boolean);
   const startsAt = toIso(event?.date || event?.startsAt);
   const uidHash = compactText(event?.calendarUidHash, 64);
   for (const tracked of entries) {
     const occurrenceMatch = tracked.id.match(/^(.*)__(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z)$/);
     const baseId = occurrenceMatch?.[1] || tracked.id;
     const occurrenceStartsAt = occurrenceMatch?.[2] || null;
-    if (eventId && (tracked.id === eventId || (baseId === eventId && occurrenceStartsAt === startsAt))) return true;
+    if (eventIds.some((eventId) => (
+      tracked.id === eventId || (baseId === eventId && occurrenceStartsAt === startsAt)
+    ))) return true;
     if (!uidHash) continue;
     if (hashFamilyShareCalendarEventUid(baseId) !== uidHash) continue;
     if (occurrenceStartsAt ? occurrenceStartsAt === startsAt : !tracked.startsAt || tracked.startsAt === startsAt) return true;
@@ -358,9 +362,16 @@ function buildExternalCalendarEvents(icsText, { sourceId, sourceLabel = 'Shared 
       ? `uid:${uid}`
       : `uid-missing:${summary}:${toIso(event.dtend) || ''}:${compactText(event.location, 300)}`;
     const idSeed = `${sourceId || ''}:${eventDiscriminator}:${date || ''}`;
+    const legacyOpaqueId = uid
+      ? hashFamilyShareOpaqueValue(
+          'calendar-event-public-id',
+          `${sourceId || ''}:${event.uid || ''}:${date || ''}:${summary}`
+        )
+      : '';
     return {
       eventKey: hashFamilyShareOpaqueValue('calendar-event-instance', idSeed),
       id: hashFamilyShareOpaqueValue('calendar-event-public-id', idSeed),
+      ...(legacyOpaqueId ? { legacyOpaqueId } : {}),
       calendarUidHash: hashFamilyShareCalendarEventUid(event.uid),
       teamId: compactText(teamId, 128),
       teamName: compactText(teamName, 160) || compactText(sourceLabel, 160),

--- a/functions/family-share-view-core.cjs
+++ b/functions/family-share-view-core.cjs
@@ -360,20 +360,10 @@ function buildExternalCalendarEvents(icsText, { sourceId, sourceLabel = 'Shared 
     const summary = compactText(event.summary).replace(/\[CANCELED\]\s*/ig, '');
     const type = isPracticeSummary(summary) ? 'practice' : 'game';
     const date = toIso(event.dtstart);
-    const uid = compactText(event.uid, 256);
-    // Calendar summaries and opponents are mutable. Keep UID-backed occurrence
-    // IDs stable across those edits, while retaining a hashed discriminator for
-    // malformed feeds that omit UID entirely.
-    const eventDiscriminator = uid
-      ? `uid:${uid}`
-      : `uid-missing:${summary}:${toIso(event.dtend) || ''}:${compactText(event.location, 300)}`;
-    const eventKeySeed = `${sourceId || ''}:${eventDiscriminator}:${date || ''}`;
-    const publicIdSeed = uid
-      ? `${sourceId || ''}:${event.uid || ''}:${date || ''}:${summary}`
-      : eventKeySeed;
+    const idSeed = `${sourceId || ''}:${event.uid || ''}:${date || ''}:${summary}`;
     return {
-      eventKey: hashFamilyShareOpaqueValue('calendar-event-instance', eventKeySeed),
-      id: hashFamilyShareOpaqueValue('calendar-event-public-id', publicIdSeed),
+      eventKey: hashFamilyShareOpaqueValue('calendar-event-instance', idSeed),
+      id: hashFamilyShareOpaqueValue('calendar-event-public-id', idSeed),
       calendarUidHash: hashFamilyShareCalendarEventUid(event.uid),
       teamId: compactText(teamId, 128),
       teamName: compactText(teamName, 160) || compactText(sourceLabel, 160),
@@ -480,6 +470,7 @@ function sanitizeFamilyShareGame(game = {}) {
 
 function sanitizeFamilyShareViewResponse({ token, children = [], teams = [], externalEvents = [], calendarWarnings = [] } = {}) {
   const externalEventFields = [
+    'eventKey',
     'id',
     'teamId',
     'teamName',

--- a/functions/family-share-view-core.cjs
+++ b/functions/family-share-view-core.cjs
@@ -47,12 +47,13 @@ function isFamilyShareCalendarEventTracked(event = {}, trackedEvents = []) {
   const startsAt = toIso(event?.date || event?.startsAt);
   const uidHash = compactText(event?.calendarUidHash, 64);
   for (const tracked of entries) {
-    if (tracked.startsAt && startsAt && tracked.startsAt !== startsAt) continue;
-    if (eventId && (tracked.id === eventId || (startsAt && tracked.id === `${eventId}__${startsAt}`))) return true;
+    const occurrenceMatch = tracked.id.match(/^(.*)__(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z)$/);
+    const baseId = occurrenceMatch?.[1] || tracked.id;
+    const occurrenceStartsAt = occurrenceMatch?.[2] || null;
+    if (eventId && (tracked.id === eventId || (baseId === eventId && occurrenceStartsAt === startsAt))) return true;
     if (!uidHash) continue;
-    const baseId = tracked.id
-      .replace(/__\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/, '');
-    if (hashFamilyShareCalendarEventUid(baseId) === uidHash) return true;
+    if (hashFamilyShareCalendarEventUid(baseId) !== uidHash) continue;
+    if (occurrenceStartsAt ? occurrenceStartsAt === startsAt : !tracked.startsAt || tracked.startsAt === startsAt) return true;
   }
   return false;
 }

--- a/functions/family-share-view-core.cjs
+++ b/functions/family-share-view-core.cjs
@@ -43,7 +43,7 @@ function isFamilyShareCalendarEventTracked(event = {}, trackedEvents = []) {
       startsAt: typeof tracked === 'object' ? toIso(tracked?.date || tracked?.startsAt) : null
     }))
     .filter((tracked) => tracked.id);
-  const eventIds = [event?.id || event?.eventKey, event?.legacyOpaqueId]
+  const eventIds = [event?.id, event?.eventKey]
     .map((id) => compactText(id, 256))
     .filter(Boolean);
   const startsAt = toIso(event?.date || event?.startsAt);
@@ -367,17 +367,13 @@ function buildExternalCalendarEvents(icsText, { sourceId, sourceLabel = 'Shared 
     const eventDiscriminator = uid
       ? `uid:${uid}`
       : `uid-missing:${summary}:${toIso(event.dtend) || ''}:${compactText(event.location, 300)}`;
-    const idSeed = `${sourceId || ''}:${eventDiscriminator}:${date || ''}`;
-    const legacyOpaqueId = uid
-      ? hashFamilyShareOpaqueValue(
-          'calendar-event-public-id',
-          `${sourceId || ''}:${event.uid || ''}:${date || ''}:${summary}`
-        )
-      : '';
+    const eventKeySeed = `${sourceId || ''}:${eventDiscriminator}:${date || ''}`;
+    const publicIdSeed = uid
+      ? `${sourceId || ''}:${event.uid || ''}:${date || ''}:${summary}`
+      : eventKeySeed;
     return {
-      eventKey: hashFamilyShareOpaqueValue('calendar-event-instance', idSeed),
-      id: hashFamilyShareOpaqueValue('calendar-event-public-id', idSeed),
-      ...(legacyOpaqueId ? { legacyOpaqueId } : {}),
+      eventKey: hashFamilyShareOpaqueValue('calendar-event-instance', eventKeySeed),
+      id: hashFamilyShareOpaqueValue('calendar-event-public-id', publicIdSeed),
       calendarUidHash: hashFamilyShareCalendarEventUid(event.uid),
       teamId: compactText(teamId, 128),
       teamName: compactText(teamName, 160) || compactText(sourceLabel, 160),
@@ -484,7 +480,6 @@ function sanitizeFamilyShareGame(game = {}) {
 
 function sanitizeFamilyShareViewResponse({ token, children = [], teams = [], externalEvents = [], calendarWarnings = [] } = {}) {
   const externalEventFields = [
-    'eventKey',
     'id',
     'teamId',
     'teamName',

--- a/functions/family-share-view-core.cjs
+++ b/functions/family-share-view-core.cjs
@@ -56,8 +56,14 @@ function isFamilyShareCalendarEventTracked(event = {}, trackedEvents = []) {
       tracked.id === eventId || (baseId === eventId && occurrenceStartsAt === startsAt)
     ))) return true;
     if (!uidHash) continue;
-    if (hashFamilyShareCalendarEventUid(baseId) !== uidHash) continue;
-    if (occurrenceStartsAt ? occurrenceStartsAt === startsAt : !tracked.startsAt || tracked.startsAt === startsAt) return true;
+    if (hashFamilyShareCalendarEventUid(baseId) === uidHash) {
+      if (occurrenceStartsAt ? occurrenceStartsAt === startsAt : !tracked.startsAt || tracked.startsAt === startsAt) return true;
+      continue;
+    }
+    // Prior public IDs are irreversible 32-hex hashes. Their embedded occurrence
+    // timestamp is the only stable correlation available after a provider edits
+    // mutable summary metadata, and mirrors the existing team/time conflict guard.
+    if (/^[a-f0-9]{32}$/i.test(baseId) && occurrenceStartsAt === startsAt) return true;
   }
   return false;
 }

--- a/functions/family-share-view-core.cjs
+++ b/functions/family-share-view-core.cjs
@@ -350,7 +350,14 @@ function buildExternalCalendarEvents(icsText, { sourceId, sourceLabel = 'Shared 
     const summary = compactText(event.summary).replace(/\[CANCELED\]\s*/ig, '');
     const type = isPracticeSummary(summary) ? 'practice' : 'game';
     const date = toIso(event.dtstart);
-    const idSeed = `${sourceId || ''}:${event.uid || ''}:${date || ''}:${summary}`;
+    const uid = compactText(event.uid, 256);
+    // Calendar summaries and opponents are mutable. Keep UID-backed occurrence
+    // IDs stable across those edits, while retaining a hashed discriminator for
+    // malformed feeds that omit UID entirely.
+    const eventDiscriminator = uid
+      ? `uid:${uid}`
+      : `uid-missing:${summary}:${toIso(event.dtend) || ''}:${compactText(event.location, 300)}`;
+    const idSeed = `${sourceId || ''}:${eventDiscriminator}:${date || ''}`;
     return {
       eventKey: hashFamilyShareOpaqueValue('calendar-event-instance', idSeed),
       id: hashFamilyShareOpaqueValue('calendar-event-public-id', idSeed),

--- a/functions/index.js
+++ b/functions/index.js
@@ -17310,9 +17310,7 @@ exports.getPublicTeamCalendarProjection = functions
 
     const trackedCalendarEvents = await scanBoundedPublicCalendarTrackingEvents(async ({ after, limit }) => {
       let query = firestore.collection(`teams/${teamId}/games`)
-        .where('date', '>=', range.fromDate)
-        .where('date', '<=', range.toDate)
-        .orderBy('date')
+        .orderBy(admin.firestore.FieldPath.documentId())
         .select('calendarEventUid', 'date');
       if (after) query = query.startAfter(after);
       const snapshot = await query.limit(limit).get();

--- a/functions/index.js
+++ b/functions/index.js
@@ -17308,6 +17308,31 @@ exports.getPublicTeamCalendarProjection = functions
     const team = await getStrictPublicTeam(teamId);
     if (!team) throwOpportunityError('not-found', 'Public team not found.');
 
+    const calendarUrls = [];
+    const seenUrls = new Set();
+    (Array.isArray(team.calendarUrls) ? team.calendarUrls : []).forEach((url) => {
+      const normalizedUrl = normalizeFamilyShareText(url);
+      if (
+        !normalizedUrl ||
+        seenUrls.has(normalizedUrl) ||
+        calendarUrls.length >= MAX_FAMILY_SHARE_CALENDAR_URLS
+      ) return;
+      seenUrls.add(normalizedUrl);
+      calendarUrls.push(normalizedUrl);
+    });
+    if (calendarUrls.length === 0) {
+      return {
+        events: [],
+        warnings: [],
+        range: {
+          from: range.from,
+          to: range.to,
+          truncated: false
+        },
+        nextCursor: null
+      };
+    }
+
     const trackedCalendarEvents = await scanBoundedPublicCalendarTrackingEvents(async ({ after, limit }) => {
       let query = firestore.collection(`teams/${teamId}/games`)
         .orderBy(admin.firestore.FieldPath.documentId())
@@ -17322,19 +17347,6 @@ exports.getPublicTeamCalendarProjection = functions
         nextCursor: snapshot.docs[snapshot.docs.length - 1] || null
       };
     }, { maxDocuments: PUBLIC_TEAM_API_MAX_GAME_SCAN_DOCUMENTS });
-
-    const calendarUrls = [];
-    const seenUrls = new Set();
-    (Array.isArray(team.calendarUrls) ? team.calendarUrls : []).forEach((url) => {
-      const normalizedUrl = normalizeFamilyShareText(url);
-      if (
-        !normalizedUrl ||
-        seenUrls.has(normalizedUrl) ||
-        calendarUrls.length >= MAX_FAMILY_SHARE_CALENDAR_URLS
-      ) return;
-      seenUrls.add(normalizedUrl);
-      calendarUrls.push(normalizedUrl);
-    });
 
     const settled = await Promise.allSettled(calendarUrls.map((url, index) => (
       fetchFamilyShareCalendarEvents({

--- a/functions/index.js
+++ b/functions/index.js
@@ -122,6 +122,7 @@ const { buildPublicGamesIcs, canExposeEmptyPublicFeed, isPublicFanGame } = requi
 const {
   buildPublicGamesResponse,
   buildPublicRosterResponse,
+  canTrackedCalendarEventSuppressPublicProjection,
   canProjectPublicGame,
   getPublicOpponentStatKeys,
   isStrictPublicTeam,
@@ -17333,20 +17334,22 @@ exports.getPublicTeamCalendarProjection = functions
       };
     }
 
-    const trackedCalendarEvents = await scanBoundedPublicCalendarTrackingEvents(async ({ after, limit }) => {
+    const trackedCalendarEvents = (await scanBoundedPublicCalendarTrackingEvents(async ({ after, limit }) => {
       let query = firestore.collection(`teams/${teamId}/games`)
         .orderBy(admin.firestore.FieldPath.documentId())
-        .select('calendarEventUid', 'date');
+        .select('calendarEventUid', 'date', 'type');
       if (after) query = query.startAfter(after);
       const snapshot = await query.limit(limit).get();
       return {
         documents: snapshot.docs.map((gameSnap) => ({
           calendarEventUid: normalizeFamilyShareText(gameSnap.data()?.calendarEventUid),
-          date: gameSnap.data()?.date || null
+          date: gameSnap.data()?.date || null,
+          type: normalizeFamilyShareText(gameSnap.data()?.type)
         })),
         nextCursor: snapshot.docs[snapshot.docs.length - 1] || null
       };
-    }, { maxDocuments: PUBLIC_TEAM_API_MAX_GAME_SCAN_DOCUMENTS });
+    }, { maxDocuments: PUBLIC_TEAM_API_MAX_GAME_SCAN_DOCUMENTS }))
+      .filter(canTrackedCalendarEventSuppressPublicProjection);
 
     const settled = await Promise.allSettled(calendarUrls.map((url, index) => (
       fetchFamilyShareCalendarEvents({

--- a/functions/index.js
+++ b/functions/index.js
@@ -37,6 +37,7 @@ const {
   buildExternalCalendarEvents,
   getFamilyShareCalendarDedupTimestamps,
   hashFamilyShareCalendarEventUid,
+  isFamilyShareCalendarEventTracked,
   sanitizeFamilyShareViewResponse
 } = require('./family-share-view-core.cjs');
 const { createVerifiedEmailSensitiveActionGuard } = require('./verified-email-policy.cjs');
@@ -17306,6 +17307,19 @@ exports.getPublicTeamCalendarProjection = functions
     const team = await getStrictPublicTeam(teamId);
     if (!team) throwOpportunityError('not-found', 'Public team not found.');
 
+    const trackedGameSnap = await firestore.collection(`teams/${teamId}/games`)
+      .where('date', '>=', range.fromDate)
+      .where('date', '<=', range.toDate)
+      .orderBy('date')
+      .limit(MAX_FAMILY_SHARE_DB_EVENTS)
+      .get();
+    const trackedCalendarEvents = trackedGameSnap.docs
+      .map((gameSnap) => ({
+        calendarEventUid: normalizeFamilyShareText(gameSnap.data()?.calendarEventUid),
+        date: gameSnap.data()?.date || null
+      }))
+      .filter((event) => event.calendarEventUid);
+
     const calendarUrls = [];
     const seenUrls = new Set();
     (Array.isArray(team.calendarUrls) ? team.calendarUrls : []).forEach((url) => {
@@ -17343,6 +17357,7 @@ exports.getPublicTeamCalendarProjection = functions
       warnings.push(`Calendar source ${index + 1} could not be loaded.`);
     });
     const events = projectedEvents
+      .filter((event) => !isFamilyShareCalendarEventTracked(event, trackedCalendarEvents))
       .map(serializePublicCalendarEvent)
       .filter(Boolean)
       .filter((event) => {

--- a/functions/index.js
+++ b/functions/index.js
@@ -130,6 +130,7 @@ const {
   paginatePublicProjectionItems,
   parsePublicProjectionCursor,
   parsePublicGamesQuery,
+  scanBoundedPublicCalendarTrackingEvents,
   serializePublicCalendarEvent,
   serializePublicGame,
   serializePublicTeamDiscovery,
@@ -17307,18 +17308,22 @@ exports.getPublicTeamCalendarProjection = functions
     const team = await getStrictPublicTeam(teamId);
     if (!team) throwOpportunityError('not-found', 'Public team not found.');
 
-    const trackedGameSnap = await firestore.collection(`teams/${teamId}/games`)
-      .where('date', '>=', range.fromDate)
-      .where('date', '<=', range.toDate)
-      .orderBy('date')
-      .limit(MAX_FAMILY_SHARE_DB_EVENTS)
-      .get();
-    const trackedCalendarEvents = trackedGameSnap.docs
-      .map((gameSnap) => ({
-        calendarEventUid: normalizeFamilyShareText(gameSnap.data()?.calendarEventUid),
-        date: gameSnap.data()?.date || null
-      }))
-      .filter((event) => event.calendarEventUid);
+    const trackedCalendarEvents = await scanBoundedPublicCalendarTrackingEvents(async ({ after, limit }) => {
+      let query = firestore.collection(`teams/${teamId}/games`)
+        .where('date', '>=', range.fromDate)
+        .where('date', '<=', range.toDate)
+        .orderBy('date')
+        .select('calendarEventUid', 'date');
+      if (after) query = query.startAfter(after);
+      const snapshot = await query.limit(limit).get();
+      return {
+        documents: snapshot.docs.map((gameSnap) => ({
+          calendarEventUid: normalizeFamilyShareText(gameSnap.data()?.calendarEventUid),
+          date: gameSnap.data()?.date || null
+        })),
+        nextCursor: snapshot.docs[snapshot.docs.length - 1] || null
+      };
+    }, { maxDocuments: PUBLIC_TEAM_API_MAX_GAME_SCAN_DOCUMENTS });
 
     const calendarUrls = [];
     const seenUrls = new Set();

--- a/functions/index.js
+++ b/functions/index.js
@@ -17337,14 +17337,20 @@ exports.getPublicTeamCalendarProjection = functions
     const trackedCalendarEvents = (await scanBoundedPublicCalendarTrackingEvents(async ({ after, limit }) => {
       let query = firestore.collection(`teams/${teamId}/games`)
         .orderBy(admin.firestore.FieldPath.documentId())
-        .select('calendarEventUid', 'date', 'type');
+        .select('calendarEventUid', 'date', 'type', 'visibility', 'isPrivate', 'private', 'deleted', 'status', 'liveStatus');
       if (after) query = query.startAfter(after);
       const snapshot = await query.limit(limit).get();
       return {
         documents: snapshot.docs.map((gameSnap) => ({
           calendarEventUid: normalizeFamilyShareText(gameSnap.data()?.calendarEventUid),
           date: gameSnap.data()?.date || null,
-          type: normalizeFamilyShareText(gameSnap.data()?.type)
+          type: normalizeFamilyShareText(gameSnap.data()?.type),
+          visibility: normalizeFamilyShareText(gameSnap.data()?.visibility),
+          isPrivate: gameSnap.data()?.isPrivate === true,
+          private: gameSnap.data()?.private === true,
+          deleted: gameSnap.data()?.deleted === true,
+          status: normalizeFamilyShareText(gameSnap.data()?.status),
+          liveStatus: normalizeFamilyShareText(gameSnap.data()?.liveStatus)
         })),
         nextCursor: snapshot.docs[snapshot.docs.length - 1] || null
       };

--- a/functions/index.js
+++ b/functions/index.js
@@ -17337,7 +17337,7 @@ exports.getPublicTeamCalendarProjection = functions
     const trackedCalendarEvents = (await scanBoundedPublicCalendarTrackingEvents(async ({ after, limit }) => {
       let query = firestore.collection(`teams/${teamId}/games`)
         .orderBy(admin.firestore.FieldPath.documentId())
-        .select('calendarEventUid', 'date', 'type', 'visibility', 'isPrivate', 'private', 'deleted', 'status', 'liveStatus');
+        .select('calendarEventUid', 'date', 'type', 'location', 'opponent', 'title', 'visibility', 'isPrivate', 'private', 'deleted', 'status', 'liveStatus');
       if (after) query = query.startAfter(after);
       const snapshot = await query.limit(limit).get();
       return {
@@ -17345,6 +17345,9 @@ exports.getPublicTeamCalendarProjection = functions
           calendarEventUid: normalizeFamilyShareText(gameSnap.data()?.calendarEventUid),
           date: gameSnap.data()?.date || null,
           type: normalizeFamilyShareText(gameSnap.data()?.type),
+          location: normalizeFamilyShareText(gameSnap.data()?.location),
+          opponent: normalizeFamilyShareText(gameSnap.data()?.opponent),
+          title: normalizeFamilyShareText(gameSnap.data()?.title),
           visibility: normalizeFamilyShareText(gameSnap.data()?.visibility),
           isPrivate: gameSnap.data()?.isPrivate === true,
           private: gameSnap.data()?.private === true,

--- a/functions/public-team-api-core.cjs
+++ b/functions/public-team-api-core.cjs
@@ -586,6 +586,29 @@ function paginatePublicProjectionItems(items = [], limit = PUBLIC_TEAM_API_DEFAU
   };
 }
 
+async function scanBoundedPublicCalendarTrackingEvents(loadPage, {
+  maxDocuments = 5000,
+  pageSize = 500
+} = {}) {
+  const trackedEvents = [];
+  let after = null;
+  let scannedDocuments = 0;
+  while (scannedDocuments < maxDocuments) {
+    const limit = Math.min(pageSize, maxDocuments - scannedDocuments);
+    const page = await loadPage({ after, limit });
+    const documents = Array.isArray(page?.documents) ? page.documents : [];
+    if (documents.length > limit) throw new Error('Public calendar tracking page exceeded its requested limit.');
+    trackedEvents.push(...documents.filter((event) => compactText(event?.calendarEventUid, 512)));
+    scannedDocuments += documents.length;
+    if (documents.length < limit) return trackedEvents;
+    after = page?.nextCursor || null;
+    if (!after || scannedDocuments >= maxDocuments) {
+      throw new Error('Public calendar tracking scan limit exceeded.');
+    }
+  }
+  throw new Error('Public calendar tracking scan limit exceeded.');
+}
+
 module.exports = {
   PUBLIC_TEAM_API_DEFAULT_GAMES,
   PUBLIC_TEAM_API_MAX_GAMES,
@@ -608,6 +631,7 @@ module.exports = {
   parsePublicProjectionCursor,
   parsePublicGamesQuery,
   publicHttpUrl,
+  scanBoundedPublicCalendarTrackingEvents,
   sanitizePublicLocation,
   serializePublicCalendarEvent,
   serializePublicGame,

--- a/functions/public-team-api-core.cjs
+++ b/functions/public-team-api-core.cjs
@@ -586,6 +586,10 @@ function paginatePublicProjectionItems(items = [], limit = PUBLIC_TEAM_API_DEFAU
   };
 }
 
+function canTrackedCalendarEventSuppressPublicProjection(event = {}) {
+  return compactText(event?.type, 32).toLowerCase() !== 'practice';
+}
+
 async function scanBoundedPublicCalendarTrackingEvents(loadPage, {
   maxDocuments = 5000,
   pageSize = 500
@@ -616,6 +620,7 @@ module.exports = {
   PUBLIC_TEAM_API_VERSION,
   buildPublicGamesResponse,
   buildPublicRosterResponse,
+  canTrackedCalendarEventSuppressPublicProjection,
   canProjectPublicGame,
   comparePublicProjectionItems,
   compareRosterPlayers,

--- a/functions/public-team-api-core.cjs
+++ b/functions/public-team-api-core.cjs
@@ -587,7 +587,7 @@ function paginatePublicProjectionItems(items = [], limit = PUBLIC_TEAM_API_DEFAU
 }
 
 function canTrackedCalendarEventSuppressPublicProjection(event = {}) {
-  return compactText(event?.type, 32).toLowerCase() !== 'practice';
+  return isPublicGame(event);
 }
 
 async function scanBoundedPublicCalendarTrackingEvents(loadPage, {

--- a/functions/test/family-share-view-core.test.cjs
+++ b/functions/test/family-share-view-core.test.cjs
@@ -81,18 +81,25 @@ test('preserves UID-backed public IDs and event keys across rollout', () => {
   assert.notEqual(edited.id, original.id);
   assert.notEqual(edited.eventKey, original.eventKey);
   assert.notEqual(edited.opponent, original.opponent);
-  assert.equal(isFamilyShareCalendarEventTracked(edited, [
-    `${original.id}__${originalStartsAt}`
-  ]), true);
+  const priorTrackedOccurrence = {
+    calendarEventUid: `${original.id}__${originalStartsAt}`,
+    type: 'game',
+    location: 'public field'
+  };
+  assert.equal(isFamilyShareCalendarEventTracked(edited, [priorTrackedOccurrence]), true);
   assert.equal(isFamilyShareCalendarEventTracked(original, [{
     calendarEventUid: `${priorOpaqueId}__${originalStartsAt}`,
-    date: '2026-08-08T18:00:00.000Z'
+    date: '2026-08-08T18:00:00.000Z',
+    type: 'game',
+    location: 'Public Field'
   }]), true);
   // The old hash is irreversible after a title edit, but its exact embedded
-  // occurrence time remains a narrow compatibility signal.
-  assert.equal(isFamilyShareCalendarEventTracked(edited, [
-    `${priorOpaqueId}__${originalStartsAt}`
-  ]), true);
+  // occurrence time plus stable location remains a narrow compatibility signal.
+  assert.equal(isFamilyShareCalendarEventTracked(edited, [{
+    calendarEventUid: `${priorOpaqueId}__${originalStartsAt}`,
+    type: 'game',
+    location: 'PUBLIC FIELD'
+  }]), true);
   const differentStartsAt = '2026-08-01T19:00:00.000Z';
   assert.equal(isFamilyShareCalendarEventTracked(edited, [
     `${priorOpaqueId}__${differentStartsAt}`
@@ -105,6 +112,51 @@ test('preserves UID-backed public IDs and event keys across rollout', () => {
   const uidMissingOther = buildEvent({ uid: '', summary: 'Bears vs. Falcons' });
   assert.notEqual(uidMissingOther.id, uidMissingOriginal.id);
   assert.notEqual(uidMissingOther.eventKey, uidMissingOriginal.eventKey);
+});
+
+test('does not correlate distinct same-time opaque events without a matching shape', () => {
+  const startsAt = '2026-08-01T18:00:00.000Z';
+  const event = {
+    id: 'new-opaque-event-id',
+    type: 'game',
+    startsAt,
+    location: 'Field 3',
+    opponent: 'Tigers',
+    calendarUidHash: hashFamilyShareCalendarEventUid('different-raw-uid')
+  };
+  assert.equal(isFamilyShareCalendarEventTracked(event, [{
+    calendarEventUid: `7bca28b6105ee23830c3517602e276d3__${startsAt}`,
+    type: 'game',
+    location: 'Field 2',
+    opponent: 'Hawks'
+  }]), false);
+  assert.equal(isFamilyShareCalendarEventTracked({
+    ...event,
+    location: 'TBD',
+    opponent: 'unknown'
+  }, [{
+    calendarEventUid: `7bca28b6105ee23830c3517602e276d3__${startsAt}`,
+    type: 'game',
+    location: 'unknown',
+    opponent: 'TBD'
+  }]), false);
+});
+
+test('does not treat a generic practice title as a same-time discriminator', () => {
+  const startsAt = '2026-08-01T18:00:00.000Z';
+  assert.equal(isFamilyShareCalendarEventTracked({
+    id: 'new-opaque-practice-id',
+    type: 'practice',
+    startsAt,
+    location: 'Field 3',
+    title: 'Practice',
+    calendarUidHash: hashFamilyShareCalendarEventUid('different-raw-uid')
+  }, [{
+    calendarEventUid: `7bca28b6105ee23830c3517602e276d3__${startsAt}`,
+    type: 'practice',
+    location: 'Field 2',
+    title: 'Practice'
+  }]), false);
 });
 
 test('scopes team calendar timestamp de-duplication without weakening token-level de-duplication', () => {

--- a/functions/test/family-share-view-core.test.cjs
+++ b/functions/test/family-share-view-core.test.cjs
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
 const test = require('node:test');
 const {
   MAX_FAMILY_SHARE_CALENDAR_URLS,
@@ -61,12 +62,32 @@ test('keeps UID-backed occurrence IDs stable across summary edits and discrimina
 
   const original = buildEvent({ summary: 'Bears vs. Hawks' });
   const edited = buildEvent({ summary: 'Bears vs. Falcons' });
+  const originalStartsAt = '2026-08-01T18:00:00.000Z';
+  const priorOpaqueId = crypto.createHash('sha256')
+    .update(`family-share:calendar-event-public-id:v1:stable-source-id:stable-provider-uid:${originalStartsAt}:Bears vs. Hawks`)
+    .digest('hex')
+    .slice(0, 32);
   assert.equal(edited.id, original.id);
   assert.equal(edited.eventKey, original.eventKey);
   assert.notEqual(edited.opponent, original.opponent);
   assert.equal(isFamilyShareCalendarEventTracked(edited, [
-    `${original.id}__2026-08-01T18:00:00.000Z`
+    `${original.id}__${originalStartsAt}`
   ]), true);
+  assert.equal(original.legacyOpaqueId, priorOpaqueId);
+  assert.equal(edited.legacyOpaqueId, crypto.createHash('sha256')
+    .update(`family-share:calendar-event-public-id:v1:stable-source-id:stable-provider-uid:${originalStartsAt}:Bears vs. Falcons`)
+    .digest('hex')
+    .slice(0, 32));
+  assert.equal(isFamilyShareCalendarEventTracked(original, [{
+    calendarEventUid: `${priorOpaqueId}__${originalStartsAt}`,
+    date: '2026-08-08T18:00:00.000Z'
+  }]), true);
+  // A pre-stable-ID opaque hash created from an older summary is irreversible.
+  // Existing raw-UID records and all newly tracked stable IDs survive edits;
+  // this assertion prevents claiming compatibility the stored data cannot prove.
+  assert.equal(isFamilyShareCalendarEventTracked(edited, [
+    `${priorOpaqueId}__${originalStartsAt}`
+  ]), false);
 
   const uidMissingOriginal = buildEvent({ uid: '', summary: 'Bears vs. Hawks' });
   const uidMissingOther = buildEvent({ uid: '', summary: 'Bears vs. Falcons' });
@@ -133,6 +154,8 @@ test('projects bounded recurring ICS events without returning source URLs or sen
   assert.equal(payload.includes('extraCalendarUrls'), false);
   assert.equal(payload.includes('calendarUrls'), false);
   assert.equal(payload.includes('calendarUidHash'), false);
+  assert.equal(payload.includes(events[0].legacyOpaqueId), false);
+  assert.equal(Object.hasOwn(response.externalEvents[0], 'legacyOpaqueId'), false);
   assert.equal(response.externalEvents[0].locationDetail, 'Field 14');
   assert.equal(response.presentation.label, 'Grandma');
 });

--- a/functions/test/family-share-view-core.test.cjs
+++ b/functions/test/family-share-view-core.test.cjs
@@ -46,6 +46,34 @@ test('correlates projected events with legacy UID and current opaque occurrence 
   assert.equal(isFamilyShareCalendarEventTracked(event, ['different-event']), false);
 });
 
+test('keeps UID-backed occurrence IDs stable across summary edits and discriminates UID-missing events', () => {
+  const buildEvent = ({ uid = 'stable-provider-uid', summary }) => buildExternalCalendarEvents([
+    'BEGIN:VCALENDAR',
+    'BEGIN:VEVENT',
+    ...(uid ? [`UID:${uid}`] : []),
+    'DTSTART:20260801T180000Z',
+    'DTEND:20260801T200000Z',
+    `SUMMARY:${summary}`,
+    'LOCATION:Public Field',
+    'END:VEVENT',
+    'END:VCALENDAR'
+  ].join('\r\n'), { sourceId: 'stable-source-id', teamName: 'Bears' })[0];
+
+  const original = buildEvent({ summary: 'Bears vs. Hawks' });
+  const edited = buildEvent({ summary: 'Bears vs. Falcons' });
+  assert.equal(edited.id, original.id);
+  assert.equal(edited.eventKey, original.eventKey);
+  assert.notEqual(edited.opponent, original.opponent);
+  assert.equal(isFamilyShareCalendarEventTracked(edited, [
+    `${original.id}__2026-08-01T18:00:00.000Z`
+  ]), true);
+
+  const uidMissingOriginal = buildEvent({ uid: '', summary: 'Bears vs. Hawks' });
+  const uidMissingOther = buildEvent({ uid: '', summary: 'Bears vs. Falcons' });
+  assert.notEqual(uidMissingOther.id, uidMissingOriginal.id);
+  assert.notEqual(uidMissingOther.eventKey, uidMissingOriginal.eventKey);
+});
+
 test('scopes team calendar timestamp de-duplication without weakening token-level de-duplication', () => {
   const teams = [
     { teamId: 'team-a', games: [{ date: '2026-07-20T18:00:00.000Z' }] },

--- a/functions/test/family-share-view-core.test.cjs
+++ b/functions/test/family-share-view-core.test.cjs
@@ -82,11 +82,17 @@ test('keeps UID-backed occurrence IDs stable across summary edits and discrimina
     calendarEventUid: `${priorOpaqueId}__${originalStartsAt}`,
     date: '2026-08-08T18:00:00.000Z'
   }]), true);
-  // A pre-stable-ID opaque hash created from an older summary is irreversible.
-  // Existing raw-UID records and all newly tracked stable IDs survive edits;
-  // this assertion prevents claiming compatibility the stored data cannot prove.
+  // The old hash is irreversible after a title edit, but its exact embedded
+  // occurrence time remains a narrow compatibility signal.
   assert.equal(isFamilyShareCalendarEventTracked(edited, [
     `${priorOpaqueId}__${originalStartsAt}`
+  ]), true);
+  const differentStartsAt = '2026-08-01T19:00:00.000Z';
+  assert.equal(isFamilyShareCalendarEventTracked(edited, [
+    `${priorOpaqueId}__${differentStartsAt}`
+  ]), false);
+  assert.equal(isFamilyShareCalendarEventTracked(edited, [
+    `stable-provider-uid__${differentStartsAt}`
   ]), false);
 
   const uidMissingOriginal = buildEvent({ uid: '', summary: 'Bears vs. Hawks' });

--- a/functions/test/family-share-view-core.test.cjs
+++ b/functions/test/family-share-view-core.test.cjs
@@ -6,9 +6,36 @@ const {
   buildExternalCalendarEvents,
   getFamilyShareCalendarDedupTimestamps,
   hashFamilyShareCalendarEventUid,
+  isFamilyShareCalendarEventTracked,
   parseBoundedIcsEvents,
   sanitizeFamilyShareViewResponse
 } = require('../family-share-view-core.cjs');
+
+test('correlates projected events with legacy UID and current opaque occurrence tracking IDs', () => {
+  const startsAt = '2026-08-01T18:00:00.000Z';
+  const event = {
+    id: 'opaque-projected-id',
+    date: startsAt,
+    calendarUidHash: hashFamilyShareCalendarEventUid('raw-calendar-uid')
+  };
+  for (const trackedId of [
+    'raw-calendar-uid',
+    `raw-calendar-uid__${startsAt}`,
+    'opaque-projected-id',
+    `opaque-projected-id__${startsAt}`
+  ]) {
+    assert.equal(isFamilyShareCalendarEventTracked(event, [trackedId]), true, trackedId);
+  }
+  assert.equal(isFamilyShareCalendarEventTracked(event, [{
+    calendarEventUid: 'raw-calendar-uid',
+    date: startsAt
+  }]), true);
+  assert.equal(isFamilyShareCalendarEventTracked(event, [{
+    calendarEventUid: 'raw-calendar-uid',
+    date: '2026-08-08T18:00:00.000Z'
+  }]), false);
+  assert.equal(isFamilyShareCalendarEventTracked(event, ['different-event']), false);
+});
 
 test('scopes team calendar timestamp de-duplication without weakening token-level de-duplication', () => {
   const teams = [

--- a/functions/test/family-share-view-core.test.cjs
+++ b/functions/test/family-share-view-core.test.cjs
@@ -47,7 +47,7 @@ test('correlates projected events with legacy UID and current opaque occurrence 
   assert.equal(isFamilyShareCalendarEventTracked(event, ['different-event']), false);
 });
 
-test('preserves UID-backed public IDs and keeps internal occurrence keys stable across summary edits', () => {
+test('preserves UID-backed public IDs and event keys across rollout', () => {
   const buildEvent = ({ uid = 'stable-provider-uid', summary }) => buildExternalCalendarEvents([
     'BEGIN:VCALENDAR',
     'BEGIN:VEVENT',
@@ -67,14 +67,19 @@ test('preserves UID-backed public IDs and keeps internal occurrence keys stable 
     .update(`family-share:calendar-event-public-id:v1:stable-source-id:stable-provider-uid:${originalStartsAt}:Bears vs. Hawks`)
     .digest('hex')
     .slice(0, 32);
+  const priorEventKey = crypto.createHash('sha256')
+    .update(`family-share:calendar-event-instance:v1:stable-source-id:stable-provider-uid:${originalStartsAt}:Bears vs. Hawks`)
+    .digest('hex')
+    .slice(0, 32);
   assert.equal(original.id, priorOpaqueId);
+  assert.equal(original.eventKey, priorEventKey);
   assert.equal(Object.hasOwn(original, 'legacyOpaqueId'), false);
   assert.equal(
     `/app/#/schedule/team-1/${original.id}`,
     `/app/#/schedule/team-1/${priorOpaqueId}`
   );
   assert.notEqual(edited.id, original.id);
-  assert.equal(edited.eventKey, original.eventKey);
+  assert.notEqual(edited.eventKey, original.eventKey);
   assert.notEqual(edited.opponent, original.opponent);
   assert.equal(isFamilyShareCalendarEventTracked(edited, [
     `${original.id}__${originalStartsAt}`
@@ -161,8 +166,7 @@ test('projects bounded recurring ICS events without returning source URLs or sen
   assert.equal(payload.includes('extraCalendarUrls'), false);
   assert.equal(payload.includes('calendarUrls'), false);
   assert.equal(payload.includes('calendarUidHash'), false);
-  assert.equal(payload.includes(events[0].eventKey), false);
-  assert.equal(Object.hasOwn(response.externalEvents[0], 'eventKey'), false);
+  assert.equal(response.externalEvents[0].eventKey, events[0].eventKey);
   assert.equal(response.externalEvents[0].locationDetail, 'Field 14');
   assert.equal(response.presentation.label, 'Grandma');
 });

--- a/functions/test/family-share-view-core.test.cjs
+++ b/functions/test/family-share-view-core.test.cjs
@@ -47,7 +47,7 @@ test('correlates projected events with legacy UID and current opaque occurrence 
   assert.equal(isFamilyShareCalendarEventTracked(event, ['different-event']), false);
 });
 
-test('keeps UID-backed occurrence IDs stable across summary edits and discriminates UID-missing events', () => {
+test('preserves UID-backed public IDs and keeps internal occurrence keys stable across summary edits', () => {
   const buildEvent = ({ uid = 'stable-provider-uid', summary }) => buildExternalCalendarEvents([
     'BEGIN:VCALENDAR',
     'BEGIN:VEVENT',
@@ -67,17 +67,18 @@ test('keeps UID-backed occurrence IDs stable across summary edits and discrimina
     .update(`family-share:calendar-event-public-id:v1:stable-source-id:stable-provider-uid:${originalStartsAt}:Bears vs. Hawks`)
     .digest('hex')
     .slice(0, 32);
-  assert.equal(edited.id, original.id);
+  assert.equal(original.id, priorOpaqueId);
+  assert.equal(Object.hasOwn(original, 'legacyOpaqueId'), false);
+  assert.equal(
+    `/app/#/schedule/team-1/${original.id}`,
+    `/app/#/schedule/team-1/${priorOpaqueId}`
+  );
+  assert.notEqual(edited.id, original.id);
   assert.equal(edited.eventKey, original.eventKey);
   assert.notEqual(edited.opponent, original.opponent);
   assert.equal(isFamilyShareCalendarEventTracked(edited, [
     `${original.id}__${originalStartsAt}`
   ]), true);
-  assert.equal(original.legacyOpaqueId, priorOpaqueId);
-  assert.equal(edited.legacyOpaqueId, crypto.createHash('sha256')
-    .update(`family-share:calendar-event-public-id:v1:stable-source-id:stable-provider-uid:${originalStartsAt}:Bears vs. Falcons`)
-    .digest('hex')
-    .slice(0, 32));
   assert.equal(isFamilyShareCalendarEventTracked(original, [{
     calendarEventUid: `${priorOpaqueId}__${originalStartsAt}`,
     date: '2026-08-08T18:00:00.000Z'
@@ -160,8 +161,8 @@ test('projects bounded recurring ICS events without returning source URLs or sen
   assert.equal(payload.includes('extraCalendarUrls'), false);
   assert.equal(payload.includes('calendarUrls'), false);
   assert.equal(payload.includes('calendarUidHash'), false);
-  assert.equal(payload.includes(events[0].legacyOpaqueId), false);
-  assert.equal(Object.hasOwn(response.externalEvents[0], 'legacyOpaqueId'), false);
+  assert.equal(payload.includes(events[0].eventKey), false);
+  assert.equal(Object.hasOwn(response.externalEvents[0], 'eventKey'), false);
   assert.equal(response.externalEvents[0].locationDetail, 'Field 14');
   assert.equal(response.presentation.label, 'Grandma');
 });

--- a/functions/test/family-share-view-core.test.cjs
+++ b/functions/test/family-share-view-core.test.cjs
@@ -34,6 +34,15 @@ test('correlates projected events with legacy UID and current opaque occurrence 
     calendarEventUid: 'raw-calendar-uid',
     date: '2026-08-08T18:00:00.000Z'
   }]), false);
+  for (const trackedId of [
+    `raw-calendar-uid__${startsAt}`,
+    `opaque-projected-id__${startsAt}`
+  ]) {
+    assert.equal(isFamilyShareCalendarEventTracked(event, [{
+      calendarEventUid: trackedId,
+      date: '2026-08-08T18:00:00.000Z'
+    }]), true, `stable occurrence survives edited game date: ${trackedId}`);
+  }
   assert.equal(isFamilyShareCalendarEventTracked(event, ['different-event']), false);
 });
 

--- a/functions/test/public-team-api-core.test.cjs
+++ b/functions/test/public-team-api-core.test.cjs
@@ -3,6 +3,7 @@ const test = require('node:test');
 const {
   buildPublicGamesResponse,
   buildPublicRosterResponse,
+  canTrackedCalendarEventSuppressPublicProjection,
   canProjectPublicGame,
   getPublicOpponentStatKeys,
   isStrictPublicTeam,
@@ -64,6 +65,12 @@ test('keeps a moved tracked occurrence available to suppress its original in-ran
     id: 'opaque-projected-id',
     startsAt: originalStartsAt
   }, trackedEvents), true);
+});
+
+test('only tracked events represented by public games suppress calendar projections', () => {
+  assert.equal(canTrackedCalendarEventSuppressPublicProjection({ type: 'game' }), true);
+  assert.equal(canTrackedCalendarEventSuppressPublicProjection({}), true);
+  assert.equal(canTrackedCalendarEventSuppressPublicProjection({ type: 'PRACTICE' }), false);
 });
 
 test('strict public teams require an explicit public flag and cannot be inactive', () => {
@@ -192,6 +199,7 @@ test('public calendar projection hides feed credentials and keeps only event pre
     location: 'Public Field',
     status: 'CONFIRMED',
     calendarUidHash: 'SENTINEL_CALENDAR_UID_HASH',
+    eventKey: 'SENTINEL_INTERNAL_EVENT_KEY',
     legacyOpaqueId: 'SENTINEL_LEGACY_OPAQUE_ID',
     sourceUrl: 'https://calendar.example.test/team.ics?token=secret',
     description: 'Private calendar notes',
@@ -212,6 +220,8 @@ test('public calendar projection hides feed credentials and keeps only event pre
   assert.equal(serialized.includes('token=secret'), false);
   assert.equal(serialized.includes('SENTINEL_CALENDAR_UID_HASH'), false);
   assert.equal(serialized.includes('calendarUidHash'), false);
+  assert.equal(serialized.includes('SENTINEL_INTERNAL_EVENT_KEY'), false);
+  assert.equal(serialized.includes('eventKey'), false);
   assert.equal(serialized.includes('SENTINEL_LEGACY_OPAQUE_ID'), false);
   assert.equal(serialized.includes('legacyOpaqueId'), false);
   assert.equal(serialized.includes('Private calendar notes'), false);

--- a/functions/test/public-team-api-core.test.cjs
+++ b/functions/test/public-team-api-core.test.cjs
@@ -192,6 +192,7 @@ test('public calendar projection hides feed credentials and keeps only event pre
     location: 'Public Field',
     status: 'CONFIRMED',
     calendarUidHash: 'SENTINEL_CALENDAR_UID_HASH',
+    legacyOpaqueId: 'SENTINEL_LEGACY_OPAQUE_ID',
     sourceUrl: 'https://calendar.example.test/team.ics?token=secret',
     description: 'Private calendar notes',
     childNames: ['Private Child']
@@ -211,6 +212,8 @@ test('public calendar projection hides feed credentials and keeps only event pre
   assert.equal(serialized.includes('token=secret'), false);
   assert.equal(serialized.includes('SENTINEL_CALENDAR_UID_HASH'), false);
   assert.equal(serialized.includes('calendarUidHash'), false);
+  assert.equal(serialized.includes('SENTINEL_LEGACY_OPAQUE_ID'), false);
+  assert.equal(serialized.includes('legacyOpaqueId'), false);
   assert.equal(serialized.includes('Private calendar notes'), false);
   assert.equal(serialized.includes('Private Child'), false);
 });

--- a/functions/test/public-team-api-core.test.cjs
+++ b/functions/test/public-team-api-core.test.cjs
@@ -71,6 +71,12 @@ test('only tracked events represented by public games suppress calendar projecti
   assert.equal(canTrackedCalendarEventSuppressPublicProjection({ type: 'game' }), true);
   assert.equal(canTrackedCalendarEventSuppressPublicProjection({}), true);
   assert.equal(canTrackedCalendarEventSuppressPublicProjection({ type: 'PRACTICE' }), false);
+  assert.equal(canTrackedCalendarEventSuppressPublicProjection({ type: 'game', visibility: 'PRIVATE' }), false);
+  assert.equal(canTrackedCalendarEventSuppressPublicProjection({ type: 'game', isPrivate: true }), false);
+  assert.equal(canTrackedCalendarEventSuppressPublicProjection({ type: 'game', private: true }), false);
+  assert.equal(canTrackedCalendarEventSuppressPublicProjection({ type: 'game', deleted: true }), false);
+  assert.equal(canTrackedCalendarEventSuppressPublicProjection({ type: 'game', status: 'DELETED' }), false);
+  assert.equal(canTrackedCalendarEventSuppressPublicProjection({ type: 'game', liveStatus: 'deleted' }), false);
 });
 
 test('strict public teams require an explicit public flag and cannot be inactive', () => {

--- a/functions/test/public-team-api-core.test.cjs
+++ b/functions/test/public-team-api-core.test.cjs
@@ -10,12 +10,33 @@ const {
   parsePublicProjectionCursor,
   parsePublicGamesQuery,
   publicHttpUrl,
+  scanBoundedPublicCalendarTrackingEvents,
   sanitizePublicLocation,
   serializePublicCalendarEvent,
   serializePublicGame,
   serializePublicOpponentStats,
   serializePublicTeamProfile
 } = require('../public-team-api-core.cjs');
+
+test('paginates calendar tracking scans and fails closed at the document cap', async () => {
+  const pages = [
+    { documents: [{ date: 'ordinary-1' }, { date: 'ordinary-2' }], nextCursor: 'page-2' },
+    { documents: [{ calendarEventUid: 'tracked-later', date: 'game-date' }], nextCursor: null }
+  ];
+  const tracked = await scanBoundedPublicCalendarTrackingEvents(
+    async () => pages.shift(),
+    { maxDocuments: 4, pageSize: 2 }
+  );
+  assert.deepEqual(tracked, [{ calendarEventUid: 'tracked-later', date: 'game-date' }]);
+
+  await assert.rejects(
+    scanBoundedPublicCalendarTrackingEvents(
+      async ({ after }) => ({ documents: [{ calendarEventUid: `tracked-${after || 1}` }], nextCursor: 'next' }),
+      { maxDocuments: 2, pageSize: 1 }
+    ),
+    /tracking scan limit exceeded/
+  );
+});
 
 test('strict public teams require an explicit public flag and cannot be inactive', () => {
   assert.equal(isStrictPublicTeam({ isPublic: true, active: true }), true);

--- a/functions/test/public-team-api-core.test.cjs
+++ b/functions/test/public-team-api-core.test.cjs
@@ -17,6 +17,7 @@ const {
   serializePublicOpponentStats,
   serializePublicTeamProfile
 } = require('../public-team-api-core.cjs');
+const { isFamilyShareCalendarEventTracked } = require('../family-share-view-core.cjs');
 
 test('paginates calendar tracking scans and fails closed at the document cap', async () => {
   const pages = [
@@ -36,6 +37,33 @@ test('paginates calendar tracking scans and fails closed at the document cap', a
     ),
     /tracking scan limit exceeded/
   );
+});
+
+test('keeps a moved tracked occurrence available to suppress its original in-range calendar event', async () => {
+  const originalStartsAt = '2026-08-03T18:00:00.000Z';
+  const movedStartsAt = '2026-08-10T18:00:00.000Z';
+  const feedRange = {
+    from: new Date('2026-08-03T00:00:00.000Z'),
+    to: new Date('2026-08-03T23:59:59.999Z')
+  };
+  assert.equal(new Date(originalStartsAt) >= feedRange.from && new Date(originalStartsAt) <= feedRange.to, true);
+  assert.equal(new Date(movedStartsAt) > feedRange.to, true);
+
+  const trackedEvents = await scanBoundedPublicCalendarTrackingEvents(
+    async () => ({
+      documents: [{
+        calendarEventUid: `opaque-projected-id__${originalStartsAt}`,
+        date: movedStartsAt
+      }],
+      nextCursor: null
+    }),
+    { maxDocuments: 2, pageSize: 2 }
+  );
+
+  assert.equal(isFamilyShareCalendarEventTracked({
+    id: 'opaque-projected-id',
+    startsAt: originalStartsAt
+  }, trackedEvents), true);
 });
 
 test('strict public teams require an explicit public flag and cannot be inactive', () => {

--- a/functions/test/public-team-api-core.test.cjs
+++ b/functions/test/public-team-api-core.test.cjs
@@ -191,6 +191,7 @@ test('public calendar projection hides feed credentials and keeps only event pre
     opponent: 'Falcons',
     location: 'Public Field',
     status: 'CONFIRMED',
+    calendarUidHash: 'SENTINEL_CALENDAR_UID_HASH',
     sourceUrl: 'https://calendar.example.test/team.ics?token=secret',
     description: 'Private calendar notes',
     childNames: ['Private Child']
@@ -208,6 +209,8 @@ test('public calendar projection hides feed credentials and keeps only event pre
   });
   const serialized = JSON.stringify(event);
   assert.equal(serialized.includes('token=secret'), false);
+  assert.equal(serialized.includes('SENTINEL_CALENDAR_UID_HASH'), false);
+  assert.equal(serialized.includes('calendarUidHash'), false);
   assert.equal(serialized.includes('Private calendar notes'), false);
   assert.equal(serialized.includes('Private Child'), false);
 });

--- a/services/chatgpt-mcp/src/core.js
+++ b/services/chatgpt-mcp/src/core.js
@@ -90,8 +90,8 @@ export async function loadPublicTeamCalendarProjection({
                 body: JSON.stringify({
                     data: {
                         teamId: normalizedTeamId,
-                        from: start.toISOString(),
-                        to: end.toISOString(),
+                        from: start.toISOString().slice(0, 10),
+                        to: end.toISOString().slice(0, 10),
                         limit: MAX_EVENTS_PER_TEAM,
                         ...(cursor ? { cursor } : {})
                     }

--- a/services/chatgpt-mcp/src/core.js
+++ b/services/chatgpt-mcp/src/core.js
@@ -359,6 +359,31 @@ function calendarOccurrenceId(sourceId, startsAt) {
     return sourceId.endsWith(suffix) ? sourceId : `${sourceId}${suffix}`;
 }
 
+function parseCalendarOccurrenceId(sourceId) {
+    const normalizedId = cleanString(sourceId).trim();
+    if (!normalizedId) return { id: '', startsAt: null };
+    const occurrenceMatch = normalizedId.match(/^(.*)__(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z)$/);
+    return {
+        id: normalizedId,
+        startsAt: occurrenceMatch ? toDate(occurrenceMatch[2]) : null
+    };
+}
+
+function isProjectedCalendarEventTracked(projectedId, projectedStartsAt, trackedEvents) {
+    const eventId = cleanString(projectedId).trim();
+    const startsAt = toDate(projectedStartsAt);
+    if (!eventId || !startsAt) return false;
+    const occurrenceId = calendarOccurrenceId(eventId, startsAt);
+    const occurrenceTime = startsAt.getTime();
+
+    return trackedEvents.some((tracked) => {
+        if (tracked.id === eventId || tracked.id === occurrenceId) return true;
+        const parsed = parseCalendarOccurrenceId(tracked.id);
+        if (parsed.startsAt) return parsed.startsAt.getTime() === occurrenceTime;
+        return tracked.date?.getTime() === occurrenceTime;
+    });
+}
+
 function whitelistRsvp(data, linkedPlayerIds) {
     if (!data) return null;
     const playerIds = (Array.isArray(data.playerIds) ? data.playerIds : [data.playerId])
@@ -384,7 +409,7 @@ export async function getFamilySchedule(db, context, args = {}, now = new Date()
 
     for (const entry of context.teams.values()) {
         const teamEvents = [];
-        const trackedCalendarEventIds = new Set();
+        const trackedCalendarEvents = [];
         const snap = await db.collection(`teams/${entry.teamId}/games`)
             .where('date', '>=', start)
             .where('date', '<=', end)
@@ -395,7 +420,6 @@ export async function getFamilySchedule(db, context, args = {}, now = new Date()
         for (const doc of snap.docs) {
             const data = doc.data() || {};
             const trackedCalendarEventId = cleanString(data.calendarEventUid).trim();
-            if (trackedCalendarEventId) trackedCalendarEventIds.add(trackedCalendarEventId);
             const event = {
                 teamId: entry.teamId,
                 teamName: cleanString(entry.team.name),
@@ -409,6 +433,15 @@ export async function getFamilySchedule(db, context, args = {}, now = new Date()
                 linkedPlayerIds: [...entry.linkedPlayerIds],
                 deepLink: gameDeepLink(entry.teamId, doc.id)
             };
+            if (trackedCalendarEventId) {
+                trackedCalendarEvents.push({
+                    id: trackedCalendarEventId,
+                    type: event.type,
+                    date: toDate(data.date),
+                    location: event.location,
+                    opponent: event.opponent
+                });
+            }
 
             if (entry.roles.has('parent')) {
                 const rsvpSnap = await safeGetDoc(db, `teams/${entry.teamId}/games/${doc.id}/rsvps/${context.uid}`);
@@ -444,8 +477,7 @@ export async function getFamilySchedule(db, context, args = {}, now = new Date()
                 const date = toDate(projected?.startsAt);
                 if (
                     !eventId || !date || date < start || date > end
-                    || trackedCalendarEventIds.has(eventId)
-                    || trackedCalendarEventIds.has(calendarOccurrenceId(eventId, date))
+                    || isProjectedCalendarEventTracked(eventId, date, trackedCalendarEvents)
                 ) continue;
                 const eventKey = `${eventId}::${date.toISOString()}`;
                 if (projectedEventKeys.has(eventKey)) continue;

--- a/services/chatgpt-mcp/src/core.js
+++ b/services/chatgpt-mcp/src/core.js
@@ -421,6 +421,7 @@ export async function getFamilySchedule(db, context, args = {}, now = new Date()
                 const date = toDate(projected?.startsAt);
                 if (
                     !eventId || !date || date < start || date > end
+                    || trackedCalendarEventIds.has(eventId)
                     || trackedCalendarEventIds.has(calendarOccurrenceId(eventId, date))
                 ) continue;
                 const eventKey = `${eventId}::${date.toISOString()}`;

--- a/services/chatgpt-mcp/src/core.js
+++ b/services/chatgpt-mcp/src/core.js
@@ -161,18 +161,32 @@ export async function loadManagedTeamsFromCallable({ projectId, idToken, fetchIm
         throw new DomainError('unauthenticated', 'Managed team discovery requires an authenticated project context.');
     }
     const requestUrl = `https://us-central1-${encodeURIComponent(projectId)}.cloudfunctions.net/listManagedTeams`;
-    const response = await fetchImpl(requestUrl, {
-        method: 'POST',
-        headers: {
-            Authorization: `Bearer ${idToken}`,
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ data: {} })
-    });
-    const payload = await response.json().catch(() => ({}));
+    let response;
+    try {
+        response = await fetchImpl(requestUrl, {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${idToken}`,
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ data: {} })
+        });
+    } catch {
+        throw new DomainError('unavailable', 'Managed team discovery is unavailable.');
+    }
+    let payload = null;
+    try {
+        payload = await response?.json?.();
+    } catch {
+        // Missing endpoints can return HTML, while malformed successful
+        // responses are classified as unavailable below.
+    }
     const result = payload?.result || payload?.data;
-    if (!response.ok || !Array.isArray(result?.items)) {
-        const code = response.status === 404 ? 'not_found' : callableErrorCode(payload);
+    if (!response?.ok || !Array.isArray(result?.items)) {
+        // A pre-rollout endpoint is an empty/non-callable HTTP 404. A valid
+        // callable error envelope (including domain NOT_FOUND) must fail closed.
+        const missingEndpoint = response?.status === 404 && !payload?.error;
+        const code = missingEndpoint ? 'not_found' : 'unavailable';
         throw new DomainError(code, payload?.error?.message || 'Managed team discovery is unavailable.');
     }
     return {

--- a/services/chatgpt-mcp/src/core.js
+++ b/services/chatgpt-mcp/src/core.js
@@ -369,18 +369,41 @@ function parseCalendarOccurrenceId(sourceId) {
     };
 }
 
-function isProjectedCalendarEventTracked(projectedId, projectedStartsAt, trackedEvents) {
-    const eventId = cleanString(projectedId).trim();
-    const startsAt = toDate(projectedStartsAt);
+function normalizeCalendarEventType(value) {
+    return cleanString(value).trim().toLowerCase() === 'practice' ? 'practice' : 'game';
+}
+
+function normalizeCalendarDiscriminator(value) {
+    const normalized = cleanString(value).trim().replace(/\s+/g, ' ').toLowerCase();
+    return normalized && normalized !== 'tbd' && normalized !== 'unknown' ? normalized : '';
+}
+
+function hasMatchingCalendarDiscriminator(projected, tracked, type) {
+    const projectedLocation = normalizeCalendarDiscriminator(projected?.location);
+    const trackedLocation = normalizeCalendarDiscriminator(tracked?.location);
+    if (projectedLocation && projectedLocation === trackedLocation) return true;
+
+    const field = type === 'practice' ? 'title' : 'opponent';
+    const projectedValue = normalizeCalendarDiscriminator(projected?.[field]);
+    const trackedValue = normalizeCalendarDiscriminator(tracked?.[field]);
+    return Boolean(projectedValue && projectedValue === trackedValue);
+}
+
+function isProjectedCalendarEventTracked(projected, trackedEvents) {
+    const eventId = cleanString(projected?.id).trim();
+    const startsAt = toDate(projected?.startsAt);
     if (!eventId || !startsAt) return false;
     const occurrenceId = calendarOccurrenceId(eventId, startsAt);
     const occurrenceTime = startsAt.getTime();
+    const type = normalizeCalendarEventType(projected?.type);
 
     return trackedEvents.some((tracked) => {
         if (tracked.id === eventId || tracked.id === occurrenceId) return true;
+        if (normalizeCalendarEventType(tracked.type) !== type) return false;
         const parsed = parseCalendarOccurrenceId(tracked.id);
-        if (parsed.startsAt) return parsed.startsAt.getTime() === occurrenceTime;
-        return tracked.date?.getTime() === occurrenceTime;
+        const trackedOccurrenceTime = parsed.startsAt?.getTime() ?? tracked.date?.getTime();
+        return trackedOccurrenceTime === occurrenceTime
+            && hasMatchingCalendarDiscriminator(projected, tracked, type);
     });
 }
 
@@ -439,7 +462,8 @@ export async function getFamilySchedule(db, context, args = {}, now = new Date()
                     type: event.type,
                     date: toDate(data.date),
                     location: event.location,
-                    opponent: event.opponent
+                    opponent: event.opponent,
+                    title: cleanString(data.title) || null
                 });
             }
 
@@ -477,7 +501,7 @@ export async function getFamilySchedule(db, context, args = {}, now = new Date()
                 const date = toDate(projected?.startsAt);
                 if (
                     !eventId || !date || date < start || date > end
-                    || isProjectedCalendarEventTracked(eventId, date, trackedCalendarEvents)
+                    || isProjectedCalendarEventTracked(projected, trackedCalendarEvents)
                 ) continue;
                 const eventKey = `${eventId}::${date.toISOString()}`;
                 if (projectedEventKeys.has(eventKey)) continue;

--- a/services/chatgpt-mcp/src/core.js
+++ b/services/chatgpt-mcp/src/core.js
@@ -163,7 +163,8 @@ export async function loadManagedTeamsFromCallable({ projectId, idToken, fetchIm
     const payload = await response.json().catch(() => ({}));
     const result = payload?.result || payload?.data;
     if (!response.ok || !Array.isArray(result?.items)) {
-        throw new DomainError('unavailable', payload?.error?.message || 'Managed team discovery is unavailable.');
+        const code = response.status === 404 ? 'not_found' : callableErrorCode(payload);
+        throw new DomainError(code, payload?.error?.message || 'Managed team discovery is unavailable.');
     }
     return {
         teams: result.items.filter((team) => team && typeof team === 'object' && !Array.isArray(team)),
@@ -327,7 +328,12 @@ function gameDeepLink(teamId, gameId, { replay = false } = {}) {
 }
 
 function calendarEventDeepLink(teamId, eventId) {
-    return `${APP_BASE_URL}/app/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(eventId)}`;
+    return `${APP_BASE_URL}/app/#/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(eventId)}`;
+}
+
+function calendarOccurrenceId(sourceId, startsAt) {
+    const suffix = `__${startsAt.toISOString()}`;
+    return sourceId.endsWith(suffix) ? sourceId : `${sourceId}${suffix}`;
 }
 
 function whitelistRsvp(data, linkedPlayerIds) {
@@ -413,7 +419,10 @@ export async function getFamilySchedule(db, context, args = {}, now = new Date()
             for (const projected of Array.isArray(projectedEvents) ? projectedEvents : []) {
                 const eventId = cleanString(projected?.id).trim();
                 const date = toDate(projected?.startsAt);
-                if (!eventId || !date || date < start || date > end || trackedCalendarEventIds.has(eventId)) continue;
+                if (
+                    !eventId || !date || date < start || date > end
+                    || trackedCalendarEventIds.has(calendarOccurrenceId(eventId, date))
+                ) continue;
                 const eventKey = `${eventId}::${date.toISOString()}`;
                 if (projectedEventKeys.has(eventKey)) continue;
                 projectedEventKeys.add(eventKey);

--- a/services/chatgpt-mcp/src/core.js
+++ b/services/chatgpt-mcp/src/core.js
@@ -147,6 +147,15 @@ async function safeGetDoc(db, path) {
     }
 }
 
+async function safeLegacyOwnershipQuery(query) {
+    try {
+        return await query.get();
+    } catch (error) {
+        if (error instanceof DomainError && error.code === 'permission_denied') return { docs: [] };
+        throw error;
+    }
+}
+
 export async function loadManagedTeamsFromCallable({ projectId, idToken, fetchImpl = fetch }) {
     if (!projectId || !idToken) {
         throw new DomainError('unauthenticated', 'Managed team discovery requires an authenticated project context.');
@@ -232,10 +241,10 @@ export async function resolveUserContext(db, { uid, email }, { managedTeams = nu
                 ? db.collection('teams').where('adminEmails', 'array-contains', normalizedEmail).get()
                 : Promise.resolve({ docs: [] }),
             normalizedEmail
-                ? db.collection('teams').where('ownerEmailLower', '==', normalizedEmail).get().catch(() => ({ docs: [] }))
+                ? safeLegacyOwnershipQuery(db.collection('teams').where('ownerEmailLower', '==', normalizedEmail))
                 : Promise.resolve({ docs: [] }),
             ...ownerEmailCandidates.map((ownerEmail) => (
-                db.collection('teams').where('ownerEmail', '==', ownerEmail).get().catch(() => ({ docs: [] }))
+                safeLegacyOwnershipQuery(db.collection('teams').where('ownerEmail', '==', ownerEmail))
             ))
         ]);
         for (const doc of ownedSnap.docs) addTeam(doc.id, doc.data(), 'owner');

--- a/services/chatgpt-mcp/src/core.js
+++ b/services/chatgpt-mcp/src/core.js
@@ -9,6 +9,7 @@ export const APP_BASE_URL = 'https://allplays.ai';
 export const DEFAULT_SCHEDULE_DAYS = 7;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const MAX_EVENTS_PER_TEAM = 50;
+const MAX_CALENDAR_PROJECTION_PAGES = 20;
 const MAX_PLAYER_STATS = 60;
 
 export class DomainError extends Error {
@@ -39,6 +40,90 @@ function cleanString(value) {
     return typeof value === 'string' ? value : '';
 }
 
+function requireProjectionText(value, label) {
+    const normalized = cleanString(value).trim();
+    if (!normalized) throw new DomainError('invalid_argument', `${label} is required.`);
+    return normalized;
+}
+
+function callableErrorCode(payload) {
+    const status = cleanString(payload?.error?.status || payload?.error?.code).toUpperCase();
+    return status.includes('NOT_FOUND') ? 'not_found' : 'unavailable';
+}
+
+export async function loadPublicTeamCalendarProjection({
+    projectId,
+    idToken,
+    teamId,
+    startDate,
+    endDate,
+    fetchImpl = fetch
+}) {
+    const normalizedProjectId = requireProjectionText(projectId, 'Firebase project ID');
+    const normalizedIdToken = requireProjectionText(idToken, 'Authenticated ID token');
+    const normalizedTeamId = requireProjectionText(teamId, 'teamId');
+    const start = toDate(startDate);
+    const end = toDate(endDate);
+    if (!start || !end || end < start) {
+        throw new DomainError('invalid_argument', 'A valid calendar projection date range is required.');
+    }
+
+    const requestUrl = `https://us-central1-${encodeURIComponent(normalizedProjectId)}.cloudfunctions.net/getPublicTeamCalendarProjection`;
+    const events = [];
+    const seenCursors = new Set();
+    let cursor = '';
+
+    for (let page = 0; page < MAX_CALENDAR_PROJECTION_PAGES; page += 1) {
+        let response;
+        let payload;
+        try {
+            response = await fetchImpl(requestUrl, {
+                method: 'POST',
+                headers: {
+                    Authorization: `Bearer ${normalizedIdToken}`,
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    data: {
+                        teamId: normalizedTeamId,
+                        from: start.toISOString(),
+                        to: end.toISOString(),
+                        limit: MAX_EVENTS_PER_TEAM,
+                        ...(cursor ? { cursor } : {})
+                    }
+                })
+            });
+            payload = await response.json();
+        } catch {
+            throw new DomainError('unavailable', 'Imported calendar events are temporarily unavailable.');
+        }
+
+        const result = payload?.result || payload?.data;
+        if (!response.ok || !result || !Array.isArray(result.events)) {
+            throw new DomainError(
+                callableErrorCode(payload),
+                response.ok ? 'Imported calendar response is invalid.' : 'Imported calendar events are temporarily unavailable.'
+            );
+        }
+        if (Array.isArray(result.warnings) && result.warnings.length > 0) {
+            throw new DomainError('unavailable', 'Imported calendar events could not be loaded completely.');
+        }
+        events.push(...result.events);
+
+        if (result?.range?.truncated !== true || events.length >= MAX_EVENTS_PER_TEAM) {
+            return events.slice(0, MAX_EVENTS_PER_TEAM);
+        }
+        const nextCursor = cleanString(result.nextCursor).trim();
+        if (!nextCursor || seenCursors.has(nextCursor)) {
+            throw new DomainError('unavailable', 'Imported calendar pagination could not be completed.');
+        }
+        seenCursors.add(nextCursor);
+        cursor = nextCursor;
+    }
+
+    throw new DomainError('unavailable', 'Imported calendar pagination exceeded its safety limit.');
+}
+
 function parseParentPlayerKey(value) {
     if (typeof value !== 'string') return null;
     const separatorIndex = value.indexOf('::');
@@ -62,16 +147,40 @@ async function safeGetDoc(db, path) {
     }
 }
 
+export async function loadManagedTeamsFromCallable({ projectId, idToken, fetchImpl = fetch }) {
+    if (!projectId || !idToken) {
+        throw new DomainError('unauthenticated', 'Managed team discovery requires an authenticated project context.');
+    }
+    const requestUrl = `https://us-central1-${encodeURIComponent(projectId)}.cloudfunctions.net/listManagedTeams`;
+    const response = await fetchImpl(requestUrl, {
+        method: 'POST',
+        headers: {
+            Authorization: `Bearer ${idToken}`,
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ data: {} })
+    });
+    const payload = await response.json().catch(() => ({}));
+    const result = payload?.result || payload?.data;
+    if (!response.ok || !Array.isArray(result?.items)) {
+        throw new DomainError('unavailable', payload?.error?.message || 'Managed team discovery is unavailable.');
+    }
+    return {
+        teams: result.items.filter((team) => team && typeof team === 'object' && !Array.isArray(team)),
+        isPartial: result.isPartial === true
+    };
+}
+
 /**
  * Build the caller's authorization context from Firestore. Roles are always
  * re-derived per request; nothing supplied by the model is trusted.
  */
-export async function resolveUserContext(db, { uid, email }) {
+export async function resolveUserContext(db, { uid, email }, { managedTeams = null } = {}) {
     if (!uid) throw new DomainError('unauthenticated', 'Missing authenticated user.');
 
     const userSnap = await safeGetDoc(db, `users/${uid}`);
     const profile = userSnap.exists ? userSnap.data() || {} : {};
-    const normalizedEmail = normalizeEmail(email || profile.email);
+    const normalizedEmail = normalizeEmail(email);
     const legacyParentLinks = (Array.isArray(profile.parentOf) ? profile.parentOf : [])
         .filter((link) => link && typeof link.teamId === 'string' && link.teamId);
     const parentTeamIds = new Set([
@@ -94,21 +203,6 @@ export async function resolveUserContext(db, { uid, email }) {
         if (link) addLinkedPlayer(link.teamId, link.playerId);
     }
 
-    const ownerEmailCandidates = [...new Set([email, profile.email, normalizedEmail]
-        .filter((value) => typeof value === 'string' && value))];
-    const [ownedSnap, adminSnap, ownerEmailLowerSnap, ...ownerEmailSnaps] = await Promise.all([
-        db.collection('teams').where('ownerId', '==', uid).get(),
-        normalizedEmail
-            ? db.collection('teams').where('adminEmails', 'array-contains', normalizedEmail).get()
-            : Promise.resolve({ docs: [] }),
-        normalizedEmail
-            ? db.collection('teams').where('ownerEmailLower', '==', normalizedEmail).get()
-            : Promise.resolve({ docs: [] }),
-        ...ownerEmailCandidates.map((ownerEmail) => (
-            db.collection('teams').where('ownerEmail', '==', ownerEmail).get()
-        ))
-    ]);
-
     const teams = new Map();
     const addTeam = (teamId, teamData, role) => {
         if (!teams.has(teamId)) {
@@ -117,11 +211,45 @@ export async function resolveUserContext(db, { uid, email }) {
         teams.get(teamId).roles.add(role);
     };
 
-    for (const doc of ownedSnap.docs) addTeam(doc.id, doc.data(), 'owner');
-    for (const doc of adminSnap.docs) addTeam(doc.id, doc.data(), 'admin');
-    for (const doc of ownerEmailLowerSnap.docs) addTeam(doc.id, doc.data(), 'owner');
-    for (const snap of ownerEmailSnaps) {
-        for (const doc of snap.docs) addTeam(doc.id, doc.data(), 'owner');
+    if (Array.isArray(managedTeams)) {
+        for (const team of managedTeams) {
+            const teamId = String(team?.id || '').trim();
+            if (!teamId) continue;
+            const ownerId = String(team.ownerId || '').trim();
+            const ownerEmails = [...new Set([team.ownerEmailLower, team.ownerEmail].map(normalizeEmail).filter(Boolean))];
+            const role = ownerId === uid || (!ownerId && ownerEmails.length === 1 && normalizedEmail === ownerEmails[0])
+                ? 'owner'
+                : 'admin';
+            addTeam(teamId, team, role);
+        }
+    } else {
+        const ownerEmailCandidates = [...new Set([email, normalizedEmail]
+            .filter((value) => typeof value === 'string' && value))];
+        const [ownedSnap, adminSnap, ownerEmailLowerSnap, ...ownerEmailSnaps] = await Promise.all([
+            db.collection('teams').where('ownerId', '==', uid).get(),
+            normalizedEmail
+                ? db.collection('teams').where('adminEmails', 'array-contains', normalizedEmail).get()
+                : Promise.resolve({ docs: [] }),
+            normalizedEmail
+                ? db.collection('teams').where('ownerEmailLower', '==', normalizedEmail).get().catch(() => ({ docs: [] }))
+                : Promise.resolve({ docs: [] }),
+            ...ownerEmailCandidates.map((ownerEmail) => (
+                db.collection('teams').where('ownerEmail', '==', ownerEmail).get().catch(() => ({ docs: [] }))
+            ))
+        ]);
+        for (const doc of ownedSnap.docs) addTeam(doc.id, doc.data(), 'owner');
+        for (const doc of adminSnap.docs) addTeam(doc.id, doc.data(), 'admin');
+        const addLegacyOwnedTeam = (doc) => {
+            const team = doc.data() || {};
+            const ownerEmails = [...new Set([team.ownerEmailLower, team.ownerEmail].map(normalizeEmail).filter(Boolean))];
+            if (!String(team.ownerId || '').trim() && ownerEmails.length === 1 && ownerEmails[0] === normalizedEmail) {
+                addTeam(doc.id, team, 'owner');
+            }
+        };
+        for (const doc of ownerEmailLowerSnap.docs) addLegacyOwnedTeam(doc);
+        for (const snap of ownerEmailSnaps) {
+            for (const doc of snap.docs) addLegacyOwnedTeam(doc);
+        }
     }
 
     const parentTeamSnaps = await Promise.all([...parentTeamIds].map((teamId) => safeGetDoc(db, `teams/${teamId}`)));
@@ -198,6 +326,10 @@ function gameDeepLink(teamId, gameId, { replay = false } = {}) {
     return `${APP_BASE_URL}/live-game.html?${params.toString()}`;
 }
 
+function calendarEventDeepLink(teamId, eventId) {
+    return `${APP_BASE_URL}/app/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(eventId)}`;
+}
+
 function whitelistRsvp(data, linkedPlayerIds) {
     if (!data) return null;
     const playerIds = (Array.isArray(data.playerIds) ? data.playerIds : [data.playerId])
@@ -217,11 +349,13 @@ function whitelistRsvpSummary(summary) {
     return Object.keys(out).length ? out : null;
 }
 
-export async function getFamilySchedule(db, context, args = {}, now = new Date()) {
+export async function getFamilySchedule(db, context, args = {}, now = new Date(), { loadCalendarProjection } = {}) {
     const { start, end } = parseScheduleRange(args, now);
     const events = [];
 
     for (const entry of context.teams.values()) {
+        const teamEvents = [];
+        const trackedCalendarEventIds = new Set();
         const snap = await db.collection(`teams/${entry.teamId}/games`)
             .where('date', '>=', start)
             .where('date', '<=', end)
@@ -231,6 +365,8 @@ export async function getFamilySchedule(db, context, args = {}, now = new Date()
 
         for (const doc of snap.docs) {
             const data = doc.data() || {};
+            const trackedCalendarEventId = cleanString(data.calendarEventUid).trim();
+            if (trackedCalendarEventId) trackedCalendarEventIds.add(trackedCalendarEventId);
             const event = {
                 teamId: entry.teamId,
                 teamName: cleanString(entry.team.name),
@@ -252,8 +388,59 @@ export async function getFamilySchedule(db, context, args = {}, now = new Date()
                     : { response: 'not_responded', playerIds: [] };
             }
 
-            events.push(event);
+            teamEvents.push(event);
         }
+
+        if (typeof loadCalendarProjection === 'function') {
+            let projectedEvents;
+            try {
+                projectedEvents = await loadCalendarProjection({
+                    teamId: entry.teamId,
+                    startDate: start,
+                    endDate: end
+                });
+            } catch (error) {
+                if (error instanceof DomainError && error.code === 'not_found') {
+                    projectedEvents = [];
+                } else {
+                    throw error instanceof DomainError
+                        ? error
+                        : new DomainError('unavailable', 'Imported calendar events are temporarily unavailable.');
+                }
+            }
+
+            const projectedEventKeys = new Set();
+            for (const projected of Array.isArray(projectedEvents) ? projectedEvents : []) {
+                const eventId = cleanString(projected?.id).trim();
+                const date = toDate(projected?.startsAt);
+                if (!eventId || !date || date < start || date > end || trackedCalendarEventIds.has(eventId)) continue;
+                const eventKey = `${eventId}::${date.toISOString()}`;
+                if (projectedEventKeys.has(eventKey)) continue;
+                projectedEventKeys.add(eventKey);
+                const type = projected?.type === 'practice' ? 'practice' : 'game';
+                teamEvents.push({
+                    teamId: entry.teamId,
+                    teamName: cleanString(entry.team.name),
+                    gameId: eventId,
+                    type,
+                    date: date.toISOString(),
+                    title: type === 'practice' ? cleanString(projected?.title) || null : null,
+                    opponent: type === 'game' ? cleanString(projected?.opponent) || null : null,
+                    location: cleanString(projected?.location) || null,
+                    status: cleanString(projected?.status) || 'scheduled',
+                    rsvpSummary: null,
+                    myRsvp: null,
+                    linkedPlayerIds: [...entry.linkedPlayerIds],
+                    sourceType: 'calendar',
+                    sourceLabel: 'Imported calendar',
+                    isImported: true,
+                    deepLink: calendarEventDeepLink(entry.teamId, eventId)
+                });
+            }
+        }
+
+        teamEvents.sort((a, b) => (a.date || '').localeCompare(b.date || ''));
+        events.push(...teamEvents.slice(0, MAX_EVENTS_PER_TEAM));
     }
 
     events.sort((a, b) => (a.date || '').localeCompare(b.date || ''));

--- a/services/chatgpt-mcp/src/core.js
+++ b/services/chatgpt-mcp/src/core.js
@@ -11,6 +11,9 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const MAX_EVENTS_PER_TEAM = 50;
 const MAX_CALENDAR_PROJECTION_PAGES = 20;
 const MAX_PLAYER_STATS = 60;
+const GENERIC_CALENDAR_DISCRIMINATORS = new Set([
+    '', 'tbd', 'unknown', 'practice', 'game', 'training', 'workout', 'scrimmage'
+]);
 
 export class DomainError extends Error {
     constructor(code, message) {
@@ -375,7 +378,7 @@ function normalizeCalendarEventType(value) {
 
 function normalizeCalendarDiscriminator(value) {
     const normalized = cleanString(value).trim().replace(/\s+/g, ' ').toLowerCase();
-    return normalized && normalized !== 'tbd' && normalized !== 'unknown' ? normalized : '';
+    return GENERIC_CALENDAR_DISCRIMINATORS.has(normalized) ? '' : normalized;
 }
 
 function hasMatchingCalendarDiscriminator(projected, tracked, type) {

--- a/services/chatgpt-mcp/src/core.js
+++ b/services/chatgpt-mcp/src/core.js
@@ -9,6 +9,7 @@ export const APP_BASE_URL = 'https://allplays.ai';
 export const DEFAULT_SCHEDULE_DAYS = 7;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const MAX_EVENTS_PER_TEAM = 50;
+const MAX_TRACKED_CALENDAR_EVENTS_PER_TEAM = 5000;
 const MAX_CALENDAR_PROJECTION_PAGES = 20;
 const MAX_PLAYER_STATS = 60;
 const GENERIC_CALENDAR_DISCRIMINATORS = new Set([
@@ -429,13 +430,38 @@ function whitelistRsvpSummary(summary) {
     return Object.keys(out).length ? out : null;
 }
 
+async function loadTrackedCalendarEvents(db, teamId) {
+    const snap = await db.collection(`teams/${teamId}/games`)
+        .orderBy('__name__')
+        .select('calendarEventUid', 'date', 'type', 'location', 'opponent', 'title')
+        .limit(MAX_TRACKED_CALENDAR_EVENTS_PER_TEAM + 1)
+        .get();
+    if (snap.docs.length > MAX_TRACKED_CALENDAR_EVENTS_PER_TEAM) {
+        throw new DomainError('unavailable', 'Calendar tracking scan exceeded its safe limit.');
+    }
+    return snap.docs
+        .map((doc) => {
+            const data = doc.data() || {};
+            const id = cleanString(data.calendarEventUid).trim();
+            if (!id) return null;
+            return {
+                id,
+                type: normalizeCalendarEventType(data.type),
+                date: toDate(data.date),
+                location: cleanString(data.location) || null,
+                opponent: cleanString(data.opponent) || null,
+                title: cleanString(data.title) || null
+            };
+        })
+        .filter(Boolean);
+}
+
 export async function getFamilySchedule(db, context, args = {}, now = new Date(), { loadCalendarProjection } = {}) {
     const { start, end } = parseScheduleRange(args, now);
     const events = [];
 
     for (const entry of context.teams.values()) {
         const teamEvents = [];
-        const trackedCalendarEvents = [];
         const snap = await db.collection(`teams/${entry.teamId}/games`)
             .where('date', '>=', start)
             .where('date', '<=', end)
@@ -445,11 +471,11 @@ export async function getFamilySchedule(db, context, args = {}, now = new Date()
 
         for (const doc of snap.docs) {
             const data = doc.data() || {};
-            const trackedCalendarEventId = cleanString(data.calendarEventUid).trim();
             const event = {
                 teamId: entry.teamId,
                 teamName: cleanString(entry.team.name),
                 gameId: doc.id,
+                gameSummaryAvailable: true,
                 type: data.type === 'practice' ? 'practice' : 'game',
                 date: toIso(data.date),
                 opponent: cleanString(data.opponent) || cleanString(data.opponentTeamName) || null,
@@ -459,16 +485,6 @@ export async function getFamilySchedule(db, context, args = {}, now = new Date()
                 linkedPlayerIds: [...entry.linkedPlayerIds],
                 deepLink: gameDeepLink(entry.teamId, doc.id)
             };
-            if (trackedCalendarEventId) {
-                trackedCalendarEvents.push({
-                    id: trackedCalendarEventId,
-                    type: event.type,
-                    date: toDate(data.date),
-                    location: event.location,
-                    opponent: event.opponent,
-                    title: cleanString(data.title) || null
-                });
-            }
 
             if (entry.roles.has('parent')) {
                 const rsvpSnap = await safeGetDoc(db, `teams/${entry.teamId}/games/${doc.id}/rsvps/${context.uid}`);
@@ -498,8 +514,12 @@ export async function getFamilySchedule(db, context, args = {}, now = new Date()
                 }
             }
 
+            const normalizedProjectedEvents = Array.isArray(projectedEvents) ? projectedEvents : [];
+            const trackedCalendarEvents = normalizedProjectedEvents.length
+                ? await loadTrackedCalendarEvents(db, entry.teamId)
+                : [];
             const projectedEventKeys = new Set();
-            for (const projected of Array.isArray(projectedEvents) ? projectedEvents : []) {
+            for (const projected of normalizedProjectedEvents) {
                 const eventId = cleanString(projected?.id).trim();
                 const date = toDate(projected?.startsAt);
                 if (
@@ -513,7 +533,9 @@ export async function getFamilySchedule(db, context, args = {}, now = new Date()
                 teamEvents.push({
                     teamId: entry.teamId,
                     teamName: cleanString(entry.team.name),
-                    gameId: eventId,
+                    gameId: null,
+                    calendarEventId: eventId,
+                    gameSummaryAvailable: false,
                     type,
                     date: date.toISOString(),
                     title: type === 'practice' ? cleanString(projected?.title) || null : null,

--- a/services/chatgpt-mcp/src/firestoreRest.js
+++ b/services/chatgpt-mcp/src/firestoreRest.js
@@ -62,8 +62,15 @@ function throwForStatus(status, path) {
     throw new Error(`Firestore request failed (${status}) for ${path}`);
 }
 
-export function buildStructuredQuery(collectionId, { filters = [], orderBy = null, limit = null } = {}) {
+export function buildStructuredQuery(collectionId, { filters = [], orderBy = null, limit = null, select = [] } = {}) {
     const structuredQuery = { from: [{ collectionId }] };
+    const selectedFields = (Array.isArray(select) ? select : [])
+        .filter((field) => typeof field === 'string' && field);
+    if (selectedFields.length) {
+        structuredQuery.select = {
+            fields: selectedFields.map((fieldPath) => ({ fieldPath }))
+        };
+    }
     const fieldFilters = filters.map(({ field, op, value }) => ({
         fieldFilter: {
             field: { fieldPath: field },
@@ -87,7 +94,7 @@ export function buildStructuredQuery(collectionId, { filters = [], orderBy = nul
 
 /**
  * Firestore handle scoped to one user's ID token. Interface matches what
- * core.js expects: doc(path).get(), collection(path).where().orderBy().limit().get().
+ * core.js expects: doc(path).get(), collection(path).where().orderBy().select().limit().get().
  */
 export function createUserDb({ projectId, idToken, fetchImpl = fetch }) {
     const baseUrl = `https://firestore.googleapis.com/v1/projects/${projectId}/databases/(default)/documents`;
@@ -127,6 +134,9 @@ export function createUserDb({ projectId, idToken, fetchImpl = fetch }) {
                 orderBy(field, direction = 'asc') {
                     return makeQuery({ ...options, orderBy: { field, direction } });
                 },
+                select(...fields) {
+                    return makeQuery({ ...options, select: fields.flat() });
+                },
                 limit(count) {
                     return makeQuery({ ...options, limit: count });
                 },
@@ -148,7 +158,7 @@ export function createUserDb({ projectId, idToken, fetchImpl = fetch }) {
                 }
             });
 
-            return makeQuery({ filters: [] });
+            return makeQuery({ filters: [], select: [] });
         }
     };
 }

--- a/services/chatgpt-mcp/src/server.js
+++ b/services/chatgpt-mcp/src/server.js
@@ -234,7 +234,7 @@ function buildServer(identity) {
         description: 'Score, status, summary, and aggregated player statistics for one game on a team the user belongs to.',
         inputSchema: {
             teamId: z.string().describe('Team id from get_profile'),
-            gameId: z.string().describe('Game id from list_schedule')
+            gameId: z.string().describe('Non-imported gameId from list_schedule. Imported calendar events have no gameId and do not support game summaries.')
         },
         annotations: { readOnlyHint: true }
     }, run((context, args) => getGameSummary(db, context, args)));

--- a/services/chatgpt-mcp/src/server.js
+++ b/services/chatgpt-mcp/src/server.js
@@ -184,10 +184,16 @@ function buildServer(identity) {
 
     const run = (handler) => async (args) => {
         try {
-            const managedTeamResult = await loadManagedTeamsFromCallable({
-                projectId: PROJECT_ID,
-                idToken: identity.idToken
-            });
+            let managedTeamResult;
+            try {
+                managedTeamResult = await loadManagedTeamsFromCallable({
+                    projectId: PROJECT_ID,
+                    idToken: identity.idToken
+                });
+            } catch (error) {
+                if (!(error instanceof DomainError) || error.code !== 'not_found') throw error;
+                managedTeamResult = { teams: null, isPartial: false };
+            }
             if (managedTeamResult.isPartial) {
                 throw new DomainError('unavailable', 'Managed team discovery returned incomplete results.');
             }

--- a/services/chatgpt-mcp/src/server.js
+++ b/services/chatgpt-mcp/src/server.js
@@ -16,6 +16,8 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { z } from 'zod';
 import {
     DomainError,
+    loadManagedTeamsFromCallable,
+    loadPublicTeamCalendarProjection,
     resolveUserContext,
     listMyTeams,
     getFamilySchedule,
@@ -182,7 +184,14 @@ function buildServer(identity) {
 
     const run = (handler) => async (args) => {
         try {
-            const context = await resolveUserContext(db, identity);
+            const managedTeamResult = await loadManagedTeamsFromCallable({
+                projectId: PROJECT_ID,
+                idToken: identity.idToken
+            });
+            if (managedTeamResult.isPartial) {
+                throw new DomainError('unavailable', 'Managed team discovery returned incomplete results.');
+            }
+            const context = await resolveUserContext(db, identity, { managedTeams: managedTeamResult.teams });
             return toolResult(await handler(context, args));
         } catch (error) {
             return toolError(error);
@@ -204,7 +213,15 @@ function buildServer(identity) {
             endDate: z.string().optional().describe('ISO date, inclusive. Defaults to startDate + 7 days.')
         },
         annotations: { readOnlyHint: true }
-    }, run((context, args) => getFamilySchedule(db, context, args)));
+    }, run((context, args) => getFamilySchedule(db, context, args, new Date(), {
+        loadCalendarProjection: ({ teamId, startDate, endDate }) => loadPublicTeamCalendarProjection({
+            projectId: PROJECT_ID,
+            idToken: identity.idToken,
+            teamId,
+            startDate,
+            endDate
+        })
+    })));
 
     server.registerTool('get_game_summary', {
         title: 'Get game summary',

--- a/tests/unit/chatgpt-mcp-core.test.js
+++ b/tests/unit/chatgpt-mcp-core.test.js
@@ -302,6 +302,18 @@ describe('chatgpt-mcp core: resolveUserContext', () => {
         expect([...context.teams.get('admin-team').roles]).toEqual(['admin']);
     });
 
+    it('propagates transient legacy ownership query failures', async () => {
+        const db = fakeDb({
+            docs: { 'users/coach-1': { email: 'coach@example.com' } },
+            queries: { teams: (filters) => {
+                if (filters[0]?.field === 'ownerEmailLower') throw new Error('network unavailable');
+                return [];
+            } }
+        });
+        await expect(resolveUserContext(db, { uid: 'coach-1', email: 'coach@example.com' }))
+            .rejects.toThrow('network unavailable');
+    });
+
     it('keeps private parent teams when direct team reads are denied by rules', async () => {
         const db = parentDb({
             docs: {
@@ -452,8 +464,8 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
 
     it('deduplicates a projected TeamSnap event tracked by an ALL PLAYS game', async () => {
         for (const trackedUid of [
-            'teamsnap-tracked-game',
-            'teamsnap-tracked-game__2026-07-25T17:00:00.000Z'
+            'opaque-projected-id',
+            'opaque-projected-id__2026-07-25T17:00:00.000Z'
         ]) {
             const db = scheduleDb(trackedUid);
             const context = await resolveUserContext(db, parentIdentity);
@@ -463,7 +475,7 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
                 { startDate: '2026-07-24', endDate: '2026-07-31' },
                 new Date('2026-07-24T00:00:00.000Z'),
                 { loadCalendarProjection: async () => [{
-                    id: 'teamsnap-tracked-game',
+                    id: 'opaque-projected-id',
                     type: 'game',
                     startsAt: '2026-07-25T17:00:00.000Z',
                     opponent: 'Duplicate Hawks'
@@ -471,7 +483,7 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
             );
 
             expect(result.events.filter((event) => event.gameId === 'game-1')).toHaveLength(1);
-            expect(result.events.some((event) => event.gameId === 'teamsnap-tracked-game')).toBe(false);
+            expect(result.events.some((event) => event.gameId === 'opaque-projected-id')).toBe(false);
         }
     });
 

--- a/tests/unit/chatgpt-mcp-core.test.js
+++ b/tests/unit/chatgpt-mcp-core.test.js
@@ -356,7 +356,7 @@ describe('chatgpt-mcp core: listMyTeams', () => {
 });
 
 describe('chatgpt-mcp core: getFamilySchedule', () => {
-    function scheduleDb() {
+    function scheduleDb(calendarEventUid = 'teamsnap-tracked-game__2026-07-25T17:00:00.000Z') {
         return parentDb({
             docs: {
                 'teams/team-a/games/game-1/rsvps/parent-1': {
@@ -371,7 +371,7 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
                     const start = filters.find((f) => f.op === '>=').value;
                     const end = filters.find((f) => f.op === '<=').value;
                     const all = [
-                        { id: 'game-1', data: { type: 'game', date: new Date('2026-07-25T17:00:00Z'), opponent: 'Hawks', location: 'Field 2', calendarEventUid: 'teamsnap-tracked-game__2026-07-25T17:00:00.000Z', privateNotes: 'secret', rsvpSummary: { going: 5, notResponded: 3, coachOnly: 'x' } } },
+                        { id: 'game-1', data: { type: 'game', date: new Date('2026-07-25T17:00:00Z'), opponent: 'Hawks', location: 'Field 2', calendarEventUid, privateNotes: 'secret', rsvpSummary: { going: 5, notResponded: 3, coachOnly: 'x' } } },
                         { id: 'practice-1', data: { type: 'practice', date: new Date('2026-07-27T22:30:00Z') } },
                         { id: 'game-end-date', data: { type: 'game', date: new Date('2026-07-31T17:00:00Z') } },
                         { id: 'game-out-of-range', data: { type: 'game', date: new Date('2026-09-01T17:00:00Z') } }
@@ -451,25 +451,28 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
     });
 
     it('deduplicates a projected TeamSnap event tracked by an ALL PLAYS game', async () => {
-        const db = scheduleDb();
-        const context = await resolveUserContext(db, parentIdentity);
-        const result = await getFamilySchedule(
-            db,
-            context,
-            { startDate: '2026-07-24', endDate: '2026-07-31' },
-            new Date('2026-07-24T00:00:00.000Z'),
-            {
-                loadCalendarProjection: async () => [{
+        for (const trackedUid of [
+            'teamsnap-tracked-game',
+            'teamsnap-tracked-game__2026-07-25T17:00:00.000Z'
+        ]) {
+            const db = scheduleDb(trackedUid);
+            const context = await resolveUserContext(db, parentIdentity);
+            const result = await getFamilySchedule(
+                db,
+                context,
+                { startDate: '2026-07-24', endDate: '2026-07-31' },
+                new Date('2026-07-24T00:00:00.000Z'),
+                { loadCalendarProjection: async () => [{
                     id: 'teamsnap-tracked-game',
                     type: 'game',
                     startsAt: '2026-07-25T17:00:00.000Z',
                     opponent: 'Duplicate Hawks'
-                }]
-            }
-        );
+                }] }
+            );
 
-        expect(result.events.filter((event) => event.gameId === 'game-1')).toHaveLength(1);
-        expect(result.events.some((event) => event.gameId === 'teamsnap-tracked-game')).toBe(false);
+            expect(result.events.filter((event) => event.gameId === 'game-1')).toHaveLength(1);
+            expect(result.events.some((event) => event.gameId === 'teamsnap-tracked-game')).toBe(false);
+        }
     });
 
     it('fails explicitly when imported calendar projection is unavailable', async () => {

--- a/tests/unit/chatgpt-mcp-core.test.js
+++ b/tests/unit/chatgpt-mcp-core.test.js
@@ -416,7 +416,10 @@ describe('chatgpt-mcp core: listMyTeams', () => {
 });
 
 describe('chatgpt-mcp core: getFamilySchedule', () => {
-    function scheduleDb(calendarEventUid = 'teamsnap-tracked-game__2026-07-25T17:00:00.000Z') {
+    function scheduleDb(
+        calendarEventUid = 'teamsnap-tracked-game__2026-07-25T17:00:00.000Z',
+        trackedGameOverrides = {}
+    ) {
         return parentDb({
             docs: {
                 'teams/team-a/games/game-1/rsvps/parent-1': {
@@ -431,7 +434,7 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
                     const start = filters.find((f) => f.op === '>=').value;
                     const end = filters.find((f) => f.op === '<=').value;
                     const all = [
-                        { id: 'game-1', data: { type: 'game', date: new Date('2026-07-25T17:00:00Z'), opponent: 'Hawks', location: 'Field 2', calendarEventUid, privateNotes: 'secret', rsvpSummary: { going: 5, notResponded: 3, coachOnly: 'x' } } },
+                        { id: 'game-1', data: { type: 'game', date: new Date('2026-07-25T17:00:00Z'), opponent: 'Hawks', location: 'Field 2', calendarEventUid, privateNotes: 'secret', rsvpSummary: { going: 5, notResponded: 3, coachOnly: 'x' }, ...trackedGameOverrides } },
                         { id: 'practice-1', data: { type: 'practice', date: new Date('2026-07-27T22:30:00Z') } },
                         { id: 'game-end-date', data: { type: 'game', date: new Date('2026-07-31T17:00:00Z') } },
                         { id: 'game-out-of-range', data: { type: 'game', date: new Date('2026-09-01T17:00:00Z') } }
@@ -542,6 +545,80 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
             expect(result.events.filter((event) => event.gameId === 'game-1')).toHaveLength(1);
             expect(result.events.some((event) => event.gameId === 'opaque-projected-id')).toBe(false);
         }
+    });
+
+    it.each([
+        ['practice', 'legacy-practice-uid', { type: 'practice' }],
+        ['private game', 'legacy-private-uid__2026-07-25T17:00:00.000Z', { visibility: 'private' }],
+        ['deleted game', '7bca28b6105ee23830c3517602e276d3__2026-07-25T17:00:00.000Z', { deleted: true }]
+    ])('deduplicates a projected event materialized as an authorized %s record', async (_label, trackedUid, overrides) => {
+        const db = scheduleDb(trackedUid, overrides);
+        const context = await resolveUserContext(db, parentIdentity);
+        const result = await getFamilySchedule(
+            db,
+            context,
+            { startDate: '2026-07-24', endDate: '2026-07-31' },
+            new Date('2026-07-24T00:00:00.000Z'),
+            { loadCalendarProjection: async () => [{
+                id: 'opaque-safe-projection-id',
+                type: overrides.type === 'practice' ? 'practice' : 'game',
+                startsAt: '2026-07-25T17:00:00.000Z',
+                opponent: 'Duplicate Hawks',
+                location: 'Field 2',
+                calendarUidHash: 'SENTINEL_PRIVATE_CORRELATION_HASH'
+            }] }
+        );
+
+        expect(result.events.filter((event) => event.gameId === 'game-1')).toHaveLength(1);
+        expect(result.events.some((event) => event.gameId === 'opaque-safe-projection-id')).toBe(false);
+        expect(JSON.stringify(result)).not.toContain(trackedUid);
+        expect(JSON.stringify(result)).not.toContain('SENTINEL_PRIVATE_CORRELATION_HASH');
+        expect(JSON.stringify(result)).not.toContain('calendarUidHash');
+        expect(JSON.stringify(result)).not.toContain('calendarEventUid');
+    });
+
+    it('uses the embedded original occurrence time when a materialized event moves', async () => {
+        const trackedUid = 'legacy-moved-uid__2026-07-25T17:00:00.000Z';
+        const db = scheduleDb(trackedUid, { date: new Date('2026-07-26T20:00:00.000Z') });
+        const context = await resolveUserContext(db, parentIdentity);
+        const result = await getFamilySchedule(
+            db,
+            context,
+            { startDate: '2026-07-24', endDate: '2026-07-31' },
+            new Date('2026-07-24T00:00:00.000Z'),
+            { loadCalendarProjection: async () => [{
+                id: 'opaque-safe-projection-id',
+                type: 'game',
+                startsAt: '2026-07-25T17:00:00.000Z',
+                opponent: 'Original Hawks'
+            }] }
+        );
+
+        expect(result.events.filter((event) => event.gameId === 'game-1')).toHaveLength(1);
+        expect(result.events.some((event) => event.gameId === 'opaque-safe-projection-id')).toBe(false);
+        expect(JSON.stringify(result)).not.toContain(trackedUid);
+    });
+
+    it('keeps a projected event at a different occurrence time', async () => {
+        const trackedUid = 'legacy-moved-uid__2026-07-25T17:00:00.000Z';
+        const db = scheduleDb(trackedUid, { date: new Date('2026-07-26T20:00:00.000Z') });
+        const context = await resolveUserContext(db, parentIdentity);
+        const result = await getFamilySchedule(
+            db,
+            context,
+            { startDate: '2026-07-24', endDate: '2026-07-31' },
+            new Date('2026-07-24T00:00:00.000Z'),
+            { loadCalendarProjection: async () => [{
+                id: 'opaque-safe-projection-id',
+                type: 'game',
+                startsAt: '2026-07-25T18:00:00.000Z',
+                opponent: 'Different Hawks'
+            }] }
+        );
+
+        expect(result.events.some((event) => event.gameId === 'game-1')).toBe(true);
+        expect(result.events.some((event) => event.gameId === 'opaque-safe-projection-id')).toBe(true);
+        expect(JSON.stringify(result)).not.toContain(trackedUid);
     });
 
     it('fails explicitly when imported calendar projection is unavailable', async () => {

--- a/tests/unit/chatgpt-mcp-core.test.js
+++ b/tests/unit/chatgpt-mcp-core.test.js
@@ -480,6 +480,7 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
             status: 'scheduled',
             calendarUrl: 'https://calendar.example.test/private-token',
             calendarUidHash: 'SENTINEL_CALENDAR_UID_HASH',
+            eventKey: 'SENTINEL_INTERNAL_EVENT_KEY',
             legacyOpaqueId: 'SENTINEL_LEGACY_OPAQUE_ID',
             privateNotes: 'do not expose'
         }]);
@@ -511,6 +512,8 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
         expect(JSON.stringify(result)).not.toContain('private-token');
         expect(JSON.stringify(result)).not.toContain('SENTINEL_CALENDAR_UID_HASH');
         expect(JSON.stringify(result)).not.toContain('calendarUidHash');
+        expect(JSON.stringify(result)).not.toContain('SENTINEL_INTERNAL_EVENT_KEY');
+        expect(JSON.stringify(result)).not.toContain('eventKey');
         expect(JSON.stringify(result)).not.toContain('SENTINEL_LEGACY_OPAQUE_ID');
         expect(JSON.stringify(result)).not.toContain('legacyOpaqueId');
         expect(JSON.stringify(result)).not.toContain('do not expose');

--- a/tests/unit/chatgpt-mcp-core.test.js
+++ b/tests/unit/chatgpt-mcp-core.test.js
@@ -1,7 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import {
     DomainError,
+    loadManagedTeamsFromCallable,
+    loadPublicTeamCalendarProjection,
     resolveUserContext,
     listMyTeams,
     getFamilySchedule,
@@ -87,6 +89,62 @@ function parentDb(extra = {}) {
 }
 
 describe('chatgpt-mcp core: resolveUserContext', () => {
+    it('loads legacy managed teams through the authenticated server-filtered callable', async () => {
+        const fetchImpl = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                result: {
+                    items: [{
+                        id: 'legacy-team',
+                        name: 'Legacy',
+                        ownerEmail: 'Coach@Example.com',
+                        ownerEmailLower: 'coach@example.com'
+                    }],
+                    isPartial: false
+                }
+            })
+        });
+        const managedTeamResult = await loadManagedTeamsFromCallable({
+            projectId: 'all-plays-prod',
+            idToken: 'user-id-token',
+            fetchImpl
+        });
+        const db = fakeDb({
+            docs: { 'users/coach-1': { email: 'coach@example.com' } },
+            queries: { teams: () => { throw new Error('Client team discovery must not run.'); } }
+        });
+
+        const context = await resolveUserContext(
+            db,
+            { uid: 'coach-1', email: 'coach@example.com' },
+            { managedTeams: managedTeamResult.teams }
+        );
+
+        expect(fetchImpl).toHaveBeenCalledWith(
+            'https://us-central1-all-plays-prod.cloudfunctions.net/listManagedTeams',
+            expect.objectContaining({
+                method: 'POST',
+                headers: expect.objectContaining({ Authorization: 'Bearer user-id-token' }),
+                body: JSON.stringify({ data: {} })
+            })
+        );
+        expect(managedTeamResult.isPartial).toBe(false);
+        expect([...context.teams.get('legacy-team').roles]).toEqual(['owner']);
+    });
+
+    it('preserves the callable partial marker so MCP tools can fail closed', async () => {
+        const result = await loadManagedTeamsFromCallable({
+            projectId: 'all-plays-prod',
+            idToken: 'user-id-token',
+            fetchImpl: vi.fn().mockResolvedValue({
+                ok: true,
+                json: async () => ({ result: { items: [{ id: 'team-1' }], isPartial: true } })
+            })
+        });
+
+        expect(result).toEqual({ teams: [{ id: 'team-1' }], isPartial: true });
+    });
+
     it('derives parent role and linked players from users/{uid}.parentOf', async () => {
         const context = await resolveUserContext(parentDb(), parentIdentity);
         expect(context.uid).toBe('parent-1');
@@ -128,10 +186,10 @@ describe('chatgpt-mcp core: resolveUserContext', () => {
                     const filter = filters[0];
                     queried.push([filter.field, filter.value]);
                     if (filter.field === 'ownerEmail' && filter.value === 'Coach@Example.com') {
-                        return [{ id: 'team-legacy-case', data: { name: 'Legacy case' } }];
+                        return [{ id: 'team-legacy-case', data: { name: 'Legacy case', ownerEmail: 'Coach@Example.com' } }];
                     }
                     if (filter.field === 'ownerEmailLower') {
-                        return [{ id: 'team-legacy-lower', data: { name: 'Legacy lower' } }];
+                        return [{ id: 'team-legacy-lower', data: { name: 'Legacy lower', ownerEmailLower: 'coach@example.com' } }];
                     }
                     return [];
                 }
@@ -145,6 +203,95 @@ describe('chatgpt-mcp core: resolveUserContext', () => {
         expect(queried).toContainEqual(['ownerEmailLower', 'coach@example.com']);
         expect([...context.teams.get('team-legacy-case').roles]).toEqual(['owner']);
         expect([...context.teams.get('team-legacy-lower').roles]).toEqual(['owner']);
+    });
+
+    it('rejects conflicting legacy owner aliases for an explicit authenticated email', async () => {
+        const db = fakeDb({
+            docs: { 'users/former-owner': { email: 'former@example.com' } },
+            queries: {
+                teams: (filters) => {
+                    const filter = filters[0];
+                    if (filter.field === 'ownerEmail' || filter.field === 'ownerEmailLower') {
+                        return [{
+                            id: 'conflicting-team',
+                            data: {
+                                ownerEmail: 'current@example.com',
+                                ownerEmailLower: 'former@example.com'
+                            }
+                        }];
+                    }
+                    return [];
+                }
+            }
+        });
+
+        const context = await resolveUserContext(db, { uid: 'former-owner', email: 'former@example.com' });
+        expect(context.teams.has('conflicting-team')).toBe(false);
+    });
+
+    it('does not use a stale profile email when the authenticated email is absent', async () => {
+        const teamQuery = vi.fn(() => []);
+        const db = fakeDb({
+            docs: { 'users/former-owner': { email: 'former@example.com', profileEmail: 'former@example.com' } },
+            queries: { teams: teamQuery }
+        });
+
+        const context = await resolveUserContext(db, { uid: 'former-owner', email: '' });
+
+        expect(context.teams.size).toBe(0);
+        expect(teamQuery).not.toHaveBeenCalledWith(expect.arrayContaining([
+            expect.objectContaining({ field: 'ownerEmail' })
+        ]));
+    });
+
+    it('does not derive ownership from stale owner email aliases when a canonical owner exists', async () => {
+        const db = fakeDb({
+            docs: { 'users/former-owner': { email: 'Former@Example.com' } },
+            queries: {
+                teams: (filters) => {
+                    const filter = filters[0];
+                    if (filter.field === 'ownerEmail' || filter.field === 'ownerEmailLower') {
+                        return [{
+                            id: 'reassigned-team',
+                            data: {
+                                name: 'Reassigned',
+                                ownerId: 'current-owner',
+                                ownerEmail: 'Former@Example.com',
+                                ownerEmailLower: 'former@example.com'
+                            }
+                        }];
+                    }
+                    return [];
+                }
+            }
+        });
+
+        const context = await resolveUserContext(db, { uid: 'former-owner', email: 'Former@Example.com' });
+
+        expect(context.teams.has('reassigned-team')).toBe(false);
+    });
+
+    it('keeps canonical and admin teams when legacy owner-email queries are denied by rules', async () => {
+        const db = fakeDb({
+            docs: { 'users/coach-1': { email: 'coach@example.com' } },
+            queries: {
+                teams: (filters) => {
+                    const filter = filters[0];
+                    if (filter.field === 'ownerId') {
+                        return [{ id: 'owned-team', data: { ownerId: 'coach-1' } }];
+                    }
+                    if (filter.field === 'adminEmails') {
+                        return [{ id: 'admin-team', data: { ownerId: 'other-owner', adminEmails: ['coach@example.com'] } }];
+                    }
+                    throw new DomainError('permission_denied', 'Legacy owner lookup denied.');
+                }
+            }
+        });
+
+        const context = await resolveUserContext(db, { uid: 'coach-1', email: 'coach@example.com' });
+
+        expect([...context.teams.get('owned-team').roles]).toEqual(['owner']);
+        expect([...context.teams.get('admin-team').roles]).toEqual(['admin']);
     });
 
     it('keeps private parent teams when direct team reads are denied by rules', async () => {
@@ -216,7 +363,7 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
                     const start = filters.find((f) => f.op === '>=').value;
                     const end = filters.find((f) => f.op === '<=').value;
                     const all = [
-                        { id: 'game-1', data: { type: 'game', date: new Date('2026-07-25T17:00:00Z'), opponent: 'Hawks', location: 'Field 2', privateNotes: 'secret', rsvpSummary: { going: 5, notResponded: 3, coachOnly: 'x' } } },
+                        { id: 'game-1', data: { type: 'game', date: new Date('2026-07-25T17:00:00Z'), opponent: 'Hawks', location: 'Field 2', calendarEventUid: 'teamsnap-tracked-game', privateNotes: 'secret', rsvpSummary: { going: 5, notResponded: 3, coachOnly: 'x' } } },
                         { id: 'practice-1', data: { type: 'practice', date: new Date('2026-07-27T22:30:00Z') } },
                         { id: 'game-end-date', data: { type: 'game', date: new Date('2026-07-31T17:00:00Z') } },
                         { id: 'game-out-of-range', data: { type: 'game', date: new Date('2026-09-01T17:00:00Z') } }
@@ -252,11 +399,188 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
         expect(result.events[1].myRsvp).toEqual({ response: 'not_responded', playerIds: [] });
     });
 
+    it('includes a TeamSnap-only next game without leaking the calendar source URL', async () => {
+        const db = scheduleDb();
+        const context = await resolveUserContext(db, parentIdentity);
+        const loadCalendarProjection = vi.fn(async () => [{
+            id: 'teamsnap-next-game',
+            type: 'game',
+            startsAt: '2026-07-26T19:00:00.000Z',
+            endsAt: '2026-07-26T21:00:00.000Z',
+            opponent: 'Jr. Tigers',
+            location: 'Field 7',
+            status: 'scheduled',
+            calendarUrl: 'https://calendar.example.test/private-token',
+            privateNotes: 'do not expose'
+        }]);
+
+        const result = await getFamilySchedule(
+            db,
+            context,
+            { startDate: '2026-07-24', endDate: '2026-07-31' },
+            new Date('2026-07-24T00:00:00.000Z'),
+            { loadCalendarProjection }
+        );
+
+        expect(loadCalendarProjection).toHaveBeenCalledWith({
+            teamId: 'team-a',
+            startDate: expect.any(Date),
+            endDate: expect.any(Date)
+        });
+        expect(result.events).toContainEqual(expect.objectContaining({
+            gameId: 'teamsnap-next-game',
+            type: 'game',
+            opponent: 'Jr. Tigers',
+            location: 'Field 7',
+            sourceType: 'calendar',
+            sourceLabel: 'Imported calendar',
+            isImported: true
+        }));
+        expect(result.events.find((event) => event.gameId === 'teamsnap-next-game')?.deepLink)
+            .toContain('/app/schedule/team-a/teamsnap-next-game');
+        expect(JSON.stringify(result)).not.toContain('private-token');
+        expect(JSON.stringify(result)).not.toContain('do not expose');
+    });
+
+    it('deduplicates a projected TeamSnap event tracked by an ALL PLAYS game', async () => {
+        const db = scheduleDb();
+        const context = await resolveUserContext(db, parentIdentity);
+        const result = await getFamilySchedule(
+            db,
+            context,
+            { startDate: '2026-07-24', endDate: '2026-07-31' },
+            new Date('2026-07-24T00:00:00.000Z'),
+            {
+                loadCalendarProjection: async () => [{
+                    id: 'teamsnap-tracked-game',
+                    type: 'game',
+                    startsAt: '2026-07-25T17:00:00.000Z',
+                    opponent: 'Duplicate Hawks'
+                }]
+            }
+        );
+
+        expect(result.events.filter((event) => event.gameId === 'game-1')).toHaveLength(1);
+        expect(result.events.some((event) => event.gameId === 'teamsnap-tracked-game')).toBe(false);
+    });
+
+    it('fails explicitly when imported calendar projection is unavailable', async () => {
+        const db = scheduleDb();
+        const context = await resolveUserContext(db, parentIdentity);
+
+        await expect(getFamilySchedule(
+            db,
+            context,
+            { startDate: '2026-07-24', endDate: '2026-07-31' },
+            new Date('2026-07-24T00:00:00.000Z'),
+            {
+                loadCalendarProjection: async () => {
+                    throw new DomainError('unavailable', 'Imported calendar events are temporarily unavailable.');
+                }
+            }
+        )).rejects.toMatchObject({ code: 'unavailable' });
+    });
+
+    it('keeps Firestore games when a private team has no public calendar projection', async () => {
+        const db = scheduleDb();
+        const context = await resolveUserContext(db, parentIdentity);
+        const result = await getFamilySchedule(
+            db,
+            context,
+            { startDate: '2026-07-24', endDate: '2026-07-31' },
+            new Date('2026-07-24T00:00:00.000Z'),
+            {
+                loadCalendarProjection: async () => {
+                    throw new DomainError('not_found', 'Public team not found.');
+                }
+            }
+        );
+
+        expect(result.events.map((event) => event.gameId)).toEqual(['game-1', 'practice-1', 'game-end-date']);
+    });
+
     it('rejects an invalid date range', async () => {
         const db = scheduleDb();
         const context = await resolveUserContext(db, parentIdentity);
         await expect(getFamilySchedule(db, context, { startDate: '2026-07-31', endDate: '2026-07-01' }))
             .rejects.toMatchObject({ code: 'invalid_argument' });
+    });
+});
+
+describe('chatgpt-mcp public calendar projection transport', () => {
+    it('forwards the caller token and follows bounded callable pagination', async () => {
+        const fetchImpl = vi.fn()
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    result: {
+                        events: [{ id: 'teamsnap-1' }],
+                        range: { truncated: true },
+                        nextCursor: 'calendar-page-2'
+                    }
+                })
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    result: {
+                        events: [{ id: 'teamsnap-2' }],
+                        range: { truncated: false },
+                        nextCursor: null
+                    }
+                })
+            });
+
+        const events = await loadPublicTeamCalendarProjection({
+            projectId: 'all-plays-prod',
+            idToken: 'caller-id-token',
+            teamId: 'team-a',
+            startDate: new Date('2026-07-24T00:00:00.000Z'),
+            endDate: new Date('2026-07-31T23:59:59.999Z'),
+            fetchImpl
+        });
+
+        expect(events).toEqual([{ id: 'teamsnap-1' }, { id: 'teamsnap-2' }]);
+        expect(fetchImpl).toHaveBeenCalledTimes(2);
+        expect(fetchImpl.mock.calls[0][0]).toBe(
+            'https://us-central1-all-plays-prod.cloudfunctions.net/getPublicTeamCalendarProjection'
+        );
+        expect(fetchImpl.mock.calls[0][1]).toEqual(expect.objectContaining({
+            method: 'POST',
+            headers: expect.objectContaining({ Authorization: 'Bearer caller-id-token' })
+        }));
+        expect(JSON.parse(fetchImpl.mock.calls[0][1].body)).toEqual({
+            data: {
+                teamId: 'team-a',
+                from: '2026-07-24T00:00:00.000Z',
+                to: '2026-07-31T23:59:59.999Z',
+                limit: 50
+            }
+        });
+        expect(JSON.parse(fetchImpl.mock.calls[1][1].body).data.cursor).toBe('calendar-page-2');
+    });
+
+    it('fails closed when any calendar source warning makes the projection partial', async () => {
+        await expect(loadPublicTeamCalendarProjection({
+            projectId: 'all-plays-prod',
+            idToken: 'caller-id-token',
+            teamId: 'team-a',
+            startDate: new Date('2026-07-24T00:00:00.000Z'),
+            endDate: new Date('2026-07-31T23:59:59.999Z'),
+            fetchImpl: vi.fn(async () => ({
+                ok: true,
+                json: async () => ({
+                    result: {
+                        events: [],
+                        warnings: ['Calendar source 1 could not be loaded.'],
+                        range: { truncated: false }
+                    }
+                })
+            }))
+        })).rejects.toMatchObject({
+            code: 'unavailable',
+            message: 'Imported calendar events could not be loaded completely.'
+        });
     });
 });
 
@@ -423,6 +747,10 @@ describe('chatgpt-mcp server configuration', () => {
         expect(source).toContain('const PROJECT_ID = process.env.FIREBASE_PROJECT_ID;');
         expect(source).toContain('const WEB_API_KEY = process.env.FIREBASE_WEB_API_KEY;');
         expect(source).toContain('if (!PROJECT_ID || !WEB_API_KEY)');
+        expect(source).toContain('if (managedTeamResult.isPartial)');
+        expect(source).toContain("throw new DomainError('unavailable', 'Managed team discovery returned incomplete results.')");
+        expect(source).toContain('loadPublicTeamCalendarProjection');
+        expect(source).toContain('idToken: identity.idToken');
         expect(source).not.toMatch(/AIza[0-9A-Za-z_-]+/);
     });
 });

--- a/tests/unit/chatgpt-mcp-core.test.js
+++ b/tests/unit/chatgpt-mcp-core.test.js
@@ -145,6 +145,14 @@ describe('chatgpt-mcp core: resolveUserContext', () => {
         expect(result).toEqual({ teams: [{ id: 'team-1' }], isPartial: true });
     });
 
+    it('identifies a missing callable so a pre-rollout server can use rules-scoped discovery', async () => {
+        await expect(loadManagedTeamsFromCallable({
+            projectId: 'all-plays-prod',
+            idToken: 'user-id-token',
+            fetchImpl: vi.fn().mockResolvedValue({ status: 404, ok: false, json: async () => ({}) })
+        })).rejects.toMatchObject({ code: 'not_found' });
+    });
+
     it('derives parent role and linked players from users/{uid}.parentOf', async () => {
         const context = await resolveUserContext(parentDb(), parentIdentity);
         expect(context.uid).toBe('parent-1');
@@ -363,7 +371,7 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
                     const start = filters.find((f) => f.op === '>=').value;
                     const end = filters.find((f) => f.op === '<=').value;
                     const all = [
-                        { id: 'game-1', data: { type: 'game', date: new Date('2026-07-25T17:00:00Z'), opponent: 'Hawks', location: 'Field 2', calendarEventUid: 'teamsnap-tracked-game', privateNotes: 'secret', rsvpSummary: { going: 5, notResponded: 3, coachOnly: 'x' } } },
+                        { id: 'game-1', data: { type: 'game', date: new Date('2026-07-25T17:00:00Z'), opponent: 'Hawks', location: 'Field 2', calendarEventUid: 'teamsnap-tracked-game__2026-07-25T17:00:00.000Z', privateNotes: 'secret', rsvpSummary: { going: 5, notResponded: 3, coachOnly: 'x' } } },
                         { id: 'practice-1', data: { type: 'practice', date: new Date('2026-07-27T22:30:00Z') } },
                         { id: 'game-end-date', data: { type: 'game', date: new Date('2026-07-31T17:00:00Z') } },
                         { id: 'game-out-of-range', data: { type: 'game', date: new Date('2026-09-01T17:00:00Z') } }
@@ -437,7 +445,7 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
             isImported: true
         }));
         expect(result.events.find((event) => event.gameId === 'teamsnap-next-game')?.deepLink)
-            .toContain('/app/schedule/team-a/teamsnap-next-game');
+            .toContain('/app/#/schedule/team-a/teamsnap-next-game');
         expect(JSON.stringify(result)).not.toContain('private-token');
         expect(JSON.stringify(result)).not.toContain('do not expose');
     });
@@ -751,6 +759,8 @@ describe('chatgpt-mcp server configuration', () => {
         expect(source).toContain("throw new DomainError('unavailable', 'Managed team discovery returned incomplete results.')");
         expect(source).toContain('loadPublicTeamCalendarProjection');
         expect(source).toContain('idToken: identity.idToken');
+        expect(source).toContain("error.code !== 'not_found'");
+        expect(source).toContain('managedTeamResult = { teams: null, isPartial: false }');
         expect(source).not.toMatch(/AIza[0-9A-Za-z_-]+/);
     });
 });

--- a/tests/unit/chatgpt-mcp-core.test.js
+++ b/tests/unit/chatgpt-mcp-core.test.js
@@ -689,6 +689,31 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
         expect(result.events.some((event) => event.gameId === 'placeholder-opaque-projection-id')).toBe(true);
     });
 
+    it('does not treat a generic practice title as a same-time discriminator', async () => {
+        const db = scheduleDb('different-legacy-source-id', {
+            type: 'practice',
+            title: 'Practice',
+            location: 'Field 2'
+        });
+        const context = await resolveUserContext(db, parentIdentity);
+        const result = await getFamilySchedule(
+            db,
+            context,
+            { startDate: '2026-07-24', endDate: '2026-07-31' },
+            new Date('2026-07-24T00:00:00.000Z'),
+            { loadCalendarProjection: async () => [{
+                id: 'distinct-practice-projection-id',
+                type: 'practice',
+                startsAt: '2026-07-25T17:00:00.000Z',
+                title: 'Practice',
+                location: 'Field 3'
+            }] }
+        );
+
+        expect(result.events.some((event) => event.gameId === 'game-1')).toBe(true);
+        expect(result.events.some((event) => event.gameId === 'distinct-practice-projection-id')).toBe(true);
+    });
+
     it('keeps a projected event at a different occurrence time', async () => {
         const trackedUid = 'legacy-moved-uid__2026-07-25T17:00:00.000Z';
         const db = scheduleDb(trackedUid, { date: new Date('2026-07-26T20:00:00.000Z') });

--- a/tests/unit/chatgpt-mcp-core.test.js
+++ b/tests/unit/chatgpt-mcp-core.test.js
@@ -23,7 +23,7 @@ import {
 } from '../../services/chatgpt-mcp/src/firestoreRest.js';
 
 // Minimal fake of the db interface core.js uses (same surface as the
-// firestoreRest adapter): doc(path).get(), collection(path).where()...get().
+// firestoreRest adapter): doc(path).get(), collection(path).where().select()...get().
 // Set docs[path] = DENIED to simulate a Firestore-rules denial.
 const DENIED = Symbol('permission-denied');
 
@@ -43,22 +43,37 @@ function fakeDb({ docs = {}, queries = {} } = {}) {
             };
         },
         collection(path) {
-            const makeQuery = (filters) => ({
+            const makeQuery = (options) => ({
                 where(field, op, value) {
-                    return makeQuery([...filters, { field, op, value }]);
+                    return makeQuery({ ...options, filters: [...options.filters, { field, op, value }] });
                 },
-                orderBy() { return makeQuery(filters); },
-                limit() { return makeQuery(filters); },
+                orderBy(field, direction = 'asc') {
+                    return makeQuery({ ...options, orderBy: { field, direction } });
+                },
+                select(...fields) {
+                    return makeQuery({ ...options, select: fields.flat() });
+                },
+                limit(count) {
+                    return makeQuery({ ...options, limit: count });
+                },
                 async get() {
                     const resolver = queries[path];
                     if (resolver === DENIED) throw new DomainError('permission_denied', 'You do not have access to this data.');
-                    const rows = resolver ? resolver(filters) : [];
+                    const rows = resolver ? resolver(options.filters, options) : [];
+                    const limitedRows = Number.isInteger(options.limit) ? rows.slice(0, options.limit) : rows;
                     return {
-                        docs: rows.map(({ id, data }) => ({ id, data: () => data }))
+                        docs: limitedRows.map(({ id, data }) => ({
+                            id,
+                            data: () => options.select.length
+                                ? Object.fromEntries(options.select
+                                    .filter((field) => Object.hasOwn(data, field))
+                                    .map((field) => [field, data[field]]))
+                                : data
+                        }))
                     };
                 }
             });
-            return makeQuery([]);
+            return makeQuery({ filters: [], orderBy: null, select: [], limit: null });
         }
     };
 }
@@ -418,7 +433,8 @@ describe('chatgpt-mcp core: listMyTeams', () => {
 describe('chatgpt-mcp core: getFamilySchedule', () => {
     function scheduleDb(
         calendarEventUid = 'teamsnap-tracked-game__2026-07-25T17:00:00.000Z',
-        trackedGameOverrides = {}
+        trackedGameOverrides = {},
+        queryLog = []
     ) {
         return parentDb({
             docs: {
@@ -430,15 +446,17 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
             },
             queries: {
                 teams: () => [],
-                'teams/team-a/games': (filters) => {
-                    const start = filters.find((f) => f.op === '>=').value;
-                    const end = filters.find((f) => f.op === '<=').value;
+                'teams/team-a/games': (filters, options) => {
+                    queryLog.push(options);
                     const all = [
                         { id: 'game-1', data: { type: 'game', date: new Date('2026-07-25T17:00:00Z'), opponent: 'Hawks', location: 'Field 2', calendarEventUid, privateNotes: 'secret', rsvpSummary: { going: 5, notResponded: 3, coachOnly: 'x' }, ...trackedGameOverrides } },
                         { id: 'practice-1', data: { type: 'practice', date: new Date('2026-07-27T22:30:00Z') } },
                         { id: 'game-end-date', data: { type: 'game', date: new Date('2026-07-31T17:00:00Z') } },
                         { id: 'game-out-of-range', data: { type: 'game', date: new Date('2026-09-01T17:00:00Z') } }
                     ];
+                    if (!filters.length) return all;
+                    const start = filters.find((f) => f.op === '>=').value;
+                    const end = filters.find((f) => f.op === '<=').value;
                     return all.filter(({ data }) => data.date >= start && data.date <= end);
                 }
             }
@@ -470,7 +488,7 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
         expect(result.events[1].myRsvp).toEqual({ response: 'not_responded', playerIds: [] });
     });
 
-    it('includes a TeamSnap-only next game without leaking the calendar source URL', async () => {
+    it('includes a TeamSnap-only next game without leaking its source or advertising a game-summary id', async () => {
         const db = scheduleDb();
         const context = await resolveUserContext(db, parentIdentity);
         const loadCalendarProjection = vi.fn(async () => [{
@@ -502,7 +520,9 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
             endDate: expect.any(Date)
         });
         expect(result.events).toContainEqual(expect.objectContaining({
-            gameId: 'teamsnap-next-game',
+            gameId: null,
+            calendarEventId: 'teamsnap-next-game',
+            gameSummaryAvailable: false,
             type: 'game',
             opponent: 'Jr. Tigers',
             location: 'Field 7',
@@ -510,8 +530,12 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
             sourceLabel: 'Imported calendar',
             isImported: true
         }));
-        expect(result.events.find((event) => event.gameId === 'teamsnap-next-game')?.deepLink)
+        const importedEvent = result.events.find((event) => event.calendarEventId === 'teamsnap-next-game');
+        expect(importedEvent?.deepLink)
             .toContain('/app/#/schedule/team-a/teamsnap-next-game');
+        expect(result.events.find((event) => event.gameId === 'game-1')).toMatchObject({
+            gameSummaryAvailable: true
+        });
         expect(JSON.stringify(result)).not.toContain('private-token');
         expect(JSON.stringify(result)).not.toContain('SENTINEL_CALENDAR_UID_HASH');
         expect(JSON.stringify(result)).not.toContain('calendarUidHash');
@@ -543,7 +567,7 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
             );
 
             expect(result.events.filter((event) => event.gameId === 'game-1')).toHaveLength(1);
-            expect(result.events.some((event) => event.gameId === 'opaque-projected-id')).toBe(false);
+            expect(result.events.some((event) => event.calendarEventId === 'opaque-projected-id')).toBe(false);
         }
     });
 
@@ -570,7 +594,7 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
         );
 
         expect(result.events.filter((event) => event.gameId === 'game-1')).toHaveLength(1);
-        expect(result.events.some((event) => event.gameId === 'opaque-safe-projection-id')).toBe(false);
+        expect(result.events.some((event) => event.calendarEventId === 'opaque-safe-projection-id')).toBe(false);
         expect(JSON.stringify(result)).not.toContain(trackedUid);
         expect(JSON.stringify(result)).not.toContain('SENTINEL_PRIVATE_CORRELATION_HASH');
         expect(JSON.stringify(result)).not.toContain('calendarUidHash');
@@ -596,8 +620,81 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
         );
 
         expect(result.events.filter((event) => event.gameId === 'game-1')).toHaveLength(1);
-        expect(result.events.some((event) => event.gameId === 'opaque-safe-projection-id')).toBe(false);
+        expect(result.events.some((event) => event.calendarEventId === 'opaque-safe-projection-id')).toBe(false);
         expect(JSON.stringify(result)).not.toContain(trackedUid);
+    });
+
+    it.each([
+        ['practice', { type: 'practice' }],
+        ['private game', { visibility: 'private' }]
+    ])('uses an independent tracking scan when a materialized %s moves outside the requested window', async (_label, overrides) => {
+        const originalStartsAt = '2026-07-25T17:00:00.000Z';
+        const trackedUid = `legacy-moved-uid__${originalStartsAt}`;
+        const queryLog = [];
+        const db = scheduleDb(trackedUid, {
+            date: new Date('2026-08-05T20:00:00.000Z'),
+            ...overrides
+        }, queryLog);
+        const context = await resolveUserContext(db, parentIdentity);
+        const result = await getFamilySchedule(
+            db,
+            context,
+            { startDate: '2026-07-24', endDate: '2026-07-31' },
+            new Date('2026-07-24T00:00:00.000Z'),
+            { loadCalendarProjection: async () => [{
+                id: 'opaque-safe-projection-id',
+                type: overrides.type === 'practice' ? 'practice' : 'game',
+                startsAt: originalStartsAt,
+                title: overrides.type === 'practice' ? 'Practice' : null,
+                opponent: overrides.type === 'practice' ? null : 'Hawks',
+                location: 'Field 2'
+            }] }
+        );
+
+        expect(result.events.some((event) => event.gameId === 'game-1')).toBe(false);
+        expect(result.events.some((event) => event.calendarEventId === 'opaque-safe-projection-id')).toBe(false);
+        const trackingQuery = queryLog.find((options) => options.filters.length === 0);
+        expect(trackingQuery).toMatchObject({
+            orderBy: { field: '__name__', direction: 'asc' },
+            select: ['calendarEventUid', 'date', 'type', 'location', 'opponent', 'title'],
+            limit: 5001
+        });
+    });
+
+    it('fails closed when the independent tracking scan exceeds its cap', async () => {
+        const trackingRows = Array.from({ length: 5001 }, (_, index) => ({
+            id: `tracked-${index}`,
+            data: {
+                calendarEventUid: `legacy-uid-${index}`,
+                date: new Date('2026-08-05T20:00:00.000Z'),
+                type: 'game',
+                location: 'Field 2',
+                opponent: 'Hawks'
+            }
+        }));
+        const db = parentDb({
+            queries: {
+                'teams/team-a/games': (filters) => filters.length ? [] : trackingRows
+            }
+        });
+        const context = await resolveUserContext(db, parentIdentity);
+
+        await expect(getFamilySchedule(
+            db,
+            context,
+            { startDate: '2026-07-24', endDate: '2026-07-31' },
+            new Date('2026-07-24T00:00:00.000Z'),
+            { loadCalendarProjection: async () => [{
+                id: 'opaque-safe-projection-id',
+                type: 'game',
+                startsAt: '2026-07-25T17:00:00.000Z',
+                opponent: 'Hawks',
+                location: 'Field 2'
+            }] }
+        )).rejects.toMatchObject({
+            code: 'unavailable',
+            message: 'Calendar tracking scan exceeded its safe limit.'
+        });
     });
 
     it.each([
@@ -620,7 +717,7 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
         );
 
         expect(result.events.some((event) => event.gameId === 'game-1')).toBe(true);
-        expect(result.events.some((event) => event.gameId === 'distinct-opaque-projection-id')).toBe(true);
+        expect(result.events.some((event) => event.calendarEventId === 'distinct-opaque-projection-id')).toBe(true);
     });
 
     it('deduplicates a same-time event with a meaningful case-insensitive location match', async () => {
@@ -641,7 +738,7 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
         );
 
         expect(result.events.some((event) => event.gameId === 'game-1')).toBe(true);
-        expect(result.events.some((event) => event.gameId === 'opaque-safe-projection-id')).toBe(false);
+        expect(result.events.some((event) => event.calendarEventId === 'opaque-safe-projection-id')).toBe(false);
     });
 
     it('keeps exact ID deduplication unconditional when event shape differs', async () => {
@@ -662,7 +759,7 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
         );
 
         expect(result.events.some((event) => event.gameId === 'game-1')).toBe(true);
-        expect(result.events.some((event) => event.gameId === 'exact-projected-id')).toBe(false);
+        expect(result.events.some((event) => event.calendarEventId === 'exact-projected-id')).toBe(false);
     });
 
     it('does not collapse placeholder-only events that share a start time', async () => {
@@ -686,7 +783,7 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
         );
 
         expect(result.events.some((event) => event.gameId === 'game-1')).toBe(true);
-        expect(result.events.some((event) => event.gameId === 'placeholder-opaque-projection-id')).toBe(true);
+        expect(result.events.some((event) => event.calendarEventId === 'placeholder-opaque-projection-id')).toBe(true);
     });
 
     it('does not treat a generic practice title as a same-time discriminator', async () => {
@@ -711,7 +808,7 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
         );
 
         expect(result.events.some((event) => event.gameId === 'game-1')).toBe(true);
-        expect(result.events.some((event) => event.gameId === 'distinct-practice-projection-id')).toBe(true);
+        expect(result.events.some((event) => event.calendarEventId === 'distinct-practice-projection-id')).toBe(true);
     });
 
     it('keeps a projected event at a different occurrence time', async () => {
@@ -732,7 +829,7 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
         );
 
         expect(result.events.some((event) => event.gameId === 'game-1')).toBe(true);
-        expect(result.events.some((event) => event.gameId === 'opaque-safe-projection-id')).toBe(true);
+        expect(result.events.some((event) => event.calendarEventId === 'opaque-safe-projection-id')).toBe(true);
         expect(JSON.stringify(result)).not.toContain(trackedUid);
     });
 
@@ -1025,6 +1122,7 @@ describe('chatgpt-mcp server configuration', () => {
         expect(source).toContain('idToken: identity.idToken');
         expect(source).toContain("error.code !== 'not_found'");
         expect(source).toContain('managedTeamResult = { teams: null, isPartial: false }');
+        expect(source).toContain('Non-imported gameId from list_schedule. Imported calendar events have no gameId');
         expect(source).not.toMatch(/AIza[0-9A-Za-z_-]+/);
     });
 });
@@ -1041,8 +1139,9 @@ describe('chatgpt-mcp firestore REST adapter', () => {
         expect(decodeValue(encodeValue({ a: [1, 'b'] }))).toEqual({ a: [1, 'b'] });
     });
 
-    it('builds structured queries with filters, order, and limit', () => {
+    it('builds structured queries with selected fields, filters, order, and limit', () => {
         const query = buildStructuredQuery('games', {
+            select: ['calendarEventUid', 'date', 'type'],
             filters: [
                 { field: 'date', op: '>=', value: new Date('2026-07-24T00:00:00Z') },
                 { field: 'date', op: '<=', value: new Date('2026-07-31T00:00:00Z') }
@@ -1051,6 +1150,13 @@ describe('chatgpt-mcp firestore REST adapter', () => {
             limit: 50
         });
         expect(query.from).toEqual([{ collectionId: 'games' }]);
+        expect(query.select).toEqual({
+            fields: [
+                { fieldPath: 'calendarEventUid' },
+                { fieldPath: 'date' },
+                { fieldPath: 'type' }
+            ]
+        });
         expect(query.where.compositeFilter.op).toBe('AND');
         expect(query.where.compositeFilter.filters[0].fieldFilter.op).toBe('GREATER_THAN_OR_EQUAL');
         expect(query.orderBy).toEqual([{ field: { fieldPath: 'date' }, direction: 'ASCENDING' }]);
@@ -1112,10 +1218,14 @@ describe('chatgpt-mcp firestore REST adapter', () => {
         const snap = await db.collection('teams/team-a/games')
             .where('date', '>=', new Date('2026-07-24T00:00:00Z'))
             .orderBy('date')
+            .select('opponent')
             .limit(10)
             .get();
         expect(captured.url).toContain('/documents/teams/team-a:runQuery');
         expect(captured.body.structuredQuery.from).toEqual([{ collectionId: 'games' }]);
+        expect(captured.body.structuredQuery.select).toEqual({
+            fields: [{ fieldPath: 'opponent' }]
+        });
         expect(snap.docs).toHaveLength(1);
         expect(snap.docs[0].id).toBe('game-1');
         expect(snap.docs[0].data()).toEqual({ opponent: 'Hawks' });

--- a/tests/unit/chatgpt-mcp-core.test.js
+++ b/tests/unit/chatgpt-mcp-core.test.js
@@ -151,6 +151,54 @@ describe('chatgpt-mcp core: resolveUserContext', () => {
             idToken: 'user-id-token',
             fetchImpl: vi.fn().mockResolvedValue({ status: 404, ok: false, json: async () => ({}) })
         })).rejects.toMatchObject({ code: 'not_found' });
+
+        await expect(loadManagedTeamsFromCallable({
+            projectId: 'all-plays-prod',
+            idToken: 'user-id-token',
+            fetchImpl: vi.fn().mockResolvedValue({
+                status: 404,
+                ok: false,
+                json: async () => { throw new SyntaxError('non-callable response'); }
+            })
+        })).rejects.toMatchObject({ code: 'not_found' });
+    });
+
+    it.each([
+        ['callable domain NOT_FOUND', 404, { error: { status: 'NOT_FOUND', message: 'Domain object missing.' } }],
+        ['404 with an error marker', 404, { error: 'upstream route rejected the request' }],
+        ['unauthorized', 401, { error: { status: 'UNAUTHENTICATED' } }],
+        ['forbidden', 403, { error: { status: 'PERMISSION_DENIED' } }],
+        ['rate limited', 429, { error: { status: 'RESOURCE_EXHAUSTED' } }],
+        ['server failure', 500, { error: { status: 'INTERNAL' } }],
+        ['non-404 domain NOT_FOUND', 400, { error: { status: 'NOT_FOUND' } }]
+    ])('fails closed for %s managed-team responses', async (_label, status, payload) => {
+        await expect(loadManagedTeamsFromCallable({
+            projectId: 'all-plays-prod',
+            idToken: 'user-id-token',
+            fetchImpl: vi.fn().mockResolvedValue({
+                status,
+                ok: false,
+                json: async () => payload
+            })
+        })).rejects.toMatchObject({ code: 'unavailable' });
+    });
+
+    it('fails closed for network failures and malformed successful responses', async () => {
+        await expect(loadManagedTeamsFromCallable({
+            projectId: 'all-plays-prod',
+            idToken: 'user-id-token',
+            fetchImpl: vi.fn().mockRejectedValue(new Error('network down'))
+        })).rejects.toMatchObject({ code: 'unavailable' });
+
+        await expect(loadManagedTeamsFromCallable({
+            projectId: 'all-plays-prod',
+            idToken: 'user-id-token',
+            fetchImpl: vi.fn().mockResolvedValue({
+                status: 200,
+                ok: true,
+                json: async () => { throw new SyntaxError('malformed success'); }
+            })
+        })).rejects.toMatchObject({ code: 'unavailable' });
     });
 
     it('derives parent role and linked players from users/{uid}.parentOf', async () => {
@@ -431,6 +479,7 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
             location: 'Field 7',
             status: 'scheduled',
             calendarUrl: 'https://calendar.example.test/private-token',
+            calendarUidHash: 'SENTINEL_CALENDAR_UID_HASH',
             privateNotes: 'do not expose'
         }]);
 
@@ -459,6 +508,8 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
         expect(result.events.find((event) => event.gameId === 'teamsnap-next-game')?.deepLink)
             .toContain('/app/#/schedule/team-a/teamsnap-next-game');
         expect(JSON.stringify(result)).not.toContain('private-token');
+        expect(JSON.stringify(result)).not.toContain('SENTINEL_CALENDAR_UID_HASH');
+        expect(JSON.stringify(result)).not.toContain('calendarUidHash');
         expect(JSON.stringify(result)).not.toContain('do not expose');
     });
 

--- a/tests/unit/chatgpt-mcp-core.test.js
+++ b/tests/unit/chatgpt-mcp-core.test.js
@@ -590,13 +590,103 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
                 id: 'opaque-safe-projection-id',
                 type: 'game',
                 startsAt: '2026-07-25T17:00:00.000Z',
-                opponent: 'Original Hawks'
+                opponent: 'Original Hawks',
+                location: 'FIELD 2'
             }] }
         );
 
         expect(result.events.filter((event) => event.gameId === 'game-1')).toHaveLength(1);
         expect(result.events.some((event) => event.gameId === 'opaque-safe-projection-id')).toBe(false);
         expect(JSON.stringify(result)).not.toContain(trackedUid);
+    });
+
+    it.each([
+        ['game', { opponent: 'Hawks', location: 'Field 2' }, { opponent: 'Tigers', location: 'Field 3' }],
+        ['practice', { title: 'Batting practice', location: 'Field 2' }, { title: 'Defense practice', location: 'Field 3' }]
+    ])('keeps a distinct same-time %s with different discriminators', async (type, overrides, projectedFields) => {
+        const db = scheduleDb('different-legacy-source-id', { type, ...overrides });
+        const context = await resolveUserContext(db, parentIdentity);
+        const result = await getFamilySchedule(
+            db,
+            context,
+            { startDate: '2026-07-24', endDate: '2026-07-31' },
+            new Date('2026-07-24T00:00:00.000Z'),
+            { loadCalendarProjection: async () => [{
+                id: 'distinct-opaque-projection-id',
+                type,
+                startsAt: '2026-07-25T17:00:00.000Z',
+                ...projectedFields
+            }] }
+        );
+
+        expect(result.events.some((event) => event.gameId === 'game-1')).toBe(true);
+        expect(result.events.some((event) => event.gameId === 'distinct-opaque-projection-id')).toBe(true);
+    });
+
+    it('deduplicates a same-time event with a meaningful case-insensitive location match', async () => {
+        const db = scheduleDb('different-legacy-source-id');
+        const context = await resolveUserContext(db, parentIdentity);
+        const result = await getFamilySchedule(
+            db,
+            context,
+            { startDate: '2026-07-24', endDate: '2026-07-31' },
+            new Date('2026-07-24T00:00:00.000Z'),
+            { loadCalendarProjection: async () => [{
+                id: 'opaque-safe-projection-id',
+                type: 'game',
+                startsAt: '2026-07-25T17:00:00.000Z',
+                opponent: 'Different opponent',
+                location: '  FIELD   2  '
+            }] }
+        );
+
+        expect(result.events.some((event) => event.gameId === 'game-1')).toBe(true);
+        expect(result.events.some((event) => event.gameId === 'opaque-safe-projection-id')).toBe(false);
+    });
+
+    it('keeps exact ID deduplication unconditional when event shape differs', async () => {
+        const db = scheduleDb('exact-projected-id');
+        const context = await resolveUserContext(db, parentIdentity);
+        const result = await getFamilySchedule(
+            db,
+            context,
+            { startDate: '2026-07-24', endDate: '2026-07-31' },
+            new Date('2026-07-24T00:00:00.000Z'),
+            { loadCalendarProjection: async () => [{
+                id: 'exact-projected-id',
+                type: 'practice',
+                startsAt: '2026-07-25T17:00:00.000Z',
+                title: 'Unrelated practice',
+                location: 'Different complex'
+            }] }
+        );
+
+        expect(result.events.some((event) => event.gameId === 'game-1')).toBe(true);
+        expect(result.events.some((event) => event.gameId === 'exact-projected-id')).toBe(false);
+    });
+
+    it('does not collapse placeholder-only events that share a start time', async () => {
+        const db = scheduleDb('different-legacy-source-id', {
+            opponent: 'unknown',
+            location: 'TBD'
+        });
+        const context = await resolveUserContext(db, parentIdentity);
+        const result = await getFamilySchedule(
+            db,
+            context,
+            { startDate: '2026-07-24', endDate: '2026-07-31' },
+            new Date('2026-07-24T00:00:00.000Z'),
+            { loadCalendarProjection: async () => [{
+                id: 'placeholder-opaque-projection-id',
+                type: 'game',
+                startsAt: '2026-07-25T17:00:00.000Z',
+                opponent: 'TBD',
+                location: 'unknown'
+            }] }
+        );
+
+        expect(result.events.some((event) => event.gameId === 'game-1')).toBe(true);
+        expect(result.events.some((event) => event.gameId === 'placeholder-opaque-projection-id')).toBe(true);
     });
 
     it('keeps a projected event at a different occurrence time', async () => {

--- a/tests/unit/chatgpt-mcp-core.test.js
+++ b/tests/unit/chatgpt-mcp-core.test.js
@@ -480,6 +480,7 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
             status: 'scheduled',
             calendarUrl: 'https://calendar.example.test/private-token',
             calendarUidHash: 'SENTINEL_CALENDAR_UID_HASH',
+            legacyOpaqueId: 'SENTINEL_LEGACY_OPAQUE_ID',
             privateNotes: 'do not expose'
         }]);
 
@@ -510,6 +511,8 @@ describe('chatgpt-mcp core: getFamilySchedule', () => {
         expect(JSON.stringify(result)).not.toContain('private-token');
         expect(JSON.stringify(result)).not.toContain('SENTINEL_CALENDAR_UID_HASH');
         expect(JSON.stringify(result)).not.toContain('calendarUidHash');
+        expect(JSON.stringify(result)).not.toContain('SENTINEL_LEGACY_OPAQUE_ID');
+        expect(JSON.stringify(result)).not.toContain('legacyOpaqueId');
         expect(JSON.stringify(result)).not.toContain('do not expose');
     });
 

--- a/tests/unit/chatgpt-mcp-core.test.js
+++ b/tests/unit/chatgpt-mcp-core.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
+import publicTeamApiCore from '../../functions/public-team-api-core.cjs';
 import {
     DomainError,
     loadManagedTeamsFromCallable,
@@ -21,6 +22,8 @@ import {
     buildStructuredQuery,
     createUserDb
 } from '../../services/chatgpt-mcp/src/firestoreRest.js';
+
+const { parsePublicGamesQuery } = publicTeamApiCore;
 
 // Minimal fake of the db interface core.js uses (same surface as the
 // firestoreRest adapter): doc(path).get(), collection(path).where().select()...get().
@@ -918,13 +921,26 @@ describe('chatgpt-mcp public calendar projection transport', () => {
             method: 'POST',
             headers: expect.objectContaining({ Authorization: 'Bearer caller-id-token' })
         }));
-        expect(JSON.parse(fetchImpl.mock.calls[0][1].body)).toEqual({
+        const firstRequest = JSON.parse(fetchImpl.mock.calls[0][1].body);
+        expect(firstRequest).toEqual({
             data: {
                 teamId: 'team-a',
-                from: '2026-07-24T00:00:00.000Z',
-                to: '2026-07-31T23:59:59.999Z',
+                from: '2026-07-24',
+                to: '2026-07-31',
                 limit: 50
             }
+        });
+        const parsedRange = parsePublicGamesQuery({
+            from: firstRequest.data.from,
+            to: firstRequest.data.to,
+            limit: firstRequest.data.limit
+        }, new Date('2026-07-24T12:00:00.000Z'));
+        expect(parsedRange).not.toHaveProperty('error');
+        expect(parsedRange).toMatchObject({
+            from: '2026-07-24',
+            to: '2026-07-31',
+            fromDate: new Date('2026-07-24T00:00:00.000Z'),
+            toDate: new Date('2026-07-31T23:59:59.999Z')
         });
         expect(JSON.parse(fetchImpl.mock.calls[1][1].body).data.cursor).toBe('calendar-page-2');
     });

--- a/tests/unit/public-opportunities-functions-source.test.js
+++ b/tests/unit/public-opportunities-functions-source.test.js
@@ -35,6 +35,8 @@ describe('public opportunity callable wiring', () => {
       source.indexOf('exports.getPublicGameProjection')
     );
     expect(calendarProjection).toContain("firestore.collection(`teams/${teamId}/games`)");
+    expect(calendarProjection).not.toContain(".where('date'");
+    expect(calendarProjection).toContain('orderBy(admin.firestore.FieldPath.documentId())');
     expect(calendarProjection).toContain(".select('calendarEventUid', 'date')");
     expect(calendarProjection).toContain('scanBoundedPublicCalendarTrackingEvents');
     expect(calendarProjection).toContain('maxDocuments: PUBLIC_TEAM_API_MAX_GAME_SCAN_DOCUMENTS');

--- a/tests/unit/public-opportunities-functions-source.test.js
+++ b/tests/unit/public-opportunities-functions-source.test.js
@@ -37,11 +37,17 @@ describe('public opportunity callable wiring', () => {
     expect(calendarProjection).toContain("firestore.collection(`teams/${teamId}/games`)");
     expect(calendarProjection).not.toContain(".where('date'");
     expect(calendarProjection).toContain('orderBy(admin.firestore.FieldPath.documentId())');
-    expect(calendarProjection).toContain(".select('calendarEventUid', 'date', 'type')");
+    expect(calendarProjection).toContain(".select('calendarEventUid', 'date', 'type', 'visibility', 'isPrivate', 'private', 'deleted', 'status', 'liveStatus')");
     expect(calendarProjection).toContain('scanBoundedPublicCalendarTrackingEvents');
     expect(calendarProjection).toContain('maxDocuments: PUBLIC_TEAM_API_MAX_GAME_SCAN_DOCUMENTS');
     expect(calendarProjection).toContain('calendarEventUid: normalizeFamilyShareText(gameSnap.data()?.calendarEventUid)');
     expect(calendarProjection).toContain('type: normalizeFamilyShareText(gameSnap.data()?.type)');
+    expect(calendarProjection).toContain('visibility: normalizeFamilyShareText(gameSnap.data()?.visibility)');
+    expect(calendarProjection).toContain('isPrivate: gameSnap.data()?.isPrivate === true');
+    expect(calendarProjection).toContain('private: gameSnap.data()?.private === true');
+    expect(calendarProjection).toContain('deleted: gameSnap.data()?.deleted === true');
+    expect(calendarProjection).toContain('status: normalizeFamilyShareText(gameSnap.data()?.status)');
+    expect(calendarProjection).toContain('liveStatus: normalizeFamilyShareText(gameSnap.data()?.liveStatus)');
     expect(calendarProjection).toContain('.filter(canTrackedCalendarEventSuppressPublicProjection)');
     const sourceListIndex = calendarProjection.indexOf('const calendarUrls = []');
     const emptyReturnIndex = calendarProjection.indexOf('if (calendarUrls.length === 0)');

--- a/tests/unit/public-opportunities-functions-source.test.js
+++ b/tests/unit/public-opportunities-functions-source.test.js
@@ -35,6 +35,9 @@ describe('public opportunity callable wiring', () => {
       source.indexOf('exports.getPublicGameProjection')
     );
     expect(calendarProjection).toContain("firestore.collection(`teams/${teamId}/games`)");
+    expect(calendarProjection).toContain(".select('calendarEventUid', 'date')");
+    expect(calendarProjection).toContain('scanBoundedPublicCalendarTrackingEvents');
+    expect(calendarProjection).toContain('maxDocuments: PUBLIC_TEAM_API_MAX_GAME_SCAN_DOCUMENTS');
     expect(calendarProjection).toContain('calendarEventUid: normalizeFamilyShareText(gameSnap.data()?.calendarEventUid)');
     expect(calendarProjection).toContain('!isFamilyShareCalendarEventTracked(event, trackedCalendarEvents)');
     expect(calendarProjection.indexOf('isFamilyShareCalendarEventTracked'))

--- a/tests/unit/public-opportunities-functions-source.test.js
+++ b/tests/unit/public-opportunities-functions-source.test.js
@@ -41,6 +41,15 @@ describe('public opportunity callable wiring', () => {
     expect(calendarProjection).toContain('scanBoundedPublicCalendarTrackingEvents');
     expect(calendarProjection).toContain('maxDocuments: PUBLIC_TEAM_API_MAX_GAME_SCAN_DOCUMENTS');
     expect(calendarProjection).toContain('calendarEventUid: normalizeFamilyShareText(gameSnap.data()?.calendarEventUid)');
+    const sourceListIndex = calendarProjection.indexOf('const calendarUrls = []');
+    const emptyReturnIndex = calendarProjection.indexOf('if (calendarUrls.length === 0)');
+    const trackingScanIndex = calendarProjection.indexOf('const trackedCalendarEvents');
+    expect(sourceListIndex).toBeGreaterThan(-1);
+    expect(emptyReturnIndex).toBeGreaterThan(sourceListIndex);
+    expect(trackingScanIndex).toBeGreaterThan(emptyReturnIndex);
+    expect(calendarProjection.slice(emptyReturnIndex, trackingScanIndex)).toContain('events: []');
+    expect(calendarProjection.slice(emptyReturnIndex, trackingScanIndex)).toContain('truncated: false');
+    expect(calendarProjection.slice(emptyReturnIndex, trackingScanIndex)).toContain('nextCursor: null');
     expect(calendarProjection).toContain('!isFamilyShareCalendarEventTracked(event, trackedCalendarEvents)');
     expect(calendarProjection.indexOf('isFamilyShareCalendarEventTracked'))
       .toBeLessThan(calendarProjection.indexOf('serializePublicCalendarEvent'));

--- a/tests/unit/public-opportunities-functions-source.test.js
+++ b/tests/unit/public-opportunities-functions-source.test.js
@@ -29,6 +29,18 @@ describe('public opportunity callable wiring', () => {
     ].forEach((name) => expect(source).toContain(`exports.${name}`));
   });
 
+  it('deduplicates public calendar projections against tracked team games before serialization', () => {
+    const calendarProjection = source.slice(
+      source.indexOf('exports.getPublicTeamCalendarProjection'),
+      source.indexOf('exports.getPublicGameProjection')
+    );
+    expect(calendarProjection).toContain("firestore.collection(`teams/${teamId}/games`)");
+    expect(calendarProjection).toContain('calendarEventUid: normalizeFamilyShareText(gameSnap.data()?.calendarEventUid)');
+    expect(calendarProjection).toContain('!isFamilyShareCalendarEventTracked(event, trackedCalendarEvents)');
+    expect(calendarProjection.indexOf('isFamilyShareCalendarEventTracked'))
+      .toBeLessThan(calendarProjection.indexOf('serializePublicCalendarEvent'));
+  });
+
   it('server-verifies publishing roles, verified email, expiration, rate limits, and private notifications', () => {
     expect(source).toContain("context.auth.token?.email_verified !== true");
     expect(source).toContain('hasTeamAdminAccess({ team, user: caller.user, uid: caller.uid, email: caller.email })');

--- a/tests/unit/public-opportunities-functions-source.test.js
+++ b/tests/unit/public-opportunities-functions-source.test.js
@@ -37,10 +37,12 @@ describe('public opportunity callable wiring', () => {
     expect(calendarProjection).toContain("firestore.collection(`teams/${teamId}/games`)");
     expect(calendarProjection).not.toContain(".where('date'");
     expect(calendarProjection).toContain('orderBy(admin.firestore.FieldPath.documentId())');
-    expect(calendarProjection).toContain(".select('calendarEventUid', 'date')");
+    expect(calendarProjection).toContain(".select('calendarEventUid', 'date', 'type')");
     expect(calendarProjection).toContain('scanBoundedPublicCalendarTrackingEvents');
     expect(calendarProjection).toContain('maxDocuments: PUBLIC_TEAM_API_MAX_GAME_SCAN_DOCUMENTS');
     expect(calendarProjection).toContain('calendarEventUid: normalizeFamilyShareText(gameSnap.data()?.calendarEventUid)');
+    expect(calendarProjection).toContain('type: normalizeFamilyShareText(gameSnap.data()?.type)');
+    expect(calendarProjection).toContain('.filter(canTrackedCalendarEventSuppressPublicProjection)');
     const sourceListIndex = calendarProjection.indexOf('const calendarUrls = []');
     const emptyReturnIndex = calendarProjection.indexOf('if (calendarUrls.length === 0)');
     const trackingScanIndex = calendarProjection.indexOf('const trackedCalendarEvents');

--- a/tests/unit/public-opportunities-functions-source.test.js
+++ b/tests/unit/public-opportunities-functions-source.test.js
@@ -37,11 +37,14 @@ describe('public opportunity callable wiring', () => {
     expect(calendarProjection).toContain("firestore.collection(`teams/${teamId}/games`)");
     expect(calendarProjection).not.toContain(".where('date'");
     expect(calendarProjection).toContain('orderBy(admin.firestore.FieldPath.documentId())');
-    expect(calendarProjection).toContain(".select('calendarEventUid', 'date', 'type', 'visibility', 'isPrivate', 'private', 'deleted', 'status', 'liveStatus')");
+    expect(calendarProjection).toContain(".select('calendarEventUid', 'date', 'type', 'location', 'opponent', 'title', 'visibility', 'isPrivate', 'private', 'deleted', 'status', 'liveStatus')");
     expect(calendarProjection).toContain('scanBoundedPublicCalendarTrackingEvents');
     expect(calendarProjection).toContain('maxDocuments: PUBLIC_TEAM_API_MAX_GAME_SCAN_DOCUMENTS');
     expect(calendarProjection).toContain('calendarEventUid: normalizeFamilyShareText(gameSnap.data()?.calendarEventUid)');
     expect(calendarProjection).toContain('type: normalizeFamilyShareText(gameSnap.data()?.type)');
+    expect(calendarProjection).toContain('location: normalizeFamilyShareText(gameSnap.data()?.location)');
+    expect(calendarProjection).toContain('opponent: normalizeFamilyShareText(gameSnap.data()?.opponent)');
+    expect(calendarProjection).toContain('title: normalizeFamilyShareText(gameSnap.data()?.title)');
     expect(calendarProjection).toContain('visibility: normalizeFamilyShareText(gameSnap.data()?.visibility)');
     expect(calendarProjection).toContain('isPrivate: gameSnap.data()?.isPrivate === true');
     expect(calendarProjection).toContain('private: gameSnap.data()?.private === true');


### PR DESCRIPTION
## What changed

- route ChatGPT MCP team discovery through the authenticated `listManagedTeams` callable instead of Firestore owner-email list queries
- include imported TeamSnap calendar events in MCP schedule results through the authenticated public calendar projection
- fail closed on partial discovery/projection results, bound pagination, deduplicate imported events, and expose only whitelisted fields/deep links

## Why

PR #4433 tightens Firestore team-list authorization. This focused precursor keeps the external AI surface on the same server-authorized team boundary before those rules land and completes the original TeamSnap next-game behavior for AI chat.

## Validation

- `npx vitest run tests/unit/chatgpt-mcp-core.test.js --reporter=verbose` — 40/40 passed
- `node --check services/chatgpt-mcp/src/core.js`
- `node --check services/chatgpt-mcp/src/server.js`
- `git diff --check`

Blocks #4433 until merged.