### PR TITLE
Report redacted Firestore rule evidence

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -941,6 +941,10 @@ jobs:
           certificate_compatibility_recovery_ruleset="projects/game-flow-c6311/rulesets/6da601e4-12e3-420a-8db3-907153c712c7"
           certificate_compatibility_recovery_source_sha256="825ec3d3a56a067dc5c80c0e6e6f3fc1ceba2b09b249e0605889dc3d964dc6f2"
           certificate_compatibility_recovery_canonical_sha256="0334471987fba5fbb95f7acf49382e3e412849f02cb2ed333f87249f1674b4de"
+          active_ruleset_observed_id="unknown"
+          active_ruleset_observed_create_time="unknown"
+          active_ruleset_observed_source_sha256="unknown"
+          active_ruleset_observed_fingerprint_present="false"
 
           if ! jq -e '
             .firestore.rules == "firestore.rules"
@@ -1051,6 +1055,36 @@ jobs:
               return 2
             fi
 
+            local observed_rules_b64 observed_create_time observed_fingerprint
+            observed_rules_b64="$(
+              jq -er '
+                (.source.files // [])
+                | if length == 1 and .[0].name == "firestore.rules"
+                  then (.[0].content | @base64)
+                  else error("expected exactly one firestore.rules source file")
+                  end
+              ' "$ruleset_json" 2>/dev/null || true
+            )"
+            [[ -n "$observed_rules_b64" ]] || {
+              rm -f "$release_json" "$ruleset_json"
+              return 2
+            }
+            observed_create_time="$(jq -r '.createTime // ""' "$ruleset_json")"
+            if [[ ! "$observed_create_time" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z$ ]]; then
+              observed_create_time="unknown"
+            fi
+            observed_fingerprint="$(jq -r '.source.files[0].fingerprint // ""' "$ruleset_json")"
+            active_ruleset_observed_id="${ruleset_name##*/}"
+            active_ruleset_observed_create_time="$observed_create_time"
+            active_ruleset_observed_source_sha256="$(
+              printf '%s' "$observed_rules_b64" | base64 --decode | sha256sum | awk '{print $1}'
+            )"
+            if [[ -n "$observed_fingerprint" ]]; then
+              active_ruleset_observed_fingerprint_present="true"
+            else
+              active_ruleset_observed_fingerprint_present="false"
+            fi
+
             local source_match_status
             if firestore_ruleset_source_matches "$ruleset_json" "$ruleset_name" "$expected_rules_source"; then
               rm -f "$release_json" "$ruleset_json"
@@ -1060,6 +1094,34 @@ jobs:
             fi
             rm -f "$release_json" "$ruleset_json"
             return "$source_match_status"
