### PR TITLE
Create release emulator in explicit AVD home

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -115,10 +115,14 @@ jobs:
           sudo udevadm trigger --name-match=kvm
       - name: Start Android release emulator
         run: |
-          echo no | avdmanager create avd \
+          export ANDROID_AVD_HOME="$RUNNER_TEMP/android-avd"
+          mkdir -p "$ANDROID_AVD_HOME"
+          avdmanager create avd \
             --force \
             --name allplays-release \
-            --package "system-images;android-35;google_apis;x86_64"
+            --package "system-images;android-35;google_apis;x86_64" \
+            --device "pixel_2"
+          test -f "$ANDROID_AVD_HOME/allplays-release.ini"
           "$ANDROID_SDK_ROOT/emulator/emulator" \
             -avd allplays-release \
             -no-window \

--- a/tests/unit/mobile-release-workflow.test.js
+++ b/tests/unit/mobile-release-workflow.test.js
@@ -49,6 +49,9 @@ describe('mobile release workflow', () => {
         expect(artifactStep.with.path).toContain('app-release.aab');
         expect(artifactStep.with.path).toContain('app-release.apk');
         expect(startStep.run).toContain('"$ANDROID_SDK_ROOT/emulator/emulator"');
+        expect(startStep.run).toContain('export ANDROID_AVD_HOME="$RUNNER_TEMP/android-avd"');
+        expect(startStep.run).toContain('--device "pixel_2"');
+        expect(startStep.run).toContain('test -f "$ANDROID_AVD_HOME/allplays-release.ini"');
         expect(startStep.run).not.toContain('adb wait-for-device');
         expect(startStep.run).toContain('kill -0 "$emulator_pid"');
         expect(startStep.run).toContain('boot_deadline=$((SECONDS + 180))');


### PR DESCRIPTION
## Summary
- create the Android release AVD in an explicit runner-temporary AVD home
- select the Pixel 2 hardware profile non-interactively
- verify the AVD descriptor exists before attempting emulator startup

## Evidence
Release run #12 launched the emulator binary but failed with `Unknown AVD name [allplays-release]`; emulator verification and Play upload were skipped.

## Validation
- `npx vitest run tests/unit/mobile-release-workflow.test.js --reporter=verbose` (3 passed)