### PR TITLE
Restore required Firestore query indexes

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -703,6 +703,14 @@
       "collectionGroup": "officials",
       "fieldPath": "name",
       "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION" },
+        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
+      ]
+    },
+    {
+      "collectionGroup": "officials",
+      "fieldPath": "officialUserId",
+      "indexes": [
         { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
       ]
     },
@@ -736,6 +744,13 @@
       "indexes": [
         { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" },
         { "order": "DESCENDING", "queryScope": "COLLECTION_GROUP" }
+      ]
+    },
+    {
+      "collectionGroup": "games",
+      "fieldPath": "scheduleNotifications.nextReminderAt",
+      "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
       ]
     },
     {
@@ -871,6 +886,13 @@
     {
       "collectionGroup": "registrations",
       "fieldPath": "submittedByUserId",
+      "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
+      ]
+    },
+    {
+      "collectionGroup": "registrations",
+      "fieldPath": "paymentReminder.nextReminderAt",
       "indexes": [
         { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
       ]

--- a/tests/unit/firestore-rules-architecture-fixes.test.js
+++ b/tests/unit/firestore-rules-architecture-fixes.test.js
@@ -88,8 +88,27 @@ describe('firestore.rules architecture fixes', () => {
             'email',
             'emailLower',
             'name',
+            'officialUserId',
             'phone',
             'phoneDigits'
+        ]));
+        const officialNameIndexes = indexes.fieldOverrides
+            .find((override) =>
+                override.collectionGroup === 'officials' &&
+                override.fieldPath === 'name'
+            )?.indexes || [];
+        expect(officialNameIndexes).toEqual(expect.arrayContaining([
+            { order: 'ASCENDING', queryScope: 'COLLECTION' },
+            { order: 'ASCENDING', queryScope: 'COLLECTION_GROUP' }
+        ]));
+        const collectionGroupAscendingFields = indexes.fieldOverrides
+            .filter((override) => override.indexes.some((index) =>
+                index.order === 'ASCENDING' && index.queryScope === 'COLLECTION_GROUP'
+            ))
+            .map((override) => `${override.collectionGroup}.${override.fieldPath}`);
+        expect(collectionGroupAscendingFields).toEqual(expect.arrayContaining([
+            'games.scheduleNotifications.nextReminderAt',
+            'registrations.paymentReminder.nextReminderAt'
         ]));
         const assignmentIndexes = indexes.indexes
             .filter((index) => ['games', 'sharedGames'].includes(index.collectionGroup))


### PR DESCRIPTION
## What changed
- add the missing `officials.officialUserId` collection-group index required by `listOfficialLinkedTeamIds`
- restore the direct ascending `officials.name` index retained by the officials directory UI
- add the missing collection-group indexes for scheduled pre-event reminders and registration payment-reminder backlog scans
- extend the index contract regression so these query/index pairs cannot drift again

## Why
Production post-deploy smoke for #4592 repeatedly failed on the Officials route. Firestore data-access logs showed `listOfficialLinkedTeamIds` failing before requested-team evaluation because `officials.officialUserId` had no collection-group index. The same log audit found the direct officials directory query missing its `name` index and both scheduled reminder workers repeatedly failing for missing nested-field indexes.

## Verification
- `npx vitest run tests/unit/firestore-rules-architecture-fixes.test.js tests/unit/pre-event-reminder-dispatcher.test.js tests/unit/registration-payment-reminders-source.test.js --reporter=verbose` (22 passed, 3 environment-gated skipped)
- `npm run ci:firebase-rules`
- `npm test` (5,917 passed, 201 skipped)
- `git diff --check`

## Production verification after merge
- confirm all four indexes reach READY state
- run the production fixture audit and exact-SHA post-deploy smoke
- verify no new missing-index errors for these four fields
- rerun Android and iOS authenticated navigation using the current native build
