### PR TITLE
Repair completed officials smoke fixtures

### DIFF
--- a/scripts/maintain-production-smoke-official-fixture.mjs
+++ b/scripts/maintain-production-smoke-official-fixture.mjs
@@ -34,8 +34,20 @@ function getGameDate(fields) {
     return String(value.timestampValue || value.stringValue || '');
 }
 
-function getGameStatus(fields) {
-    return getStringField(fields, 'status').trim().toLowerCase();
+function getGameStatus(fields, fieldName) {
+    return getStringField(fields, fieldName).trim().toLowerCase();
+}
+
+function isClosedGameStatus(status) {
+    return [
+        'cancelled',
+        'canceled',
+        'completed',
+        'complete',
+        'final',
+        'finished',
+        'ended'
+    ].includes(status);
 }
 
 export function assertSmokeFixtureIdentifier(value, label) {
@@ -48,19 +60,24 @@ export function inspectOfficialFixture(document, now = new Date()) {
     const fields = document?.fields || {};
     const dateValue = getGameDate(fields);
     const date = dateValue ? new Date(dateValue) : null;
-    const status = getGameStatus(fields);
+    const status = getGameStatus(fields, 'status');
+    const liveStatus = getGameStatus(fields, 'liveStatus');
     const slots = getArrayValues(fields.officiatingSlots);
     const openSlotCount = slots.filter(isUnassignedOpenSlot).length;
     const isUpcoming = Boolean(date && Number.isFinite(date.getTime()) && date.getTime() > now.getTime());
     const isCancelled = status === 'cancelled' || status === 'canceled';
+    const isClosed = isClosedGameStatus(status) || isClosedGameStatus(liveStatus);
 
     return {
         ready: fields.officiatingSelfAssignmentEnabled?.booleanValue === true &&
             isUpcoming &&
-            !isCancelled &&
+            !isClosed &&
             openSlotCount > 0,
         isUpcoming,
         isCancelled,
+        isClosed,
+        status,
+        liveStatus,
         openSlotCount,
         selfAssignmentEnabled: fields.officiatingSelfAssignmentEnabled?.booleanValue === true
     };
@@ -99,8 +116,11 @@ export function buildOfficialFixturePatch(document, now = new Date()) {
     if (!inspection.isUpcoming) {
         patch.date = { timestampValue: officialFixtureDate };
     }
-    if (inspection.isCancelled) {
+    if (isClosedGameStatus(inspection.status)) {
         patch.status = { stringValue: 'scheduled' };
+    }
+    if (isClosedGameStatus(inspection.liveStatus)) {
+        patch.liveStatus = { stringValue: 'scheduled' };
     }
 
     return { fields: patch };
@@ -162,7 +182,7 @@ async function main() {
         throw new Error(
             `Officials fixture is not ready (upcoming=${inspection.isUpcoming}, ` +
             `self-assignment=${inspection.selfAssignmentEnabled}, open-slots=${inspection.openSlotCount}, ` +
-            `cancelled=${inspection.isCancelled})`
+            `status=${inspection.status || 'unset'}, live-status=${inspection.liveStatus || 'unset'})`
         );
     }
 

--- a/tests/unit/production-smoke-official-fixture.test.js
+++ b/tests/unit/production-smoke-official-fixture.test.js
@@ -22,6 +22,7 @@ const workflowSource = readFileSync('.github/workflows/production-smoke-fixture.
 function buildDocument({
     date = '2025-01-01T18:00:00.000Z',
     enabled = false,
+    liveStatus = '',
     slots = [],
     status = 'cancelled'
 } = {}) {
@@ -31,7 +32,8 @@ function buildDocument({
             date: { timestampValue: date },
             officiatingSelfAssignmentEnabled: { booleanValue: enabled },
             officiatingSlots: { arrayValue: { values: slots } },
-            status: { stringValue: status }
+            status: { stringValue: status },
+            ...(liveStatus ? { liveStatus: { stringValue: liveStatus } } : {})
         }
     };
 }
@@ -98,12 +100,49 @@ describe('production officials smoke fixture maintenance', () => {
             ready: true,
             isUpcoming: true,
             isCancelled: false,
+            isClosed: false,
+            status: 'scheduled',
+            liveStatus: '',
             openSlotCount: 1,
             selfAssignmentEnabled: true
         });
         expect(buildOfficialFixturePatch(document).fields).toEqual({
             officiatingSelfAssignmentEnabled: { booleanValue: true },
             officiatingSlots: document.fields.officiatingSlots
+        });
+    });
+
+    it.each([
+        ['completed', 'completed'],
+        ['scheduled', 'final']
+    ])('repairs a terminal %s/%s game that the app correctly hides', (status, liveStatus) => {
+        const document = buildDocument({
+            date: officialFixtureDate,
+            enabled: true,
+            status,
+            liveStatus,
+            slots: [
+                {
+                    mapValue: {
+                        fields: {
+                            id: { stringValue: officialFixtureSlotId },
+                            position: { stringValue: 'Smoke official' },
+                            status: { stringValue: 'open' }
+                        }
+                    }
+                }
+            ]
+        });
+
+        expect(inspectOfficialFixture(document)).toMatchObject({
+            ready: false,
+            isClosed: true,
+            status,
+            liveStatus
+        });
+        expect(buildOfficialFixturePatch(document).fields).toMatchObject({
+            ...(status === 'scheduled' ? {} : { status: { stringValue: 'scheduled' } }),
+            liveStatus: { stringValue: 'scheduled' }
         });
     });
 


### PR DESCRIPTION
## What changed
- treat completed, final, finished, and ended officials smoke games as unusable, matching the app route filter
- repair terminal `status` and `liveStatus` values back to `scheduled` without touching unrelated game fields
- add regressions for completed and live-final fixture states

## Why
Post-deploy smoke run 31586971987 proved the dedicated game had an open slot and future date but both status fields were `completed`. The fixture audit reported it healthy while the app correctly hid it, causing the role smoke to fail.

## Verification
- `npx vitest run tests/unit/production-smoke-official-fixture.test.js --reporter=verbose` (16 passed)
- `npm test -- --run` (5,933 passed; 204 skipped)
- `git diff --check`

## Production follow-up
After merge, dispatch `production-smoke-fixture` in repair mode, verify the game is scheduled and claimable, then rerun the exact post-deploy role smoke.