### PR TITLE
Stabilize authoritative team chooser

### DIFF
--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -886,6 +886,33 @@ describe('parent schedule child scope', () => {
     expect(scope.staffTeamsPartial).toBe(false);
   });
 
+  it('retries a transient HTTP verification before accepting a nonempty incomplete web result', async () => {
+    const staffUser = { uid: 'staff-1', email: 'staff@example.com', roles: ['staff'], coachOf: [] } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: [] } as any);
+    vi.mocked(getStaffTeams).mockResolvedValue({
+      teams: [{ id: 'team-visible', name: 'Visible Team', active: true }],
+      isPartial: false
+    } as any);
+    vi.mocked(loadManagedTeamsFromNativeCallable)
+      .mockRejectedValueOnce(new Error('temporary function cold start'))
+      .mockResolvedValueOnce({
+        teams: [
+          { id: 'team-visible', name: 'Visible Team', active: true },
+          { id: 'team-authoritative', name: 'Authoritative Team', active: true }
+        ],
+        isPartial: false
+      });
+
+    const scope = await loadParentScheduleScope(staffUser);
+
+    expect(loadManagedTeamsFromNativeCallable).toHaveBeenCalledTimes(2);
+    expect(scope.staffTeams).toEqual([
+      { teamId: 'team-visible', teamName: 'Visible Team' },
+      { teamId: 'team-authoritative', teamName: 'Authoritative Team' }
+    ]);
+    expect(scope.staffTeamsPartial).toBe(false);
+  });
+
   it('confirms an empty web SDK result even when the account lacks staff access signals', async () => {
     const parentUser = { uid: 'parent-1', email: 'parent@example.com', roles: ['parent'], coachOf: [] } as any;
     vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: [] } as any);

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -913,6 +913,33 @@ describe('parent schedule child scope', () => {
     expect(scope.staffTeamsPartial).toBe(false);
   });
 
+  it('retries an empty partial HTTP verification before returning staff scope', async () => {
+    const staffUser = { uid: 'staff-1', email: 'staff@example.com', roles: ['staff'], coachOf: [] } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: [] } as any);
+    vi.mocked(getStaffTeams).mockResolvedValue({
+      teams: [{ id: 'team-visible', name: 'Visible Team', active: true }],
+      isPartial: false
+    } as any);
+    vi.mocked(loadManagedTeamsFromNativeCallable)
+      .mockResolvedValueOnce({ teams: [], isPartial: true })
+      .mockResolvedValueOnce({
+        teams: [
+          { id: 'team-visible', name: 'Visible Team', active: true },
+          { id: 'team-authoritative', name: 'Authoritative Team', active: true }
+        ],
+        isPartial: false
+      });
+
+    const scope = await loadParentScheduleScope(staffUser);
+
+    expect(loadManagedTeamsFromNativeCallable).toHaveBeenCalledTimes(2);
+    expect(scope.staffTeams).toEqual([
+      { teamId: 'team-visible', teamName: 'Visible Team' },
+      { teamId: 'team-authoritative', teamName: 'Authoritative Team' }
+    ]);
+    expect(scope.staffTeamsPartial).toBe(false);
+  });
+
   it('confirms an empty web SDK result even when the account lacks staff access signals', async () => {
     const parentUser = { uid: 'parent-1', email: 'parent@example.com', roles: ['parent'], coachOf: [] } as any;
     vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: [] } as any);

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -940,6 +940,35 @@ describe('parent schedule child scope', () => {
     expect(scope.staffTeamsPartial).toBe(false);
   });
 
+  it('unions different partial HTTP team subsets across retries', async () => {
+    const staffUser = { uid: 'staff-1', email: 'staff@example.com', roles: ['staff'], coachOf: [] } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: [] } as any);
+    vi.mocked(getStaffTeams).mockResolvedValue({
+      teams: [{ id: 'team-visible', name: 'Visible Team', active: true }],
+      isPartial: false
+    } as any);
+    vi.mocked(loadManagedTeamsFromNativeCallable)
+      .mockResolvedValueOnce({
+        teams: [{ id: 'team-first', name: 'First Partial Team', active: true }],
+        isPartial: true
+      })
+      .mockResolvedValueOnce({
+        teams: [{ id: 'team-second', name: 'Second Partial Team', active: true }],
+        isPartial: true
+      });
+
+    const scope = await loadParentScheduleScope(staffUser);
+
+    expect(loadManagedTeamsFromNativeCallable).toHaveBeenCalledTimes(2);
+    expect(scope.staffTeams).toEqual([
+      { teamId: 'team-visible', teamName: 'Visible Team' },
+      { teamId: 'team-first', teamName: 'First Partial Team' },
+      { teamId: 'team-second', teamName: 'Second Partial Team' }
+    ]);
+    expect(scope.staffTeamsPartial).toBe(true);
+    expect(scope.isPartial).toBe(true);
+  });
+
   it('confirms an empty web SDK result even when the account lacks staff access signals', async () => {
     const parentUser = { uid: 'parent-1', email: 'parent@example.com', roles: ['parent'], coachOf: [] } as any;
     vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: [] } as any);

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -1800,6 +1800,18 @@ async function loadStaffTeamsFromRest(): Promise<StaffTeamsLoadResult> {
   };
 }
 
