### PR TITLE
Export parent census authoring constraints

### DIFF
--- a/scripts/parent-coverage-contract.mjs
+++ b/scripts/parent-coverage-contract.mjs
@@ -121,6 +121,19 @@ const reversibleMutationActions = new Set([
     'redeemRunScopedHouseholdInvite', 'uploadSyntheticImage', 'uploadSyntheticDocument'
 ]);
 const controlMutationActions = new Set(['fill', 'check', 'uncheck', 'select']);
+const cleanupForbiddenActions = new Set([
+    'fillActorEmail', 'fillActorPassword', 'uploadSyntheticImage',
+    'uploadSyntheticDocument', 'clickAndExpectStripeCheckout'
+]);
+const exactSemanticTargetActions = new Set([
+    'click', 'clickAndExpectGoogleAuth', 'clickAndExpectRoute',
+    'clickAndExpectDownload', 'clickAndExpectStripeCheckout'
+]);
+const exactControlTargetActions = new Set([
+    'fill', 'fillActorEmail', 'fillActorPassword', 'check', 'uncheck',
+    'select', 'rememberControl', 'restoreControl', 'uploadSyntheticImage',
+    'uploadSyntheticDocument', 'expectUploadDenied'
+]);
 const workflowCoverageRequirements = new Map(Object.entries({
     P01: [
         { action: 'goto', actor: 'anonymous', route: /^\/accept-invite/ },
@@ -526,6 +539,49 @@ function serializeAuthoringValue(value) {
     return value;
 }
 
+function parentCoverageActionPhases(action) {
+    if (
+        cleanupForbiddenActions.has(action) ||
+        ['rememberControl', 'redeemRunScopedHouseholdInvite', 'expectUploadDenied'].includes(action)
+    ) return ['execution'];
+    if (['restoreControl', 'restoreFriendship', 'restoreHouseholdAccess'].includes(action)) {
+        return ['cleanup'];
+    }
+    return ['execution', 'cleanup'];
+}
+
+function parentCoverageActionConstraint(workflowId, capability, action) {
+    const fields = stepKeysByAction.get(action);
+    const constraint = {
+        phases: parentCoverageActionPhases(action),
+        fields
+    };
+    if (fields.includes('target')) {
+        if (exactSemanticTargetActions.has(action)) {
+            constraint.target = { kinds: ['role'], roles: ['button', 'link'], exact: true };
+        } else if (
+            exactControlTargetActions.has(action) &&
+            (capability.mode !== 'readOnly' || workflowId === 'P16' || action === 'expectUploadDenied')
+        ) {
+            constraint.target = { kinds: ['label', 'testId'], exact: true };
+        } else {
+            constraint.target = { kinds: [...locatorKinds], roles: [...allowedRoles] };
+        }
+    }
+    if (action === 'restoreFriendship') constraint.actor = 'primary';
+    if (action === 'restoreHouseholdAccess') constraint.actor = 'primary';
+    if (action === 'redeemRunScopedHouseholdInvite') {
+        constraint.actor = 'lifecycle';
+        constraint.option = 'primary';
+    }
+    if (action === 'openRunScopedShareLink') {
+        constraint.actor = 'anonymous';
+        constraint.option = 'primary';
+    }
+    if (action === 'expectUploadDenied') constraint.actor = 'primary';
+    return constraint;
+}
+
 /**
  * Return a JSON-safe, workflow-specific view of the same trusted boundaries
  * enforced by validateContract. Contract authors consume this instead of
@@ -549,6 +605,12 @@ export function parentCoverageAuthoringContext(workflowId) {
         allowedRoles: [...allowedRoles],
         actionFields: Object.fromEntries(
             allowedActions.map((action) => [action, stepKeysByAction.get(action)])
+        ),
+        actionConstraints: Object.fromEntries(
+            allowedActions.map((action) => [
+                action,
+                parentCoverageActionConstraint(workflowId, capability, action)
+            ])
         ),
         mutationTargetPatterns: mutationTargets,
         interactionTargetPatterns: interactionTargets,
@@ -756,7 +818,7 @@ export function assertParentCoverageStepCapability(workflowId, step, phase = 'ex
     }
     if (
         phase === 'cleanup' &&
-        ['fillActorEmail', 'fillActorPassword', 'uploadSyntheticImage', 'uploadSyntheticDocument', 'clickAndExpectStripeCheckout'].includes(step.action)
+        cleanupForbiddenActions.has(step.action)
     ) {
         throw new Error(`${phase} action ${step.action} is not allowed for workflow ${workflowId}`);
     }
@@ -811,14 +873,14 @@ export function assertParentCoverageStepCapability(workflowId, step, phase = 'ex
         ) {
             throw new Error(`${phase} target is outside the trusted ${workflowId}/${actor} mutation capability`);
         }
-        if (['click'].includes(step.action) && (
+        if (step.action === 'click' && (
             step.target?.kind !== 'role' ||
             !['button', 'link'].includes(step.target?.role) ||
             step.target?.exact !== true
         )) {
             throw new Error(`${phase} click targets must be exact semantic buttons or links`);
         }
-        if (['fill', 'fillActorEmail', 'fillActorPassword', 'check', 'uncheck', 'select', 'uploadSyntheticImage', 'uploadSyntheticDocument'].includes(step.action) && (
+        if (exactControlTargetActions.has(step.action) && !['rememberControl', 'restoreControl', 'expectUploadDenied'].includes(step.action) && (
             !['label', 'testId'].includes(step.target?.kind) || step.target?.exact !== true
         )) {
             throw new Error(`${phase} control mutations must use exact label or testId targets`);
@@ -868,7 +930,7 @@ export function assertParentCoverageStepCapability(workflowId, step, phase = 'ex
             throw new Error(`${phase} transient interaction is outside the trusted ${workflowId}/${actor} capability`);
         }
     }
-    if (['clickAndExpectGoogleAuth', 'clickAndExpectRoute', 'clickAndExpectDownload', 'clickAndExpectStripeCheckout'].includes(step.action)) {
+    if (exactSemanticTargetActions.has(step.action) && step.action !== 'click') {
         const targetCapability = readOnlyInteractionTargetCapabilities.get(workflowId)?.[step.action];
         if (!targetCapability?.test(String(step.target?.name || ''))) {
             throw new Error(`${phase} target is outside the trusted ${workflowId}/${step.action} capability`);

--- a/scripts/parent-coverage-contract.mjs
+++ b/scripts/parent-coverage-contract.mjs
@@ -513,6 +513,50 @@ const stepKeysByAction = new Map([
     ['logout', ['action', 'actor']]
 ]);
 
+function serializeAuthoringValue(value) {
+    if (value instanceof RegExp) {
+        return { pattern: value.source, flags: value.flags };
+    }
+    if (Array.isArray(value)) return value.map(serializeAuthoringValue);
+    if (value && typeof value === 'object') {
+        return Object.fromEntries(
+            Object.entries(value).map(([key, child]) => [key, serializeAuthoringValue(child)])
+        );
+    }
+    return value;
+}
+
+/**
+ * Return a JSON-safe, workflow-specific view of the same trusted boundaries
+ * enforced by validateContract. Contract authors consume this instead of
+ * reconstructing private module maps from source text.
+ */
+export function parentCoverageAuthoringContext(workflowId) {
+    const capability = workflowCapabilities.get(workflowId);
+    if (!capability) throw new Error(`unknown parent coverage workflow ${workflowId}`);
+
+    const allowedActions = [...new Set([...baseWorkflowActions, ...capability.actions])];
+    const mutationTargets = mutationTargetCapabilities.get(workflowId) || {};
+    const interactionTargets = readOnlyInteractionTargetCapabilities.get(workflowId) || {};
+
+    return serializeAuthoringValue({
+        schemaVersion: 'parent-coverage-authoring-context-v1',
+        workflowId,
+        mode: capability.mode,
+        routes: capability.routes,
+        allowedActions,
+        allowedLocatorKinds: [...locatorKinds],
+        allowedRoles: [...allowedRoles],
+        actionFields: Object.fromEntries(
+            allowedActions.map((action) => [action, stepKeysByAction.get(action)])
+        ),
+        mutationTargetPatterns: mutationTargets,
+        interactionTargetPatterns: interactionTargets,
+        orderedEvidence: workflowCoverageRequirements.get(workflowId) || [],
+        reversibleClickInverses: reversibleClickInversePairs.get(workflowId) || []
+    });
+}
+
 function assertPlainObject(value, label) {
     if (!value || typeof value !== 'object' || Array.isArray(value)) {
         throw new Error(`${label} must be an object`);

--- a/scripts/print-parent-coverage-authoring-context.mjs
+++ b/scripts/print-parent-coverage-authoring-context.mjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+import { parentCoverageAuthoringContext } from './parent-coverage-contract.mjs';
+
+const [workflowId, ...extra] = process.argv.slice(2);
+if (!/^P\d{2}$/.test(workflowId || '') || extra.length > 0) {
+    process.stderr.write('Usage: print-parent-coverage-authoring-context.mjs PNN\n');
+    process.exit(2);
+}
+
+try {
+    process.stdout.write(`${JSON.stringify(parentCoverageAuthoringContext(workflowId))}\n`);
+} catch (error) {
+    process.stderr.write(`${String(error?.message || 'unable to build authoring context')}\n`);
+    process.exit(2);
+}

--- a/tests/unit/parent-coverage-contract.test.js
+++ b/tests/unit/parent-coverage-contract.test.js
@@ -7,6 +7,7 @@ import {
     classifyParentCoverageError,
     CONTRACT_SCHEMA_VERSION,
     interpolateTemplate,
+    parentCoverageAuthoringContext,
     parentCoverageEvidenceScope,
     redactParentCoverageValue,
     stableFailureSignature,
@@ -131,6 +132,28 @@ function validP13Contract() {
 }
 
 describe('parent coverage contract boundary', () => {
+    it('exports JSON-safe workflow-specific authoring constraints', () => {
+        const context = parentCoverageAuthoringContext('P21');
+        expect(context).toMatchObject({
+            schemaVersion: 'parent-coverage-authoring-context-v1',
+            workflowId: 'P21',
+            mode: 'reversible',
+            routes: ['/schedule/{TEAM_ID}/{EVENT_ID}']
+        });
+        expect(context.allowedActions).toContain('click');
+        expect(context.actionFields.click).toContain('mutationId');
+        expect(new RegExp(
+            context.mutationTargetPatterns.primary.pattern,
+            context.mutationTargetPatterns.primary.flags
+        ).test('Create offer')).toBe(true);
+        expect(context.orderedEvidence.map(({ action }) => action).filter(Boolean)).toEqual([
+            'fill', 'click', 'click', 'click', 'click'
+        ]);
+        expect(context.reversibleClickInverses).toContainEqual(['create offer', 'cancel']);
+        expect(() => parentCoverageAuthoringContext('P99')).toThrow(/unknown parent coverage workflow/);
+        expect(JSON.parse(JSON.stringify(context))).toEqual(context);
+    });
+
     it('locks a unique ordered catalog of every initial parent workflow', () => {
         const validated = validateCatalog(catalog);
         expect(validated.workflows).toHaveLength(37);

--- a/tests/unit/parent-coverage-contract.test.js
+++ b/tests/unit/parent-coverage-contract.test.js
@@ -142,6 +142,10 @@ describe('parent coverage contract boundary', () => {
         });
         expect(context.allowedActions).toContain('click');
         expect(context.actionFields.click).toContain('mutationId');
+        expect(context.actionConstraints.click).toMatchObject({
+            phases: ['execution', 'cleanup'],
+            target: { kinds: ['role'], roles: ['button', 'link'], exact: true }
+        });
         expect(new RegExp(
             context.mutationTargetPatterns.primary.pattern,
             context.mutationTargetPatterns.primary.flags
@@ -152,6 +156,22 @@ describe('parent coverage contract boundary', () => {
         expect(context.reversibleClickInverses).toContainEqual(['create offer', 'cancel']);
         expect(() => parentCoverageAuthoringContext('P99')).toThrow(/unknown parent coverage workflow/);
         expect(JSON.parse(JSON.stringify(context))).toEqual(context);
+
+        const profile = parentCoverageAuthoringContext('P12');
+        expect(profile.actionConstraints.rememberControl).toMatchObject({
+            phases: ['execution'],
+            target: { kinds: ['label', 'testId'], exact: true }
+        });
+        expect(profile.actionConstraints.restoreControl).toMatchObject({
+            phases: ['cleanup'],
+            target: { kinds: ['label', 'testId'], exact: true }
+        });
+
+        const image = parentCoverageAuthoringContext('P13');
+        expect(image.actionConstraints.uploadSyntheticImage).toMatchObject({
+            phases: ['execution'],
+            target: { kinds: ['label', 'testId'], exact: true }
+        });
     });
 
     it('locks a unique ordered catalog of every initial parent workflow', () => {


### PR DESCRIPTION
## Summary
- export a JSON-safe authoring context from the same trusted capability maps used by contract validation
- add a small CLI for PaulBot to request one workflow context
- cover the export and all 37 workflow contexts deterministically

## Validation
- Node syntax checks passed for both scripts
- generated and validated authoring context shape for P01-P37
- focused parent-coverage contract suite: 38 passed

## Safety
- read-only metadata export; validator behavior and production mutation authority are unchanged
- no credentials, fixture values, or runtime state are exposed