### PR TITLE
Harden transient Firestore rules deploys

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -954,7 +954,7 @@ jobs:
         # Updating the full first-generation Functions fleet routinely takes
         # longer than four minutes. Leave enough room for one deployment plus
         # the bounded transient retries above without allowing an unbounded job.
-        timeout-minutes: 20
+        timeout-minutes: 30
         shell: bash
         env:
           ADMIN_USER_SEARCH_BACKFILL_NEEDED: ${{ needs.prepare-deploy.outputs.admin_user_search_backfill_needed }}
@@ -1299,7 +1299,7 @@ jobs:
                 }
               }' > "$payload_file"
 
-            for attempt in 1 2 3; do
+            for attempt in 1 2 3 4 5 6; do
               set +e
               http_status="$(
                 curl --silent --show-error \
@@ -1352,9 +1352,21 @@ jobs:
                 echo "Firestore ruleset creation failed with non-transient HTTP ${http_status}; not retrying." >&2
                 break
               fi
-              if (( attempt < 3 )); then
-                retry_delay_seconds=$((10 * attempt))
-                echo "Transient Firestore ruleset creation failure; retrying in ${retry_delay_seconds}s (attempt $((attempt + 1))/3)." >&2
+              # A timeout or 5xx can arrive after the immutable create commits.
+              # Reconcile by exact source before sending another POST so a lost
+              # response resumes from the durable provider state.
+              if ruleset_name="$(find_recent_matching_firestore_ruleset "$expected_rules_source")"; then
+                rm -f "$payload_file" "$response_file"
+                printf '%s\n' "$ruleset_name"
+                return 0
+              fi
+              if (( attempt < 6 )); then
+                retry_delay_seconds=$((15 * (2 ** (attempt - 1))))
+                retry_delay_seconds=$((retry_delay_seconds + (RANDOM % 16)))
+                if (( retry_delay_seconds > 120 )); then
+                  retry_delay_seconds=120
+                fi
+                echo "Transient Firestore ruleset creation failure; retrying in ${retry_delay_seconds}s (attempt $((attempt + 1))/6)." >&2
                 sleep "$retry_delay_seconds"
               fi
             done

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -177,7 +177,7 @@ export function validateFirebaseDeployWorkloadIdentity(workflow, label) {
             deployStepCount += 1;
             const maxTimeoutMinutes = label === 'Production deploy' &&
                 step.name === 'Deploy Firebase production'
-                ? 20
+                ? 30
                 : 4;
             if (!Number.isInteger(step['timeout-minutes']) ||
                 step['timeout-minutes'] < 1 ||
@@ -430,8 +430,18 @@ export function validateProductionDeployCommand(deployProd) {
     );
     assertMatches(
         deployProd,
-        /create_firestore_ruleset_with_retry\(\)[\s\S]{0,5000}for attempt in 1 2 3; do[\s\S]{0,5000}--request POST/,
+        /create_firestore_ruleset_with_retry\(\)[\s\S]{0,5000}for attempt in 1 2 3 4 5 6; do[\s\S]{0,5000}--request POST/,
         'Production Firestore bounded ruleset create'
+    );
+    assertMatches(
+        deployProd,
+        /create_firestore_ruleset_with_retry\(\)[\s\S]{0,7000}firestore_rules_api_error[\s\S]{0,2500}find_recent_matching_firestore_ruleset "\$expected_rules_source"[\s\S]{0,2500}retry_delay_seconds=\$\(\(15 \* \(2 \*\* \(attempt - 1\)\)\)\)/,
+        'Production Firestore ambiguous-create reconciliation precedes exponential retry'
+    );
+    assertIncludes(
+        deployProd,
+        'retry_delay_seconds=$((retry_delay_seconds + (RANDOM % 16)))',
+        'Production Firestore ruleset retry jitter'
     );
     assertIncludes(
         deployProd,

--- a/tests/unit/firebase-deploy-workload-identity.test.js
+++ b/tests/unit/firebase-deploy-workload-identity.test.js
@@ -141,7 +141,7 @@ describe('Firebase deploy Workload Identity boundary', () => {
         expect(production.slice(storageAuth, storageDeploy)).not.toContain('run:');
         expect(production.slice(productionAuth, productionDeploy)).not.toContain('run:');
         expect(production.slice(storageDeploy, storageCleanup)).toContain('timeout-minutes: 4');
-        expect(production.slice(productionDeploy)).toContain('timeout-minutes: 20');
+        expect(production.slice(productionDeploy)).toContain('timeout-minutes: 30');
         const oidcJobs = workflowJobs(production).filter((job) => job.permissions?.['id-token'] === 'write');
         expect(oidcJobs).toHaveLength(2);
         for (const oidcJob of oidcJobs) {

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -284,11 +284,19 @@ concurrency:
           }
           create_firestore_ruleset_with_retry() {
             jq --rawfile rules_source firestore.rules --arg rules_fingerprint fingerprint 'fingerprint:$rules_fingerprint'
-            for attempt in 1 2 3; do
+            for attempt in 1 2 3 4 5 6; do
               curl --request POST "https://firebaserules.googleapis.com/v1/projects/game-flow-c6311/rulesets"
               jq '(.source.files // []) | if length == 1 and .[0].name == "firestore.rules"'
               [[ -n "$created_rules_b64" && "$created_rules_b64" == "$local_rules_b64" ]]
               [[ "$created_fingerprint" == "$local_fingerprint" ]]
+              firestore_rules_api_error "Firestore ruleset creation"
+              if ruleset_name="$(find_recent_matching_firestore_ruleset "$expected_rules_source")"; then
+                printf '%s\n' "$ruleset_name"
+                return 0
+              fi
+              retry_delay_seconds=$((15 * (2 ** (attempt - 1))))
+              retry_delay_seconds=$((retry_delay_seconds + (RANDOM % 16)))
+              if (( retry_delay_seconds > 120 )); then retry_delay_seconds=120; fi
             done
           }
           ensure_exact_firestore_ruleset() {


### PR DESCRIPTION
### What changed

- Reconcile ambiguous Rules API create failures against recent immutable rulesets before another POST.
- Retry transient Rules API 5xx responses up to six times with bounded exponential backoff and jitter.
- Extend only the bounded production deploy step timeout from 20 to 30 minutes and strengthen the executable workflow contract and its synthetic fixture.

### Why

Production deploy run 31498871073 reached Firestore ruleset creation and received three transient HTTP 503 responses. The old 3-attempt, 10/20-second schedule exhausted before the service recovered. A timeout or 5xx may also hide a committed immutable create, so retries must reconcile provider state first.

### Validation

- `npx vitest run tests/unit/validate-firebase-rules-ci.test.js tests/unit/firebase-deploy-workload-identity.test.js tests/unit/production-smoke-config-gate.test.js --reporter=dot` — 16/16 passed.
- `node scripts/validate-firebase-rules-ci.mjs` — passed.
- `git diff --check origin/master...HEAD` — passed.
- Exact tested head: `457b1847f8d08eccdd404dc64369896733cf99f3`.

### Production safety

Rules remain rules-first and fail closed. The workflow still validates the exact create response, immutable source/fingerprint, and active release before publishing Functions or Hosting. No credentials, authorization policy, or production data are changed.