### PR TITLE
Harden Firestore release activation retries

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1431,7 +1431,7 @@ jobs:
                 updateMask:"rulesetName"
               }' > "$payload_file"
 
-            for attempt in 1 2 3 4 5; do
+            for attempt in 1 2 3 4 5 6 7 8; do
               set +e
               http_status="$(
                 curl --silent --show-error \
@@ -1467,9 +1467,19 @@ jobs:
               if (( curl_status == 0 )) && [[ ! "$http_status" =~ ^(408|409|429|500|502|503|504)$ ]]; then
                 break
               fi
-              if (( attempt < 5 )); then
-                retry_delay_seconds=$((15 * attempt))
-                echo "Transient Firestore release update failure; retrying in ${retry_delay_seconds}s (attempt $((attempt + 1))/5)." >&2
+              # A timeout or 5xx can arrive after the release PATCH commits.
+              # Re-read the exact release before sending another mutation.
+              if verify_active_firestore_release_name "$ruleset_name"; then
+                rm -f "$payload_file" "$response_file"
+                return 0
+              fi
+              if (( attempt < 8 )); then
+                retry_delay_seconds=$((15 * (2 ** (attempt - 1))))
+                retry_delay_seconds=$((retry_delay_seconds + (RANDOM % 16)))
+                if (( retry_delay_seconds > 120 )); then
+                  retry_delay_seconds=120
+                fi
+                echo "Transient Firestore release update failure; retrying in ${retry_delay_seconds}s (attempt $((attempt + 1))/8)." >&2
                 sleep "$retry_delay_seconds"
               fi
             done

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -583,6 +583,16 @@ export function validateProductionDeployCommand(deployProd) {
         'firestore_rules_api_error "Firestore release update"',
         'Production Firestore structured release failure diagnostics'
     );
+    assertMatches(
+        deployProd,
+        /activate_firestore_ruleset_with_retry\(\)[\s\S]{0,5000}for attempt in 1 2 3 4 5 6 7 8; do[\s\S]{0,5000}--request PATCH/,
+        'Production Firestore bounded release update'
+    );
+    assertMatches(
+        deployProd,
+        /activate_firestore_ruleset_with_retry\(\)[\s\S]{0,7000}firestore_rules_api_error "Firestore release update"[\s\S]{0,2000}verify_active_firestore_release_name "\$ruleset_name"[\s\S]{0,2000}retry_delay_seconds=\$\(\(15 \* \(2 \*\* \(attempt - 1\)\)\)\)/,
+        'Production Firestore ambiguous-release reconciliation precedes exponential retry'
+    );
     assertIncludes(
         deployProd,
         'Created or reused and activated the exact staged Firestore ruleset.',

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -312,11 +312,16 @@ concurrency:
           }
           activate_firestore_ruleset_with_retry() {
             [[ "$ruleset_name" =~ ^projects/game-flow-c6311/rulesets/[A-Za-z0-9_-]+$ ]] || return 1
-            curl --request PATCH "https://firebaserules.googleapis.com/v1/projects/game-flow-c6311/releases/cloud.firestore"
-            jq 'updateMask:"rulesetName"'
-            [[ "$(jq -r '.rulesetName // ""' "$response_file")" == "$ruleset_name" ]]
-            verify_active_firestore_release_name "$ruleset_name"
-            firestore_rules_api_error "Firestore release update"
+            for attempt in 1 2 3 4 5 6 7 8; do
+              curl --request PATCH "https://firebaserules.googleapis.com/v1/projects/game-flow-c6311/releases/cloud.firestore"
+              jq 'updateMask:"rulesetName"'
+              [[ "$(jq -r '.rulesetName // ""' "$response_file")" == "$ruleset_name" ]]
+              firestore_rules_api_error "Firestore release update"
+              if verify_active_firestore_release_name "$ruleset_name"; then return 0; fi
+              retry_delay_seconds=$((15 * (2 ** (attempt - 1))))
+              retry_delay_seconds=$((retry_delay_seconds + (RANDOM % 16)))
+              if (( retry_delay_seconds > 120 )); then retry_delay_seconds=120; fi
+            done
           }
           write_firestore_configuration_blocked_summary() {
             {


### PR DESCRIPTION
### What changed

- Re-read the active Firestore release after every ambiguous transient PATCH failure before sending another mutation.
- Expand release activation to eight bounded attempts with exponential backoff, jitter, and a 120-second wait cap.
- Add executable workflow-contract coverage for the exact retry and reconciliation order.

### Why

Exact-master production retry 31498871073 passed the earlier create boundary, then received five HTTP 503 responses while activating the exact immutable ruleset. The old activation window ended after 2m50s even though the provider outage persisted.

### Validation

- `npx vitest run tests/unit/validate-firebase-rules-ci.test.js tests/unit/firebase-deploy-workload-identity.test.js tests/unit/production-smoke-config-gate.test.js --reporter=dot` — 16/16 passed.
- `node scripts/validate-firebase-rules-ci.mjs` — passed.
- `git diff --check origin/master...HEAD` — passed.
- Exact tested head: `c6dee0aa32536ed2f13ff891f84dbe4ee76fde2d`.

### Production safety

Activation remains bound to the exact validated immutable ruleset name. Ambiguous responses are reconciled by reading the exact active release; Hosting and the full Functions publish remain fail-closed until activation is proven. No authorization policy, credentials, or production data change.