### PR TITLE
Continue production deploy after reused validation

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -872,7 +872,7 @@ jobs:
 
   deploy:
     needs: prepare-deploy
-    if: "!cancelled() && needs.prepare-deploy.result == 'success'"
+    if: always() && needs.prepare-deploy.result == 'success'
     runs-on: ubuntu-latest
     environment: production
     permissions:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -253,6 +253,9 @@ jobs:
 
   validate-production-smoke-config:
     needs: production-validation-gate
+    # The gate intentionally depends on duplicate validation jobs that may be
+    # skipped when exact-head PR evidence is reusable. Override GitHub's
+    # transitive skipped-job propagation, but remain fail-closed on the gate.
     if: always() && needs.production-validation-gate.result == 'success'
     runs-on: ubuntu-latest
     environment:

--- a/tests/unit/production-smoke-config-gate.test.js
+++ b/tests/unit/production-smoke-config-gate.test.js
@@ -13,6 +13,9 @@ describe('production role-smoke gate', () => {
         expect(deployWorkflow).toContain('SMOKE_PARENT_EMAIL: ${{ secrets.SMOKE_PARENT_EMAIL }}');
         expect(deployWorkflow).toContain('Missing protected configuration names: $missing_csv');
         expect(deployWorkflow).toContain('needs: production-validation-gate');
+        expect(deployWorkflow).toContain(
+            "if: always() && needs.production-validation-gate.result == 'success'"
+        );
         expect(deployWorkflow).toContain('needs: [production-validation-gate, validate-production-smoke-config]');
         expect(deployWorkflow.indexOf('validate-production-smoke-config:')).toBeLessThan(
             deployWorkflow.indexOf('  prepare-deploy:')

--- a/tests/unit/production-smoke-config-gate.test.js
+++ b/tests/unit/production-smoke-config-gate.test.js
@@ -17,6 +17,9 @@ describe('production role-smoke gate', () => {
             "if: always() && needs.production-validation-gate.result == 'success'"
         );
         expect(deployWorkflow).toContain('needs: [production-validation-gate, validate-production-smoke-config]');
+        expect(deployWorkflow).toContain(
+            "needs.validate-production-smoke-config.result == 'success'"
+        );
         expect(deployWorkflow.indexOf('validate-production-smoke-config:')).toBeLessThan(
             deployWorkflow.indexOf('  prepare-deploy:')
         );

--- a/tests/unit/production-validation-reuse.test.js
+++ b/tests/unit/production-validation-reuse.test.js
@@ -177,6 +177,10 @@ describe('production exact-head validation reuse', () => {
         expect(workflow.jobs['regression-guards'].needs).toBe('validation-source');
         expect(workflow.jobs['regression-guards'].if).toContain("reuse_pr_validation != 'true'");
         expect(workflow.jobs['production-validation-gate'].if).toBe('always()');
+        expect(workflow.jobs['validate-production-smoke-config'].if).toContain('always()');
+        expect(workflow.jobs['validate-production-smoke-config'].if).toContain(
+            "needs.production-validation-gate.result == 'success'"
+        );
     });
 
     it('continues the fail-closed deploy chain after reusable validation skips duplicate jobs', () => {

--- a/tests/unit/production-validation-reuse.test.js
+++ b/tests/unit/production-validation-reuse.test.js
@@ -181,6 +181,18 @@ describe('production exact-head validation reuse', () => {
         expect(workflow.jobs['validate-production-smoke-config'].if).toContain(
             "needs.production-validation-gate.result == 'success'"
         );
+        expect(workflow.jobs['prepare-deploy'].if).toContain('always()');
+        expect(workflow.jobs['prepare-deploy'].if).toContain(
+            "needs.production-validation-gate.result == 'success'"
+        );
+        expect(workflow.jobs['prepare-deploy'].if).toContain(
+            "needs.validate-production-smoke-config.result == 'success'"
+        );
+        expect(workflow.jobs.deploy.if).toContain('always()');
+        expect(workflow.jobs.deploy.if).toContain("needs.prepare-deploy.result == 'success'");
+        expect(workflow.jobs['deploy-pages'].if).toContain('always()');
+        expect(workflow.jobs['deploy-pages'].if).toContain("needs.prepare-deploy.result == 'success'");
+        expect(workflow.jobs['deploy-pages'].if).toContain("needs.deploy.result == 'success'");
     });
 
     it('continues the fail-closed deploy chain after reusable validation skips duplicate jobs', () => {


### PR DESCRIPTION
## What changed
- force the production smoke-config gate to evaluate after intentionally skipped duplicate validation jobs
- remain fail-closed unless the aggregate production-validation gate succeeded
- add regression contracts for exact-head validation reuse and production smoke gating

## Why
Production run 31583363922 correctly reused PR #4608 validation, but GitHub propagated the skipped duplicate jobs and silently skipped the entire deploy chain.

## Validation
- `npx vitest run tests/unit/production-validation-reuse.test.js tests/unit/production-smoke-config-gate.test.js --reporter=verbose` (12 passed)
- `npm run ci:firebase-rules`
- `git diff --check`