### PR TITLE
Verify all empty managed team results

### DIFF
--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -825,14 +825,15 @@ describe('parent schedule child scope', () => {
     expect(scope.isPartial).toBe(false);
   });
 
-  it('does not verify an empty web SDK result for an account without staff access signals', async () => {
+  it('confirms an empty web SDK result even when the account lacks staff access signals', async () => {
     const parentUser = { uid: 'parent-1', email: 'parent@example.com', roles: ['parent'], coachOf: [] } as any;
     vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: [] } as any);
     vi.mocked(getStaffTeams).mockResolvedValue({ teams: [], isPartial: false } as any);
+    vi.mocked(loadManagedTeamsFromNativeCallable).mockResolvedValueOnce({ teams: [], isPartial: false });
 
     const scope = await loadParentScheduleScope(parentUser);
 
-    expect(loadManagedTeamsFromNativeCallable).not.toHaveBeenCalled();
+    expect(loadManagedTeamsFromNativeCallable).toHaveBeenCalledTimes(1);
     expect(scope.staffTeams).toEqual([]);
     expect(scope.staffTeamsPartial).toBe(false);
     expect(scope.isPartial).toBe(false);

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -3134,7 +3134,11 @@ export async function loadParentScheduleScope(user: AuthUser | null): Promise<Pa
   const nativeRuntime = isNativeRuntime();
   const shouldVerifyStaffResultWithHttp = nativeRuntime
     ? (staffTeamResult.isPartial || hasMissingDeclaredCoachTeam || shouldVerifyEmptyStaffResult)
-    : (shouldVerifyEmptyStaffResult && staffTeamResult.isPartial !== true);
+    // A complete-empty browser SDK result has proved nondeterministic in the
+    // production staff workflow. Confirm every empty result through the same
+    // bounded, authenticated server projection instead of depending on stale
+    // role hints to decide whether the account might manage a team.
+    : (staffTeamResult.teams.length === 0 && staffTeamResult.isPartial !== true);
   if (shouldVerifyStaffResultWithHttp) {
     try {
       const restResult = await loadStaffTeamsFromRest();

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -559,7 +559,7 @@ describe('React app schedule service contract integration', () => {
         expect(legacyScheduleDbSource).toContain("legacyFirebaseHttpsCallable(legacyFirebaseFunctions, 'listManagedTeams')");
         expect(legacyScheduleDbSource).not.toContain("legacyFirebaseWhere('ownerEmailLower', '==', normalizedEmail)");
         expect(scheduleServiceSource).toContain('const shouldVerifyStaffResultWithHttp = nativeRuntime');
-        expect(scheduleServiceSource).toContain(': (shouldVerifyEmptyStaffResult && staffTeamResult.isPartial !== true)');
+        expect(scheduleServiceSource).toContain(': (staffTeamResult.teams.length === 0 && staffTeamResult.isPartial !== true)');
     });
 
     it('discovers official teams and native assignments through one authenticated bounded callable', () => {


### PR DESCRIPTION
## Summary
- confirm every complete-empty web managed-team result through the bounded authenticated server projection
- remove dependence on stale client role hints for staff team discovery
- add regression coverage for empty results from accounts without staff-role hints

## Validation
- `npm run test:app -- src/lib/scheduleService.test.ts` (194 passed)
- `npx vitest run tests/unit/app-schedule-service-contracts.test.js --reporter=verbose` (43 passed)
- `npm run app:build`

## Production evidence
Post-deploy smoke run 31581959352 failed twice because the staff fixture had no team link after a complete-empty SDK result; the prior signal-gated fallback therefore remained nondeterministic.