### PR TITLE
Verify empty web staff team results

### DIFF
--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -796,25 +796,35 @@ describe('parent schedule child scope', () => {
     expect(scope.isPartial).toBe(false);
   });
 
-  it('accepts an empty complete web callable result without issuing permission-noise REST requests', async () => {
-    const previousFetch = globalThis.fetch;
+  it('verifies an empty web SDK result over authenticated HTTP for a known staff account', async () => {
     const coachUser = { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'], coachOf: [] } as any;
     vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: [] } as any);
     vi.mocked(getStaffTeams).mockResolvedValue({ teams: [], isPartial: false } as any);
-    const fetchMock = vi.fn();
-    (globalThis as any).fetch = fetchMock;
+    vi.mocked(loadManagedTeamsFromNativeCallable).mockResolvedValueOnce({
+      teams: [{ id: 'team-coached', name: 'Coach Bears', active: true }],
+      isPartial: false
+    });
 
-    try {
-      const scope = await loadParentScheduleScope(coachUser);
+    const scope = await loadParentScheduleScope(coachUser);
 
-      expect(getStaffTeams).toHaveBeenCalledTimes(1);
-      expect(scope.staffTeams).toEqual([]);
-      expect(scope.staffTeamsPartial).toBe(false);
-      expect(scope.isPartial).toBe(false);
-      expect(fetchMock).not.toHaveBeenCalled();
-    } finally {
-      globalThis.fetch = previousFetch;
-    }
+    expect(getStaffTeams).toHaveBeenCalledTimes(1);
+    expect(loadManagedTeamsFromNativeCallable).toHaveBeenCalledTimes(1);
+    expect(scope.staffTeams).toEqual([{ teamId: 'team-coached', teamName: 'Coach Bears' }]);
+    expect(scope.staffTeamsPartial).toBe(false);
+    expect(scope.isPartial).toBe(false);
+  });
+
+  it('does not verify an empty web SDK result for an account without staff access signals', async () => {
+    const parentUser = { uid: 'parent-1', email: 'parent@example.com', roles: ['parent'], coachOf: [] } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: [] } as any);
+    vi.mocked(getStaffTeams).mockResolvedValue({ teams: [], isPartial: false } as any);
+
+    const scope = await loadParentScheduleScope(parentUser);
+
+    expect(loadManagedTeamsFromNativeCallable).not.toHaveBeenCalled();
+    expect(scope.staffTeams).toEqual([]);
+    expect(scope.staffTeamsPartial).toBe(false);
+    expect(scope.isPartial).toBe(false);
   });
 
   it('retries partial owner and admin discovery when the profile has no coach links', async () => {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -3125,7 +3125,11 @@ export async function loadParentScheduleScope(user: AuthUser | null): Promise<Pa
   ));
   const shouldVerifyEmptyStaffResult = staffTeamResult.teams.length === 0
     && (hasStaffRole || uniqueDeclaredCoachTeamIds.length > 0 || user.isAdmin === true || user.isPlatformAdmin === true);
-  if (isNativeRuntime() && (staffTeamResult.isPartial || hasMissingDeclaredCoachTeam || shouldVerifyEmptyStaffResult)) {
+  const nativeRuntime = isNativeRuntime();
+  const shouldVerifyStaffResultWithHttp = nativeRuntime
+    ? (staffTeamResult.isPartial || hasMissingDeclaredCoachTeam || shouldVerifyEmptyStaffResult)
+    : (shouldVerifyEmptyStaffResult && staffTeamResult.isPartial !== true);
+  if (shouldVerifyStaffResultWithHttp) {
     try {
       const restResult = await loadStaffTeamsFromRest();
       const teamsById = new Map<string, any>();

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -558,7 +558,8 @@ describe('React app schedule service contract integration', () => {
         expect(scheduleServiceSource).toContain('ownerEmails.length === 1 && email === ownerEmails[0]');
         expect(legacyScheduleDbSource).toContain("legacyFirebaseHttpsCallable(legacyFirebaseFunctions, 'listManagedTeams')");
         expect(legacyScheduleDbSource).not.toContain("legacyFirebaseWhere('ownerEmailLower', '==', normalizedEmail)");
-        expect(scheduleServiceSource).toContain('isNativeRuntime() && (staffTeamResult.isPartial');
+        expect(scheduleServiceSource).toContain('const shouldVerifyStaffResultWithHttp = nativeRuntime');
+        expect(scheduleServiceSource).toContain(': (shouldVerifyEmptyStaffResult && staffTeamResult.isPartial !== true)');
     });
 
     it('routes parent schedule event detail reads through typed schedule mappers', () => {


### PR DESCRIPTION
## What changed
- verify a complete-but-empty web managed-team SDK result through the authenticated HTTP callable for accounts with staff access signals
- preserve the existing bounded retry behavior for partial failures and skip the extra request for ordinary parent accounts
- add regression coverage for both staff recovery and parent no-op behavior

## Why
Production fixture smoke after #4603 proved the listManagedTeams server and authenticated HTTP path authorize the staff fixture, while the web SDK path can return a complete empty list. The Teams chooser trusted that empty list and omitted the managed team.

## Validation
- `npm run test:app -- src/lib/scheduleService.test.ts` (179 passed)
- `npm run app:build`
- `git diff --check`

## Production validation
After merge and exact-SHA deploy, rerun the fixture-backed authenticated production smoke and require the staff `/teams/allplays-smoke-team-v1` link to pass.