### PR TITLE
Reuse exact PR validation for production

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -13,7 +13,109 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  validation-source:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+      statuses: read
+    outputs:
+      reuse_pr_validation: ${{ steps.source.outputs.reuse_pr_validation }}
+      validated_head_sha: ${{ steps.source.outputs.validated_head_sha }}
+
+    steps:
+      - name: Resolve exact production validation source
+        id: source
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          echo "reuse_pr_validation=false" >> "$GITHUB_OUTPUT"
+          echo "validated_head_sha=" >> "$GITHUB_OUTPUT"
+
+          if [[ "$GITHUB_EVENT_NAME" != "push" || "$GITHUB_REF" != "refs/heads/master" ]]; then
+            echo "Production validation will run because this is not a master push."
+            exit 0
+          fi
+
+          pr_json=""
+          for attempt in 1 2 3; do
+            if pr_json="$(gh api --method GET \
+              -H 'Accept: application/vnd.github+json' \
+              "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" 2>/dev/null)"; then
+              break
+            fi
+            pr_json=""
+            sleep $((attempt * 2))
+          done
+          if [[ -z "$pr_json" ]]; then
+            echo "::warning::Could not resolve the merged PR; running production validation."
+            exit 0
+          fi
+
+          matching_prs="$(jq --arg sha "$GITHUB_SHA" --arg repo "$GITHUB_REPOSITORY" '[
+            .[]
+            | select(
+                .state == "closed"
+                and .merged_at != null
+                and .merge_commit_sha == $sha
+                and .base.ref == "master"
+                and .head.repo.full_name == $repo
+              )
+          ]' <<< "$pr_json")"
+          if [[ "$(jq 'length' <<< "$matching_prs")" != "1" ]]; then
+            echo "Production validation will run because the commit is not bound to exactly one merged same-repository PR."
+            exit 0
+          fi
+
+          pr_number="$(jq -r '.[0].number' <<< "$matching_prs")"
+          head_sha="$(jq -r '.[0].head.sha' <<< "$matching_prs")"
+          if [[ ! "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::warning::Merged PR #${pr_number} did not expose a valid exact head SHA; running production validation."
+            exit 0
+          fi
+
+          merge_tree="$(gh api --method GET "repos/${GITHUB_REPOSITORY}/git/commits/${GITHUB_SHA}" --jq '.tree.sha' 2>/dev/null || true)"
+          head_tree="$(gh api --method GET "repos/${GITHUB_REPOSITORY}/git/commits/${head_sha}" --jq '.tree.sha' 2>/dev/null || true)"
+          if [[ ! "$merge_tree" =~ ^[0-9a-f]{40}$ || "$merge_tree" != "$head_tree" ]]; then
+            echo "Production validation will run because the merged tree differs from PR #${pr_number} head ${head_sha:0:12}."
+            exit 0
+          fi
+
+          workflow_passed() {
+            local workflow_file="$1"
+            gh api --method GET \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow_file}/runs" \
+              -f head_sha="$head_sha" \
+              -f event=pull_request \
+              -f status=success \
+              -F per_page=20 2>/dev/null \
+              | jq -r --arg expected_path ".github/workflows/${workflow_file}" --arg head_sha "$head_sha" \
+                'any(.workflow_runs[]?; .head_sha == $head_sha and .event == "pull_request" and .conclusion == "success" and .path == $expected_path)'
+          }
+
+          pr_fast_passed="$(workflow_passed pr-fast.yml || true)"
+          pr_integration_passed="$(workflow_passed pr-integration.yml || true)"
+          paulbot_state="$(gh api --method GET "repos/${GITHUB_REPOSITORY}/commits/${head_sha}/status" \
+            --jq '[.statuses[]? | select(.context == "paulbot-review-gate")] | sort_by(.updated_at) | last | .state // ""' \
+            2>/dev/null || true)"
+
+          if [[ "$pr_fast_passed" != "true" ||
+                "$pr_integration_passed" != "true" ||
+                "$paulbot_state" != "success" ]]; then
+            echo "Production validation will run because exact-head PR validation is incomplete."
+            exit 0
+          fi
+
+          echo "reuse_pr_validation=true" >> "$GITHUB_OUTPUT"
+          echo "validated_head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "Reusing exact-head validation for merged PR #${pr_number} at ${head_sha:0:12}; the production tree is identical."
+
   unit-tests:
+    needs: validation-source
+    if: needs.validation-source.outputs.reuse_pr_validation != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -50,6 +152,8 @@ jobs:
         run: npm run test:functions:auth-email
 
   regression-guards:
+    needs: validation-source
+    if: needs.validation-source.outputs.reuse_pr_validation != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -88,8 +192,32 @@ jobs:
           name: prod-regression-guards-http-log
           path: /tmp/allplays-prod-regression-guards.log
 
+  production-validation-gate:
+    needs: [validation-source, unit-tests, regression-guards]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Require reusable or freshly successful validation
+        env:
+          REUSE_PR_VALIDATION: ${{ needs.validation-source.outputs.reuse_pr_validation }}
+          UNIT_TEST_RESULT: ${{ needs.unit-tests.result }}
+          REGRESSION_GUARD_RESULT: ${{ needs.regression-guards.result }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$REUSE_PR_VALIDATION" == "true" ]]; then
+            echo "Exact-head PR validation is reusable for this identical production tree."
+            exit 0
+          fi
+          if [[ "$UNIT_TEST_RESULT" != "success" || "$REGRESSION_GUARD_RESULT" != "success" ]]; then
+            echo "::error::Fresh production validation did not complete successfully."
+            exit 1
+          fi
+          echo "Fresh production validation passed."
+
   validate-production-smoke-config:
-    needs: [unit-tests, regression-guards]
+    needs: production-validation-gate
     runs-on: ubuntu-latest
     environment:
       name: production-smoke
@@ -147,7 +275,7 @@ jobs:
           fi
 
   prepare-deploy:
-    needs: [unit-tests, regression-guards, validate-production-smoke-config]
+    needs: [production-validation-gate, validate-production-smoke-config]
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -62,6 +62,7 @@ jobs:
                 and .merged_at != null
                 and .merge_commit_sha == $sha
                 and .base.ref == "master"
+                and .base.repo.full_name == $repo
                 and .head.repo.full_name == $repo
               )
           ]' <<< "$pr_json")"
@@ -71,9 +72,10 @@ jobs:
           fi
 
           pr_number="$(jq -r '.[0].number' <<< "$matching_prs")"
+          repo_id="$(jq -r '.[0].base.repo.id' <<< "$matching_prs")"
           head_sha="$(jq -r '.[0].head.sha' <<< "$matching_prs")"
