### PR TITLE
Diagnose production team discovery and restore smoke viewport

### DIFF
--- a/scripts/maintain-production-smoke-parent-fixture.mjs
+++ b/scripts/maintain-production-smoke-parent-fixture.mjs
@@ -230,6 +230,46 @@ function queryContainsDocument(documents, documentPath) {
     return documents.some((document) => getFirestoreDocumentPath(document) === documentPath);
 }
 
+async function queryManagedTeamCallable(session, fetchImpl) {
+    const response = await fetchImpl(
+        `https://us-central1-${encodeURIComponent(session.projectId)}.cloudfunctions.net/listManagedTeams`,
+        {
+            method: 'POST',
+            headers: {
+                authorization: `Bearer ${session.idToken}`,
+                'content-type': 'application/json'
+            },
+            body: JSON.stringify({ data: {} }),
+            signal: AbortSignal.timeout(30_000)
+        }
+    );
+    const payload = await response.json().catch(() => ({}));
+    const result = payload?.result || payload?.data;
+    if (!response.ok || !Array.isArray(result?.items)) {
+        const errorStatus = String(payload?.error?.status || '').trim() || 'invalid-response';
+        throw new Error(`Managed-team callable failed with HTTP ${response.status} (${errorStatus})`);
+    }
+    return {
+        items: result.items.filter((item) => item && typeof item === 'object' && !Array.isArray(item)),
+        isPartial: result.isPartial === true
+    };
+}
+
+export async function loadManagedTeamCallable(session, teamId, fetchImpl = fetch) {
+    let result;
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+        result = await queryManagedTeamCallable(session, fetchImpl);
+        const foundFixture = result.items.some(
+            (item) => String(item?.id || '').trim() === teamId
+        );
+        if (foundFixture || !result.isPartial) return result;
+    }
+    throw new Error(
+        `The app managed-team callable result is inconclusive and retryable after a partial retry ` +
+        `(items=${result.items.length}, partial=true)`
+    );
+}
+
 async function queryStaffTeamDiscovery(session, teamId, email) {
     const normalizedEmail = String(email || '').trim().toLowerCase();
     const teamPath = `teams/${teamId}`;
@@ -388,6 +428,16 @@ async function main() {
             `coach-link=${staffDiscovery.hasCoachTeamId}, owner-query=${staffDiscovery.ownerQueryFound}, ` +
             `admin-query=${staffDiscovery.adminQueryFound}, owner-query-failed=${staffQueryDiscovery.ownerQueryFailed}, ` +
             `admin-query-failed=${staffQueryDiscovery.adminQueryFailed})`
+        );
+    }
+    const managedTeamResult = await loadManagedTeamCallable(staffSession, teamId);
+    const callableFoundFixture = managedTeamResult.items.some(
+        (item) => String(item?.id || '').trim() === teamId
+    );
+    if (!callableFoundFixture) {
+        throw new Error(
+            `The app managed-team callable omitted the fixture team ` +
+            `(items=${managedTeamResult.items.length}, partial=${managedTeamResult.isPartial})`
         );
     }
     const playerPath = `teams/${teamId}/players/${playerId}`;

--- a/tests/smoke/app-authenticated-core.spec.js
+++ b/tests/smoke/app-authenticated-core.spec.js
@@ -101,6 +101,7 @@ test('staff account reaches every critical app workflow with smoke fixtures', as
         expect(trayBox.y + trayBox.height).toBeLessThanOrEqual(navBox.y);
         await page.reload({ waitUntil: 'domcontentloaded' });
         await expect(page.getByRole('heading', { name: /Team settings|Edit team/ })).toBeVisible({ timeout: 20_000 });
+        await page.setViewportSize({ width: 1280, height: 720 });
         await openAuthenticatedAppRoute(page, config.appBaseUrl, `/schedule?teamId=${encodeURIComponent(config.teamId)}`, {
             heading: /Schedule|Your team calendar/,
             requiredHref: `/schedule/${encodeURIComponent(config.teamId)}/${encodeURIComponent(config.eventId)}`

--- a/tests/unit/production-smoke-parent-fixture.test.js
+++ b/tests/unit/production-smoke-parent-fixture.test.js
@@ -373,4 +373,22 @@ describe('production parent smoke fixture maintenance', () => {
             "page.getByText('Create invite', { exact: true })"
         );
     });
+
+    it('restores the desktop viewport before asserting the desktop messages header', () => {
+        const mobileViewport = authenticatedCoreSource.indexOf(
+            'page.setViewportSize({ width: 390, height: 844 })'
+        );
+        const desktopViewport = authenticatedCoreSource.indexOf(
+            'page.setViewportSize({ width: 1280, height: 720 })',
+            mobileViewport + 1
+        );
+        const conversationsHeading = authenticatedCoreSource.indexOf(
+            "heading: 'Conversations'",
+            mobileViewport + 1
+        );
+
+        expect(mobileViewport).toBeGreaterThan(-1);
+        expect(desktopViewport).toBeGreaterThan(mobileViewport);
+        expect(conversationsHeading).toBeGreaterThan(desktopViewport);
+    });
 });