+          }
+
+          write_unrecognized_active_firestore_rules_evidence() {
+            local current_final_sha256 current_compatibility_sha256
+            local baseline_final_sha256 baseline_compatibility_sha256
+            current_final_sha256="$(firestore_source_sha256 "$final_firestore_rules")"
+            current_compatibility_sha256="$(firestore_source_sha256 "$compatibility_firestore_rules")"
+            baseline_final_sha256="$(firestore_source_sha256 "$baseline_firestore_rules")"
+            baseline_compatibility_sha256="$(firestore_source_sha256 "$baseline_compatibility_firestore_rules")"
+
+            echo "::error title=Unrecognized active Firestore rules::ruleset_id=${active_ruleset_observed_id}, create_time=${active_ruleset_observed_create_time}, remote_source_sha256=${active_ruleset_observed_source_sha256}, fingerprint_present=${active_ruleset_observed_fingerprint_present}"
+            echo "::notice title=Trusted Firestore candidate digests::current_final_sha256=${current_final_sha256}, current_compatibility_sha256=${current_compatibility_sha256}, baseline_final_sha256=${baseline_final_sha256}, baseline_compatibility_sha256=${baseline_compatibility_sha256}"
+            {
+              echo "### Unrecognized active Firestore rules"
+              echo
+              echo "Only immutable identifiers and SHA-256 digests are reported; rule source and credentials remain redacted."
+              echo
+              echo "| Signal | Value |"
+              echo "| --- | --- |"
+              echo "| Active ruleset ID | \`${active_ruleset_observed_id}\` |"
+              echo "| Active ruleset creation time | \`${active_ruleset_observed_create_time}\` |"
+              echo "| Active canonical source SHA-256 | \`${active_ruleset_observed_source_sha256}\` |"
+              echo "| Source fingerprint present | \`${active_ruleset_observed_fingerprint_present}\` |"
+              echo "| Current final formatted SHA-256 | \`${current_final_sha256}\` |"
+              echo "| Current compatibility formatted SHA-256 | \`${current_compatibility_sha256}\` |"
+              echo "| Baseline final formatted SHA-256 | \`${baseline_final_sha256}\` |"
+              echo "| Baseline compatibility formatted SHA-256 | \`${baseline_compatibility_sha256}\` |"
+            } >> "$GITHUB_STEP_SUMMARY"
           }
 
           find_recent_matching_firestore_ruleset() {
@@ -1583,6 +1645,7 @@ jobs:
               fi
             fi
             if [[ -z "$active_rules_variant" ]]; then
+              write_unrecognized_active_firestore_rules_evidence
               write_firestore_configuration_blocked_summary "active Firestore rules did not match a trusted final or compatibility baseline"
               exit 2
             fi

--- a/docs/observability-runbook.md
+++ b/docs/observability-runbook.md
@@ -79,6 +79,7 @@ Safe manual retry:
 
 1. Confirm the failed run targeted `master` and that its summary reports a transient Google API failure rather than a configuration or authorization error. Check the Firebase deploy log or console to determine whether Rules or indexes were already applied.
 2. Confirm `master` still contains the intended Firestore configuration. If a newer production deployment succeeded, no retry is needed.
+   When live source classification fails, use only the emitted immutable ruleset ID, creation time, and SHA-256 digests to investigate. Never copy rule source, credentials, or API response bodies into an issue or pull request. A pre-fingerprint recovery must independently pin the immutable ruleset ID, the exact formatted repository-source digest, and the canonical remote-source digest before it can be accepted.
 3. In GitHub Actions, open `deploy-prod`, choose **Run workflow**, select `master`, and run it. Manual dispatch is restricted to the current `master` branch and repeats the protected tests, change detection, keyless authentication, bounded ruleset create/release flow, exact-SHA Firebase/Pages ordering, and fail-closed release marker.
 4. Confirm the Firestore configuration step succeeds before Hosting and Functions, then confirm the production smoke workflow succeeds.
 

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -460,6 +460,34 @@ export function validateProductionDeployCommand(deployProd) {
     );
     assertIncludes(
         deployProd,
+        'write_unrecognized_active_firestore_rules_evidence()',
+        'Production Firestore unrecognized-source evidence helper'
+    );
+    assertIncludes(
+        deployProd,
+        'remote_source_sha256=${active_ruleset_observed_source_sha256}',
+        'Production Firestore redacted active-source digest evidence'
+    );
+    assertIncludes(
+        deployProd,
+        'current_compatibility_sha256=${current_compatibility_sha256}',
+        'Production Firestore current compatibility candidate digest evidence'
+    );
+    assertIncludes(
+        deployProd,
+        'baseline_compatibility_sha256=${baseline_compatibility_sha256}',
+        'Production Firestore baseline compatibility candidate digest evidence'
+    );
+    assertMatches(
+        deployProd,
+        /if \[\[ -z "\$active_rules_variant" \]\]; then\s+write_unrecognized_active_firestore_rules_evidence\s+write_firestore_configuration_blocked_summary "active Firestore rules did not match a trusted final or compatibility baseline"\s+exit 2/,
+        'Production Firestore unrecognized-source evidence before fail-closed exit'
+    );
+    if (deployProd.includes('echo "$observed_rules_b64"') || deployProd.includes('echo "$remote_rules_b64"')) {
+        throw new Error('Production Firestore diagnostics must never print rule source content.');
+    }
+    assertIncludes(
+        deployProd,
         'ensure_exact_firestore_ruleset()',
         'Production Firestore create-or-reuse coordinator'
     );

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -89,6 +89,31 @@ async function mockAppModules(page, { user = null, emailLink = false, friendInvi
         mockFriendInviteReplay: friendInviteReplay
     });
 
+    // The app startup timer lazily initializes Firebase Performance. Keep this
+    // module mocked across reloads so auth-flow tests cannot contact Firebase
+    // Installations with the intentionally non-production preview config.
+    await page.route(/\/src\/lib\/performanceInstrumentation\.ts(\?.*)?$/, async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/javascript',
+            body: `
+                export function now() {
+                    return window.performance.now();
+                }
+
+                export function startPerformanceSpan() {
+                    return {
+                        startedAt: now(),
+                        traceName: 'mock-performance-span',
+                        end() {}
+                    };
+                }
+
+                export function recordCompletedPerformanceSpan() {}
+            `
+        });
+    });
+
     await page.route(/\/src\/lib\/useAuth\.ts(\?.*)?$/, async (route) => {
         await route.fulfill({
             status: 200,

--- a/tests/unit/certificate-defaults-rules.test.js
+++ b/tests/unit/certificate-defaults-rules.test.js
@@ -127,6 +127,12 @@ describe('certificate defaults Firestore rules', () => {
         expect(deployWorkflow).toContain(
             'active Firestore rules did not match a trusted final or compatibility baseline'
         );
+        expect(deployWorkflow).toMatch(
+            /write_unrecognized_active_firestore_rules_evidence[\s\S]*remote_source_sha256=\$\{active_ruleset_observed_source_sha256\}/
+        );
+        expect(deployWorkflow).toContain(
+            'Only immutable identifiers and SHA-256 digests are reported; rule source and credentials remain redacted.'
+        );
         expect(deployWorkflow).toContain('[[ "$active_rules_variant" == *-final ]]');
         expect(deployWorkflow).toContain('firestore-baseline-compat.rules');
         expect(deployWorkflow).toContain('advancing its SHA and forcing live mode classification');

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -228,6 +228,7 @@ concurrency:
             certificate_compatibility_recovery_ruleset="projects/game-flow-c6311/rulesets/6da601e4-12e3-420a-8db3-907153c712c7"
             certificate_compatibility_recovery_source_sha256="825ec3d3a56a067dc5c80c0e6e6f3fc1ceba2b09b249e0605889dc3d964dc6f2"
             certificate_compatibility_recovery_canonical_sha256="0334471987fba5fbb95f7acf49382e3e412849f02cb2ed333f87249f1674b4de"
+            active_ruleset_observed_source_sha256="unknown"
             if [[ "$deploy_targets" != "$retry_enabled_function_targets"
               && "$deploy_targets" != "$retry_enabled_inventory_producer_target"
               && "$deploy_targets" != "$retry_enabled_cleanup_compatibility_target" ]]; then
@@ -255,6 +256,11 @@ concurrency:
             jq '(.source.files // []) | if length == 1 and .[0].name == "firestore.rules"'
             [[ "$local_rules_sha256" == "$certificate_compatibility_recovery_source_sha256" ]]
             [[ "$remote_rules_sha256" == "$certificate_compatibility_recovery_canonical_sha256" ]]
+          }
+          write_unrecognized_active_firestore_rules_evidence() {
+            echo "remote_source_sha256=\${active_ruleset_observed_source_sha256}"
+            echo "current_compatibility_sha256=\${current_compatibility_sha256}"
+            echo "baseline_compatibility_sha256=\${baseline_compatibility_sha256}"
           }
           find_recent_matching_firestore_ruleset() {
             curl "https://firebaserules.googleapis.com/v1/projects/game-flow-c6311/rulesets?pageSize=20"
@@ -315,6 +321,11 @@ concurrency:
               if [[ "$baseline_firestore_mode" == "ambiguous" ]]; then active_rules_variant="baseline-final"; fi
               active_rules_variant="baseline-compatibility"
               if (( active_rules_status == 2 )); then exit 2; fi
+              if [[ -z "$active_rules_variant" ]]; then
+                write_unrecognized_active_firestore_rules_evidence
+                write_firestore_configuration_blocked_summary "active Firestore rules did not match a trusted final or compatibility baseline"
+                exit 2
+              fi
               if [[ "$active_rules_variant" == *-final ]]; then
                 ensure_exact_firestore_ruleset "$final_firestore_rules"
               fi
@@ -482,6 +493,10 @@ concurrency:
             '[[ "$remote_rules_sha256" == "$certificate_compatibility_recovery_canonical_sha256" ]]',
             '[[ -n "$remote_rules_sha256" ]]'
         ))).toThrow('Production Firestore compatibility recovery canonical-source proof');
+        expect(() => validateProductionDeployCommand(validDeployCommand.replace(
+            'remote_source_sha256=${active_ruleset_observed_source_sha256}',
+            'active_rules_source=redacted'
+        ))).toThrow('Production Firestore redacted active-source digest evidence');
         expect(() => validateProductionDeployCommand(validDeployCommand.replace(
             'verify_active_firestore_release_name "$ruleset_name"',
             'verify_active_firestore_rules "$expected_rules_source"'


### PR DESCRIPTION
## Summary
- emit only the immutable active Firestore ruleset ID, creation time, and canonical SHA-256 when live classification is unknown
- emit SHA-256 values for the four trusted repository candidates without exposing rule source or credentials
- preserve the existing fail-closed deployment block and document the three-part recovery proof
- isolate the auth smoke harness from Firebase Performance so reload tests cannot leak preview Firebase Installations calls

## Why
Production deployment is blocked because the active pre-fingerprint ruleset cannot be classified safely. This observability-first slice provides the evidence needed for a separate, bounded recovery without weakening the production gate. During exact-head CI, the required preview gate reproduced a pre-existing Firebase Installations test-isolation failure twice; the same head fixes that gate instead of retrying it again.

## Validation
- `node scripts/validate-firebase-rules-ci.mjs`
- `npx vitest run tests/unit/validate-firebase-rules-ci.test.js tests/unit/certificate-defaults-rules.test.js --reporter=verbose` (14 passed; 9 existing emulator-gated tests skipped)
- `npm test` (745 files passed; 5,755 tests passed; 165 existing skips)
- `npm run app:build`
- focused invite-replay Playwright smoke repeated 30 times in parallel (30/30 passed)
- clean worktree and merge-base `git diff --check`

## Production safety
This PR does not deploy or accept an unknown ruleset. The active source remains blocked; only validated identifiers, timestamps, booleans, and SHA-256 digests are reported.