### PR TITLE
Keep discovered teams usable during partial loads

### DIFF
--- a/apps/app/src/lib/homeService.test.ts
+++ b/apps/app/src/lib/homeService.test.ts
@@ -213,7 +213,7 @@ describe('homeService Teams bootstrap reuse', () => {
         ]);
     });
 
-    it('rejects a partial nonempty chooser so a later complete load cannot be masked', async () => {
+    it('renders a partial nonempty chooser without caching it as complete', async () => {
         scheduleServiceMocks.loadParentScheduleScope
             .mockResolvedValueOnce({
                 profile: {},
@@ -233,11 +233,13 @@ describe('homeService Teams bootstrap reuse', () => {
                 isPartial: false
             });
 
-        await expect(loadParentTeamsSummaryBootstrap(user)).rejects.toThrow(
-            'Team access discovery is incomplete'
-        );
+        const partial = await loadParentTeamsSummaryBootstrap(user);
         const complete = await loadParentTeamsSummaryBootstrap(user);
 
+        expect(partial.scheduleScope.isPartial).toBe(true);
+        expect(partial.home.teams).toEqual([
+            expect.objectContaining({ teamId: 'team-1', teamName: 'Vipers' })
+        ]);
         expect(complete.home.teams).toHaveLength(2);
         expect(scheduleServiceMocks.loadParentScheduleScope).toHaveBeenCalledTimes(2);
     });

--- a/apps/app/src/lib/homeService.ts
+++ b/apps/app/src/lib/homeService.ts
@@ -151,8 +151,8 @@ export async function loadParentTeamsSummaryBootstrap(
             throw toAppServiceError(error, 'Unable to load teams.');
           })
         ]);
-        const hasParentLinkedTeams = scheduleScope.children.length > 0;
-        if (scheduleScope.isPartial === true && !hasParentLinkedTeams) {
+        const hasDiscoveredTeams = scheduleScope.children.length > 0 || Boolean(scheduleScope.staffTeams?.length);
+        if (scheduleScope.isPartial === true && !hasDiscoveredTeams) {
           if (chatInboxResult.error) {
             throw chatInboxResult.error;
           }


### PR DESCRIPTION
## What changed
- keep already-authorized staff teams visible when one access-discovery query is temporarily partial
- continue failing closed when a partial discovery returns no usable parent or staff team
- keep partial results out of cache so a subsequent load can recover the complete chooser

## Why
The post-deploy production smoke repeatedly authenticated successfully but `/app/#/teams` discarded the seeded staff team whenever one parallel discovery query was transiently unavailable. The production fixture audit passed, confirming data was valid.

## Validation
- `npm test -- --run src/lib/homeService.test.ts` (9/9)
- `npm run build`
- `git diff --check`

## Coordination
PR #4592 also touches these files as part of a much larger access-query change. This narrow production-monitoring repair is based on current master; #4592 should incorporate or preserve this behavior when rebased.