### PR TITLE
Fix account deletion census contract

### DIFF
--- a/scripts/parent-coverage-contract.mjs
+++ b/scripts/parent-coverage-contract.mjs
@@ -110,7 +110,7 @@ const workflowCapabilities = new Map(Object.entries({
     P34: { mode: 'reversible', routes: ['/home', '/people/*'], actions: ['fill', 'click', 'uploadSyntheticImage'] },
     P35: { mode: 'reversible', routes: ['/ai'], actions: ['fill', 'click'] },
     P36: { mode: 'reversible', routes: ['/ai'], actions: ['fill', 'click', 'uploadSyntheticImage', 'uploadSyntheticDocument'] },
-    P37: { mode: 'lifecycle', routes: ['/profile/settings'], actions: ['fill', 'fillActorPassword', 'click'] }
+    P37: { mode: 'lifecycle', routes: ['/profile/settings', '/auth'], actions: ['fill', 'fillActorPassword', 'click'] }
 }));
 const stateChangingActions = new Set([
     'click', 'fill', 'fillActorEmail', 'fillActorPassword', 'check', 'uncheck',
@@ -403,10 +403,11 @@ const workflowCoverageRequirements = new Map(Object.entries({
     ],
     P37: [
         { action: 'login', actor: 'lifecycle' },
-        { action: 'goto', actor: 'lifecycle', route: /profile\/settings/ },
-        { action: 'fillActorPassword', actor: 'lifecycle', target: /password/i },
-        { action: 'fill', actor: 'lifecycle', target: /type delete to confirm/i, value: /^DELETE$/ },
-        { action: 'click', actor: 'lifecycle', target: /delete account|confirm deletion/i },
+        { action: 'goto', actor: 'lifecycle', route: /profile\/settings\?section=security/ },
+        { action: 'click', actor: 'lifecycle', target: /^delete my account$/i },
+        { action: 'fillActorPassword', actor: 'lifecycle', target: /^account password \(email sign-in only\)$/i },
+        { action: 'fill', actor: 'lifecycle', target: /^type delete to confirm$/i, value: /^DELETE$/ },
+        { action: 'click', actor: 'lifecycle', target: /^delete account$/i },
         { actions: ['expectVisible', 'expectText'], actor: 'lifecycle', target: /deleted|sign in|goodbye/i },
         { action: 'expectRoute', actor: 'lifecycle', route: /auth/ }
     ]
@@ -482,7 +483,7 @@ const mutationTargetCapabilities = new Map(Object.entries({
     },
     P35: { primary: /^(?:ai|chat|prompt|send|delete message|clear chat|new conversation)$/i },
     P36: { primary: /^(?:ai|chat|prompt|attachment|image|document|upload|attach image, CSV, or PDF|send|delete message|remove attachment|clear chat|new conversation)$/i },
-    P37: { lifecycle: /^(?:password|type delete to confirm|account password \(email sign-in only\)|cancel account deletion|delete account|confirm deletion|confirm|cancel)$/i }
+    P37: { lifecycle: /^(?:delete my account|type delete to confirm|account password \(email sign-in only\)|delete account)$/i }
 }));
 const readOnlyInteractionTargetCapabilities = new Map(Object.entries({
     P07: { clickAndExpectGoogleAuth: /^(?:continue with google|sign in with google|google)$/i },
@@ -903,16 +904,23 @@ export function assertParentCoverageStepCapability(workflowId, step, phase = 'ex
         }
         const normalizedTarget = targetName.toLowerCase();
         const isCredentialInput = ['fill', 'fillActorEmail', 'fillActorPassword'].includes(step.action);
+        const targetMentionsPassword = /password/.test(normalizedTarget);
+        const targetMentionsEmail = /email/.test(normalizedTarget);
+        const isPasswordTarget = targetMentionsPassword && (
+            !targetMentionsEmail || step.action !== 'fillActorEmail'
+        );
+        const isEmailTarget = targetMentionsEmail && (
+            !targetMentionsPassword || step.action !== 'fillActorPassword'
+        );
         const lifecycleEmailInput = step.action === 'fill' && step.value === '{LIFECYCLE_EMAIL}' ||
             step.action === 'fillActorEmail' && actor === 'lifecycle';
-        if (capability.mode === 'lifecycle' && isCredentialInput && /email/.test(normalizedTarget) && !lifecycleEmailInput) {
+        if (capability.mode === 'lifecycle' && isCredentialInput && isEmailTarget && !lifecycleEmailInput) {
             throw new Error(`${phase} lifecycle email inputs must bind to the protected lifecycle actor`);
         }
         if (
             capability.mode === 'lifecycle' &&
             isCredentialInput &&
-            !/email/.test(normalizedTarget) &&
-            /password/.test(normalizedTarget) &&
+            isPasswordTarget &&
             step.action !== 'fillActorPassword'
         ) {
             throw new Error(`${phase} lifecycle password inputs must bind to the protected lifecycle actor`);

--- a/scripts/parent-coverage-contract.mjs
+++ b/scripts/parent-coverage-contract.mjs
@@ -110,7 +110,7 @@ const workflowCapabilities = new Map(Object.entries({
     P34: { mode: 'reversible', routes: ['/home', '/people/*'], actions: ['fill', 'click', 'uploadSyntheticImage'] },
     P35: { mode: 'reversible', routes: ['/ai'], actions: ['fill', 'click'] },
     P36: { mode: 'reversible', routes: ['/ai'], actions: ['fill', 'click', 'uploadSyntheticImage', 'uploadSyntheticDocument'] },
-    P37: { mode: 'lifecycle', routes: ['/profile/settings', '/auth'], actions: ['fill', 'fillActorPassword', 'click'] }
+    P37: { mode: 'lifecycle', routes: ['/profile/settings'], actions: ['fill', 'fillActorPassword', 'click'] }
 }));
 const stateChangingActions = new Set([
     'click', 'fill', 'fillActorEmail', 'fillActorPassword', 'check', 'uncheck',
@@ -822,6 +822,12 @@ export function workflowRouteAllowed(workflowId, route, resolved = false) {
     return Boolean(capability?.routes.some((allowedRoute) => routeMatchesCapability(route, allowedRoute, resolved)));
 }
 
+function workflowStepRouteAllowed(workflowId, action, route) {
+    if (workflowRouteAllowed(workflowId, route)) return true;
+    return workflowId === 'P37' && action === 'expectRoute' &&
+        routeMatchesCapability(route, '/auth');
+}
+
 export function assertParentCoverageStepCapability(workflowId, step, phase = 'execution', defaultActor = '') {
     const capability = workflowCapabilities.get(workflowId);
     if (!capability) throw new Error(`${phase} has no trusted workflow capability for ${workflowId}`);
@@ -835,7 +841,7 @@ export function assertParentCoverageStepCapability(workflowId, step, phase = 'ex
     ) {
         throw new Error(`${phase} action ${step.action} is not allowed for workflow ${workflowId}`);
     }
-    if (['goto', 'expectRoute'].includes(step.action) && !workflowRouteAllowed(workflowId, step.route)) {
+    if (['goto', 'expectRoute'].includes(step.action) && !workflowStepRouteAllowed(workflowId, step.action, step.route)) {
         throw new Error(`${phase} route is outside the trusted ${workflowId} capability`);
     }
     if (step.action === 'clickAndExpectRoute' && !workflowRouteAllowed(workflowId, step.route)) {
@@ -1004,7 +1010,7 @@ function validateStep(step, index, declaredActors, workflowId, phase = 'executio
         if (!step.route.startsWith('/') || step.route.startsWith('//')) {
             throw new Error(`${label} route must be an app-relative route`);
         }
-        if (!workflowRouteAllowed(workflowId, step.route)) {
+        if (!workflowStepRouteAllowed(workflowId, step.action, step.route)) {
             throw new Error(`${label} route is outside the trusted ${workflowId} capability`);
         }
     }

--- a/tests/unit/parent-coverage-contract.test.js
+++ b/tests/unit/parent-coverage-contract.test.js
@@ -347,6 +347,49 @@ describe('parent coverage contract boundary', () => {
         expect(parentCoverageEvidenceScope('P27')).toBe('end-to-end');
     });
 
+    it('locks account deletion to the security tab and its two-step confirmation', () => {
+        const button = (name) => ({ kind: 'role', role: 'button', name, exact: true });
+        const deletion = {
+            schemaVersion: CONTRACT_SCHEMA_VERSION,
+            workflowId: 'P37', title: catalog.workflows[36].title, actors: ['lifecycle'],
+            viewport: 'mobile',
+            mutatesProduction: true, cleanupRequired: false, lifecycleTransition: true,
+            steps: [
+                { action: 'login', actor: 'lifecycle' },
+                { action: 'goto', actor: 'lifecycle', route: '/profile/settings?section=security' },
+                { action: 'click', actor: 'lifecycle', target: button('Delete my account') },
+                {
+                    action: 'fillActorPassword', actor: 'lifecycle',
+                    target: { kind: 'label', name: 'Account password (email sign-in only)', exact: true }
+                },
+                {
+                    action: 'fill', actor: 'lifecycle',
+                    target: { kind: 'label', name: 'Type DELETE to confirm', exact: true },
+                    value: 'DELETE'
+                },
+                { action: 'click', actor: 'lifecycle', target: button('Delete account') },
+                {
+                    action: 'expectVisible', actor: 'lifecycle',
+                    target: { kind: 'role', role: 'heading', name: 'Sign in', exact: true }
+                },
+                { action: 'expectRoute', actor: 'lifecycle', route: '/auth' }
+            ],
+            cleanupSteps: []
+        };
+
+        expect(validateContract(deletion, catalog, 'P37').workflowId).toBe('P37');
+        expect(() => validateContract({
+            ...deletion,
+            steps: deletion.steps.filter((step) => step.target?.name !== 'Delete my account')
+        }, catalog, 'P37')).toThrow(/ordered trusted P37 lifecycle click workflow behavior/);
+        expect(() => validateContract({
+            ...deletion,
+            steps: deletion.steps.map((step) => step.action === 'goto'
+                ? { ...step, route: '/profile/settings' }
+                : step)
+        }, catalog, 'P37')).toThrow(/ordered trusted P37 lifecycle goto workflow behavior/);
+    });
+
     it('restricts the checkout popup primitive to the two checkout workflows', () => {
         const target = { kind: 'role', role: 'button', name: 'Pay fee', exact: true };
         expect(() => validateContract({

--- a/tests/unit/parent-coverage-contract.test.js
+++ b/tests/unit/parent-coverage-contract.test.js
@@ -388,6 +388,12 @@ describe('parent coverage contract boundary', () => {
                 ? { ...step, route: '/profile/settings' }
                 : step)
         }, catalog, 'P37')).toThrow(/ordered trusted P37 lifecycle goto workflow behavior/);
+        expect(() => validateContract({
+            ...deletion,
+            steps: deletion.steps.flatMap((step) => step.target?.name === 'Delete account'
+                ? [step, { action: 'goto', actor: 'lifecycle', route: '/auth' }]
+                : [step])
+        }, catalog, 'P37')).toThrow(/route is outside the trusted P37 capability/);
     });
 
     it('restricts the checkout popup primitive to the two checkout workflows', () => {


### PR DESCRIPTION
## Summary
- route P37 to the actual Sign-in & security tab and require the modal-opening click before confirmation
- distinguish protected password fields whose labels also mention email, and allow the expected post-deletion `/auth` route
- narrow P37 mutation targets to the exact account-deletion controls
- add a regression contract for the complete disposable-account deletion sequence

## Validation
- `npx vitest run tests/unit/parent-coverage-contract.test.js tests/unit/parent-coverage-invite.test.js tests/unit/parent-coverage-mailbox.test.js tests/unit/parent-coverage-runner.test.js tests/unit/parent-coverage-workflow.test.js --reporter=verbose` (77 passed)
- `npm test -- --run` (745 files passed, 5,757 tests passed, 3 files/165 tests skipped)
- `git diff --check`

## Safety
- no product runtime, credentials, or production data changed
- P37 remains restricted to the disposable lifecycle actor and exact destructive controls
- no live P37 execution was triggered during local validation