### PR TITLE
Fix reusable validation deployment gate

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -253,6 +253,7 @@ jobs:
 
   validate-production-smoke-config:
     needs: production-validation-gate
+    if: always() && needs.production-validation-gate.result == 'success'
     runs-on: ubuntu-latest
     environment:
       name: production-smoke
@@ -311,6 +312,10 @@ jobs:
 
   prepare-deploy:
     needs: [production-validation-gate, validate-production-smoke-config]
+    if: >-
+      always() &&
+      needs.production-validation-gate.result == 'success' &&
+      needs.validate-production-smoke-config.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -864,6 +869,7 @@ jobs:
 
   deploy:
     needs: prepare-deploy
+    if: always() && needs.prepare-deploy.result == 'success'
     runs-on: ubuntu-latest
     environment: production
     permissions:
@@ -2091,7 +2097,11 @@ jobs:
           } >> "$GITHUB_ENV"
 
   deploy-pages:
-    if: vars.RELEASE_GITHUB_PAGES_DEPLOY_ENABLED == 'true'
+    if: >-
+      always() &&
+      needs.prepare-deploy.result == 'success' &&
+      needs.deploy.result == 'success' &&
+      vars.RELEASE_GITHUB_PAGES_DEPLOY_ENABLED == 'true'
     needs: [prepare-deploy, deploy]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -869,7 +869,7 @@ jobs:
 
   deploy:
     needs: prepare-deploy
-    if: always() && needs.prepare-deploy.result == 'success'
+    if: "!cancelled() && needs.prepare-deploy.result == 'success'"
     runs-on: ubuntu-latest
     environment: production
     permissions:

--- a/tests/unit/production-validation-reuse.test.js
+++ b/tests/unit/production-validation-reuse.test.js
@@ -187,7 +187,7 @@ describe('production exact-head validation reuse', () => {
             "always() && needs.production-validation-gate.result == 'success' && needs.validate-production-smoke-config.result == 'success'"
         );
         expect(workflow.jobs.deploy.if).toBe(
-            "always() && needs.prepare-deploy.result == 'success'"
+            "!cancelled() && needs.prepare-deploy.result == 'success'"
         );
         expect(workflow.jobs['deploy-pages'].if).toBe(
             "always() && needs.prepare-deploy.result == 'success' && needs.deploy.result == 'success' && vars.RELEASE_GITHUB_PAGES_DEPLOY_ENABLED == 'true'"

--- a/tests/unit/production-validation-reuse.test.js
+++ b/tests/unit/production-validation-reuse.test.js
@@ -178,4 +178,19 @@ describe('production exact-head validation reuse', () => {
         expect(workflow.jobs['regression-guards'].if).toContain("reuse_pr_validation != 'true'");
         expect(workflow.jobs['production-validation-gate'].if).toBe('always()');
     });
+
+    it('continues the fail-closed deploy chain after reusable validation skips duplicate jobs', () => {
+        expect(workflow.jobs['validate-production-smoke-config'].if).toBe(
+            "always() && needs.production-validation-gate.result == 'success'"
+        );
+        expect(workflow.jobs['prepare-deploy'].if).toBe(
+            "always() && needs.production-validation-gate.result == 'success' && needs.validate-production-smoke-config.result == 'success'"
+        );
+        expect(workflow.jobs.deploy.if).toBe(
+            "always() && needs.prepare-deploy.result == 'success'"
+        );
+        expect(workflow.jobs['deploy-pages'].if).toBe(
+            "always() && needs.prepare-deploy.result == 'success' && needs.deploy.result == 'success' && vars.RELEASE_GITHUB_PAGES_DEPLOY_ENABLED == 'true'"
+        );
+    });
 });


### PR DESCRIPTION
## What changed
- keep the production release chain running when exact-head PR validation safely skips duplicate unit and regression jobs
- require each downstream job to observe successful direct gates before it may proceed
- add a regression that locks the fail-closed continuation conditions

## Why
PR #4605 introduced exact-head validation reuse today. GitHub Actions propagated its intentionally skipped duplicate jobs through the dependency graph, so deploy runs for master SHAs c7c9bbed3 and 10f021f69 completed green while skipping smoke configuration, preparation, deployment, and release-marker jobs.

## Verification
- focused production validation, smoke gate, and Firebase CI contract tests: 20 passed
- full root unit suite: 759 files, 5,930 tests passed; 3 files and 202 tests skipped
- Firestore and Storage rules suite: 18 files, 250 tests passed
- callable transaction suite: 45 tests passed
- npm run ci:firebase-rules: passed
- git diff --check: passed

## Production handoff
After merge, verify the exact merge SHA reaches deploy, release-marker, and authenticated post-deploy smoke before considering the release complete.