--- a/tests/unit/production-smoke-parent-fixture.test.js
+++ b/tests/unit/production-smoke-parent-fixture.test.js
@@ -8,7 +8,8 @@ import {
     buildCanonicalStaffProfilePatch,
     buildParentMembershipPatch,
     inspectParentFixture,
-    inspectStaffTeamDiscovery
+    inspectStaffTeamDiscovery,
+    loadManagedTeamCallable
 } from '../../scripts/maintain-production-smoke-parent-fixture.mjs';
 
 const workflowSource = readFileSync('.github/workflows/production-smoke-fixture.yml', 'utf8');
@@ -88,6 +89,47 @@ const teamId = 'allplays-smoke-team-v1';
 const playerId = 'allplays-smoke-player-v1';
 
 describe('production parent smoke fixture maintenance', () => {
+    it('retries a partial managed-team result that omits the fixture', async () => {
+        const payloads = [
+            { result: { items: [{ id: 'other-team' }], isPartial: true } },
+            { result: { items: [{ id: teamId }], isPartial: false } }
+        ];
+        let requestCount = 0;
+        const result = await loadManagedTeamCallable(
+            { projectId: 'project-1', idToken: 'token-1' },
+            teamId,
+            async () => ({
+                ok: true,
+                status: 200,
+                json: async () => payloads[requestCount++]
+            })
+        );
+
+        expect(requestCount).toBe(2);
+        expect(result).toEqual({ items: [{ id: teamId }], isPartial: false });
+    });
+
+    it('bounds retries when partial managed-team results keep omitting the fixture', async () => {
+        let requestCount = 0;
+        const loadResult = loadManagedTeamCallable(
+            { projectId: 'project-1', idToken: 'token-1' },
+            teamId,
+            async () => {
+                requestCount += 1;
+                return {
+                    ok: true,
+                    status: 200,
+                    json: async () => ({
+                        result: { items: [{ id: 'other-team' }], isPartial: true }
+                    })
+                };
+            }
+        );
+
+        await expect(loadResult).rejects.toThrow(/inconclusive and retryable after a partial retry/);
+        expect(requestCount).toBe(2);
+    });
+
     it('requires the exact normalized admin value used by app discovery and Firestore rules', () => {
         const legacyTeam = buildTeamDocument({
             ownerId: 'other-owner',


### PR DESCRIPTION
## What changed
- exercise the deployed `listManagedTeams` callable with the protected staff account and require the exact fixture team
- retry one partial callable result, then fail with bounded status/count diagnostics
- restore the configured 1280×720 desktop viewport after the isolated mobile settings-tray assertion
- add regression coverage for callable retry bounds and viewport ordering

## Why
The direct owner/admin query audit passes while the production chooser intermittently omits the staff team, so readiness must exercise the callable used by the current app. Separately, the smoke leaked a 390px viewport into a later desktop-only Conversations assertion.

## Validation
- `npx vitest run tests/unit/production-smoke-parent-fixture.test.js --reporter=verbose` (12/12)
- `node --check scripts/maintain-production-smoke-parent-fixture.mjs`
- `node --check tests/smoke/app-authenticated-core.spec.js`
- `git diff --check`

## Safety
- production fixture audit remains protected and master-only
- audit mode performs no writes
- credentials and response bodies are never logged