### PR TITLE
Recover omitted managed teams on web

### DIFF
--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -825,6 +825,40 @@ describe('parent schedule child scope', () => {
     expect(scope.isPartial).toBe(false);
   });
 
+  it('merges the authenticated HTTP result when a nonempty web result omits a declared coach team', async () => {
+    const coachUser = {
+      uid: 'coach-1',
+      email: 'coach@example.com',
+      roles: ['coach'],
+      coachOf: ['team-direct', 'team-declared']
+    } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({
+      parentOf: [],
+      coachOf: ['team-direct', 'team-declared']
+    } as any);
+    vi.mocked(getStaffTeams).mockResolvedValue({
+      teams: [{ id: 'team-direct', name: 'Direct Team', active: true }],
+      isPartial: false
+    } as any);
+    vi.mocked(loadManagedTeamsFromNativeCallable).mockResolvedValueOnce({
+      teams: [
+        { id: 'team-direct', name: 'Direct Team', active: true },
+        { id: 'team-declared', name: 'Declared Team', active: true }
+      ],
+      isPartial: false
+    });
+
+    const scope = await loadParentScheduleScope(coachUser);
+
+    expect(loadManagedTeamsFromNativeCallable).toHaveBeenCalledTimes(1);
+    expect(scope.staffTeams).toEqual([
+      { teamId: 'team-direct', teamName: 'Direct Team' },
+      { teamId: 'team-declared', teamName: 'Declared Team' }
+    ]);
+    expect(scope.staffTeamsPartial).toBe(false);
+    expect(scope.isPartial).toBe(false);
+  });
+
   it('confirms an empty web SDK result even when the account lacks staff access signals', async () => {
     const parentUser = { uid: 'parent-1', email: 'parent@example.com', roles: ['parent'], coachOf: [] } as any;
     vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: [] } as any);

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -825,6 +825,40 @@ describe('parent schedule child scope', () => {
     expect(scope.isPartial).toBe(false);
   });
 
+  it('merges the authenticated HTTP result when a nonempty web result omits a declared coach team', async () => {
+    const coachUser = {
+      uid: 'coach-1',
+      email: 'coach@example.com',
+      roles: ['coach'],
+      coachOf: ['team-direct', 'team-declared']
+    } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({
+      parentOf: [],
+      coachOf: ['team-direct', 'team-declared']
+    } as any);
+    vi.mocked(getStaffTeams).mockResolvedValue({
+      teams: [{ id: 'team-direct', name: 'Direct Team', active: true }],
+      isPartial: false
+    } as any);
+    vi.mocked(loadManagedTeamsFromNativeCallable).mockResolvedValueOnce({
+      teams: [
+        { id: 'team-direct', name: 'Direct Team', active: true },
+        { id: 'team-declared', name: 'Declared Team', active: true }
+      ],
+      isPartial: false
+    });
+
+    const scope = await loadParentScheduleScope(coachUser);
+
+    expect(loadManagedTeamsFromNativeCallable).toHaveBeenCalledTimes(1);
+    expect(scope.staffTeams).toEqual([
+      { teamId: 'team-direct', teamName: 'Direct Team' },
+      { teamId: 'team-declared', teamName: 'Declared Team' }
+    ]);
+    expect(scope.staffTeamsPartial).toBe(false);
+    expect(scope.isPartial).toBe(false);
+  });
+
   it('does not verify an empty web SDK result for an account without staff access signals', async () => {
     const parentUser = { uid: 'parent-1', email: 'parent@example.com', roles: ['parent'], coachOf: [] } as any;
     vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: [] } as any);

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -3134,7 +3134,7 @@ export async function loadParentScheduleScope(user: AuthUser | null): Promise<Pa
   const nativeRuntime = isNativeRuntime();
   const shouldVerifyStaffResultWithHttp = nativeRuntime
     ? (staffTeamResult.isPartial || hasMissingDeclaredCoachTeam || shouldVerifyEmptyStaffResult)
-    : (shouldVerifyEmptyStaffResult && staffTeamResult.isPartial !== true);
+    : ((hasMissingDeclaredCoachTeam || shouldVerifyEmptyStaffResult) && staffTeamResult.isPartial !== true);
   if (shouldVerifyStaffResultWithHttp) {
     try {
       const restResult = await loadStaffTeamsFromRest();

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -559,7 +559,7 @@ describe('React app schedule service contract integration', () => {
         expect(legacyScheduleDbSource).toContain("legacyFirebaseHttpsCallable(legacyFirebaseFunctions, 'listManagedTeams')");
         expect(legacyScheduleDbSource).not.toContain("legacyFirebaseWhere('ownerEmailLower', '==', normalizedEmail)");
         expect(scheduleServiceSource).toContain('const shouldVerifyStaffResultWithHttp = nativeRuntime');
-        expect(scheduleServiceSource).toContain(': (shouldVerifyEmptyStaffResult && staffTeamResult.isPartial !== true)');
+        expect(scheduleServiceSource).toContain(': ((hasMissingDeclaredCoachTeam || shouldVerifyEmptyStaffResult) && staffTeamResult.isPartial !== true)');
     });
 
     it('discovers official teams and native assignments through one authenticated bounded callable', () => {


### PR DESCRIPTION
## What changed
- verify complete-looking web managed-team results when they omit a team declared by the signed-in profile
- merge the server-authorized callable result without replacing already discovered teams
- add focused regression and source-contract coverage for the nonempty partial chooser case

## Why
The production role smoke proved the fixture and `listManagedTeams` callable were healthy, but `/teams` stopped at a nonempty direct-query result that omitted the fixture team. That treated incomplete access discovery as authoritative absence.

## Verification
- production fixture audit: success (run 31582495465)
- `npm run test:app -- src/lib/scheduleService.test.ts` (195 passed)
- `npx vitest run tests/unit/app-schedule-service-contracts.test.js --reporter=dot` (43 passed)
- `npm --prefix apps/app run test:ci` (1,959 passed)
- `npm test -- --reporter=dot`, isolated (5,929 passed, 202 skipped)
- `npm --prefix apps/app run lint`
- `npm run app:build`

## Manual/production evidence
- post-deploy baseline, canonical origin, and authenticated login probes passed on merge `7824f034`; only the fixture staff `/teams` link assertion failed
- production audit independently confirmed the team is active, staff-linked, and returned by the authoritative callable

No data migration, rules change, or external mutation is included.