### PR TITLE
Skip preview smoke for parent QA policy

### DIFF
--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -48,10 +48,12 @@ jobs:
 
           # Paths that cannot affect the served static site or the /app/ bundle the
           # smoke exercises: backend functions, security rules, native shells, docs,
-          # migrations, and unit tests. preview-smoke only needs to run when the diff
-          # touches something OUTSIDE this set. Anything unrecognized, including
+          # migrations, unit tests, and the exact parent-census policy/contract
+          # sources that are never copied into either served bundle. preview-smoke
+          # only needs to run when the diff touches something OUTSIDE this set.
+          # Anything unrecognized, including smoke runners, staging scripts, and
           # workflow changes under .github/workflows/, runs the smoke.
-          SKIPPABLE='^(functions/|ios/|android/|docs/|_migration/|tests/unit/)|^firestore\.(rules|indexes\.json)$|^storage\.rules$|^[A-Za-z0-9_.-]+\.md$'
+          SKIPPABLE='^(functions/|ios/|android/|docs/|_migration/|tests/unit/|tests/parent-census/)|^scripts/(audit-parent-coverage-mailbox|maintain-parent-coverage-invite|parent-coverage-contract|parent-coverage-mailbox|print-parent-coverage-authoring-context|validate-parent-coverage-contract)\.mjs$|^firestore\.(rules|indexes\.json)$|^storage\.rules$|^[A-Za-z0-9_.-]+\.md$'
 
           if echo "$CHANGED" | grep -Ev "$SKIPPABLE" | grep -q .; then
             echo "web=true" >> "$GITHUB_OUTPUT"

--- a/tests/unit/preview-smoke-workflow.test.js
+++ b/tests/unit/preview-smoke-workflow.test.js
@@ -56,7 +56,17 @@ describe('preview-smoke CI workflow', () => {
 
         expect(shouldRun([])).toBe(false);
         expect(shouldRun(['docs/testing.md', 'functions/index.js'])).toBe(false);
+        expect(shouldRun([
+            'scripts/parent-coverage-contract.mjs',
+            'tests/unit/parent-coverage-contract.test.js'
+        ])).toBe(false);
+        expect(shouldRun([
+            'scripts/validate-parent-coverage-contract.mjs',
+            'tests/parent-census/workflows.json'
+        ])).toBe(false);
         expect(shouldRun(['js/auth.js'])).toBe(true);
+        expect(shouldRun(['scripts/stage-pages-bundle.mjs'])).toBe(true);
+        expect(shouldRun(['tests/smoke/helpers/parent-coverage-runner.js'])).toBe(true);
         expect(shouldRun(['.github/workflows/preview-smoke.yml'])).toBe(true);
         expect(workflow).not.toContain('[ -z "$CHANGED" ] ||');
     });


### PR DESCRIPTION
## What changed

- Skip the heavy browser preview job when a PR changes only exact parent-census policy/contract sources, parent-census fixtures, and unit tests.
- Keep the stable `preview-smoke` aggregate fail-closed.
- Continue running browser smoke for web code, smoke runners, staging scripts, unknown paths, and workflow changes.

## Why

PR #4470 changed only `scripts/parent-coverage-contract.mjs` and its unit test. All code checks passed by 5m38s, but an irrelevant preview job took 13m39s and delayed merge to 16m12s.

## Validation

- `npx vitest run tests/unit/preview-smoke-workflow.test.js tests/unit/pr-ci-consolidation.test.js tests/unit/pr-fast-closeout-workflow.test.js tests/unit/visual-regression-wiring.test.js tests/unit/pages-bundle-staging.test.js --reporter=verbose` — 48 passed
- `node scripts/validate-firebase-rules-ci.mjs`
- `git diff --check`

## Security boundary

The skip list names only test-policy files that are not copied into either served bundle. Workflow files and any unrecognized path still run the smoke job.