### PR TITLE
Budget cold staff team discovery

### DIFF
--- a/apps/app/src/lib/profileService.test.ts
+++ b/apps/app/src/lib/profileService.test.ts
@@ -368,6 +368,18 @@ describe('native parent-team fallback hydration', () => {
         }));
     });
 
+    it('honors a caller-specific timeout for cold managed-team discovery', async () => {
+        mockNativeProfileFallbackFetch();
+
+        await loadManagedTeamsFromNativeCallable({ timeoutMs: 15000 });
+
+        expect(capacitorHttpMocks.post).toHaveBeenCalledWith(expect.objectContaining({
+            data: { data: {} },
+            connectTimeout: 15000,
+            readTimeout: 15000
+        }));
+    });
+
     it('uses per-document team reads for notification teams so parent hydration stays rule-compatible', async () => {
         dbMocks.getUserTeamsWithAccess.mockRejectedValue(new Error('sdk failed'));
         dbMocks.getParentTeams.mockRejectedValue(new Error('sdk failed'));

--- a/apps/app/src/lib/profileService.ts
+++ b/apps/app/src/lib/profileService.ts
@@ -291,7 +291,8 @@ async function nativeRunQuery(collectionId: string, fieldPath: string, op: 'EQUA
     : [];
 }
 
-export async function loadManagedTeamsFromNativeCallable(options: { includeChatMetadata?: boolean } = {}) {
+export async function loadManagedTeamsFromNativeCallable(options: { includeChatMetadata?: boolean; timeoutMs?: number } = {}) {
+  const timeoutMs = options.timeoutMs ?? profileTimeoutMs;
   const token = await getNativeAuthIdToken(true);
   if (!token) throw new Error('Native auth token is unavailable.');
   const requestUrl = `https://us-central1-${getProjectId()}.cloudfunctions.net/listManagedTeams`;
@@ -302,9 +303,9 @@ export async function loadManagedTeamsFromNativeCallable(options: { includeChatM
       'Content-Type': 'application/json'
     }, requestUrl) as Record<string, string>,
     data: { data: options.includeChatMetadata === true ? { includeChatMetadata: true } : {} },
-    connectTimeout: profileTimeoutMs,
-    readTimeout: profileTimeoutMs
-  }), 'Managed team load');
+    connectTimeout: timeoutMs,
+    readTimeout: timeoutMs
+  }), 'Managed team load', timeoutMs);
   const payload = response.data && typeof response.data === 'object' ? response.data : {};
   const result = payload?.result || payload?.data;
   if (response.status < 200 || response.status >= 300 || !Array.isArray(result?.items)) {

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -705,7 +705,7 @@ describe('parent schedule child scope', () => {
     }
   });
 
-  it('falls back to authenticated HTTP before a cold staff callable exhausts the production chooser wait', async () => {
+  it('budgets a measured cold authenticated staff response within the production chooser wait', async () => {
     vi.useFakeTimers();
     const coachUser = { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'], coachOf: [] } as any;
     vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [], coachOf: ['team-owned'] } as any);
@@ -714,16 +714,17 @@ describe('parent schedule child scope', () => {
       setTimeout(() => resolve({
         teams: [{ id: 'team-owned', name: 'Vipers', active: true }],
         isPartial: false
-      }), 8000);
+      }), 11000);
     }));
 
     try {
       const scopePromise = loadParentScheduleScope(coachUser);
-      await vi.advanceTimersByTimeAsync(10000);
+      await vi.advanceTimersByTimeAsync(15000);
       const scope = await scopePromise;
 
       expect(getStaffTeams).toHaveBeenCalledTimes(1);
       expect(loadManagedTeamsFromNativeCallable).toHaveBeenCalledTimes(1);
+      expect(loadManagedTeamsFromNativeCallable).toHaveBeenCalledWith({ timeoutMs: 15000 });
       expect(scope.staffTeams).toEqual([{ teamId: 'team-owned', teamName: 'Vipers' }]);
       expect(scope.staffTeamsPartial).toBe(false);
     } finally {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -152,9 +152,10 @@ const buildPracticePacketCompletionPayloadBase = buildPracticePacketCompletionPa
 
 const primaryDataTimeoutMs = 5000;
 // Managed-team discovery can fan out across owner, admin, and legacy coach
-// grants. Give that one bounded callable enough time to finish on a cold web
-// start without raising the timeout for every schedule read.
-const staffTeamDiscoveryTimeoutMs = 7000;
+// grants. Cold production fixture audits take about 11 seconds, so keep this
+// one operation inside the 25-second chooser contract without raising the
+// timeout for every schedule read.
+const staffTeamDiscoveryTimeoutMs = 15000;
 const staffTeamHttpHedgeDelayMs = 2000;
 const officialTeamDiscoveryTimeoutMs = 12000;
 const MAX_SCHEDULE_TRACKER_CONFIG_OPTIONS = 100;
@@ -1791,7 +1792,7 @@ type StaffTeamsLoadResult = {
 };
 
 async function loadStaffTeamsFromRest(): Promise<StaffTeamsLoadResult> {
-  const result = await loadManagedTeamsFromNativeCallable();
+  const result = await loadManagedTeamsFromNativeCallable({ timeoutMs: staffTeamDiscoveryTimeoutMs });
   return {
     // The callable already applies the server-side ownership, admin, and coach
     // checks; its serialized team profiles intentionally omit some of those fields.

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -551,7 +551,8 @@ describe('React app schedule service contract integration', () => {
 
         expect(staffTeamSource).toContain('getStaffTeams({');
         expect(staffTeamSource).not.toContain('getTeams(');
-        expect(staffTeamSource).toContain('loadManagedTeamsFromNativeCallable()');
+        expect(staffTeamSource).toContain('loadManagedTeamsFromNativeCallable({ timeoutMs: staffTeamDiscoveryTimeoutMs })');
+        expect(scheduleServiceSource).toContain('const staffTeamDiscoveryTimeoutMs = 15000;');
         expect(staffTeamSource).not.toContain("nativeRunQuery('teams', 'ownerEmail'");
         expect(scheduleServiceSource).toContain('const hasCanonicalOwner = Boolean(compactString(team.ownerId));');
         expect(scheduleServiceSource).toContain('if (!hasCanonicalOwner && ownerEmails.length === 1 && email === ownerEmails[0])');


### PR DESCRIPTION
## What changed
- give only managed staff-team discovery a 15-second transport budget
- keep the 2-second SDK/HTTP hedge so cold work overlaps instead of serializing
- preserve partial-result fail-closed behavior and existing default profile timeouts
- cover the measured 11-second cold response and custom transport timeout

## Why
The exact production staff chooser failed twice because valid cold listManagedTeams work outlived the app’s 7–8 second client timeouts. A protected fixture audit immediately afterward succeeded in about 11 seconds. This keeps the operation inside the chooser’s 25-second UI contract without weakening access checks.

## Validation
- `npm --prefix apps/app test -- --run src/lib/scheduleService.test.ts src/lib/profileService.test.ts src/lib/homeService.test.ts src/pages/Teams.test.tsx` (250 passed)
- `npm run app:build` (TypeScript/build, visualizer, and 383 KB cold-start budget passed)
- production fixture audit on exact current master passed; no production data was changed

## Production verification
After merge/deploy, run the strict exact-SHA post-deploy smoke and a second fresh-worker scheduled production smoke. The staff workflow must pass first attempt; a retry is a failure.