+async function loadStaffTeamsFromRestWithRetry(maxAttempts: number): Promise<StaffTeamsLoadResult> {
+  let lastError: unknown = new Error('Managed team verification failed.');
+  for (let attempt = 0; attempt < Math.max(1, maxAttempts); attempt += 1) {
+    try {
+      return await loadStaffTeamsFromRest();
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
+}
+
 async function loadStaffTeams(user: AuthUser): Promise<StaffTeamsLoadResult> {
   const coachTeamIds = Array.isArray(user.coachOf) ? user.coachOf.map(compactString).filter(Boolean) : [];
   try {
@@ -3156,7 +3168,11 @@ export async function loadParentScheduleScope(user: AuthUser | null): Promise<Pa
     : staffTeamResult.verifiedByHttp !== true && staffTeamResult.httpAttempted !== true;
   if (shouldVerifyStaffResultWithHttp) {
     try {
-      const restResult = await loadStaffTeamsFromRest();
+      // A production function deployment or cold start can outlive the first
+      // browser request even when the SDK returns a nonempty (but incomplete)
+      // result. Give the authoritative projection one bounded retry before
+      // allowing a partial chooser to render.
+      const restResult = await loadStaffTeamsFromRestWithRetry(nativeRuntime ? 1 : 2);
       const teamsById = new Map<string, any>();
       [...staffTeamResult.teams, ...restResult.teams].forEach((team: any) => {
         const teamId = compactString(team?.id);

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -1802,13 +1802,17 @@ async function loadStaffTeamsFromRest(): Promise<StaffTeamsLoadResult> {
 
 async function loadStaffTeamsFromRestWithRetry(maxAttempts: number): Promise<StaffTeamsLoadResult> {
   let lastError: unknown = new Error('Managed team verification failed.');
+  let lastPartialResult: StaffTeamsLoadResult | null = null;
   for (let attempt = 0; attempt < Math.max(1, maxAttempts); attempt += 1) {
     try {
-      return await loadStaffTeamsFromRest();
+      const result = await loadStaffTeamsFromRest();
+      if (!result.isPartial) return result;
+      lastPartialResult = result;
     } catch (error) {
       lastError = error;
     }
   }
+  if (lastPartialResult) return lastPartialResult;
   throw lastError;
 }
 

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -1803,16 +1803,20 @@ async function loadStaffTeamsFromRest(): Promise<StaffTeamsLoadResult> {
 async function loadStaffTeamsFromRestWithRetry(maxAttempts: number): Promise<StaffTeamsLoadResult> {
   let lastError: unknown = new Error('Managed team verification failed.');
   let lastPartialResult: StaffTeamsLoadResult | null = null;
+  const partialTeamsById = new Map<string, any>();
   for (let attempt = 0; attempt < Math.max(1, maxAttempts); attempt += 1) {
     try {
       const result = await loadStaffTeamsFromRest();
       if (!result.isPartial) return result;
+      result.teams.forEach((team: any) => partialTeamsById.set(team.id, team));
       lastPartialResult = result;
     } catch (error) {
       lastError = error;
     }
   }
-  if (lastPartialResult) return lastPartialResult;
+  if (lastPartialResult) {
+    return { ...lastPartialResult, teams: [...partialTeamsById.values()] };
+  }
   throw lastError;
 }
 

--- a/apps/app/src/pages/Teams.test.tsx
+++ b/apps/app/src/pages/Teams.test.tsx
@@ -228,6 +228,37 @@ describe('Teams empty state', () => {
     expect(screen.queryByText('No teams available')).toBeNull();
   });
 
+  it('does not let a nonempty enrichment subset erase an authoritative fast team', async () => {
+    const authoritativeTeam = {
+      teamId: 'team-authoritative', teamName: 'Authoritative Aces', role: 'Coach' as const, sport: 'Soccer', photoUrl: null,
+      players: [], nextEvent: null, eventCount: 0, upcomingEventCount: 0, unreadCount: 0, openActions: 0
+    };
+    const otherTeam = {
+      teamId: 'team-other', teamName: 'Other Owls', role: 'Coach' as const, sport: 'Soccer', photoUrl: null,
+      players: [], nextEvent: null, eventCount: 0, upcomingEventCount: 0, unreadCount: 0, openActions: 0
+    };
+    const fastHome = {
+      ...emptyHome,
+      teams: [authoritativeTeam, otherTeam],
+      metrics: { ...emptyHome.metrics, teams: 2 }
+    };
+    const incompleteEnrichment = {
+      ...emptyHome,
+      teams: [{ ...otherTeam, eventCount: 2 }],
+      metrics: { ...emptyHome.metrics, teams: 1 }
+    };
+    homeServiceMocks.loadParentTeamsSummaryBootstrap.mockResolvedValueOnce(makeTeamSummaryBootstrap(fastHome));
+    homeServiceMocks.loadParentHomeSummary.mockResolvedValueOnce(incompleteEnrichment);
+
+    renderTeams();
+
+    expect(await screen.findByRole('link', { name: 'Open Authoritative Aces' })).toBeTruthy();
+    await waitFor(() => expect(homeServiceMocks.loadParentHomeSummary).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole('link', { name: 'Open Authoritative Aces' })).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Open Other Owls' })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: '2 teams ready' })).toBeTruthy();
+  });
+
   it('preserves the complete team chooser when a refresh returns incomplete access', async () => {
     const completeHome = {
       players: [],

--- a/apps/app/src/pages/Teams.tsx
+++ b/apps/app/src/pages/Teams.tsx
@@ -233,15 +233,28 @@ export function Teams({ auth }: { auth: AuthState }) {
 function mergeTeamSummary(current: ParentHomeModel, enriched: ParentHomeModel): ParentHomeModel {
   if (!enriched.teams.length) return current;
   const currentByTeamId = new Map(current.teams.map((team) => [team.teamId, team]));
-  return {
-    ...enriched,
-    teams: enriched.teams.map((team) => ({
+  const enrichedTeamIds = new Set(enriched.teams.map((team) => team.teamId));
+  const mergedTeams = [
+    ...enriched.teams.map((team) => ({
       ...team,
       unreadCount: currentByTeamId.get(team.teamId)?.unreadCount || team.unreadCount,
       role: currentByTeamId.get(team.teamId)?.role || team.role,
       sport: currentByTeamId.get(team.teamId)?.sport || team.sport,
       photoUrl: currentByTeamId.get(team.teamId)?.photoUrl || team.photoUrl
-    }))
+    })),
+    // Enrichment is optional detail, not a new access authority. Never let a
+    // nonempty but incomplete enrichment response erase a team from the
+    // authoritative fast chooser that already rendered it.
+    ...current.teams.filter((team) => !enrichedTeamIds.has(team.teamId))
+  ];
+  return {
+    ...enriched,
+    teams: mergedTeams,
+    metrics: {
+      ...enriched.metrics,
+      teams: mergedTeams.length,
+      players: mergedTeams.reduce((total, team) => total + team.players.length, 0)
+    }
   };
 }
 


### PR DESCRIPTION
## Summary

- preserve every team from the authoritative fast chooser when optional enrichment returns a nonempty subset
- retry one transient browser HTTP projection failure before rendering a partial staff chooser
- keep chooser metrics aligned with the union-preserved team list

## Why

The exact #4617 production smoke passed only after Playwright retry. Its first staff attempt still omitted `/teams/allplays-smoke-team-v1`. The release was correctly bound to #4617, so this follow-up closes the two remaining client races: subset replacement during Teams enrichment and a single transient authoritative HTTP verification attempt.

## Validation

- `npm run test:app -- src/lib/scheduleService.test.ts` (198 passed)
- `npm run test:app -- src/pages/Teams.test.tsx` (14 passed)
- `npx vitest run tests/unit/app-schedule-service-contracts.test.js --reporter=verbose` (43 passed)
- `npm run app:build`
- `git diff --check`

## Production follow-up

After deployment, rerun the exact fixture-backed production role smoke and require the staff workflow to pass on its first attempt, with no Playwright retry.