### PR TITLE
Hedge cold staff team discovery

### DIFF
--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -732,6 +732,39 @@ describe('parent schedule child scope', () => {
     }
   });
 
+  it('lets a complete HTTP hedge clear a partial cold SDK result', async () => {
+    vi.useFakeTimers();
+    const coachUser = { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'], coachOf: [] } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: ['team-owned'] } as any);
+    vi.mocked(getStaffTeams).mockImplementation(() => new Promise((resolve) => {
+      setTimeout(() => resolve({
+        teams: [],
+        isPartial: true
+      } as any), 3000);
+    }));
+    vi.mocked(loadManagedTeamsFromNativeCallable).mockImplementation(() => new Promise((resolve) => {
+      setTimeout(() => resolve({
+        teams: [{ id: 'team-owned', name: 'Vipers', active: true }],
+        isPartial: false
+      }), 1000);
+    }));
+
+    try {
+      const scopePromise = loadParentScheduleScope(coachUser);
+      await vi.advanceTimersByTimeAsync(6000);
+      const scope = await scopePromise;
+
+      expect(getStaffTeams).toHaveBeenCalledTimes(1);
+      expect(loadManagedTeamsFromNativeCallable).toHaveBeenCalledTimes(1);
+      expect(scope.staffTeams).toEqual([{ teamId: 'team-owned', teamName: 'Vipers' }]);
+      expect(scope.staffTeamsPartial).toBe(false);
+      expect(scope.isPartial).toBe(false);
+    } finally {
+      vi.mocked(getStaffTeams).mockReset();
+      vi.useRealTimers();
+    }
+  });
+
   it('marks parent scope partial when the authoritative staff-team read fails', async () => {
     const coachUser = { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'], coachOf: ['team-owned'] } as any;
     vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: ['team-owned'] } as any);

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -710,14 +710,16 @@ describe('parent schedule child scope', () => {
     const coachUser = { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'], coachOf: [] } as any;
     vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: ['team-owned'] } as any);
     vi.mocked(getStaffTeams).mockImplementation(() => new Promise(() => undefined));
-    vi.mocked(loadManagedTeamsFromNativeCallable).mockResolvedValue({
-      teams: [{ id: 'team-owned', name: 'Vipers', active: true }],
-      isPartial: false
-    });
+    vi.mocked(loadManagedTeamsFromNativeCallable).mockImplementation(() => new Promise((resolve) => {
+      setTimeout(() => resolve({
+        teams: [{ id: 'team-owned', name: 'Vipers', active: true }],
+        isPartial: false
+      }), 8000);
+    }));
 
     try {
       const scopePromise = loadParentScheduleScope(coachUser);
-      await vi.advanceTimersByTimeAsync(7000);
+      await vi.advanceTimersByTimeAsync(10000);
       const scope = await scopePromise;
 
       expect(getStaffTeams).toHaveBeenCalledTimes(1);

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -155,6 +155,7 @@ const primaryDataTimeoutMs = 5000;
 // grants. Give that one bounded callable enough time to finish on a cold web
 // start without raising the timeout for every schedule read.
 const staffTeamDiscoveryTimeoutMs = 7000;
+const staffTeamHttpHedgeDelayMs = 2000;
 const officialTeamDiscoveryTimeoutMs = 12000;
 const MAX_SCHEDULE_TRACKER_CONFIG_OPTIONS = 100;
 // Per-team schedule builds are network-bound (team + games + practiceSessions
@@ -1823,6 +1824,27 @@ async function loadStaffTeamsFromRestWithRetry(maxAttempts: number): Promise<Sta
 
 async function loadStaffTeams(user: AuthUser): Promise<StaffTeamsLoadResult> {
   const coachTeamIds = Array.isArray(user.coachOf) ? user.coachOf.map(compactString).filter(Boolean) : [];
+  const timers = getTimerScope();
+  let httpHedgeTimer: ReturnType<typeof setTimeout> | undefined;
+  let httpHedgePromise: Promise<StaffTeamsLoadResult> | null = null;
+  const startHttpHedge = () => {
+    if (!httpHedgePromise) httpHedgePromise = loadStaffTeamsFromRest();
+    return httpHedgePromise;
+  };
+  const cancelHttpHedge = () => {
+    if (httpHedgeTimer !== undefined) timers.clearTimeout(httpHedgeTimer);
+    httpHedgeTimer = undefined;
+  };
+  if (!isNativeRuntime()) {
+    // Start the equivalent authenticated HTTP transport while a cold SDK
+    // callable is still inside its timeout. If the SDK succeeds quickly the
+    // normal exact-result verification below remains unchanged; if it stalls,
+    // fallback latency overlaps instead of serializing two long waits.
+    httpHedgeTimer = timers.setTimeout(() => {
+      httpHedgeTimer = undefined;
+      void startHttpHedge().catch(() => {});
+    }, staffTeamHttpHedgeDelayMs);
+  }
   try {
     const staffTeamResult = await withTimeout(Promise.resolve(getStaffTeams({
       userId: user.uid,
@@ -1833,6 +1855,25 @@ async function loadStaffTeams(user: AuthUser): Promise<StaffTeamsLoadResult> {
     staffTeamResult.teams.filter(Boolean).forEach((team: any) => {
       if (team?.id && isTeamActive(team)) teamsById.set(team.id, team);
     });
+    const pendingHttpHedge = httpHedgePromise as Promise<StaffTeamsLoadResult> | null;
+    if (pendingHttpHedge) {
+      try {
+        const httpResult = await pendingHttpHedge;
+        httpResult.teams.forEach((team: any) => {
+          const teamId = compactString(team?.id);
+          if (teamId) teamsById.set(teamId, team);
+        });
+        return {
+          teams: [...teamsById.values()],
+          isPartial: staffTeamResult.isPartial || httpResult.isPartial,
+          verifiedByHttp: true,
+          httpAttempted: true
+        };
+      } catch {
+        // Preserve the successful SDK projection and let the caller's existing
+        // authoritative verification path retry the failed HTTP transport.
+      }
+    }
     return {
       teams: [...teamsById.values()],
       isPartial: staffTeamResult.isPartial,
@@ -1848,10 +1889,12 @@ async function loadStaffTeams(user: AuthUser): Promise<StaffTeamsLoadResult> {
       fallback: 'authenticated-http'
     });
     try {
-      return await loadStaffTeamsFromRest();
+      return await startHttpHedge();
     } catch {
       return { teams: [], isPartial: true, verifiedByHttp: false, httpAttempted: true };
     }
+  } finally {
+    cancelHttpHedge();
   }
 }
 

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -1865,7 +1865,7 @@ async function loadStaffTeams(user: AuthUser): Promise<StaffTeamsLoadResult> {
         });
         return {
           teams: [...teamsById.values()],
-          isPartial: staffTeamResult.isPartial || httpResult.isPartial,
+          isPartial: httpResult.isPartial,
           verifiedByHttp: true,
           httpAttempted: true
         };


### PR DESCRIPTION
## What changed
- start the authenticated HTTP staff-team projection after a 2-second hedge delay while a slow SDK callable remains in flight
- reuse and merge the hedged result instead of serializing SDK timeout and HTTP timeout
- preserve the native Officials timeout and the existing fast-SDK path
- strengthen the regression with an 8-second HTTP response that now completes the chooser path in 10 seconds rather than 15+

## Why
The exact #4620 post-deploy app staff workflow passed first attempt once, but the same deployed SHA failed the staff team chooser in a subsequent scheduled smoke. A shorter SDK timeout alone was insufficient because the HTTP fallback still began only after that timeout.

## Validation
- `npm run test:app -- src/lib/scheduleService.test.ts src/pages/Teams.test.tsx` (216 passed)
- `npx vitest run tests/unit/production-smoke-config-gate.test.js tests/unit/production-smoke-auth-setup-timeout.test.js --reporter=verbose` (13 passed)
- `npm run app:build`
- `git diff --check`