### PR TITLE
Bound cold staff team discovery latency

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -167,6 +167,7 @@ jobs:
           --config=playwright.smoke.config.js
           --project=smoke
           --retries=1
+          --fail-on-flaky-tests
           --reporter=line
         env:
           SMOKE_BASE_URL: https://allplays.ai
@@ -201,6 +202,7 @@ jobs:
           --project=smoke
           --workers=1
           --retries=1
+          --fail-on-flaky-tests
           --reporter=line
         env:
           SMOKE_BASE_URL: https://allplays.ai

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -2591,6 +2591,45 @@ describe('official assignments app service', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it('keeps cold native official discovery separate from the shorter staff discovery timeout', async () => {
+    vi.useFakeTimers();
+    capacitorCoreMock.isNativePlatform.mockReturnValue(true);
+    vi.mocked(getNativeAuthIdToken).mockResolvedValue('native-token');
+    capacitorCoreMock.httpPost.mockImplementation(() => new Promise((resolve) => {
+      setTimeout(() => resolve({
+        status: 200,
+        data: {
+          result: {
+            teamIds: ['team-alpha'],
+            isPartial: false,
+            assignments: [],
+            assignmentsComplete: false
+          }
+        },
+        headers: {},
+        url: ''
+      }), 8000);
+    }));
+
+    try {
+      const accessPromise = loadOfficialAssignmentsAccess(user);
+      await vi.advanceTimersByTimeAsync(8000);
+
+      await expect(accessPromise).resolves.toEqual({
+        hasAccess: true,
+        teamIds: ['team-alpha'],
+        teamCount: 1,
+        isPartial: false
+      });
+      expect(capacitorCoreMock.httpPost).toHaveBeenCalledWith(expect.objectContaining({
+        connectTimeout: 12000,
+        readTimeout: 12000
+      }));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('loads web linked-team assignments from the authenticated bounded HTTP projection', async () => {
     vi.mocked(getNativeAuthIdToken).mockResolvedValue('web-token');
     const sharedGamePath = 'tournaments/tournament-1/sharedGames/shared-assigned';

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -705,6 +705,31 @@ describe('parent schedule child scope', () => {
     }
   });
 
+  it('falls back to authenticated HTTP before a cold staff callable exhausts the production chooser wait', async () => {
+    vi.useFakeTimers();
+    const coachUser = { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'], coachOf: [] } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: ['team-owned'] } as any);
+    vi.mocked(getStaffTeams).mockImplementation(() => new Promise(() => undefined));
+    vi.mocked(loadManagedTeamsFromNativeCallable).mockResolvedValue({
+      teams: [{ id: 'team-owned', name: 'Vipers', active: true }],
+      isPartial: false
+    });
+
+    try {
+      const scopePromise = loadParentScheduleScope(coachUser);
+      await vi.advanceTimersByTimeAsync(7000);
+      const scope = await scopePromise;
+
+      expect(getStaffTeams).toHaveBeenCalledTimes(1);
+      expect(loadManagedTeamsFromNativeCallable).toHaveBeenCalledTimes(1);
+      expect(scope.staffTeams).toEqual([{ teamId: 'team-owned', teamName: 'Vipers' }]);
+      expect(scope.staffTeamsPartial).toBe(false);
+    } finally {
+      vi.mocked(getStaffTeams).mockReset();
+      vi.useRealTimers();
+    }
+  });
+
   it('marks parent scope partial when the authoritative staff-team read fails', async () => {
     const coachUser = { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'], coachOf: ['team-owned'] } as any;
     vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: ['team-owned'] } as any);

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -155,6 +155,7 @@ const primaryDataTimeoutMs = 5000;
 // grants. Give that one bounded callable enough time to finish on a cold web
 // start without raising the timeout for every schedule read.
 const staffTeamDiscoveryTimeoutMs = 7000;
+const officialTeamDiscoveryTimeoutMs = 12000;
 const MAX_SCHEDULE_TRACKER_CONFIG_OPTIONS = 100;
 // Per-team schedule builds are network-bound (team + games + practiceSessions
 // reads each); 3 workers made a 5-team account load in two serialized waves
@@ -7272,9 +7273,9 @@ async function loadOfficialLinkedTeamIdsFromNativeCallable(options: { includeAss
         ...(compactString(options.requestedTeamId) ? { requestedTeamId: compactString(options.requestedTeamId) } : {})
       }
     },
-    connectTimeout: staffTeamDiscoveryTimeoutMs,
-    readTimeout: staffTeamDiscoveryTimeoutMs
-  }), 'Official team discovery', staffTeamDiscoveryTimeoutMs);
+    connectTimeout: officialTeamDiscoveryTimeoutMs,
+    readTimeout: officialTeamDiscoveryTimeoutMs
+  }), 'Official team discovery', officialTeamDiscoveryTimeoutMs);
   const payload = response.data && typeof response.data === 'object' ? response.data : {};
   const result = payload?.result || payload?.data;
   if (response.status < 200 || response.status >= 300) {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -154,7 +154,7 @@ const primaryDataTimeoutMs = 5000;
 // Managed-team discovery can fan out across owner, admin, and legacy coach
 // grants. Give that one bounded callable enough time to finish on a cold web
 // start without raising the timeout for every schedule read.
-const staffTeamDiscoveryTimeoutMs = 12000;
+const staffTeamDiscoveryTimeoutMs = 7000;
 const MAX_SCHEDULE_TRACKER_CONFIG_OPTIONS = 100;
 // Per-team schedule builds are network-bound (team + games + practiceSessions
 // reads each); 3 workers made a 5-team account load in two serialized waves

--- a/tests/unit/production-smoke-auth-setup-timeout.test.js
+++ b/tests/unit/production-smoke-auth-setup-timeout.test.js
@@ -91,6 +91,9 @@ describe('production smoke authenticated setup timeout', () => {
         expect(workflow).toMatch(
             /tests\/smoke\/app-admin-core\.spec\.js[\s\S]*?tests\/smoke\/app-authenticated-core\.spec\.js[\s\S]*?--retries=1/
         );
+        expect(workflow).toMatch(
+            /tests\/smoke\/app-admin-core\.spec\.js[\s\S]*?tests\/smoke\/app-authenticated-core\.spec\.js[\s\S]*?--fail-on-flaky-tests/
+        );
         expect(scheduledWorkflow).toMatch(
             /tests\/smoke\/app-admin-core\.spec\.js[\s\S]*?tests\/smoke\/app-authenticated-core\.spec\.js[\s\S]*?--workers=1/
         );

--- a/tests/unit/production-smoke-config-gate.test.js
+++ b/tests/unit/production-smoke-config-gate.test.js
@@ -36,5 +36,6 @@ describe('production role-smoke gate', () => {
         expect(baselineStart).toBeGreaterThan(-1);
         expect(coreStart).toBeGreaterThan(baselineStart);
         expect(baselineBlock).toContain('--retries=1');
+        expect(baselineBlock).toContain('--fail-on-flaky-tests');
     });
 });


### PR DESCRIPTION
## What changed
- start the authenticated HTTP staff-team fallback after 7 seconds instead of allowing the SDK cold path to consume 12 seconds first
- add a deterministic regression proving the fallback returns the authoritative team inside the production chooser wait
- make post-deploy baseline and role smoke fail when Playwright only passes on retry, so flaky production behavior cannot report green

## Why
The exact #4619 production smoke still failed the staff team chooser on its first 25-second attempt and passed only after Playwright restarted the worker. The previous 12-second SDK timeout followed by an 8-second HTTP fallback left too little room for the bounded second discovery path.

## Validation
- `npm run test:app -- src/lib/scheduleService.test.ts src/pages/Teams.test.tsx` (215 passed)
- `npx vitest run tests/unit/production-smoke-config-gate.test.js tests/unit/production-smoke-auth-setup-timeout.test.js --reporter=verbose` (13 passed)
- `npm run app:build`
- `git diff --check`