### PR TITLE
Preserve authenticated deep links

### DIFF
--- a/apps/app/src/pages/AuthPage.test.tsx
+++ b/apps/app/src/pages/AuthPage.test.tsx
@@ -68,6 +68,8 @@ function renderAuthPage(path = '/auth') {
 describe('AuthPage native post-login routing', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    auth.user = null;
+    auth.loading = false;
     auth.refresh = vi.fn();
     auth.signOut = vi.fn();
     authServiceMocks.hydrateFirebaseUser.mockReset();
@@ -140,6 +142,51 @@ describe('AuthPage native post-login routing', () => {
 
     expect(await screen.findByText('Family fee destination')).toBeTruthy();
     expect(auth.refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let late auth hydration replace a newer authenticated deep link', async () => {
+    const view = renderAuthPage();
+
+    window.location.hash = '#/teams';
+    auth.user = {
+      uid: 'coach-1',
+      email: 'coach@example.com',
+      displayName: 'Coach',
+      roles: ['coach']
+    };
+    auth.loading = false;
+    view.rerender(
+      <MemoryRouter initialEntries={['/auth']}>
+        <Routes>
+          <Route path="/auth" element={<AuthPage auth={auth} />} />
+          <Route path="/home" element={<div>Home destination</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(window.location.hash).toBe('#/teams'));
+    expect(screen.queryByText('Home destination')).toBeNull();
+  });
+
+  it('still sends a restored signed-in session away from the active auth route', async () => {
+    window.location.hash = '#/auth';
+    auth.user = {
+      uid: 'coach-1',
+      email: 'coach@example.com',
+      displayName: 'Coach',
+      roles: ['coach']
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/auth']}>
+        <Routes>
+          <Route path="/auth" element={<AuthPage auth={auth} />} />
+          <Route path="/home" element={<div>Home destination</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Home destination')).toBeTruthy();
   });
 
   it('routes the Apple button through native sign-in and reloads the home page', async () => {

--- a/apps/app/src/pages/AuthPage.tsx
+++ b/apps/app/src/pages/AuthPage.tsx
@@ -68,7 +68,10 @@ export function AuthPage({ auth }: { auth: AuthState }) {
   }, [auth.user, inviteCode, inviteType, requestedNextRoute]);
 
   useEffect(() => {
-    if (!auth.loading && auth.user && !inviteCode) {
+    // Auth hydration can finish after the browser has already moved away from
+    // this route. An effect queued by the old AuthPage render must not replace
+    // that newer deep link with the signed-in default route.
+    if (!auth.loading && auth.user && !inviteCode && isBrowserAuthRouteActive()) {
       navigate(postAuthRoute, { replace: true });
     }
   }, [auth.loading, auth.user, inviteCode, navigate, postAuthRoute]);
@@ -470,6 +473,13 @@ export function AuthPage({ auth }: { auth: AuthState }) {
       />
     </AuthFrame>
   );
+}
+
+function isBrowserAuthRouteActive() {
+  if (typeof window === 'undefined') return true;
+  const hash = window.location.hash;
+  if (!hash.startsWith('#/')) return true;
+  return hash.slice(1).split('?')[0] === '/auth';
 }
 
 function Field({ icon: Icon, label, htmlFor, children }: { icon: typeof Mail; label: string; htmlFor: string; children: ReactNode }) {


### PR DESCRIPTION
## What changed
- Prevent a late AuthPage hydration effect from replacing a newer authenticated hash route with Home.
- Add a regression for the observed sign-in-to-Teams race and a safety regression proving an active Auth route still redirects a restored session.

## Why
Production smoke and a live paul@allplays.ai reproduction showed successful authentication and complete managed-team responses, followed by AuthPage replacing #/teams with #/home. The stale redirect made the Teams smoke wait on the wrong screen.

## Verification
- npm test -- --run src/pages/AuthPage.test.tsx src/App.test.tsx (49/49)
- npm test -- --run src/pages/AuthPage.test.tsx src/App.test.tsx src/lib/authService.test.ts src/lib/authNextRoute.test.ts src/lib/authBootstrapHint.test.ts (93/93)
- npm run typecheck
- npm run build
- npm run lint (0 errors; existing warnings only)
- Regression test confirmed failing against the pre-fix implementation.

## Manual production evidence
- Signed in successfully as the requested non-admin account.
- Confirmed listManagedTeams returned all three authorized teams.
- Captured AuthPage as the exact caller replacing #/teams with #/home.

The exact post-deploy production smoke will re-run after merge before the mobile store release is dispatched.