### PR TITLE
Stream verified teams into chooser

### DIFF
--- a/apps/app/src/lib/homeService.test.ts
+++ b/apps/app/src/lib/homeService.test.ts
@@ -68,6 +68,16 @@ function installTestLocalStorage() {
     });
 }
 
+function deferred<T>() {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+}
+
 describe('homeService Teams bootstrap reuse', () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -144,6 +154,58 @@ describe('homeService Teams bootstrap reuse', () => {
             })
         ]));
         expect(summary.home.metrics.teams).toBe(2);
+    });
+
+    it('streams a verified chat team before slower family scope discovery completes', async () => {
+        const scheduleScope = deferred<any>();
+        const onPartial = vi.fn();
+        chatServiceMocks.loadChatInbox.mockResolvedValue({
+            teams: [{
+                id: 'team-owned',
+                name: 'Vipers',
+                role: 'Coach',
+                unreadCount: 0
+            }]
+        });
+        scheduleServiceMocks.loadParentScheduleScope.mockReturnValue(scheduleScope.promise);
+
+        const resultPromise = loadParentTeamsSummaryBootstrap(user, { force: true, onPartial });
+        await vi.waitFor(() => {
+            expect(onPartial).toHaveBeenCalledWith(expect.objectContaining({
+                teams: [expect.objectContaining({ teamId: 'team-owned', teamName: 'Vipers' })]
+            }));
+        });
+
+        scheduleScope.resolve({
+            profile: {},
+            children: [],
+            staffTeams: [{ teamId: 'team-owned', teamName: 'Vipers' }],
+            isPartial: false
+        });
+        const result = await resultPromise;
+        expect(result.home.teams).toEqual([
+            expect.objectContaining({ teamId: 'team-owned', teamName: 'Vipers' })
+        ]);
+    });
+
+    it('does not stream an empty slice before complete access discovery', async () => {
+        const scheduleScope = deferred<any>();
+        const onPartial = vi.fn();
+        chatServiceMocks.loadChatInbox.mockResolvedValue({ teams: [] });
+        scheduleServiceMocks.loadParentScheduleScope.mockReturnValue(scheduleScope.promise);
+
+        const resultPromise = loadParentTeamsSummaryBootstrap(user, { force: true, onPartial });
+        await vi.waitFor(() => expect(chatServiceMocks.loadChatInbox).toHaveBeenCalledTimes(1));
+        expect(onPartial).not.toHaveBeenCalled();
+
+        scheduleScope.resolve({
+            profile: {},
+            children: [],
+            staffTeams: [],
+            isPartial: false
+        });
+        await expect(resultPromise).resolves.toMatchObject({ home: { teams: [] } });
+        expect(onPartial).not.toHaveBeenCalled();
     });
 
     it('surfaces a partial-empty staff scope and recovers on the next retry', async () => {

--- a/apps/app/src/lib/homeService.ts
+++ b/apps/app/src/lib/homeService.ts
@@ -43,6 +43,11 @@ type ParentHomeSummaryBootstrapOptions = ParentHomeSummaryOptions & {
   onPartial?: (result: ParentHomeSummaryBootstrapResult) => void;
 };
 
+type ParentTeamsSummaryBootstrapOptions = {
+  force?: boolean;
+  onPartial?: (home: ParentHomeModel) => void;
+};
+
 function normalizeSecondaryError(error: unknown, fallbackMessage: string) {
   return toAppServiceError(error, fallbackMessage);
 }
@@ -123,7 +128,7 @@ export async function loadParentTeamsSummary(user: AuthUser | null, options: { f
 
 export async function loadParentTeamsSummaryBootstrap(
   user: AuthUser | null,
-  options: { force?: boolean } = {}
+  options: ParentTeamsSummaryBootstrapOptions = {}
 ): Promise<{ home: ParentHomeModel; scheduleScope: ParentScheduleScope }> {
   if (!user?.uid) {
     return {
@@ -137,17 +142,44 @@ export async function loadParentTeamsSummaryBootstrap(
     async () => {
       const timer = startUxTimer('teams summary load');
       try {
+        let availableChatTeams: any[] = [];
+        let availableScheduleScope: ParentScheduleScope | null = null;
+        const emitAvailableTeams = () => {
+          const model = buildParentHomeModel({
+            children: availableScheduleScope?.children || [],
+            events: [],
+            inboxTeams: mergeTeamSummaries(
+              normalizeStaffTeams({ children: [], events: [], staffTeams: availableScheduleScope?.staffTeams }),
+              normalizeInboxTeams(availableChatTeams)
+            ),
+            fees: []
+          });
+          // A verified nonempty result can unblock the chooser while slower,
+          // unrelated family-scope reads finish. Empty or failed slices stay
+          // fail-closed until the complete bootstrap result is known.
+          if (model.teams.length > 0) options.onPartial?.(model);
+        };
         const [chatInboxResult, scheduleScope] = await Promise.all([
           loadChatInbox(user, { includeLastMessages: false })
             .then(requireCompleteChatInbox)
-            .then((chatInbox) => ({ chatInbox, error: null }))
+            .then((chatInbox) => {
+              availableChatTeams = chatInbox.teams || [];
+              emitAvailableTeams();
+              return { chatInbox, error: null };
+            })
             .catch((error) => ({
               chatInbox: { teams: [] },
               error: toAppServiceError(error, 'Unable to load team chat.')
             })),
-          loadParentScheduleScope(user).catch((error) => {
-            throw toAppServiceError(error, 'Unable to load teams.');
-          })
+          loadParentScheduleScope(user)
+            .then((scheduleScope) => {
+              availableScheduleScope = scheduleScope;
+              emitAvailableTeams();
+              return scheduleScope;
+            })
+            .catch((error) => {
+              throw toAppServiceError(error, 'Unable to load teams.');
+            })
         ]);
         const hasDiscoveredTeams = scheduleScope.children.length > 0 || Boolean(scheduleScope.staffTeams?.length);
         if (scheduleScope.isPartial === true && !hasDiscoveredTeams) {

--- a/apps/app/src/pages/Teams.test.tsx
+++ b/apps/app/src/pages/Teams.test.tsx
@@ -226,6 +226,66 @@ describe('Teams empty state', () => {
     expect(screen.getByText('Unable to load teams while offline. Check your connection and try again.')).toBeVisible();
   });
 
+  it('merges a streamed refresh slice without erasing the existing chooser when completion fails', async () => {
+    const existingHome: ParentHomeModel = {
+      ...emptyHome,
+      teams: [{
+        teamId: 'team-existing',
+        teamName: 'Existing Eagles',
+        role: 'Parent',
+        sport: 'Soccer',
+        photoUrl: null,
+        players: [{
+          teamId: 'team-existing',
+          teamName: 'Existing Eagles',
+          playerId: 'player-1',
+          playerName: 'Alex Eagle'
+        }],
+        nextEvent: null,
+        eventCount: 2,
+        upcomingEventCount: 1,
+        unreadCount: 1,
+        openActions: 1
+      }],
+      metrics: { ...emptyHome.metrics, teams: 1, players: 1, unreadMessages: 1 }
+    };
+    const streamedHome: ParentHomeModel = {
+      ...emptyHome,
+      teams: [{
+        teamId: 'team-streamed',
+        teamName: 'Streamed Stars',
+        role: 'Coach',
+        sport: null,
+        photoUrl: null,
+        players: [],
+        nextEvent: null,
+        eventCount: 0,
+        upcomingEventCount: 0,
+        unreadCount: 0,
+        openActions: 0
+      }],
+      metrics: { ...emptyHome.metrics, teams: 1 }
+    };
+    homeServiceMocks.loadParentTeamsSummaryBootstrap
+      .mockResolvedValueOnce(makeTeamSummaryBootstrap(existingHome))
+      .mockImplementationOnce(async (_user, options) => {
+        options?.onPartial?.(streamedHome);
+        throw new Error('Family scope timed out');
+      });
+    homeServiceMocks.loadParentHomeSummary.mockResolvedValueOnce(existingHome);
+
+    renderTeams();
+    expect(await screen.findByRole('link', { name: 'Open Existing Eagles' })).toBeVisible();
+    await waitFor(() => expect(homeServiceMocks.loadParentHomeSummary).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh teams' }));
+
+    expect(await screen.findByRole('link', { name: 'Open Streamed Stars' })).toBeVisible();
+    expect(screen.getByRole('link', { name: 'Open Existing Eagles' })).toBeVisible();
+    expect(screen.getByText('Alex Eagle')).toBeVisible();
+    expect(screen.queryByText('Teams could not load')).toBeNull();
+  });
+
   it('opens the native Browse Teams route from the empty state recovery action', async () => {
     renderTeams();
 

--- a/apps/app/src/pages/Teams.test.tsx
+++ b/apps/app/src/pages/Teams.test.tsx
@@ -160,6 +160,72 @@ describe('Teams empty state', () => {
     cleanup();
   });
 
+  it('renders a verified streamed team while complete scope discovery is still pending', async () => {
+    const completeLoad = deferred<ReturnType<typeof makeTeamSummaryBootstrap>>();
+    const streamedHome: ParentHomeModel = {
+      ...emptyHome,
+      teams: [{
+        teamId: 'team-streamed',
+        teamName: 'Streamed Stars',
+        role: 'Coach',
+        sport: null,
+        photoUrl: null,
+        players: [],
+        nextEvent: null,
+        eventCount: 0,
+        upcomingEventCount: 0,
+        unreadCount: 0,
+        openActions: 0
+      }],
+      metrics: { ...emptyHome.metrics, teams: 1 }
+    };
+    homeServiceMocks.loadParentTeamsSummaryBootstrap.mockImplementationOnce(async (_user, options) => {
+      options?.onPartial?.(streamedHome);
+      return completeLoad.promise;
+    });
+
+    renderTeams();
+
+    expect(await screen.findByRole('link', { name: 'Open Streamed Stars' })).toHaveAttribute(
+      'href',
+      '/teams/team-streamed'
+    );
+    expect(screen.queryByText('Loading teams')).toBeNull();
+
+    completeLoad.resolve(makeTeamSummaryBootstrap(streamedHome));
+    await waitFor(() => expect(homeServiceMocks.loadParentHomeSummary).toHaveBeenCalledTimes(1));
+  });
+
+  it('preserves a streamed team if slower complete scope discovery fails', async () => {
+    const streamedHome: ParentHomeModel = {
+      ...emptyHome,
+      teams: [{
+        teamId: 'team-streamed',
+        teamName: 'Streamed Stars',
+        role: 'Coach',
+        sport: null,
+        photoUrl: null,
+        players: [],
+        nextEvent: null,
+        eventCount: 0,
+        upcomingEventCount: 0,
+        unreadCount: 0,
+        openActions: 0
+      }],
+      metrics: { ...emptyHome.metrics, teams: 1 }
+    };
+    homeServiceMocks.loadParentTeamsSummaryBootstrap.mockImplementationOnce(async (_user, options) => {
+      options?.onPartial?.(streamedHome);
+      throw new Error('Family scope timed out');
+    });
+
+    renderTeams();
+
+    expect(await screen.findByRole('link', { name: 'Open Streamed Stars' })).toBeVisible();
+    expect(screen.queryByText('Teams could not load')).toBeNull();
+    expect(screen.getByText('Unable to load teams while offline. Check your connection and try again.')).toBeVisible();
+  });
+
   it('opens the native Browse Teams route from the empty state recovery action', async () => {
     renderTeams();
 

--- a/apps/app/src/pages/Teams.tsx
+++ b/apps/app/src/pages/Teams.tsx
@@ -83,10 +83,10 @@ export function Teams({ auth }: { auth: AuthState }) {
 
     let teamSummaryBootstrap: Awaited<ReturnType<typeof loadParentTeamsSummaryBootstrap>> | null = null;
     let hasStreamedTeams = false;
-    const applyTeamSummary = (fastHome: ParentHomeModel) => {
+    const applyTeamSummary = (fastHome: ParentHomeModel, preserveExisting = false) => {
       if (loadId !== activeLoadIdRef.current) return;
       hasStreamedTeams = hasStreamedTeams || fastHome.teams.length > 0;
-      setHome(fastHome);
+      setHome((current) => preserveExisting ? mergeStreamedTeamSummary(current, fastHome) : fastHome);
       setLoadedTeamSummaryUserId(user.uid);
       setTeamsLoadError(null);
     };
@@ -94,7 +94,7 @@ export function Teams({ auth }: { auth: AuthState }) {
       async () => {
         teamSummaryBootstrap = await loadParentTeamsSummaryBootstrap(user, {
           force: !showLoading,
-          onPartial: applyTeamSummary
+          onPartial: (partialHome) => applyTeamSummary(partialHome, true)
         });
         return teamSummaryBootstrap.home;
       },
@@ -258,6 +258,24 @@ function mergeTeamSummary(current: ParentHomeModel, enriched: ParentHomeModel): 
     teams: mergedTeams,
     metrics: {
       ...enriched.metrics,
+      teams: mergedTeams.length,
+      players: mergedTeams.reduce((total, team) => total + team.players.length, 0)
+    }
+  };
+}
+
+function mergeStreamedTeamSummary(current: ParentHomeModel, streamed: ParentHomeModel): ParentHomeModel {
+  if (!streamed.teams.length) return current;
+  const currentTeamIds = new Set(current.teams.map((team) => team.teamId));
+  const mergedTeams = [
+    ...current.teams,
+    ...streamed.teams.filter((team) => !currentTeamIds.has(team.teamId))
+  ];
+  return {
+    ...current,
+    teams: mergedTeams,
+    metrics: {
+      ...current.metrics,
       teams: mergedTeams.length,
       players: mergedTeams.reduce((total, team) => total + team.players.length, 0)
     }

--- a/apps/app/src/pages/Teams.tsx
+++ b/apps/app/src/pages/Teams.tsx
@@ -82,26 +82,32 @@ export function Teams({ auth }: { auth: AuthState }) {
     setTeamsLoadError(null);
 
     let teamSummaryBootstrap: Awaited<ReturnType<typeof loadParentTeamsSummaryBootstrap>> | null = null;
+    let hasStreamedTeams = false;
+    const applyTeamSummary = (fastHome: ParentHomeModel) => {
+      if (loadId !== activeLoadIdRef.current) return;
+      hasStreamedTeams = hasStreamedTeams || fastHome.teams.length > 0;
+      setHome(fastHome);
+      setLoadedTeamSummaryUserId(user.uid);
+      setTeamsLoadError(null);
+    };
     const fastHome = await runTeamSummaryLoad(
       async () => {
-        teamSummaryBootstrap = await loadParentTeamsSummaryBootstrap(user, { force: !showLoading });
+        teamSummaryBootstrap = await loadParentTeamsSummaryBootstrap(user, {
+          force: !showLoading,
+          onPartial: applyTeamSummary
+        });
         return teamSummaryBootstrap.home;
       },
       {
         ignoreStale: true,
         rethrow: false,
         getErrorMessage: (loadError) => getTeamsLoadErrorMessage(toAppServiceError(loadError, 'Unable to load teams.'), hasExistingTeams),
-        onSuccess: (fastHome) => {
-          if (loadId !== activeLoadIdRef.current) return;
-          setHome(fastHome);
-          setLoadedTeamSummaryUserId(user.uid);
-          setTeamsLoadError(null);
-        },
+        onSuccess: applyTeamSummary,
         onError: (loadError) => {
           if (loadId !== activeLoadIdRef.current) return;
           const appError = toAppServiceError(loadError, 'Unable to load teams.');
           setTeamsLoadError(appError);
-          if (!hasExistingTeams) {
+          if (!hasExistingTeams && !hasStreamedTeams) {
             setHome(emptyHome());
             setLoadedTeamSummaryUserId(null);
             setLoadedTeamUserId(null);
@@ -158,7 +164,7 @@ export function Teams({ auth }: { auth: AuthState }) {
 
   useRefreshOnResume(() => loadTeams(), { enabled: Boolean(auth.user?.uid) });
 
-  const showBlockingErrorState = !loading && !hasLoadedTeamDetails && Boolean(teamsLoadError);
+  const showBlockingErrorState = !loading && !hasLoadedTeamSummary && !hasLoadedTeamDetails && Boolean(teamsLoadError);
 
   const teamRoles = useMemo(() => getLoadedTeamRoles(home.teams), [home.teams]);
 

--- a/tests/unit/app-teams-async-operation-contract.test.js
+++ b/tests/unit/app-teams-async-operation-contract.test.js
@@ -38,7 +38,9 @@ describe('Teams async operation contract', () => {
         expect(loadTeamsSource).toContain("getTeamsLoadErrorMessage(toAppServiceError(loadError, 'Unable to load teams.'), hasExistingTeams)");
         expect(loadTeamsSource).toContain("const appError = toAppServiceError(loadError, 'Unable to load teams.');");
         expect(loadTeamsSource).toContain('setTeamsLoadError(appError);');
-        expect(loadTeamsSource).toContain('if (!hasExistingTeams) {');
+        expect(loadTeamsSource).toContain('onPartial: (partialHome) => applyTeamSummary(partialHome, true)');
+        expect(loadTeamsSource).toContain('mergeStreamedTeamSummary(current, fastHome)');
+        expect(loadTeamsSource).toContain('if (!hasExistingTeams && !hasStreamedTeams) {');
         expect(loadTeamsSource).toContain('setHome(emptyHome());');
         expect(loadTeamsSource).toContain('const hasFastTeams = fastHome.teams.length > 0;');
         expect(loadTeamsSource).toContain("getTeamsLoadErrorMessage(toAppServiceError(enrichError, 'Unable to load teams.'), true)");

--- a/tests/unit/app-teams-integration.test.jsx
+++ b/tests/unit/app-teams-integration.test.jsx
@@ -204,7 +204,10 @@ describe('React app Teams page', () => {
     it('renders the same parent and staff/admin teams used by the app inbox', async () => {
         const { container } = await renderTeams('/teams?selectedTeamId=team-staff&from=home');
 
-        expect(homeMocks.loadParentTeamsSummaryBootstrap).toHaveBeenCalledWith(auth.user, { force: false });
+        expect(homeMocks.loadParentTeamsSummaryBootstrap).toHaveBeenCalledWith(auth.user, {
+            force: false,
+            onPartial: expect.any(Function)
+        });
         expect(homeMocks.loadParentHomeSummary).toHaveBeenCalledWith(auth.user, {
             force: false,
             scheduleScope: expect.objectContaining({


### PR DESCRIPTION
## Summary
- render a verified staff/parent team as soon as either authenticated chat access or schedule access resolves
- keep slower family-scope discovery running for the complete chooser and enrichment
- preserve streamed teams if unrelated completion work fails, while keeping empty/failed slices fail-closed

## Why
Production smoke showed `listManagedTeams` returning authenticated HTTP 200 responses in 0.2–3.8 seconds, but `/teams` still withheld the fixture link until the combined schedule/family scope completed and exceeded the 25-second UI contract.

## Validation
- `npm run test:app -- src/lib/homeLogic.test.ts src/lib/homeService.test.ts src/pages/Teams.test.tsx`
- `npx vitest run tests/unit/app-performance-baseline-contract.test.js tests/unit/app-teams-integration.test.jsx --reporter=verbose`
- `npm run app:build`
- `git diff --check origin/master...HEAD`

## Manual test
- No credentialed local production test; validate through the protected exact-SHA production smoke after merge.
- No layout change; the existing team chooser becomes usable earlier.