### PR TITLE
Add held privacy data-use draft with legal-review READMEs

### DIFF
--- a/docs/legal/README.md
+++ b/docs/legal/README.md
@@ -1,0 +1,89 @@
+# Legal drafts — held for counsel review
+
+> **STATUS: DRAFT · NOT IN FORCE · NOT LEGAL ADVICE**
+>
+> Nothing in this directory is published, active, or binding. These are
+> **proposed** documents that require review and approval by qualified legal
+> counsel before any of the language is placed into a live policy
+> (`privacy.html`, `terms.html`) or relied upon. Authored by engineering as a
+> starting point for counsel — not by a lawyer.
+
+## Why this directory exists
+
+[PR #4554](https://github.com/pauljsnider/allplays/pull/4554) added a Terms of
+Service / Privacy Policy **agreement gate** at signup (web app, legacy site, and
+the ChatGPT MCP OAuth flow). That change shipped.
+
+As part of that PR, a proposed **data-use / de-identification / marketing**
+section was drafted for `privacy.html`. It was **intentionally removed before
+merge** because it makes material privacy commitments — including about
+**minors' data** — that must not be published until counsel has reviewed them.
+A regression test now guards against that language reappearing in `privacy.html`
+without review (see [Guardrail](#guardrail)).
+
+This directory preserves that proposed language so it is ready to finalize once
+legal sign-off is obtained, rather than being lost or re-drafted from scratch.
+
+## Contents
+
+| File | What it is |
+| --- | --- |
+| [`privacy-data-use-monetization.draft.md`](privacy-data-use-monetization.draft.md) | Proposed Privacy Policy section covering de-identified/aggregated data, product development, and marketing, with clause-by-clause annotations and open questions for counsel. |
+
+## Background context (product intent)
+
+The product goal is to **keep monetization options open** (subscriptions,
+de-identified aggregate insights, first-party marketing) while holding firm
+**bright lines** appropriate for a youth-sports product:
+
+- No **selling** of personal information.
+- No use of **athlete or minors'** information for third-party advertising.
+- No **sharing** of identifiable data with third parties for their own marketing.
+
+The draft is written conservatively around those lines. A broader-monetization
+variant is described in the draft but flagged as higher risk.
+
+## Why counsel review is non-negotiable here
+
+This app stores children's data (athlete profiles, medical/emergency fields,
+photos, guardian contacts). That triggers legal regimes a self-authored policy
+should not attempt to satisfy alone, including but not limited to:
+
+- **COPPA** — verifiable parental consent for under-13 data; a coach checking a
+  box is not sufficient.
+- **State youth-privacy / student-privacy laws.**
+- **CCPA/CPRA** and other state comprehensive privacy laws — the statutory
+  definitions of "sale" and "share" are broad and do not always match lay usage.
+- **App Store / Play Store** kids/data policies.
+
+Engineering can describe *what the system does with data*; only counsel can
+decide *what may be committed to in a published policy*.
+
+## Adoption process (when counsel approves)
+
+1. **Counsel reviews and edits** the draft to final, jurisdiction-correct
+   wording.
+2. **Product/engineering confirm** the app's actual data practices match the
+   approved wording (do not publish commitments the system does not honor).
+3. Copy the approved language into `privacy.html` and **bump the `Effective`
+   date**. Consider whether existing users must **re-consent** to the new
+   version.
+4. **Update the guardrail test** `tests/unit/mobile-store-legal-pages.test.js`
+   (the `does not publish unapproved privacy policy expansion language` case) so
+   it asserts the *approved* language is present, rather than asserting its
+   absence.
+5. Verify the signup consent flow still links the current published policy.
+
+## Guardrail
+
+`tests/unit/mobile-store-legal-pages.test.js` fails if `privacy.html` contains
+the unapproved markers (e.g. `LEGAL REVIEW REQUIRED`, the section heading, or the
+marketing sentence). This is deliberate: it prevents the held language from being
+merged into the live policy before step 4 above is done.
+
+## Disclaimer
+
+These documents are engineering work product for the purpose of obtaining legal
+review. They are **not legal advice** and do **not** represent ALL PLAYS's
+current privacy commitments. The live policy is whatever is published at
+`https://allplays.ai/privacy.html`.

--- a/docs/legal/privacy-data-use-monetization.draft.md
+++ b/docs/legal/privacy-data-use-monetization.draft.md
@@ -1,0 +1,109 @@
+# DRAFT — Privacy Policy: data-use, de-identification, and marketing
+
+> **STATUS: DRAFT · NOT IN FORCE · NOT LEGAL ADVICE**
+>
+> This is proposed language for a section of `privacy.html`. It is **not
+> published** and **not binding**. It must be reviewed and approved by qualified
+> legal counsel before any of it is placed into the live Privacy Policy. See
+> [`README.md`](README.md) for the adoption process.
+
+## Proposed section (conservative baseline)
+
+The following is the exact language proposed for insertion into `privacy.html`,
+after the "How information is used" section and before "Service providers".
+
+> ### Product development, de-identified data, and marketing
+>
+> We may create de-identified and aggregated information — information that does
+> not identify, and cannot reasonably be used to identify, any individual,
+> athlete, or team — and use or share it to operate, analyze, secure, benchmark,
+> and improve ALL PLAYS, to develop new features and products, and to report on
+> overall trends. We maintain de-identified information as non-personal and do
+> not attempt to re-identify it.
+>
+> We may use an adult account holder's contact information to send information
+> about ALL PLAYS features, subscriptions, and offers; you can opt out of
+> non-essential messages at any time. **We do not sell personal information, and
+> we do not use athlete or minors' information for third-party advertising or
+> share it with third parties for their own marketing.** Paid subscriptions and
+> features are billed through the applicable app store or payment provider under
+> their terms.
+
+## Clause-by-clause notes (for counsel)
+
+1. **De-identified & aggregated data** — Intends to reserve broad internal use
+   plus sharing of *non-personal* aggregates (analytics, benchmarking, new
+   features, trend reporting), with a commitment not to re-identify.
+   - *Counsel to confirm:* Does the stated de-identification standard meet the
+     applicable legal bar (e.g. CCPA/CPRA "deidentified" requirements —
+     technical safeguards, business-process prohibitions on re-identification,
+     and contractual obligations on recipients)? Is "aggregated" defined
+     adequately?
+
+2. **First-party marketing to adults** — Uses account-holder contact info for
+   ALL PLAYS's own product/subscription messaging, with opt-out.
+   - *Counsel to confirm:* Opt-out vs opt-in requirements; CAN-SPAM / TCPA if
+     SMS is ever used; whether any marketing may reach accounts that manage
+     minors.
+
+3. **Bright lines (bolded)** — No sale of personal information; no use of
+   athlete/minors' data for third-party advertising; no sharing of identifiable
+   data for third parties' own marketing.
+   - *Counsel to confirm:* Whether "sell" and "share" here should be tied to the
+     **statutory** definitions (CCPA/CPRA define both broadly — e.g. some
+     cross-context behavioral advertising counts as a "share"), and whether a
+     "Do Not Sell or Share" mechanism is required.
+
+4. **Billing** — Paid features billed via app store / payment provider under
+   their terms.
+   - *Counsel to confirm:* Consistency with Apple/Google billing rules and any
+     refund/renewal disclosures.
+
+## Bright lines this draft preserves
+
+- **No selling** of personal information.
+- **No** athlete/minors' information used for third-party advertising.
+- **No** sharing of identifiable data with third parties for their own
+  marketing.
+
+These are the commitments the youth-sports context most needs; counsel should
+treat them as constraints to keep, not soften, absent a specific reason.
+
+## Optional broader-monetization variant (HIGHER RISK — not recommended without counsel)
+
+The product intent is to *not rule out* future monetization. If, after legal
+review, ALL PLAYS wants to reserve options beyond the conservative baseline
+(e.g. sharing pseudonymous data with partners, or third-party analytics/ad
+SDKs), that is a **materially higher-risk** posture for a product holding
+children's data and would require, at minimum:
+
+- Explicit, separately-consented disclosures (not buried in a general policy).
+- A COPPA analysis for anything touching under-13 data, including verifiable
+  parental consent mechanics.
+- CCPA/CPRA "sale"/"share" treatment and a "Do Not Sell or Share My Personal
+  Information" link and workflow.
+- App/Play Store data-practice disclosures kept in sync.
+
+**Do not draft or publish the broader variant without counsel leading it.** This
+file intentionally does not contain broader-variant wording.
+
+## Open questions for counsel
+
+- [ ] Is the de-identification/aggregation standard sufficient under CCPA/CPRA
+      (and any other applicable state law)?
+- [ ] Should "sell" / "share" map to statutory definitions, and is a
+      Do-Not-Sell-or-Share mechanism required?
+- [ ] COPPA: does any described use touch under-13 data, and if so what consent
+      is required?
+- [ ] Are there jurisdictions in scope beyond the US? (Product intent today is
+      US-only.)
+- [ ] Marketing: opt-out sufficient, or opt-in required for any channel/segment?
+- [ ] Does the app's *actual* behavior match every commitment above? (Do not
+      publish commitments the system does not enforce.)
+
+## Provenance
+
+This language was originally proposed in
+[PR #4554](https://github.com/pauljsnider/allplays/pull/4554) and removed before
+merge pending this review. It corresponds to the section previously marked in
+`privacy.html` with an inline `LEGAL REVIEW REQUIRED` comment.


### PR DESCRIPTION
## Summary
Preserves the Privacy Policy **data-use / de-identification / marketing** language that was drafted in [#4554](https://github.com/pauljsnider/allplays/pull/4554) and **removed before merge** pending legal review — now stored as clearly-marked drafts under [`docs/legal/`](docs/legal/). **Nothing here is published, active, or binding.**

- [`docs/legal/README.md`](docs/legal/README.md) — purpose, status banner, product intent (keep monetization open behind firm youth-data bright lines), why counsel review is non-negotiable (COPPA/CCPA-CPRA/store policies), the **adoption process**, and the guardrail.
- [`docs/legal/privacy-data-use-monetization.draft.md`](docs/legal/privacy-data-use-monetization.draft.md) — the exact proposed `privacy.html` section, clause-by-clause notes for counsel, preserved bright lines, an explicitly higher-risk broader-monetization note (not drafted), and open questions.

## Why
This app stores children's data, so publishing data-use/monetization commitments requires counsel sign-off. Holding the language in-repo means it's ready to finalize once approved instead of re-drafted, without going live prematurely.

## Guardrail interaction
The live policy is unchanged. `tests/unit/mobile-store-legal-pages.test.js` still guards `privacy.html` against the unapproved language; these markdown drafts are outside its scope. The README's adoption steps include updating that test when the approved wording is eventually published.

## Not legal advice
Engineering work product to support legal review; not ALL PLAYS's current privacy commitments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)