### PR TITLE
Use authoritative projections for staff workflows

### DIFF
--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -2485,6 +2485,8 @@ describe('official assignments app service', () => {
 
   it('loads web linked-team assignments from the authenticated bounded HTTP projection', async () => {
     vi.mocked(getNativeAuthIdToken).mockResolvedValue('web-token');
+    const sharedGamePath = 'tournaments/tournament-1/sharedGames/shared-assigned';
+    const gameId = `shared_${encodeURIComponent(sharedGamePath)}`;
     capacitorCoreMock.httpPost.mockResolvedValue({
       status: 200,
       data: {
@@ -2498,7 +2500,8 @@ describe('official assignments app service', () => {
             kind: 'assigned',
             teamId: 'team-alpha',
             teamName: 'Alpha FC',
-            gameId: 'game-assigned',
+            gameId,
+            sharedGamePath,
             slotId: 'center',
             position: 'Center Referee',
             status: 'pending',
@@ -2520,7 +2523,7 @@ describe('official assignments app service', () => {
       hasAccess: true,
       teamIds: ['team-alpha'],
       isPartial: false,
-      assignments: [expect.objectContaining({ gameId: 'game-assigned', slotId: 'center' })]
+      assignments: [expect.objectContaining({ gameId, sharedGamePath, slotId: 'center' })]
     }));
     expect(capacitorCoreMock.httpPost).toHaveBeenCalledWith(expect.objectContaining({
       data: { data: { includeAssignments: true, requestedTeamId: 'team-alpha' } },
@@ -2529,6 +2532,29 @@ describe('official assignments app service', () => {
     expect(getOfficialLinkedTeamIds).not.toHaveBeenCalled();
     expect(getTeam).not.toHaveBeenCalled();
     expect(getGames).not.toHaveBeenCalled();
+
+    const [item] = result.assignments;
+    await respondToOfficialAssignmentItem(item, 'accepted');
+    await respondToOfficialAssignmentItem(item, 'declined');
+    await claimOfficialAssignmentItem({ ...item, kind: 'open', canClaim: true }, user);
+
+    expect(nativeCallableMock.callNativeFirebaseFunction).toHaveBeenNthCalledWith(1,
+      'respondToOfficiatingAssignment',
+      { teamId: 'team-alpha', gameId, sharedGamePath, slotId: 'center', status: 'accepted' },
+      { errorLabel: 'Officiating response' }
+    );
+    expect(nativeCallableMock.callNativeFirebaseFunction).toHaveBeenNthCalledWith(2,
+      'respondToOfficiatingAssignment',
+      { teamId: 'team-alpha', gameId, sharedGamePath, slotId: 'center', status: 'declined' },
+      { errorLabel: 'Officiating response' }
+    );
+    expect(nativeCallableMock.callNativeFirebaseFunction).toHaveBeenNthCalledWith(3,
+      'claimOpenOfficiatingSlot',
+      { teamId: 'team-alpha', gameId, sharedGamePath, slotId: 'center' },
+      { errorLabel: 'Officiating claim' }
+    );
+    expect(respondToOfficiatingAssignment).not.toHaveBeenCalled();
+    expect(claimOpenOfficiatingSlot).not.toHaveBeenCalled();
   });
 
   it('loads a requested native team and its shared assignments only from the complete callable projection', async () => {

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -426,6 +426,7 @@ describe('parent schedule child scope', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(loadManagedTeamsFromNativeCallable).mockReset().mockResolvedValue({ teams: [], isPartial: false });
     vi.mocked(getNativeAuthIdToken).mockRejectedValue(new Error('REST auth unavailable in isolated staff-scope tests'));
     vi.mocked(isTeamActive).mockImplementation((team: any) => (
       team?.active !== false &&
@@ -748,7 +749,7 @@ describe('parent schedule child scope', () => {
     expect(scope.isPartial).toBe(false);
   });
 
-  it('uses the authoritative web callable result without browser Firestore REST verification', async () => {
+  it('merges the authoritative web callable result with the authenticated HTTP projection', async () => {
     const previousFetch = globalThis.fetch;
     const coachUser = { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'], coachOf: [] } as any;
     vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: ['team-owned'] } as any);
@@ -763,6 +764,7 @@ describe('parent schedule child scope', () => {
       const scope = await loadParentScheduleScope(coachUser);
 
       expect(getStaffTeams).toHaveBeenCalledTimes(1);
+      expect(loadManagedTeamsFromNativeCallable).toHaveBeenCalledTimes(1);
       expect(scope.staffTeams).toEqual([{ teamId: 'team-owned', teamName: 'Vipers' }]);
       expect(scope.staffTeamsPartial).toBe(false);
       expect(scope.isPartial).toBe(false);
@@ -859,6 +861,31 @@ describe('parent schedule child scope', () => {
     expect(scope.isPartial).toBe(false);
   });
 
+  it('merges an HTTP-authorized team omitted from a nonempty web result without profile role hints', async () => {
+    const staffUser = { uid: 'staff-1', email: 'staff@example.com', roles: ['staff'], coachOf: [] } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: [] } as any);
+    vi.mocked(getStaffTeams).mockResolvedValue({
+      teams: [{ id: 'team-visible', name: 'Visible Team', active: true }],
+      isPartial: false
+    } as any);
+    vi.mocked(loadManagedTeamsFromNativeCallable).mockResolvedValueOnce({
+      teams: [
+        { id: 'team-visible', name: 'Visible Team', active: true },
+        { id: 'team-authoritative', name: 'Authoritative Team', active: true }
+      ],
+      isPartial: false
+    });
+
+    const scope = await loadParentScheduleScope(staffUser);
+
+    expect(loadManagedTeamsFromNativeCallable).toHaveBeenCalledTimes(1);
+    expect(scope.staffTeams).toEqual([
+      { teamId: 'team-visible', teamName: 'Visible Team' },
+      { teamId: 'team-authoritative', teamName: 'Authoritative Team' }
+    ]);
+    expect(scope.staffTeamsPartial).toBe(false);
+  });
+
   it('confirms an empty web SDK result even when the account lacks staff access signals', async () => {
     const parentUser = { uid: 'parent-1', email: 'parent@example.com', roles: ['parent'], coachOf: [] } as any;
     vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: [] } as any);
@@ -916,7 +943,7 @@ describe('parent schedule child scope', () => {
     const scope = await loadParentScheduleScope(coachUser);
 
     expect(getStaffTeams).toHaveBeenCalledTimes(2);
-    expect(loadManagedTeamsFromNativeCallable).toHaveBeenCalledTimes(1);
+    expect(loadManagedTeamsFromNativeCallable).toHaveBeenCalledTimes(2);
     expect(scope.staffTeams).toEqual([{ teamId: 'team-owned', teamName: 'Vipers' }]);
     expect(scope.staffTeamsPartial).toBe(false);
     expect(scope.isPartial).toBe(false);
@@ -929,6 +956,7 @@ describe('parent schedule child scope', () => {
       teams: [{ id: 'team-owned', name: 'Vipers', ownerId: 'coach-1', active: true }],
       isPartial: true
     } as any);
+    vi.mocked(loadManagedTeamsFromNativeCallable).mockResolvedValue({ teams: [], isPartial: true });
 
     const scope = await loadParentScheduleScope(coachUser);
 
@@ -2288,6 +2316,7 @@ describe('official assignments app service', () => {
     vi.unstubAllGlobals();
     vi.clearAllMocks();
     capacitorCoreMock.isNativePlatform.mockReturnValue(false);
+    vi.mocked(getNativeAuthIdToken).mockRejectedValue(new Error('HTTP projection unavailable in browser fallback tests'));
     vi.mocked(loadProfileDocument).mockResolvedValue({ parentTeamIds: ['team-alpha'], phone: '(555) 123-4567' } as any);
     vi.mocked(getOfficialLinkedTeamIds).mockResolvedValue({ teamIds: ['team-alpha'], isPartial: false });
     vi.mocked(getTeam).mockResolvedValue({ id: 'team-alpha', name: 'Alpha FC', ownerId: 'coach-1', adminEmails: [] } as any);
@@ -2452,6 +2481,54 @@ describe('official assignments app service', () => {
     expect(getTeam).not.toHaveBeenCalled();
     expect(getGames).not.toHaveBeenCalled();
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('loads web linked-team assignments from the authenticated bounded HTTP projection', async () => {
+    vi.mocked(getNativeAuthIdToken).mockResolvedValue('web-token');
+    capacitorCoreMock.httpPost.mockResolvedValue({
+      status: 200,
+      data: {
+        result: {
+          teamIds: ['team-alpha'],
+          teamCount: 1,
+          isPartial: false,
+          assignmentsComplete: true,
+          teams: [{ id: 'team-alpha', name: 'Alpha FC' }],
+          assignments: [{
+            kind: 'assigned',
+            teamId: 'team-alpha',
+            teamName: 'Alpha FC',
+            gameId: 'game-assigned',
+            slotId: 'center',
+            position: 'Center Referee',
+            status: 'pending',
+            opponent: 'Tigers',
+            location: 'Field 2',
+            date: futureDate,
+            canClaim: false,
+            scheduleReviewRequired: false
+          }]
+        }
+      },
+      headers: {},
+      url: ''
+    });
+
+    const result = await loadOfficialAssignments(user, { teamId: 'team-alpha' });
+
+    expect(result).toEqual(expect.objectContaining({
+      hasAccess: true,
+      teamIds: ['team-alpha'],
+      isPartial: false,
+      assignments: [expect.objectContaining({ gameId: 'game-assigned', slotId: 'center' })]
+    }));
+    expect(capacitorCoreMock.httpPost).toHaveBeenCalledWith(expect.objectContaining({
+      data: { data: { includeAssignments: true, requestedTeamId: 'team-alpha' } },
+      headers: expect.objectContaining({ Authorization: 'Bearer web-token' })
+    }));
+    expect(getOfficialLinkedTeamIds).not.toHaveBeenCalled();
+    expect(getTeam).not.toHaveBeenCalled();
+    expect(getGames).not.toHaveBeenCalled();
   });
 
   it('loads a requested native team and its shared assignments only from the complete callable projection', async () => {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -1784,6 +1784,8 @@ function isTeamStaff(team: any, user: AuthUser | null) {
 type StaffTeamsLoadResult = {
   teams: any[];
   isPartial: boolean;
+  verifiedByHttp?: boolean;
+  httpAttempted?: boolean;
 };
 
 async function loadStaffTeamsFromRest(): Promise<StaffTeamsLoadResult> {
@@ -1792,7 +1794,9 @@ async function loadStaffTeamsFromRest(): Promise<StaffTeamsLoadResult> {
     // The callable already applies the server-side ownership, admin, and coach
     // checks; its serialized team profiles intentionally omit some of those fields.
     teams: result.teams.filter((team: any) => team?.id && isTeamActive(team)),
-    isPartial: result.isPartial
+    isPartial: result.isPartial,
+    verifiedByHttp: true,
+    httpAttempted: true
   };
 }
 
@@ -1808,7 +1812,12 @@ async function loadStaffTeams(user: AuthUser): Promise<StaffTeamsLoadResult> {
     staffTeamResult.teams.filter(Boolean).forEach((team: any) => {
       if (team?.id && isTeamActive(team)) teamsById.set(team.id, team);
     });
-    return { teams: [...teamsById.values()], isPartial: staffTeamResult.isPartial };
+    return {
+      teams: [...teamsById.values()],
+      isPartial: staffTeamResult.isPartial,
+      verifiedByHttp: false,
+      httpAttempted: false
+    };
   } catch (error) {
     // The SDK callable and the authenticated HTTP callable reach the same
     // server-authorized listManagedTeams function. Keep the HTTP transport as
@@ -1817,7 +1826,11 @@ async function loadStaffTeams(user: AuthUser): Promise<StaffTeamsLoadResult> {
     logScheduleWarning('Falling back to authenticated HTTP for staff teams.', 'staff-team-callable-fallback', error, {
       fallback: 'authenticated-http'
     });
-    return loadStaffTeamsFromRest();
+    try {
+      return await loadStaffTeamsFromRest();
+    } catch {
+      return { teams: [], isPartial: true, verifiedByHttp: false, httpAttempted: true };
+    }
   }
 }
 
@@ -3095,7 +3108,7 @@ export async function loadParentScheduleScope(user: AuthUser | null): Promise<Pa
       return {};
     }),
     loadStaffTeams(user).catch(() => {
-      return { teams: [], isPartial: true };
+      return { teams: [], isPartial: true, verifiedByHttp: false, httpAttempted: true };
     })
   ]);
   let staffTeamResult = initialStaffTeamResult;
@@ -3118,7 +3131,9 @@ export async function loadParentScheduleScope(user: AuthUser | null): Promise<Pa
       });
       staffTeamResult = {
         teams: [...teamsById.values()],
-        isPartial: retryResult.isPartial
+        isPartial: retryResult.isPartial,
+        verifiedByHttp: retryResult.verifiedByHttp,
+        httpAttempted: retryResult.httpAttempted
       };
     } catch {
       staffTeamResult = { ...staffTeamResult, isPartial: true };
@@ -3134,11 +3149,11 @@ export async function loadParentScheduleScope(user: AuthUser | null): Promise<Pa
   const nativeRuntime = isNativeRuntime();
   const shouldVerifyStaffResultWithHttp = nativeRuntime
     ? (staffTeamResult.isPartial || hasMissingDeclaredCoachTeam || shouldVerifyEmptyStaffResult)
-    // A complete-empty browser SDK result has proved nondeterministic in the
-    // production staff workflow. Confirm every empty result through the same
-    // bounded, authenticated server projection. Also verify a nonempty result
-    // that omitted a team explicitly declared by the freshly loaded profile.
-    : ((staffTeamResult.teams.length === 0 || hasMissingDeclaredCoachTeam) && staffTeamResult.isPartial !== true);
+    // Browser callable results have proved nondeterministically incomplete in
+    // production even when they are nonempty and claim to be complete. Merge
+    // every result with the bounded authenticated HTTP projection so a team
+    // that is not duplicated in profile role hints cannot disappear.
+    : staffTeamResult.verifiedByHttp !== true && staffTeamResult.httpAttempted !== true;
   if (shouldVerifyStaffResultWithHttp) {
     try {
       const restResult = await loadStaffTeamsFromRest();
@@ -3149,7 +3164,9 @@ export async function loadParentScheduleScope(user: AuthUser | null): Promise<Pa
       });
       staffTeamResult = {
         teams: [...teamsById.values()],
-        isPartial: restResult.isPartial
+        isPartial: restResult.isPartial,
+        verifiedByHttp: true,
+        httpAttempted: true
       };
     } catch {
       staffTeamResult = { ...staffTeamResult, isPartial: true };
@@ -7248,6 +7265,18 @@ async function loadOfficialLinkedTeamIds(options: { includeAssignments?: boolean
   if (isNativeRuntime()) {
     return loadOfficialLinkedTeamIdsFromNativeCallable(options);
   }
+  if (options.includeAssignments) {
+    try {
+      return await loadOfficialLinkedTeamIdsFromNativeCallable(options);
+    } catch (error) {
+      logScheduleWarning(
+        'Falling back to browser official assignment reads.',
+        'official-assignment-callable-fallback',
+        error,
+        { fallback: 'browser-sdk' }
+      );
+    }
+  }
   return normalizeOfficialLinkedTeamIdsResponse(await getOfficialLinkedTeamIds());
 }
 
@@ -7301,8 +7330,8 @@ export async function loadOfficialAssignments(user: AuthUser, options: { teamId?
   let discoveryError: unknown = null;
   try {
     const linkedTeamResult = await loadOfficialLinkedTeamIds({
-      includeAssignments: nativeRuntime,
-      ...(nativeRuntime && requestedTeamId ? { requestedTeamId } : {})
+      includeAssignments: true,
+      ...(requestedTeamId ? { requestedTeamId } : {})
     });
     linkedTeamIds = linkedTeamResult.teamIds;
     linkedTeamIdsPartial = linkedTeamResult.isPartial;
@@ -7313,17 +7342,17 @@ export async function loadOfficialAssignments(user: AuthUser, options: { teamId?
     discoveryError = error;
   }
   const linkedRequestedTeamIds = requestedTeamId ? linkedTeamIds.filter((teamId) => teamId === requestedTeamId) : linkedTeamIds;
-  if (nativeRuntime && linkedAssignmentsComplete) {
-    const nativeTeamIds = requestedTeamId ? linkedRequestedTeamIds : linkedTeamIds;
-    const nativeAssignments = linkedAssignments
-      .filter((item) => nativeTeamIds.includes(item.teamId))
+  if (linkedAssignmentsComplete) {
+    const projectedTeamIds = requestedTeamId ? linkedRequestedTeamIds : linkedTeamIds;
+    const projectedAssignments = linkedAssignments
+      .filter((item) => projectedTeamIds.includes(item.teamId))
       .sort((left, right) => left.date.getTime() - right.date.getTime());
     return {
-      hasAccess: nativeTeamIds.length > 0,
-      teamIds: nativeTeamIds,
-      teamCount: nativeTeamIds.length,
+      hasAccess: projectedTeamIds.length > 0,
+      teamIds: projectedTeamIds,
+      teamCount: projectedTeamIds.length,
       isPartial: false,
-      assignments: nativeAssignments
+      assignments: projectedAssignments
     };
   }
   const teamIds = linkedRequestedTeamIds.length

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -7480,7 +7480,7 @@ export async function loadOfficialAssignments(user: AuthUser, options: { teamId?
 }
 
 export async function respondToOfficialAssignmentItem(item: OfficialAssignmentItem, status: 'accepted' | 'declined') {
-  if (isNativeRuntime()) {
+  if (isNativeRuntime() || item.sharedGamePath) {
     await callNativeFirebaseFunction('respondToOfficiatingAssignment', {
       teamId: item.teamId,
       gameId: item.gameId,
@@ -7494,7 +7494,7 @@ export async function respondToOfficialAssignmentItem(item: OfficialAssignmentIt
 }
 
 export async function claimOfficialAssignmentItem(item: OfficialAssignmentItem, user: AuthUser) {
-  if (isNativeRuntime()) {
+  if (isNativeRuntime() || item.sharedGamePath) {
     await callNativeFirebaseFunction('claimOpenOfficiatingSlot', {
       teamId: item.teamId,
       gameId: item.gameId,

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -559,7 +559,7 @@ describe('React app schedule service contract integration', () => {
         expect(legacyScheduleDbSource).toContain("legacyFirebaseHttpsCallable(legacyFirebaseFunctions, 'listManagedTeams')");
         expect(legacyScheduleDbSource).not.toContain("legacyFirebaseWhere('ownerEmailLower', '==', normalizedEmail)");
         expect(scheduleServiceSource).toContain('const shouldVerifyStaffResultWithHttp = nativeRuntime');
-        expect(scheduleServiceSource).toContain(': ((staffTeamResult.teams.length === 0 || hasMissingDeclaredCoachTeam) && staffTeamResult.isPartial !== true)');
+        expect(scheduleServiceSource).toContain(': staffTeamResult.verifiedByHttp !== true && staffTeamResult.httpAttempted !== true;');
     });
 
     it('discovers official teams and native assignments through one authenticated bounded callable', () => {
@@ -580,7 +580,8 @@ describe('React app schedule service contract integration', () => {
         expect(officialDiscoverySource).not.toContain("collectionGroup(db, 'officials')");
         expect(officialDiscoverySource).not.toContain('Promise.allSettled');
         expect(officialAssignmentsSource).toContain('linkedAssignmentsComplete');
-        expect(officialAssignmentsSource).toContain('includeAssignments: nativeRuntime');
+        expect(officialAssignmentsSource).toContain('includeAssignments: true');
+        expect(officialAssignmentsSource).toContain('if (linkedAssignmentsComplete)');
         expect(officialAssignmentsSource).toContain('requestedTeamId');
         expect(officialAssignmentsSource).toContain('Promise.allSettled');
         expect(officialAssignmentsSource).toContain("teamResult.status === 'rejected' || gamesResult.status === 'rejected'");


### PR DESCRIPTION
## Summary

- merge every browser managed-team result with the authenticated server projection, including nonempty results
- load officials teams and assignments from one bounded authenticated server projection before using the browser SDK fallback
- cap staff projection retries and retain partial-state semantics when both transports fail

## Why

Production smoke showed nondeterministic incomplete browser reads: the staff team chooser intermittently omitted the fixture team, and the officials workflow omitted that team or its game. The existing server projections already return the authoritative bounded data, but web clients only used them for some empty/error cases.

## Validation

- `npm run test:app -- src/lib/scheduleService.test.ts` (197 passed)
- `npx vitest run tests/unit/app-schedule-service-contracts.test.js --reporter=verbose` (43 passed)
- `npm run app:build`
- `git diff --check`

## Manual verification

After merge and production deployment, run the fixture smoke and confirm the staff team route plus officials assignment route both complete without missing-team or missing-game failures.