-          if [[ ! "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "::warning::Merged PR #${pr_number} did not expose a valid exact head SHA; running production validation."
+          if [[ ! "$repo_id" =~ ^[1-9][0-9]*$ || ! "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::warning::Merged PR #${pr_number} did not expose a valid repository or exact head SHA; running production validation."
             exit 0
           fi
 
@@ -86,25 +88,89 @@ jobs:
 
           workflow_passed() {
             local workflow_file="$1"
-            gh api --method GET \
+            shift
+            local required_jobs=("$@")
+            local workflow_runs workflow_jobs workflow_run_id
+            local -a workflow_run_ids
+            workflow_runs="$(gh api --method GET \
               "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow_file}/runs" \
               -f head_sha="$head_sha" \
               -f event=pull_request \
               -f status=success \
-              -F per_page=20 2>/dev/null \
-              | jq -r --arg expected_path ".github/workflows/${workflow_file}" --arg head_sha "$head_sha" \
-                'any(.workflow_runs[]?; .head_sha == $head_sha and .event == "pull_request" and .conclusion == "success" and .path == $expected_path)'
+              -F per_page=100 2>/dev/null)" || return 1
+            mapfile -t workflow_run_ids < <(jq -r \
+              --arg expected_path ".github/workflows/${workflow_file}" \
+              --arg head_sha "$head_sha" \
+              --arg repo "$GITHUB_REPOSITORY" \
+              --argjson pr_number "$pr_number" \
+              --argjson repo_id "$repo_id" '
+                .workflow_runs[]?
+                | select(
+                    .head_sha == $head_sha
+                    and .head_repository.full_name == $repo
+                    and .event == "pull_request"
+                    and .status == "completed"
+                    and .conclusion == "success"
+                    and .path == $expected_path
+                    and ([
+                      .pull_requests[]?
+                      | select(
+                          .number == $pr_number
+                          and .head.sha == $head_sha
+                          and .head.repo.id == $repo_id
+                          and .base.ref == "master"
+                          and .base.repo.id == $repo_id
+                        )
+                    ] | length) == 1
+                  )
+                | .id
+              ' <<< "$workflow_runs")
+            for workflow_run_id in "${workflow_run_ids[@]}"; do
+              workflow_jobs="$(gh api --method GET \
+                "repos/${GITHUB_REPOSITORY}/actions/runs/${workflow_run_id}/jobs?filter=latest&per_page=100" \
+                2>/dev/null)" || continue
+              if jq -e --args "${required_jobs[@]}" '
+                $ARGS.positional as $required_jobs
+                | all($required_jobs[]; . as $required_job
+                    | ([.jobs[]? | select(
+                        .name == $required_job
+                        and .status == "completed"
+                        and .conclusion == "success"
+                      )] | length) == 1)
+              ' <<< "$workflow_jobs" >/dev/null; then
+                return 0
+              fi
+            done
+            return 1
           }
 
-          pr_fast_passed="$(workflow_passed pr-fast.yml || true)"
-          pr_integration_passed="$(workflow_passed pr-integration.yml || true)"
-          paulbot_state="$(gh api --method GET "repos/${GITHUB_REPOSITORY}/commits/${head_sha}/status" \
-            --jq '[.statuses[]? | select(.context == "paulbot-review-gate")] | sort_by(.updated_at) | last | .state // ""' \
-            2>/dev/null || true)"
+          if workflow_passed pr-fast.yml cache-bust-guard unit-tests app-quality; then
+            pr_fast_passed=true
+          else
+            pr_fast_passed=false
+          fi
+          if workflow_passed pr-integration.yml mobile-build preview-smoke; then
+            pr_integration_passed=true
+          else
+            pr_integration_passed=false
+          fi
+          paulbot_target="https://github.com/${GITHUB_REPOSITORY}/pull/${pr_number}"
+          # Commit-status avatar URLs are server-generated. Bind PaulBot's status
+          # to the immutable numeric account ID used by the trusted writer.
+          paulbot_issuer_avatar="https://avatars.githubusercontent.com/u/211066188?"
+          paulbot_passed="$(gh api --method GET "repos/${GITHUB_REPOSITORY}/commits/${head_sha}/status" \
+            2>/dev/null | jq -r --arg target "$paulbot_target" --arg issuer_avatar "$paulbot_issuer_avatar" '
+              [.statuses[]? | select(.context == "paulbot-review-gate")]
+              | sort_by(.updated_at, .id)
+              | last
+              | (.state == "success"
+                  and .target_url == $target
+                  and (.avatar_url | type == "string" and startswith($issuer_avatar)))
+            ' || true)"
 
           if [[ "$pr_fast_passed" != "true" ||
                 "$pr_integration_passed" != "true" ||
-                "$paulbot_state" != "success" ]]; then
+                "$paulbot_passed" != "true" ]]; then
             echo "Production validation will run because exact-head PR validation is incomplete."
             exit 0
           fi

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -25,6 +25,11 @@ jobs:
       validated_head_sha: ${{ steps.source.outputs.validated_head_sha }}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
       - name: Resolve exact production validation source
         id: source
         shell: bash
@@ -72,112 +77,76 @@ jobs:
           fi
 
           pr_number="$(jq -r '.[0].number' <<< "$matching_prs")"
-          repo_id="$(jq -r '.[0].base.repo.id' <<< "$matching_prs")"
           head_sha="$(jq -r '.[0].head.sha' <<< "$matching_prs")"
-          if [[ ! "$repo_id" =~ ^[1-9][0-9]*$ || ! "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "::warning::Merged PR #${pr_number} did not expose a valid repository or exact head SHA; running production validation."
+          if [[ ! "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::warning::Merged PR #${pr_number} did not expose a valid exact head SHA; running production validation."
             exit 0
           fi
 
-          merge_tree="$(gh api --method GET "repos/${GITHUB_REPOSITORY}/git/commits/${GITHUB_SHA}" --jq '.tree.sha' 2>/dev/null || true)"
-          head_tree="$(gh api --method GET "repos/${GITHUB_REPOSITORY}/git/commits/${head_sha}" --jq '.tree.sha' 2>/dev/null || true)"
-          if [[ ! "$merge_tree" =~ ^[0-9a-f]{40}$ || "$merge_tree" != "$head_tree" ]]; then
-            echo "Production validation will run because the merged tree differs from PR #${pr_number} head ${head_sha:0:12}."
-            exit 0
-          fi
+          evidence_dir="$RUNNER_TEMP/production-validation-evidence"
+          mkdir -p "$evidence_dir"
+          printf '%s\n' "$pr_json" > "$evidence_dir/pulls.json"
 
-          workflow_passed() {
-            local workflow_file="$1"
+          fetch_json() {
+            local output_path="$1"
             shift
-            local required_jobs=("$@")
-            local workflow_runs workflow_jobs workflow_run_id
-            local -a workflow_run_ids
-            workflow_runs="$(gh api --method GET \
-              "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow_file}/runs" \
-              -f head_sha="$head_sha" \
-              -f event=pull_request \
-              -f status=success \
-              -F per_page=100 2>/dev/null)" || return 1
-            mapfile -t workflow_run_ids < <(jq -r \
-              --arg expected_path ".github/workflows/${workflow_file}" \
-              --arg head_sha "$head_sha" \
-              --arg repo "$GITHUB_REPOSITORY" \
-              --argjson pr_number "$pr_number" \
-              --argjson repo_id "$repo_id" '
-                .workflow_runs[]?
-                | select(
-                    .head_sha == $head_sha
-                    and .head_repository.full_name == $repo
-                    and .event == "pull_request"
-                    and .status == "completed"
-                    and .conclusion == "success"
-                    and .path == $expected_path
-                    and ([
-                      .pull_requests[]?
-                      | select(
-                          .number == $pr_number
-                          and .head.sha == $head_sha
-                          and .head.repo.id == $repo_id
-                          and .base.ref == "master"
-                          and .base.repo.id == $repo_id
-                        )
-                    ] | length) == 1
-                  )
-                | .id
-              ' <<< "$workflow_runs")
-            for workflow_run_id in "${workflow_run_ids[@]}"; do
-              workflow_jobs="$(gh api --method GET \
-                "repos/${GITHUB_REPOSITORY}/actions/runs/${workflow_run_id}/jobs?filter=latest&per_page=100" \
-                2>/dev/null)" || continue
-              if jq -e --args "${required_jobs[@]}" '
-                $ARGS.positional as $required_jobs
-                | all($required_jobs[]; . as $required_job
-                    | ([.jobs[]? | select(
-                        .name == $required_job
-                        and .status == "completed"
-                        and .conclusion == "success"
-                      )] | length) == 1)
-              ' <<< "$workflow_jobs" >/dev/null; then
+            for attempt in 1 2 3; do
+              if gh api --method GET "$@" > "$output_path" 2>/dev/null; then
                 return 0
               fi
+              sleep $((attempt * 2))
             done
             return 1
           }
 
-          if workflow_passed pr-fast.yml cache-bust-guard unit-tests app-quality; then
-            pr_fast_passed=true
-          else
-            pr_fast_passed=false
+          if ! fetch_json "$evidence_dir/merge-commit.json" \
+              "repos/${GITHUB_REPOSITORY}/git/commits/${GITHUB_SHA}" ||
+            ! fetch_json "$evidence_dir/head-commit.json" \
+              "repos/${GITHUB_REPOSITORY}/git/commits/${head_sha}" ||
+            ! fetch_json "$evidence_dir/pr-fast-runs.json" \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/pr-fast.yml/runs" \
+              -f head_sha="$head_sha" -f event=pull_request -f status=success -F per_page=20 ||
+            ! fetch_json "$evidence_dir/pr-integration-runs.json" \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/pr-integration.yml/runs" \
+              -f head_sha="$head_sha" -f event=pull_request -f status=success -F per_page=20 ||
+            ! fetch_json "$evidence_dir/statuses.json" \
+              "repos/${GITHUB_REPOSITORY}/commits/${head_sha}/statuses"; then
+            echo "::warning::Could not load complete exact-head evidence; running production validation."
+            exit 0
           fi
-          if workflow_passed pr-integration.yml mobile-build preview-smoke; then
-            pr_integration_passed=true
-          else
-            pr_integration_passed=false
-          fi
-          paulbot_target="https://github.com/${GITHUB_REPOSITORY}/pull/${pr_number}"
-          # Commit-status avatar URLs are server-generated. Bind PaulBot's status
-          # to the immutable numeric account ID used by the trusted writer.
-          paulbot_issuer_avatar="https://avatars.githubusercontent.com/u/211066188?"
-          paulbot_passed="$(gh api --method GET "repos/${GITHUB_REPOSITORY}/commits/${head_sha}/status" \
-            2>/dev/null | jq -r --arg target "$paulbot_target" --arg issuer_avatar "$paulbot_issuer_avatar" '
-              [.statuses[]? | select(.context == "paulbot-review-gate")]
-              | sort_by(.updated_at, .id)
-              | last
-              | (.state == "success"
-                  and .target_url == $target
-                  and (.avatar_url | type == "string" and startswith($issuer_avatar)))
-            ' || true)"
 
-          if [[ "$pr_fast_passed" != "true" ||
-                "$pr_integration_passed" != "true" ||
-                "$paulbot_passed" != "true" ]]; then
-            echo "Production validation will run because exact-head PR validation is incomplete."
+          printf '{}\n' > "$evidence_dir/run-jobs.json"
+          while IFS= read -r run_id; do
+            if [[ ! "$run_id" =~ ^[0-9]+$ ]] ||
+              ! fetch_json "$evidence_dir/run-${run_id}-jobs.json" \
+                "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs" -f filter=latest -F per_page=100; then
+              echo "::warning::Could not load required-job evidence; running production validation."
+              exit 0
+            fi
+            jq --arg run_id "$run_id" --slurpfile jobs "$evidence_dir/run-${run_id}-jobs.json" \
+              '. + {($run_id): $jobs[0]}' "$evidence_dir/run-jobs.json" > "$evidence_dir/run-jobs.next.json"
+            mv "$evidence_dir/run-jobs.next.json" "$evidence_dir/run-jobs.json"
+          done < <(jq -r '.workflow_runs[]?.id' \
+            "$evidence_dir/pr-fast-runs.json" "$evidence_dir/pr-integration-runs.json" | sort -u)
+
+          verification="$(node scripts/verify-production-validation-reuse.mjs \
+            --repository "$GITHUB_REPOSITORY" \
+            --merge-sha "$GITHUB_SHA" \
+            --pulls "$evidence_dir/pulls.json" \
+            --merge-commit "$evidence_dir/merge-commit.json" \
+            --head-commit "$evidence_dir/head-commit.json" \
+            --pr-fast-runs "$evidence_dir/pr-fast-runs.json" \
+            --pr-integration-runs "$evidence_dir/pr-integration-runs.json" \
+            --run-jobs "$evidence_dir/run-jobs.json" \
+            --statuses "$evidence_dir/statuses.json")"
+          if [[ "$(jq -r '.reusable' <<< "$verification")" != "true" ]]; then
+            echo "Production validation will run: $(jq -r '.reason' <<< "$verification")"
             exit 0
           fi
 
           echo "reuse_pr_validation=true" >> "$GITHUB_OUTPUT"
           echo "validated_head_sha=$head_sha" >> "$GITHUB_OUTPUT"
-          echo "Reusing exact-head validation for merged PR #${pr_number} at ${head_sha:0:12}; the production tree is identical."
+          echo "Reusing exact-head validation for merged PR #${pr_number} at ${head_sha:0:12}; PR identity, tree, required jobs, and trusted PaulBot approval match."
 
   unit-tests:
     needs: validation-source

--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -1,4 +1,5 @@
 name: pr-fast
+run-name: "pr-fast #${{ github.event.pull_request.number }} -> ${{ github.event.pull_request.base.ref }} @ ${{ github.event.pull_request.head.sha }}"
 
 on:
   pull_request:

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -1,4 +1,5 @@
 name: pr-integration
+run-name: "pr-integration #${{ github.event.pull_request.number }} -> ${{ github.event.pull_request.base.ref }} @ ${{ github.event.pull_request.head.sha }}"
 
 on:
   pull_request:

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -1068,7 +1068,16 @@ export function validateFirebaseRulesCi() {
         'Production migration local application-default fallback'
     );
     validateFirebaseDeployWorkloadIdentity(deployProd, 'Production deploy');
-    assertMatches(deployProd, /needs:\s*\[\s*unit-tests\s*,\s*regression-guards\s*\]/, 'Production deploy gate');
+    assertIncludes(
+        deployProd,
+        'needs: [validation-source, unit-tests, regression-guards]',
+        'Production validation aggregate gate'
+    );
+    assertIncludes(
+        deployProd,
+        'needs: [production-validation-gate, validate-production-smoke-config]',
+        'Production deploy gate'
+    );
 
     assertIncludes(deployPreviewBuild, 'workflow_call:', 'Untrusted preview reusable workflow');
     assertIncludes(prIntegration, 'uses: ./.github/workflows/regression-guards.yml', 'PR integration regression gate');

--- a/scripts/verify-production-validation-reuse.mjs
+++ b/scripts/verify-production-validation-reuse.mjs
@@ -98,7 +98,12 @@ export function evaluateProductionValidationReuse({
         title: `pr-integration #${prNumber} -> master @ ${headSha}`
     }).find((run) => requiredJobsPassed(
         runJobs?.[run.id],
-        ['mobile-build', 'preview-smoke']
+        [
+            'regression-integration / firebase-rules-deploy-guard',
+            'regression-integration / roster-chat-media-replay-smoke',
+            'mobile-build',
+            'preview-smoke'
+        ]
     ));
     if (!fastRun || !integrationRun) {
         return { reusable: false, reason: 'exact PR-bound workflows and required jobs are incomplete' };

--- a/scripts/verify-production-validation-reuse.mjs
+++ b/scripts/verify-production-validation-reuse.mjs
@@ -1,0 +1,165 @@
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+const trustedPaulBot = Object.freeze({
+    id: 309595148,
+    login: 'allplays-paulbot[bot]',
+    type: 'Bot'
+});
+
+const successDescription = 'Current-head review, review remediation, and CI passed';
+
+function isSha(value) {
+    return /^[0-9a-f]{40}$/.test(String(value || ''));
+}
+
+function latestByUpdatedAt(values) {
+    return [...values].sort((left, right) => (
+        Date.parse(left?.updated_at || '') - Date.parse(right?.updated_at || '')
+    )).at(-1);
+}
+
+function matchingWorkflowRuns(runs, { repository, headBranch, headSha, path, title }) {
+    return (runs?.workflow_runs || []).filter((run) => (
+        Number.isInteger(run?.id)
+        && run.id > 0
+        && run?.status === 'completed'
+        && run?.conclusion === 'success'
+        && run?.event === 'pull_request'
+        && run?.head_sha === headSha
+        && run?.head_branch === headBranch
+        && run?.head_repository?.full_name === repository
+        && run?.path === path
+        && run?.display_title === title
+    ));
+}
+
+function requiredJobsPassed(runJobs, requiredNames) {
+    const jobs = Array.isArray(runJobs?.jobs) ? runJobs.jobs : [];
+    return requiredNames.every((name) => {
+        const namedJobs = jobs.filter((job) => job?.name === name);
+        return namedJobs.length === 1
+            && namedJobs[0].status === 'completed'
+            && namedJobs[0].conclusion === 'success';
+    });
+}
+
+export function evaluateProductionValidationReuse({
+    repository,
+    mergeSha,
+    pulls,
+    mergeCommit,
+    headCommit,
+    prFastRuns,
+    prIntegrationRuns,
+    runJobs,
+    statuses
+}) {
+    if (!repository || !isSha(mergeSha)) {
+        return { reusable: false, reason: 'invalid repository or production SHA' };
+    }
+
+    const matchingPulls = (Array.isArray(pulls) ? pulls : []).filter((pull) => (
+        pull?.state === 'closed'
+        && pull?.merged_at
+        && pull?.merge_commit_sha === mergeSha
+        && pull?.base?.ref === 'master'
+        && pull?.base?.repo?.full_name === repository
+        && pull?.head?.repo?.full_name === repository
+    ));
+    if (matchingPulls.length !== 1) {
+        return { reusable: false, reason: 'production SHA is not bound to exactly one merged same-repository PR' };
+    }
+
+    const pull = matchingPulls[0];
+    const prNumber = Number(pull.number);
+    const headSha = String(pull?.head?.sha || '');
+    const headBranch = String(pull?.head?.ref || '');
+    if (!Number.isInteger(prNumber) || prNumber <= 0 || !isSha(headSha) || !headBranch) {
+        return { reusable: false, reason: 'merged PR identity is incomplete' };
+    }
+    if (mergeCommit?.sha !== mergeSha || headCommit?.sha !== headSha
+        || !isSha(mergeCommit?.tree?.sha) || mergeCommit.tree.sha !== headCommit?.tree?.sha) {
+        return { reusable: false, reason: 'production tree differs from the reviewed PR head' };
+    }
+
+    const runIdentity = { repository, headBranch, headSha };
+    const fastRun = matchingWorkflowRuns(prFastRuns, {
+        ...runIdentity,
+        path: '.github/workflows/pr-fast.yml',
+        title: `pr-fast #${prNumber} -> master @ ${headSha}`
+    }).find((run) => requiredJobsPassed(
+        runJobs?.[run.id],
+        ['unit-tests', 'cache-bust-guard', 'app-quality']
+    ));
+    const integrationRun = matchingWorkflowRuns(prIntegrationRuns, {
+        ...runIdentity,
+        path: '.github/workflows/pr-integration.yml',
+        title: `pr-integration #${prNumber} -> master @ ${headSha}`
+    }).find((run) => requiredJobsPassed(
+        runJobs?.[run.id],
+        ['mobile-build', 'preview-smoke']
+    ));
+    if (!fastRun || !integrationRun) {
+        return { reusable: false, reason: 'exact PR-bound workflows and required jobs are incomplete' };
+    }
+
+    const expectedTarget = `https://github.com/${repository}/pull/${prNumber}`;
+    const trustedStatusHistory = (Array.isArray(statuses) ? statuses : []).filter((status) => (
+        status?.context === 'paulbot-review-gate'
+        && status?.creator?.id === trustedPaulBot.id
+        && status?.creator?.login === trustedPaulBot.login
+        && status?.creator?.type === trustedPaulBot.type
+        && status?.target_url === expectedTarget
+    ));
+    const paulBotStatus = latestByUpdatedAt(trustedStatusHistory);
+    if (paulBotStatus?.state !== 'success' || paulBotStatus?.description !== successDescription) {
+        return { reusable: false, reason: 'trusted PR-bound PaulBot approval is missing' };
+    }
+
+    const workflowCompletedAt = Math.max(
+        Date.parse(fastRun.updated_at || ''),
+        Date.parse(integrationRun.updated_at || '')
+    );
+    if (!Number.isFinite(workflowCompletedAt) || Date.parse(paulBotStatus.updated_at || '') < workflowCompletedAt) {
+        return { reusable: false, reason: 'PaulBot approval predates exact-head workflow completion' };
+    }
+
+    return {
+        reusable: true,
+        reason: 'identical production tree has exact PR-bound workflow and trusted PaulBot validation',
+        prNumber,
+        headSha
+    };
+}
+
+function parseArgs(args) {
+    const parsed = {};
+    for (let index = 0; index < args.length; index += 2) {
+        const key = args[index];
+        const value = args[index + 1];
+        if (!key?.startsWith('--') || value === undefined) throw new Error(`Invalid argument ${key || ''}`.trim());
+        parsed[key.slice(2)] = value;
+    }
+    return parsed;
+}
+
+function readJson(path) {
+    return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    const args = parseArgs(process.argv.slice(2));
+    const result = evaluateProductionValidationReuse({
+        repository: args.repository,
+        mergeSha: args['merge-sha'],
+        pulls: readJson(args.pulls),
+        mergeCommit: readJson(args['merge-commit']),
+        headCommit: readJson(args['head-commit']),
+        prFastRuns: readJson(args['pr-fast-runs']),
+        prIntegrationRuns: readJson(args['pr-integration-runs']),
+        runJobs: readJson(args['run-jobs']),
+        statuses: readJson(args.statuses)
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+}

--- a/scripts/verify-production-validation-reuse.mjs
+++ b/scripts/verify-production-validation-reuse.mjs
@@ -19,7 +19,22 @@ function latestByUpdatedAt(values) {
     )).at(-1);
 }
 
-function matchingWorkflowRuns(runs, { repository, headBranch, headSha, path, title }) {
+function pullAssociationMatches(run, { prNumber, headBranch, headSha }) {
+    const pulls = Array.isArray(run?.pull_requests) ? run.pull_requests : [];
+    // GitHub returns this association while a PR is open, but may return an
+    // empty array after merge. When present, fail closed on ambiguity; when
+    // absent, the immutable event/title/branch/SHA/workflow binding below is
+    // the durable association.
+    return pulls.length === 0 || (
+        pulls.length === 1
+        && pulls[0]?.number === prNumber
+        && pulls[0]?.head?.sha === headSha
+        && pulls[0]?.head?.ref === headBranch
+        && pulls[0]?.base?.ref === 'master'
+    );
+}
+
+function matchingWorkflowRuns(runs, { repository, prNumber, headBranch, headSha, path, title }) {
     return (runs?.workflow_runs || []).filter((run) => (
         Number.isInteger(run?.id)
         && run.id > 0
@@ -31,6 +46,7 @@ function matchingWorkflowRuns(runs, { repository, headBranch, headSha, path, tit
         && run?.head_repository?.full_name === repository
         && run?.path === path
         && run?.display_title === title
+        && pullAssociationMatches(run, { prNumber, headBranch, headSha })
     ));
 }
 
@@ -83,7 +99,7 @@ export function evaluateProductionValidationReuse({
         return { reusable: false, reason: 'production tree differs from the reviewed PR head' };
     }
 
-    const runIdentity = { repository, headBranch, headSha };
+    const runIdentity = { repository, prNumber, headBranch, headSha };
     const fastRun = matchingWorkflowRuns(prFastRuns, {
         ...runIdentity,
         path: '.github/workflows/pr-fast.yml',

--- a/tests/unit/production-smoke-config-gate.test.js
+++ b/tests/unit/production-smoke-config-gate.test.js
@@ -12,7 +12,8 @@ describe('production role-smoke gate', () => {
         expect(deployWorkflow).toContain('SMOKE_STAFF_EMAIL: ${{ secrets.SMOKE_STAFF_EMAIL }}');
         expect(deployWorkflow).toContain('SMOKE_PARENT_EMAIL: ${{ secrets.SMOKE_PARENT_EMAIL }}');
         expect(deployWorkflow).toContain('Missing protected configuration names: $missing_csv');
-        expect(deployWorkflow).toContain('needs: [unit-tests, regression-guards, validate-production-smoke-config]');
+        expect(deployWorkflow).toContain('needs: production-validation-gate');
+        expect(deployWorkflow).toContain('needs: [production-validation-gate, validate-production-smoke-config]');
         expect(deployWorkflow.indexOf('validate-production-smoke-config:')).toBeLessThan(
             deployWorkflow.indexOf('  prepare-deploy:')
         );

--- a/tests/unit/production-validation-reuse.test.js
+++ b/tests/unit/production-validation-reuse.test.js
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { parse as parseYaml } from 'yaml';
+
+const workflowSource = readFileSync('.github/workflows/deploy-prod.yml', 'utf8');
+const workflow = parseYaml(workflowSource);
+
+describe('production exact-head validation reuse', () => {
+    it('fails closed unless a same-repository merged PR has an identical validated tree', () => {
+        expect(workflowSource).toContain('echo "reuse_pr_validation=false" >> "$GITHUB_OUTPUT"');
+        expect(workflowSource).toContain('.merge_commit_sha == $sha');
+        expect(workflowSource).toContain('.base.ref == "master"');
+        expect(workflowSource).toContain('.head.repo.full_name == $repo');
+        expect(workflowSource).toContain('if [[ "$(jq \'length\' <<< "$matching_prs")" != "1" ]]');
+        expect(workflowSource).toContain('"repos/${GITHUB_REPOSITORY}/git/commits/${GITHUB_SHA}"');
+        expect(workflowSource).toContain('"repos/${GITHUB_REPOSITORY}/git/commits/${head_sha}"');
+        expect(workflowSource).toContain('[[ ! "$merge_tree" =~ ^[0-9a-f]{40}$ || "$merge_tree" != "$head_tree" ]]');
+    });
+
+    it('requires both exact-head PR workflows and the PaulBot gate before reuse', () => {
+        expect(workflowSource).toContain('workflow_passed pr-fast.yml');
+        expect(workflowSource).toContain('workflow_passed pr-integration.yml');
+        expect(workflowSource).toContain('.head_sha == $head_sha');
+        expect(workflowSource).toContain('.event == "pull_request"');
+        expect(workflowSource).toContain('.conclusion == "success"');
+        expect(workflowSource).toContain('.context == "paulbot-review-gate"');
+        expect(workflowSource).toContain('echo "reuse_pr_validation=true" >> "$GITHUB_OUTPUT"');
+    });
+
+    it('runs fresh tests on fallback and aggregates reused or fresh validation fail closed', () => {
+        expect(workflow.jobs['unit-tests'].needs).toBe('validation-source');
+        expect(workflow.jobs['unit-tests'].if).toContain("reuse_pr_validation != 'true'");
+        expect(workflow.jobs['regression-guards'].needs).toBe('validation-source');
+        expect(workflow.jobs['regression-guards'].if).toContain("reuse_pr_validation != 'true'");
+        expect(workflow.jobs['production-validation-gate'].needs).toEqual([
+            'validation-source',
+            'unit-tests',
+            'regression-guards'
+        ]);
+        expect(workflow.jobs['production-validation-gate'].if).toBe('always()');
+        expect(workflowSource).toContain('if [[ "$UNIT_TEST_RESULT" != "success" || "$REGRESSION_GUARD_RESULT" != "success" ]]');
+        expect(workflow.jobs['prepare-deploy'].needs).toEqual([
+            'production-validation-gate',
+            'validate-production-smoke-config'
+        ]);
+    });
+});

--- a/tests/unit/production-validation-reuse.test.js
+++ b/tests/unit/production-validation-reuse.test.js
@@ -22,6 +22,7 @@ function workflowRun(name) {
         head_repository: { full_name: 'pauljsnider/allplays' },
         path: `.github/workflows/${name}.yml`,
         display_title: `${name} #4605 -> master @ ${headSha}`,
+        pull_requests: [],
         updated_at: '2026-08-12T08:10:00Z'
     };
 }
@@ -91,6 +92,32 @@ describe('production exact-head validation reuse', () => {
         const input = evidence();
         input.prFastRuns.workflow_runs[0].display_title = `pr-fast #999 -> support @ ${headSha}`;
         input.prIntegrationRuns.workflow_runs[0].display_title = `pr-integration #999 -> support @ ${headSha}`;
+        expect(evaluateProductionValidationReuse(input).reusable).toBe(false);
+    });
+
+    it('rejects ambiguous multi-PR associations from either workflow', () => {
+        const association = (number) => ({
+            number,
+            head: { sha: headSha, ref: 'codex/production-validation-reuse' },
+            base: { ref: 'master' }
+        });
+        for (const runsKey of ['prFastRuns', 'prIntegrationRuns']) {
+            const input = evidence();
+            input[runsKey].workflow_runs[0].pull_requests = [association(4605), association(999)];
+            expect(evaluateProductionValidationReuse(input)).toEqual({
+                reusable: false,
+                reason: 'exact PR-bound workflows and required jobs are incomplete'
+            });
+        }
+    });
+
+    it('rejects a supplied association whose exact head does not match', () => {
+        const input = evidence();
+        input.prFastRuns.workflow_runs[0].pull_requests = [{
+            number: 4605,
+            head: { sha: 'd'.repeat(40), ref: 'codex/production-validation-reuse' },
+            base: { ref: 'master' }
+        }];
         expect(evaluateProductionValidationReuse(input).reusable).toBe(false);
     });
 

--- a/tests/unit/production-validation-reuse.test.js
+++ b/tests/unit/production-validation-reuse.test.js
@@ -55,7 +55,12 @@ function evidence() {
                 }))
             },
             102: {
-                jobs: ['mobile-build', 'preview-smoke'].map((name) => ({
+                jobs: [
+                    'regression-integration / firebase-rules-deploy-guard',
+                    'regression-integration / roster-chat-media-replay-smoke',
+                    'mobile-build',
+                    'preview-smoke'
+                ].map((name) => ({
                     name,
                     status: 'completed',
                     conclusion: 'success'
@@ -105,6 +110,20 @@ describe('production exact-head validation reuse', () => {
             reusable: false,
             reason: 'exact PR-bound workflows and required jobs are incomplete'
         });
+    });
+
+    it('rejects integration reuse when either regression guard did not pass', () => {
+        for (const regressionJob of [
+            'regression-integration / firebase-rules-deploy-guard',
+            'regression-integration / roster-chat-media-replay-smoke'
+        ]) {
+            const input = evidence();
+            input.runJobs[102].jobs.find((job) => job.name === regressionJob).conclusion = 'skipped';
+            expect(evaluateProductionValidationReuse(input)).toEqual({
+                reusable: false,
+                reason: 'exact PR-bound workflows and required jobs are incomplete'
+            });
+        }
     });
 
     it('rejects status evidence for another PR, stale approval, and a different tree', () => {

--- a/tests/unit/production-validation-reuse.test.js
+++ b/tests/unit/production-validation-reuse.test.js
@@ -1,67 +1,135 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { parse as parseYaml } from 'yaml';
+import { evaluateProductionValidationReuse } from '../../scripts/verify-production-validation-reuse.mjs';
 
 const workflowSource = readFileSync('.github/workflows/deploy-prod.yml', 'utf8');
+const fastWorkflowSource = readFileSync('.github/workflows/pr-fast.yml', 'utf8');
+const integrationWorkflowSource = readFileSync('.github/workflows/pr-integration.yml', 'utf8');
 const workflow = parseYaml(workflowSource);
+const mergeSha = 'a'.repeat(40);
+const headSha = 'b'.repeat(40);
+const treeSha = 'c'.repeat(40);
+
+function workflowRun(name) {
+    return {
+        id: name === 'pr-fast' ? 101 : 102,
+        status: 'completed',
+        conclusion: 'success',
+        event: 'pull_request',
+        head_sha: headSha,
+        head_branch: 'codex/production-validation-reuse',
+        head_repository: { full_name: 'pauljsnider/allplays' },
+        path: `.github/workflows/${name}.yml`,
+        display_title: `${name} #4605 -> master @ ${headSha}`,
+        updated_at: '2026-08-12T08:10:00Z'
+    };
+}
+
+function evidence() {
+    return {
+        repository: 'pauljsnider/allplays',
+        mergeSha,
+        pulls: [{
+            number: 4605,
+            state: 'closed',
+            merged_at: '2026-08-12T08:11:00Z',
+            merge_commit_sha: mergeSha,
+            base: { ref: 'master', repo: { full_name: 'pauljsnider/allplays' } },
+            head: {
+                sha: headSha,
+                ref: 'codex/production-validation-reuse',
+                repo: { full_name: 'pauljsnider/allplays' }
+            }
+        }],
+        mergeCommit: { sha: mergeSha, tree: { sha: treeSha } },
+        headCommit: { sha: headSha, tree: { sha: treeSha } },
+        prFastRuns: { workflow_runs: [workflowRun('pr-fast')] },
+        prIntegrationRuns: { workflow_runs: [workflowRun('pr-integration')] },
+        runJobs: {
+            101: {
+                jobs: ['unit-tests', 'cache-bust-guard', 'app-quality'].map((name) => ({
+                    name,
+                    status: 'completed',
+                    conclusion: 'success'
+                }))
+            },
+            102: {
+                jobs: ['mobile-build', 'preview-smoke'].map((name) => ({
+                    name,
+                    status: 'completed',
+                    conclusion: 'success'
+                }))
+            }
+        },
+        statuses: [{
+            context: 'paulbot-review-gate',
+            state: 'success',
+            creator: { id: 309595148, login: 'allplays-paulbot[bot]', type: 'Bot' },
+            target_url: 'https://github.com/pauljsnider/allplays/pull/4605',
+            description: 'Current-head review, review remediation, and CI passed',
+            updated_at: '2026-08-12T08:10:30Z'
+        }]
+    };
+}
 
 describe('production exact-head validation reuse', () => {
-    it('fails closed unless a same-repository merged PR has an identical validated tree', () => {
-        expect(workflowSource).toContain('echo "reuse_pr_validation=false" >> "$GITHUB_OUTPUT"');
-        expect(workflowSource).toContain('.merge_commit_sha == $sha');
-        expect(workflowSource).toContain('.base.ref == "master"');
-        expect(workflowSource).toContain('.base.repo.full_name == $repo');
-        expect(workflowSource).toContain('.head.repo.full_name == $repo');
-        expect(workflowSource).toContain('if [[ "$(jq \'length\' <<< "$matching_prs")" != "1" ]]');
-        expect(workflowSource).toContain('"repos/${GITHUB_REPOSITORY}/git/commits/${GITHUB_SHA}"');
-        expect(workflowSource).toContain('"repos/${GITHUB_REPOSITORY}/git/commits/${head_sha}"');
-        expect(workflowSource).toContain('[[ ! "$merge_tree" =~ ^[0-9a-f]{40}$ || "$merge_tree" != "$head_tree" ]]');
+    it('accepts an identical merged tree with exact PR-bound jobs and trusted PaulBot approval', () => {
+        expect(evaluateProductionValidationReuse(evidence())).toMatchObject({
+            reusable: true,
+            prNumber: 4605,
+            headSha
+        });
     });
 
-    it('rejects same-SHA workflow evidence from another PR, base, or repository', () => {
-        expect(workflowSource).toContain('.head_repository.full_name == $repo');
-        expect(workflowSource).toContain('.number == $pr_number');
-        expect(workflowSource).toContain('.head.repo.id == $repo_id');
-        expect(workflowSource).toContain('.base.ref == "master"');
-        expect(workflowSource).toContain('.base.repo.id == $repo_id');
-        expect(workflowSource).toContain('] | length) == 1');
+    it('rejects same-SHA workflow evidence produced for another PR and base', () => {
+        const input = evidence();
+        input.prFastRuns.workflow_runs[0].display_title = `pr-fast #999 -> support @ ${headSha}`;
+        input.prIntegrationRuns.workflow_runs[0].display_title = `pr-integration #999 -> support @ ${headSha}`;
+        expect(evaluateProductionValidationReuse(input).reusable).toBe(false);
     });
 
-    it('requires successful stable jobs instead of workflow-level success alone', () => {
-        expect(workflowSource).toContain('actions/runs/${workflow_run_id}/jobs?filter=latest&per_page=100');
-        expect(workflowSource).toContain('workflow_passed pr-fast.yml cache-bust-guard unit-tests app-quality');
-        expect(workflowSource).toContain('workflow_passed pr-integration.yml mobile-build preview-smoke');
-        expect(workflowSource).toContain('.name == $required_job');
-        expect(workflowSource).toContain('.status == "completed"');
-        expect(workflowSource).toContain('.conclusion == "success"');
+    it('rejects a forged success context from an untrusted creator', () => {
+        const input = evidence();
+        input.statuses[0].creator = { id: 1, login: 'untrusted-writer', type: 'User' };
+        expect(evaluateProductionValidationReuse(input)).toEqual({
+            reusable: false,
+            reason: 'trusted PR-bound PaulBot approval is missing'
+        });
     });
 
-    it('binds the PaulBot gate to this PR and its trusted status issuer', () => {
-        expect(workflowSource).toContain('.head_sha == $head_sha');
-        expect(workflowSource).toContain('.event == "pull_request"');
-        expect(workflowSource).toContain('.context == "paulbot-review-gate"');
-        expect(workflowSource).toContain('paulbot_target="https://github.com/${GITHUB_REPOSITORY}/pull/${pr_number}"');
-        expect(workflowSource).toContain('paulbot_issuer_avatar="https://avatars.githubusercontent.com/u/211066188?"');
-        expect(workflowSource).toContain('.target_url == $target');
-        expect(workflowSource).toContain('startswith($issuer_avatar)');
-        expect(workflowSource).toContain('echo "reuse_pr_validation=true" >> "$GITHUB_OUTPUT"');
+    it('rejects a successful workflow whose required jobs were skipped', () => {
+        const input = evidence();
+        input.runJobs[101].jobs.find((job) => job.name === 'unit-tests').conclusion = 'skipped';
+        expect(evaluateProductionValidationReuse(input)).toEqual({
+            reusable: false,
+            reason: 'exact PR-bound workflows and required jobs are incomplete'
+        });
     });
 
-    it('runs fresh tests on fallback and aggregates reused or fresh validation fail closed', () => {
+    it('rejects status evidence for another PR, stale approval, and a different tree', () => {
+        const wrongPr = evidence();
+        wrongPr.statuses[0].target_url = 'https://github.com/pauljsnider/allplays/pull/999';
+        expect(evaluateProductionValidationReuse(wrongPr).reusable).toBe(false);
+
+        const stale = evidence();
+        stale.statuses[0].updated_at = '2026-08-12T08:09:59Z';
+        expect(evaluateProductionValidationReuse(stale).reusable).toBe(false);
+
+        const differentTree = evidence();
+        differentTree.mergeCommit.tree.sha = 'd'.repeat(40);
+        expect(evaluateProductionValidationReuse(differentTree).reusable).toBe(false);
+    });
+
+    it('publishes PR/base identity in both workflow runs and gates duplicate production tests', () => {
+        const identity = '#${{ github.event.pull_request.number }} -> ${{ github.event.pull_request.base.ref }} @ ${{ github.event.pull_request.head.sha }}';
+        expect(fastWorkflowSource).toContain(`run-name: "pr-fast ${identity}"`);
+        expect(integrationWorkflowSource).toContain(`run-name: "pr-integration ${identity}"`);
+        expect(workflowSource).toContain('commits/${head_sha}/statuses');
         expect(workflow.jobs['unit-tests'].needs).toBe('validation-source');
         expect(workflow.jobs['unit-tests'].if).toContain("reuse_pr_validation != 'true'");
         expect(workflow.jobs['regression-guards'].needs).toBe('validation-source');
         expect(workflow.jobs['regression-guards'].if).toContain("reuse_pr_validation != 'true'");
-        expect(workflow.jobs['production-validation-gate'].needs).toEqual([
-            'validation-source',
-            'unit-tests',
-            'regression-guards'
-        ]);
         expect(workflow.jobs['production-validation-gate'].if).toBe('always()');
-        expect(workflowSource).toContain('if [[ "$UNIT_TEST_RESULT" != "success" || "$REGRESSION_GUARD_RESULT" != "success" ]]');
-        expect(workflow.jobs['prepare-deploy'].needs).toEqual([
-            'production-validation-gate',
-            'validate-production-smoke-config'
-        ]);
     });
 });

--- a/tests/unit/production-validation-reuse.test.js
+++ b/tests/unit/production-validation-reuse.test.js
@@ -10,6 +10,7 @@ describe('production exact-head validation reuse', () => {
         expect(workflowSource).toContain('echo "reuse_pr_validation=false" >> "$GITHUB_OUTPUT"');
         expect(workflowSource).toContain('.merge_commit_sha == $sha');
         expect(workflowSource).toContain('.base.ref == "master"');
+        expect(workflowSource).toContain('.base.repo.full_name == $repo');
         expect(workflowSource).toContain('.head.repo.full_name == $repo');
         expect(workflowSource).toContain('if [[ "$(jq \'length\' <<< "$matching_prs")" != "1" ]]');
         expect(workflowSource).toContain('"repos/${GITHUB_REPOSITORY}/git/commits/${GITHUB_SHA}"');
@@ -17,13 +18,32 @@ describe('production exact-head validation reuse', () => {
         expect(workflowSource).toContain('[[ ! "$merge_tree" =~ ^[0-9a-f]{40}$ || "$merge_tree" != "$head_tree" ]]');
     });
 
-    it('requires both exact-head PR workflows and the PaulBot gate before reuse', () => {
-        expect(workflowSource).toContain('workflow_passed pr-fast.yml');
-        expect(workflowSource).toContain('workflow_passed pr-integration.yml');
+    it('rejects same-SHA workflow evidence from another PR, base, or repository', () => {
+        expect(workflowSource).toContain('.head_repository.full_name == $repo');
+        expect(workflowSource).toContain('.number == $pr_number');
+        expect(workflowSource).toContain('.head.repo.id == $repo_id');
+        expect(workflowSource).toContain('.base.ref == "master"');
+        expect(workflowSource).toContain('.base.repo.id == $repo_id');
+        expect(workflowSource).toContain('] | length) == 1');
+    });
+
+    it('requires successful stable jobs instead of workflow-level success alone', () => {
+        expect(workflowSource).toContain('actions/runs/${workflow_run_id}/jobs?filter=latest&per_page=100');
+        expect(workflowSource).toContain('workflow_passed pr-fast.yml cache-bust-guard unit-tests app-quality');
+        expect(workflowSource).toContain('workflow_passed pr-integration.yml mobile-build preview-smoke');
+        expect(workflowSource).toContain('.name == $required_job');
+        expect(workflowSource).toContain('.status == "completed"');
+        expect(workflowSource).toContain('.conclusion == "success"');
+    });
+
+    it('binds the PaulBot gate to this PR and its trusted status issuer', () => {
         expect(workflowSource).toContain('.head_sha == $head_sha');
         expect(workflowSource).toContain('.event == "pull_request"');
-        expect(workflowSource).toContain('.conclusion == "success"');
         expect(workflowSource).toContain('.context == "paulbot-review-gate"');
+        expect(workflowSource).toContain('paulbot_target="https://github.com/${GITHUB_REPOSITORY}/pull/${pr_number}"');
+        expect(workflowSource).toContain('paulbot_issuer_avatar="https://avatars.githubusercontent.com/u/211066188?"');
+        expect(workflowSource).toContain('.target_url == $target');
+        expect(workflowSource).toContain('startswith($issuer_avatar)');
         expect(workflowSource).toContain('echo "reuse_pr_validation=true" >> "$GITHUB_OUTPUT"');
     });
 


### PR DESCRIPTION
## What changed
- prove a master push came from exactly one same-repository merged PR whose production tree is identical to the reviewed head
- reuse successful exact-head `pr-fast`, `pr-integration`, and `paulbot-review-gate` evidence for that tree
- keep full production unit and regression validation fail-closed for direct pushes, manual runs, missing evidence, or tree mismatches
- aggregate reused or fresh validation before protected smoke configuration and deployment

## Expected impact
- remove about 6m23s from the production deploy critical path for normal PaulBot merges
- avoid about 7m30s of duplicate runner work per merged PR (one full unit job plus one regression job)
- leave PR validation coverage and production smoke coverage unchanged

## Validation
- `npm run test:unit:ci`
- `npm run ci:firebase-rules`
- focused workflow/security suite: 19/19 passed
- YAML lint passed
- live read-only proof against merged PR #4592: one bound PR, identical trees, both Actions workflows green, PaulBot gate green