### PR TITLE
Fix owner migration workload identity auth

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -803,11 +803,13 @@ jobs:
           project_id: game-flow-c6311
           create_credentials_file: true
           cleanup_credentials: true
+          token_format: access_token
 
       - name: Canonicalize legacy team owners before authorization lockdown
         run: node "$FIREBASE_PRODUCTION_BUNDLE/_migration/backfill-legacy-team-owner-ids.mjs" --apply
         env:
           FIREBASE_PROJECT_ID: game-flow-c6311
+          GOOGLE_OAUTH_ACCESS_TOKEN: ${{ steps.google_auth_owner_migration.outputs.access_token }}
 
       - name: Remove legacy owner migration credential
         env:

--- a/tests/unit/backfill-legacy-team-owner-ids.test.js
+++ b/tests/unit/backfill-legacy-team-owner-ids.test.js
@@ -297,6 +297,9 @@ describe('legacy team ownerId migration planning', () => {
         expect(workflow).toContain('cp _migration/backfill-legacy-team-owner-ids.js');
         expect(workflow).toContain('test ! -L "$bundle/_migration/backfill-legacy-team-owner-ids.mjs"');
         expect(migrationCommand).toBeGreaterThan(-1);
+        expect(workflow).toMatch(
+            /id: google_auth_owner_migration[\s\S]*?token_format: access_token[\s\S]*?GOOGLE_OAUTH_ACCESS_TOKEN: \$\{\{ steps\.google_auth_owner_migration\.outputs\.access_token \}\}/
+        );
         expect(storageRulesDeploy).toBeGreaterThan(migrationCommand);
         expect(rulesBranch).toBeGreaterThan(migrationCommand);
     });

--- a/tests/unit/certificate-legacy-signature-inventory-backfill.test.js
+++ b/tests/unit/certificate-legacy-signature-inventory-backfill.test.js
@@ -61,6 +61,7 @@ describe('certificate legacy signature inventory backfill', () => {
     it('routes every automatically deployed Admin SDK backfill through the workload-identity helper', () => {
         for (const migrationName of [
             'backfill-certificate-legacy-signature-inventory.js',
+            'backfill-legacy-team-owner-ids.js',
             'backfill-team-fee-checkout-attempts.js',
             'backfill-registration-checkout-attempts.js'
         ]) {

--- a/tests/unit/firebase-deploy-workload-identity.test.js
+++ b/tests/unit/firebase-deploy-workload-identity.test.js
@@ -125,6 +125,10 @@ describe('Firebase deploy Workload Identity boundary', () => {
         expect(ownerMigrationStep).toBeGreaterThan(ownerMigrationAuth);
         expect(ownerMigration).toBeGreaterThan(ownerMigrationStep);
         expect(ownerMigrationCleanup).toBeGreaterThan(ownerMigration);
+        expect(production.slice(ownerMigrationAuth, ownerMigrationStep)).toContain('token_format: access_token');
+        expect(production.slice(ownerMigrationStep, ownerMigrationCleanup)).toContain(
+            'GOOGLE_OAUTH_ACCESS_TOKEN: ${{ steps.google_auth_owner_migration.outputs.access_token }}'
+        );
         expect(storageAuth).toBeGreaterThan(ownerMigrationCleanup);
         expect(production.slice(ownerMigrationAuth, ownerMigrationStep)).not.toContain('run:');
         expect(storageAuth).toBeGreaterThan(functionsExtract);


### PR DESCRIPTION
## What changed
- request a short-lived workload-identity access token for the legacy owner migration
- pass that token through the existing Firebase Admin migration credential helper
- add regression coverage for the workflow wiring and every automatically deployed Admin backfill

## Root cause
The new owner migration only received the generated external-account credential file. Firebase Admin 12.7 rejects that file, so deployment stopped before the migration read or wrote data.

## Validation
- `npx vitest run tests/unit/firebase-deploy-workload-identity.test.js tests/unit/backfill-legacy-team-owner-ids.test.js tests/unit/certificate-legacy-signature-inventory-backfill.test.js --reporter=verbose` (19 passed)
- `npm run ci:firebase-rules`
- `git diff --check`