### PR TITLE
Recover web managed team discovery

### DIFF
--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -699,6 +699,7 @@ describe('parent schedule child scope', () => {
     vi.mocked(getStaffTeams)
       .mockRejectedValueOnce(new Error('network unavailable'))
       .mockRejectedValueOnce(new Error('network unavailable'));
+    vi.mocked(loadManagedTeamsFromNativeCallable).mockRejectedValue(new Error('authenticated HTTP unavailable'));
 
     const scope = await loadParentScheduleScope(coachUser);
 
@@ -706,6 +707,7 @@ describe('parent schedule child scope', () => {
     expect(scope.staffTeamsPartial).toBe(true);
     expect(scope.staffTeams).toEqual([]);
     expect(getStaffTeams).toHaveBeenCalledTimes(2);
+    expect(loadManagedTeamsFromNativeCallable).toHaveBeenCalledTimes(2);
   });
 
   it('retries partial staff discovery with coach links from the freshly loaded profile', async () => {
@@ -757,6 +759,24 @@ describe('parent schedule child scope', () => {
     } finally {
       globalThis.fetch = previousFetch;
     }
+  });
+
+  it('falls back to the authenticated HTTP callable when the web SDK callable fails', async () => {
+    const coachUser = { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'], coachOf: [] } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: [] } as any);
+    vi.mocked(getStaffTeams).mockRejectedValueOnce(new Error('SDK callable unavailable'));
+    vi.mocked(loadManagedTeamsFromNativeCallable).mockResolvedValueOnce({
+      teams: [{ id: 'team-owned', name: 'Vipers', ownerId: 'coach-1', active: true }],
+      isPartial: false
+    });
+
+    const scope = await loadParentScheduleScope(coachUser);
+
+    expect(getStaffTeams).toHaveBeenCalledTimes(1);
+    expect(loadManagedTeamsFromNativeCallable).toHaveBeenCalledTimes(1);
+    expect(scope.staffTeams).toEqual([{ teamId: 'team-owned', teamName: 'Vipers' }]);
+    expect(scope.staffTeamsPartial).toBe(false);
+    expect(scope.isPartial).toBe(false);
   });
 
   it('accepts an empty complete web callable result without issuing permission-noise REST requests', async () => {
@@ -818,10 +838,12 @@ describe('parent schedule child scope', () => {
         teams: [{ id: 'team-owned', name: 'Vipers', active: true }],
         isPartial: false
       } as any);
+    vi.mocked(loadManagedTeamsFromNativeCallable).mockRejectedValueOnce(new Error('initial HTTP read unavailable'));
 
     const scope = await loadParentScheduleScope(coachUser);
 
     expect(getStaffTeams).toHaveBeenCalledTimes(2);
+    expect(loadManagedTeamsFromNativeCallable).toHaveBeenCalledTimes(1);
     expect(scope.staffTeams).toEqual([{ teamId: 'team-owned', teamName: 'Vipers' }]);
     expect(scope.staffTeamsPartial).toBe(false);
     expect(scope.isPartial).toBe(false);
@@ -849,6 +871,7 @@ describe('parent schedule child scope', () => {
     vi.mocked(getStaffTeams)
       .mockRejectedValueOnce(new Error('network unavailable'))
       .mockRejectedValueOnce(new Error('network unavailable'));
+    vi.mocked(loadManagedTeamsFromNativeCallable).mockRejectedValue(new Error('authenticated HTTP unavailable'));
 
     const firstRefresh = await loadParentSchedule(coachUser, { hydrateDetails: false, expandStaffPlayers: false });
     const secondRefresh = await loadParentSchedule(coachUser, { hydrateDetails: false, expandStaffPlayers: false });

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -779,6 +779,23 @@ describe('parent schedule child scope', () => {
     expect(scope.isPartial).toBe(false);
   });
 
+  it('keeps an HTTP-authorized coach team when the initial user lacks the freshly loaded coach link', async () => {
+    const staleCoachUser = { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'], coachOf: [] } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: ['team-coached'] } as any);
+    vi.mocked(getStaffTeams).mockRejectedValueOnce(new Error('SDK callable unavailable'));
+    vi.mocked(loadManagedTeamsFromNativeCallable).mockResolvedValueOnce({
+      teams: [{ id: 'team-coached', name: 'Coach Bears', active: true }],
+      isPartial: false
+    });
+
+    const scope = await loadParentScheduleScope(staleCoachUser);
+
+    expect(loadManagedTeamsFromNativeCallable).toHaveBeenCalledTimes(1);
+    expect(scope.staffTeams).toEqual([{ teamId: 'team-coached', teamName: 'Coach Bears' }]);
+    expect(scope.staffTeamsPartial).toBe(false);
+    expect(scope.isPartial).toBe(false);
+  });
+
   it('accepts an empty complete web callable result without issuing permission-noise REST requests', async () => {
     const previousFetch = globalThis.fetch;
     const coachUser = { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'], coachOf: [] } as any;

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -1789,24 +1789,28 @@ async function loadStaffTeamsFromRest(user: AuthUser): Promise<StaffTeamsLoadRes
 }
 
 async function loadStaffTeams(user: AuthUser): Promise<StaffTeamsLoadResult> {
-  return readWithNativeFallback(
-    'staff teams',
-    async () => {
-      const coachTeamIds = Array.isArray(user.coachOf) ? user.coachOf.map(compactString).filter(Boolean) : [];
-      const staffTeamResult = await getStaffTeams({
-        userId: user.uid,
-        email: user.email,
-        coachTeamIds
-      });
-      const teamsById = new Map<string, any>();
-      staffTeamResult.teams.filter(Boolean).forEach((team: any) => {
-        if (team?.id && isTeamActive(team)) teamsById.set(team.id, team);
-      });
-      return { teams: [...teamsById.values()], isPartial: staffTeamResult.isPartial };
-    },
-    () => loadStaffTeamsFromRest(user),
-    staffTeamDiscoveryTimeoutMs
-  );
+  const coachTeamIds = Array.isArray(user.coachOf) ? user.coachOf.map(compactString).filter(Boolean) : [];
+  try {
+    const staffTeamResult = await withTimeout(Promise.resolve(getStaffTeams({
+      userId: user.uid,
+      email: user.email,
+      coachTeamIds
+    })), 'staff teams', staffTeamDiscoveryTimeoutMs);
+    const teamsById = new Map<string, any>();
+    staffTeamResult.teams.filter(Boolean).forEach((team: any) => {
+      if (team?.id && isTeamActive(team)) teamsById.set(team.id, team);
+    });
+    return { teams: [...teamsById.values()], isPartial: staffTeamResult.isPartial };
+  } catch (error) {
+    // The SDK callable and the authenticated HTTP callable reach the same
+    // server-authorized listManagedTeams function. Keep the HTTP transport as
+    // a web fallback too: a transient SDK/App Check transport failure must not
+    // erase an otherwise valid staff team from the chooser.
+    logScheduleWarning('Falling back to authenticated HTTP for staff teams.', 'staff-team-callable-fallback', error, {
+      fallback: 'authenticated-http'
+    });
+    return loadStaffTeamsFromRest(user);
+  }
 }
 
 async function saveTeamCalendarUrls(teamId: string, calendarUrls: string[]) {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -1780,10 +1780,12 @@ type StaffTeamsLoadResult = {
   isPartial: boolean;
 };
 
-async function loadStaffTeamsFromRest(user: AuthUser): Promise<StaffTeamsLoadResult> {
+async function loadStaffTeamsFromRest(): Promise<StaffTeamsLoadResult> {
   const result = await loadManagedTeamsFromNativeCallable();
   return {
-    teams: result.teams.filter((team: any) => team?.id && isTeamActive(team) && isTeamStaff(team, user)),
+    // The callable already applies the server-side ownership, admin, and coach
+    // checks; its serialized team profiles intentionally omit some of those fields.
+    teams: result.teams.filter((team: any) => team?.id && isTeamActive(team)),
     isPartial: result.isPartial
   };
 }
@@ -1809,7 +1811,7 @@ async function loadStaffTeams(user: AuthUser): Promise<StaffTeamsLoadResult> {
     logScheduleWarning('Falling back to authenticated HTTP for staff teams.', 'staff-team-callable-fallback', error, {
       fallback: 'authenticated-http'
     });
-    return loadStaffTeamsFromRest(user);
+    return loadStaffTeamsFromRest();
   }
 }
 
@@ -3125,7 +3127,7 @@ export async function loadParentScheduleScope(user: AuthUser | null): Promise<Pa
     && (hasStaffRole || uniqueDeclaredCoachTeamIds.length > 0 || user.isAdmin === true || user.isPlatformAdmin === true);
   if (isNativeRuntime() && (staffTeamResult.isPartial || hasMissingDeclaredCoachTeam || shouldVerifyEmptyStaffResult)) {
     try {
-      const restResult = await loadStaffTeamsFromRest(staffUser);
+      const restResult = await loadStaffTeamsFromRest();
       const teamsById = new Map<string, any>();
       [...staffTeamResult.teams, ...restResult.teams].forEach((team: any) => {
         const teamId = compactString(team?.id);


### PR DESCRIPTION
## What changed
- keep the Firebase SDK `listManagedTeams` callable as the primary browser path
- fall back to the same server-authorized callable over authenticated HTTP after an SDK error or timeout
- preserve partial-state behavior when both transports fail

## Why
The protected production fixture audit proves `listManagedTeams` returns the exact staff team, while the authenticated browser chooser can still render no team when the SDK transport fails. The web path previously refused the already-supported authenticated HTTP fallback.

## Validation
- `npm run test:app -- src/lib/scheduleService.test.ts` (177 passed)
- `npm run app:build` (TypeScript, production build, visualizer, and bundle budget passed)
- `git diff --check`

## Production validation
After merge/deploy, rerun the fixture-backed authenticated production smoke and require the staff `/teams` chooser to expose the fixture team link.